### PR TITLE
fix: clear analyzer warnings (nullable, async, dispose)

### DIFF
--- a/src/BlocksBeyondTheStars.Client.Core/ClientWorld.cs
+++ b/src/BlocksBeyondTheStars.Client.Core/ClientWorld.cs
@@ -22,7 +22,7 @@ namespace BlocksBeyondTheStars.Client
         private readonly Dictionary<Vector3i, int> _lightSources = new Dictionary<Vector3i, int>();
 
         // The inherent light colour of a block id (0 = not a light block), supplied once from GameContent.
-        private System.Func<ushort, int> _blockLightColor;
+        private System.Func<ushort, int> _blockLightColor = _ => 0;
 
         public IReadOnlyDictionary<ChunkCoord, ChunkData> Chunks => _chunks;
 
@@ -37,8 +37,8 @@ namespace BlocksBeyondTheStars.Client
         // Round worlds: chunks are cached by canonical chunk coordinate (a chunk a lap away — east OR
         // north — is the same chunk), and block lookups canonicalize X AND Z so an unbounded player
         // coordinate still resolves after laps in any direction.
-        public void StoreChunk(ChunkCoord coord, ushort[] blocks, int[] modIndex = null, int[] modTint = null, int[] modGlow = null,
-            int[] shapeIndex = null, int[] shapeData = null)
+        public void StoreChunk(ChunkCoord coord, ushort[] blocks, int[]? modIndex = null, int[]? modTint = null, int[]? modGlow = null,
+            int[]? shapeIndex = null, int[]? shapeData = null)
         {
             coord = WorldConstants.CanonicalChunk(coord, _circumference);
             var chunk = ChunkData.FromRaw(coord, blocks);

--- a/src/BlocksBeyondTheStars.Client.Core/Feedback/FeedbackUploader.cs
+++ b/src/BlocksBeyondTheStars.Client.Core/Feedback/FeedbackUploader.cs
@@ -133,11 +133,13 @@ namespace BlocksBeyondTheStars.Client.Feedback
                 using var request = new HttpRequestMessage(HttpMethod.Post, _endpoint) { Content = content };
                 request.Headers.TryAddWithoutValidation(ApiKeyHeader, _apiKey);
 
+#pragma warning disable VSTHRD002 // Runs on a background uploader thread (no SynchronizationContext) — cannot deadlock.
                 using var response = _http.SendAsync(request).GetAwaiter().GetResult();
                 result.StatusCode = (int)response.StatusCode;
                 result.Ok = response.IsSuccessStatusCode;
 
                 string body = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+#pragma warning restore VSTHRD002
                 if (result.Ok)
                 {
                     result.ReportId = TryReadReportId(body);

--- a/src/BlocksBeyondTheStars.Client.Core/NetworkClient.cs
+++ b/src/BlocksBeyondTheStars.Client.Core/NetworkClient.cs
@@ -21,110 +21,110 @@ namespace BlocksBeyondTheStars.Client
     {
         private readonly IClientTransport _transport;
 
-        public event Action<JoinAccepted> JoinAccepted;
-        public event Action<JoinRejected> JoinRejected;
-        public event Action<ChunkDataMessage> ChunkReceived;
-        public event Action<BlockChanged> BlockChanged;
-        public event Action<InventoryUpdate> InventoryUpdated;
-        public event Action<PlayerStateUpdate> PlayerStateUpdated;
-        public event Action<CraftResult> CraftCompleted;
-        public event Action<ActionRejected> ActionRejected;
-        public event Action<ServerMessage> ServerMessageReceived;
+        public event Action<JoinAccepted>? JoinAccepted;
+        public event Action<JoinRejected>? JoinRejected;
+        public event Action<ChunkDataMessage>? ChunkReceived;
+        public event Action<BlockChanged>? BlockChanged;
+        public event Action<InventoryUpdate>? InventoryUpdated;
+        public event Action<PlayerStateUpdate>? PlayerStateUpdated;
+        public event Action<CraftResult>? CraftCompleted;
+        public event Action<ActionRejected>? ActionRejected;
+        public event Action<ServerMessage>? ServerMessageReceived;
 
         // Ship docking (M18) and free space flight / combat (M19). Rendering is added later;
         // these hooks let the client react to the authoritative state the server reports.
-        public event Action<DockRequestNotice> DockRequested;
-        public event Action<DockStatus> DockStatusChanged;
-        public event Action<ShipCombatStatus> ShipCombatStatusChanged;
-        public event Action<SpaceState> SpaceStateReceived;
-        public event Action<SpaceShipDesign> SpaceShipDesignReceived; // item 20 S1: own ship as a voxel structure
-        public event Action<StructureBlockChanged> StructureBlockChangedReceived; // item 20 S2: a structure cell changed
-        public event Action<LandedShipState> LandedShipReceived; // ship-as-object: a parked ship placed/replaced/removed
-        public event Action<SpaceEntityDestroyed> SpaceEntityDestroyed;
-        public event Action<SpaceClosed> SpaceClosed;
-        public event Action<SpaceWarpFx> SpaceWarpReceived; // peaceful NPC trader warp-in/out flash for bystanders
-        public event Action<StationBoarded> StationBoardedReceived;
-        public event Action<PlanetEnemyList> PlanetEnemiesReceived;
-        public event Action<PlanetEnemyDefeated> PlanetEnemyDefeated;
-        public event Action<CreatureList> CreaturesReceived;
-        public event Action<ContainerList> ContainersReceived;
-        public event Action<ShipPlacement> ShipPlacementReceived;
-        public event Action<ShipStations> ShipStationsReceived;
-        public event Action<PlanetPoiList> PlanetPoisReceived;
-        public event Action<BeaconList> BeaconsReceived;
-        public event Action<BeamList> BeamsReceived; // placed beam blocks (teleporter pads) on the current world
-        public event Action<BeamTeleported> BeamTeleportedReceived; // my arrival after a beam (snap + arrival fx)
-        public event Action<BeamFx> BeamFxReceived; // beam column VFX at both pads, shown to everyone on the world
-        public event Action<BaseList> BasesReceived; // player-founded planet bases (Grundstein) on the current world
-        public event Action<LandingPadList> LandingPadsReceived;
-        public event Action<ShipTransitFx> ShipTransitReceived;
-        public event Action<ChatMessage> ChatReceived;
+        public event Action<DockRequestNotice>? DockRequested;
+        public event Action<DockStatus>? DockStatusChanged;
+        public event Action<ShipCombatStatus>? ShipCombatStatusChanged;
+        public event Action<SpaceState>? SpaceStateReceived;
+        public event Action<SpaceShipDesign>? SpaceShipDesignReceived; // item 20 S1: own ship as a voxel structure
+        public event Action<StructureBlockChanged>? StructureBlockChangedReceived; // item 20 S2: a structure cell changed
+        public event Action<LandedShipState>? LandedShipReceived; // ship-as-object: a parked ship placed/replaced/removed
+        public event Action<SpaceEntityDestroyed>? SpaceEntityDestroyed;
+        public event Action<SpaceClosed>? SpaceClosed;
+        public event Action<SpaceWarpFx>? SpaceWarpReceived; // peaceful NPC trader warp-in/out flash for bystanders
+        public event Action<StationBoarded>? StationBoardedReceived;
+        public event Action<PlanetEnemyList>? PlanetEnemiesReceived;
+        public event Action<PlanetEnemyDefeated>? PlanetEnemyDefeated;
+        public event Action<CreatureList>? CreaturesReceived;
+        public event Action<ContainerList>? ContainersReceived;
+        public event Action<ShipPlacement>? ShipPlacementReceived;
+        public event Action<ShipStations>? ShipStationsReceived;
+        public event Action<PlanetPoiList>? PlanetPoisReceived;
+        public event Action<BeaconList>? BeaconsReceived;
+        public event Action<BeamList>? BeamsReceived; // placed beam blocks (teleporter pads) on the current world
+        public event Action<BeamTeleported>? BeamTeleportedReceived; // my arrival after a beam (snap + arrival fx)
+        public event Action<BeamFx>? BeamFxReceived; // beam column VFX at both pads, shown to everyone on the world
+        public event Action<BaseList>? BasesReceived; // player-founded planet bases (Grundstein) on the current world
+        public event Action<LandingPadList>? LandingPadsReceived;
+        public event Action<ShipTransitFx>? ShipTransitReceived;
+        public event Action<ChatMessage>? ChatReceived;
 
         // Navigation, missions & feedback (M23).
-        public event Action<StarMapData> StarMapReceived;
-        public event Action<MissionList> MissionsReceived;
-        public event Action<MissionResult> MissionResultReceived;
-        public event Action<RespawnNotice> RespawnNoticeReceived;
-        public event Action<ServerRules> ServerRulesReceived;
+        public event Action<StarMapData>? StarMapReceived;
+        public event Action<MissionList>? MissionsReceived;
+        public event Action<MissionResult>? MissionResultReceived;
+        public event Action<RespawnNotice>? RespawnNoticeReceived;
+        public event Action<ServerRules>? ServerRulesReceived;
 
         // Multiplayer presence (M24).
-        public event Action<PlayerPresence> PlayerPresenceReceived;
-        public event Action<PlayerLeft> PlayerLeftReceived;
-        public event Action<PlayerFace> PlayerFaceReceived; // another player's custom pixel face
-        public event Action<OwnedShips> OwnedShipsReceived;
-        public event Action<WorldEnvironment> WorldEnvironmentReceived;
-        public event Action<WorldReset> WorldResetReceived;
-        public event Action<NpcList> NpcsReceived;
-        public event Action<DoorList> DoorsReceived;
-        public event Action<MiningProgress> MiningProgressReceived;
+        public event Action<PlayerPresence>? PlayerPresenceReceived;
+        public event Action<PlayerLeft>? PlayerLeftReceived;
+        public event Action<PlayerFace>? PlayerFaceReceived; // another player's custom pixel face
+        public event Action<OwnedShips>? OwnedShipsReceived;
+        public event Action<WorldEnvironment>? WorldEnvironmentReceived;
+        public event Action<WorldReset>? WorldResetReceived;
+        public event Action<NpcList>? NpcsReceived;
+        public event Action<DoorList>? DoorsReceived;
+        public event Action<MiningProgress>? MiningProgressReceived;
 
         // Data-cube minigames: cubes to render on the current world + the player's downloaded-games collection.
-        public event Action<DataCubeList> DataCubesReceived;
-        public event Action<GameUnlocks> GameUnlocksReceived;
+        public event Action<DataCubeList>? DataCubesReceived;
+        public event Action<GameUnlocks>? GameUnlocksReceived;
 
         // Story system ("The VEGA Protocol"): the active story's shared progress, the world's net fragments,
         // a picked-up fragment's archive text, and a personal player memory unlocked by a machine kill.
-        public event Action<StoryStateMessage> StoryStateReceived;
-        public event Action<NetFragmentList> NetFragmentsReceived;
-        public event Action<NetFragmentRevealed> NetFragmentRevealedReceived;
-        public event Action<PlayerMemoryRevealed> PlayerMemoryReceived;
-        public event Action<GuardianSystemRevealed> GuardianSystemRevealedReceived; // finale system placed on the map
-        public event Action<CoreHackProgress> CoreHackProgressReceived;             // core-hack channel progress
-        public event Action<CoreDialogueMessage> CoreDialogueReceived;              // argument-duel node / win
+        public event Action<StoryStateMessage>? StoryStateReceived;
+        public event Action<NetFragmentList>? NetFragmentsReceived;
+        public event Action<NetFragmentRevealed>? NetFragmentRevealedReceived;
+        public event Action<PlayerMemoryRevealed>? PlayerMemoryReceived;
+        public event Action<GuardianSystemRevealed>? GuardianSystemRevealedReceived; // finale system placed on the map
+        public event Action<CoreHackProgress>? CoreHackProgressReceived;             // core-hack channel progress
+        public event Action<CoreDialogueMessage>? CoreDialogueReceived;              // argument-duel node / win
 
         // Scanning (knowledge), crashed-ship wreck repair, and player-to-player trade.
-        public event Action<ScanResult> ScanResultReceived;
-        public event Action<WreckRepairStatus> WreckRepairStatusChanged;
-        public event Action<ShipRepairStatus> ShipRepairStatusChanged;
-        public event Action<TradeUpdate> TradeUpdated;
-        public event Action<TradeClosed> TradeClosedReceived;
+        public event Action<ScanResult>? ScanResultReceived;
+        public event Action<WreckRepairStatus>? WreckRepairStatusChanged;
+        public event Action<ShipRepairStatus>? ShipRepairStatusChanged;
+        public event Action<TradeUpdate>? TradeUpdated;
+        public event Action<TradeClosed>? TradeClosedReceived;
 
         // Contextual NPC greetings (item 15): a speech-bubble line when interacting with a vendor/quartermaster.
-        public event Action<NpcGreeting> NpcGreetingReceived;
+        public event Action<NpcGreeting>? NpcGreetingReceived;
 
         // Terrain-scanner pulse result (Feature 40): ore positions for the through-wall glow markers.
-        public event Action<OreScanResult> OreScanReceived;
+        public event Action<OreScanResult>? OreScanReceived;
 
         // Ship AI companion "VEGA": onboarding/advisor/story lines + the active objective chip.
-        public event Action<ShipAiLine> ShipAiLineReceived;
+        public event Action<ShipAiLine>? ShipAiLineReceived;
 
         // Player alliances: the full roster (allies + pending requests) and a "someone proposed" toast notice.
-        public event Action<AllianceList> AllianceListReceived;
-        public event Action<AllianceRequestNotice> AllianceRequestReceived;
+        public event Action<AllianceList>? AllianceListReceived;
+        public event Action<AllianceRequestNotice>? AllianceRequestReceived;
 
         // Creature taming + companions: the live ritual state, the finished result, and the player's roster.
-        public event Action<TameProgress> TameProgressReceived;
-        public event Action<TameResult> TameResultReceived;
-        public event Action<CompanionList> CompanionsReceived;
+        public event Action<TameProgress>? TameProgressReceived;
+        public event Action<TameResult>? TameResultReceived;
+        public event Action<CompanionList>? CompanionsReceived;
 
         // Hover speeders: the world's live speeders + one-shot deploy/destruction effects.
-        public event Action<SpeederList> SpeedersReceived;
-        public event Action<SpeederFx> SpeederFxReceived;
+        public event Action<SpeederList>? SpeedersReceived;
+        public event Action<SpeederFx>? SpeederFxReceived;
 
         public bool Connected { get; private set; }
 
         /// <summary>Uses the UDP transport by default; pass a loopback transport for singleplayer.</summary>
-        public NetworkClient(IClientTransport transport = null)
+        public NetworkClient(IClientTransport? transport = null)
         {
             _transport = transport ?? new LiteNetLibClientTransport();
             _transport.Connected += () => Connected = true;
@@ -134,7 +134,7 @@ namespace BlocksBeyondTheStars.Client
 
         public void Connect(string host, int port) => _transport.Connect(host, port);
 
-        public void Join(string playerName, string password = null, string locale = "en", string token = null)
+        public void Join(string playerName, string? password = null, string locale = "en", string? token = null)
             => Send(new JoinRequest { PlayerName = playerName, Password = password, Locale = locale, Token = token });
 
         /// <summary>Asks the server for the greeting line of the nearby NPC of this role ("vendor"/"quartermaster")
@@ -167,7 +167,7 @@ namespace BlocksBeyondTheStars.Client
 
         public void SendMine(int x, int y, int z) => Send(new MineBlockIntent { X = x, Y = y, Z = z });
 
-        public void SendPlace(int x, int y, int z, string itemKey, string label = null)
+        public void SendPlace(int x, int y, int z, string itemKey, string? label = null)
             => Send(new PlaceBlockIntent { X = x, Y = y, Z = z, ItemKey = itemKey, Label = label ?? string.Empty });
 
         public void SendSetBeaconLabel(int beaconId, string label)
@@ -213,8 +213,8 @@ namespace BlocksBeyondTheStars.Client
             => Send(new BumpReport { Description = description ?? string.Empty, Image = image ?? Array.Empty<byte>() });
 
         // Admin/cheat console (server validates IsAdmin + the CheatsAllowed rule and replies with a ServerMessage).
-        public void SendAdminCommand(string command, string stringArg = null, int intArg = 0,
-            string targetPlayer = null, float x = 0f, float y = 0f, float z = 0f)
+        public void SendAdminCommand(string command, string? stringArg = null, int intArg = 0,
+            string? targetPlayer = null, float x = 0f, float y = 0f, float z = 0f)
             => Send(new AdminCommandIntent
             {
                 Command = command, StringArg = stringArg, IntArg = intArg,

--- a/src/BlocksBeyondTheStars.GameServer/GameServer.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServer.cs
@@ -19,6 +19,8 @@ namespace BlocksBeyondTheStars.GameServer;
 /// (technical requirements §7, §15). Drive it by calling <see cref="Tick"/> at the
 /// configured rate, or use <see cref="Run"/> for a blocking loop.
 /// </summary>
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA1001:Types that own disposable fields should be disposable",
+    Justification = "Process-lifetime singleton; its ManualResetEventSlim is released when the host process exits. Making it IDisposable would cascade CA2213 onto the long-lived owned services (transport, persistence) that the host tears down explicitly.")]
 public sealed partial class GameServer
 {
     private const string ShipId = "default";
@@ -1830,7 +1832,7 @@ public sealed partial class GameServer
 
     /// <summary>Places a block from a held item for a player (test/util entrypoint). An optional label rides
     /// along for labelled blocks (a radio beacon).</summary>
-    public void PlaceBlock(string playerId, int x, int y, int z, string itemKey, string label = null)
+    public void PlaceBlock(string playerId, int x, int y, int z, string itemKey, string? label = null)
     {
         if (FindSessionByPlayerId(playerId) is { } session)
         {

--- a/src/BlocksBeyondTheStars.GameServer/GameServerBump.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerBump.cs
@@ -93,7 +93,7 @@ public sealed partial class GameServer
         HandleBump(session, report.Description ?? string.Empty, image);
     }
 
-    private void HandleBump(PlayerSession session, string description, byte[] image = null)
+    private void HandleBump(PlayerSession session, string description, byte[]? image = null)
     {
         var p = session.State;
         var (systemName, planetName) = ActiveLocationNames();
@@ -109,7 +109,7 @@ public sealed partial class GameServer
         // instead and leave the planet scans empty.
         var blocks = new List<object>();
         List<object> census = new();
-        object space = null;
+        object? space = null;
         object creatures = new List<object>();
         object npcs = new List<object>();
         object others = new List<object>();
@@ -198,7 +198,7 @@ public sealed partial class GameServer
             // stem with world + UTC timestamp to keep files unique.
             string stem = $"bump_{SanitizeFileStem(_meta.WorldName)}_{DateTime.UtcNow:yyyyMMdd_HHmmss}_{_bumpCount:D3}";
             bool hasImage = image != null && image.Length > 0;
-            string imageName = hasImage ? stem + ".jpg" : null;
+            string? imageName = hasImage ? stem + ".jpg" : null;
 
             var snapshot = new
             {
@@ -231,7 +231,7 @@ public sealed partial class GameServer
             File.WriteAllText(file, JsonSerializer.Serialize(snapshot, new JsonSerializerOptions { WriteIndented = true }));
             if (hasImage)
             {
-                File.WriteAllBytes(Path.Combine(dir, imageName), image);
+                File.WriteAllBytes(Path.Combine(dir, imageName!), image!);
             }
 
             _log.Info($"Bump #{_bumpCount} captured for {p.Name}: \"{description}\"{(hasImage ? " (+screenshot)" : string.Empty)} -> {file}");

--- a/src/BlocksBeyondTheStars.GameServer/GameServerDataCubes.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerDataCubes.cs
@@ -175,7 +175,7 @@ public sealed partial class GameServer
         Send(session, new ServerMessage { Text = $"+{reward} knowledge — data fragment analysed." });
     }
 
-    private List<string> _minigameKeys;
+    private List<string>? _minigameKeys;
 
     /// <summary>Loads the bundled minigame keys from the client catalogue (synced next to the data dir), so the
     /// server can unlock them all in a Creative world. Best-effort: empty if the catalogue isn't found.</summary>

--- a/src/BlocksBeyondTheStars.GameServer/GameServerEnemies.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerEnemies.cs
@@ -205,7 +205,7 @@ public sealed partial class GameServer
     {
         // Nearest detectable player — cloaked, god-mode and companion-warded players read as undetectable, so
         // the machine never paths toward them.
-        PlayerSession nearest = null;
+        PlayerSession? nearest = null;
         double bestSq = (double)EnemyHuntRange * EnemyHuntRange;
         foreach (var s in targets)
         {

--- a/src/BlocksBeyondTheStars.GameServer/GameServerMissionTexts.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerMissionTexts.cs
@@ -67,7 +67,7 @@ public sealed partial class GameServer
         var req = BoardMissionTextRequest(def, session.Locale);
         int connId = session.ConnectionId;
 
-        System.Threading.Tasks.Task.Run(() =>
+        _ = System.Threading.Tasks.Task.Run(() =>
         {
             try
             {

--- a/src/BlocksBeyondTheStars.GameServer/GameServerNpcGreeting.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerNpcGreeting.cs
@@ -191,7 +191,7 @@ public sealed partial class GameServer
         string npcName = npc.Name;
         string role = npc.Role;
 
-        System.Threading.Tasks.Task.Run(() =>
+        _ = System.Threading.Tasks.Task.Run(() =>
         {
             try
             {

--- a/src/BlocksBeyondTheStars.GameServer/GameServerShipAi.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerShipAi.cs
@@ -508,7 +508,7 @@ public sealed partial class GameServer
 
         var req = VegaBanterRequest(session);
         int connId = session.ConnectionId;
-        System.Threading.Tasks.Task.Run(() =>
+        _ = System.Threading.Tasks.Task.Run(() =>
         {
             try
             {

--- a/src/BlocksBeyondTheStars.GameServer/GameServerSpaceCombat.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerSpaceCombat.cs
@@ -1470,7 +1470,7 @@ public sealed partial class GameServer
     /// for the flight view to render.</summary>
     private NetSpacePlayer[] OtherPlayersInSpace(string recipientId, SpaceInstance instance)
     {
-        List<NetSpacePlayer> others = null;
+        List<NetSpacePlayer>? others = null;
         foreach (var kv in instance.PlayerPoses)
         {
             if (kv.Key == recipientId || !instance.Players.Contains(kv.Key))

--- a/src/BlocksBeyondTheStars.GameServer/GameServerSpaceStructure.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerSpaceStructure.cs
@@ -726,7 +726,7 @@ public sealed partial class GameServer
     /// <summary><paramref name="kindOverride"/> = "ship_remote" sends ANOTHER player's ship design (the
     /// client caches it per pilot for the flight view + the landing/launch FX instead of treating it
     /// as the own ship).</summary>
-    private void SendShipDesign(PlayerSession session, SpaceStructure s, string kindOverride = null)
+    private void SendShipDesign(PlayerSession session, SpaceStructure s, string? kindOverride = null)
     {
         int n = s.Cells.Count;
         var xs = new int[n];

--- a/src/BlocksBeyondTheStars.GameServer/IAiMissionProvider.cs
+++ b/src/BlocksBeyondTheStars.GameServer/IAiMissionProvider.cs
@@ -124,11 +124,13 @@ public sealed class HttpAiMissionProvider : IAiMissionProvider
         _http = http ?? new HttpClient { Timeout = TimeSpan.FromSeconds(8) };
     }
 
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD002:Avoid problematic synchronous waits",
+        Justification = "Synchronous provider contract; invoked off the game tick / on background threads where the server has no SynchronizationContext, so GetAwaiter().GetResult() cannot deadlock.")]
     public MissionPlan? Generate(string context)
     {
         try
         {
-            var body = new StringContent(JsonSerializer.Serialize(new { context }), Encoding.UTF8, "application/json");
+            using var body = new StringContent(JsonSerializer.Serialize(new { context }), Encoding.UTF8, "application/json");
             using var response = _http.PostAsync(_missionUrl, body).GetAwaiter().GetResult();
             if (!response.IsSuccessStatusCode)
             {
@@ -148,11 +150,13 @@ public sealed class HttpAiMissionProvider : IAiMissionProvider
         }
     }
 
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD002:Avoid problematic synchronous waits",
+        Justification = "Synchronous provider contract; invoked off the game tick / on background threads where the server has no SynchronizationContext, so GetAwaiter().GetResult() cannot deadlock.")]
     public string? GenerateNpcLine(NpcLineRequest request)
     {
         try
         {
-            var body = new StringContent(JsonSerializer.Serialize(request), Encoding.UTF8, "application/json");
+            using var body = new StringContent(JsonSerializer.Serialize(request), Encoding.UTF8, "application/json");
             using var response = _http.PostAsync(_npcLineUrl, body).GetAwaiter().GetResult();
             if (!response.IsSuccessStatusCode)
             {
@@ -172,11 +176,13 @@ public sealed class HttpAiMissionProvider : IAiMissionProvider
         }
     }
 
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD002:Avoid problematic synchronous waits",
+        Justification = "Synchronous provider contract; invoked off the game tick / on background threads where the server has no SynchronizationContext, so GetAwaiter().GetResult() cannot deadlock.")]
     public MissionTextResult? GenerateMissionText(MissionTextRequest request)
     {
         try
         {
-            var body = new StringContent(JsonSerializer.Serialize(request), Encoding.UTF8, "application/json");
+            using var body = new StringContent(JsonSerializer.Serialize(request), Encoding.UTF8, "application/json");
             using var response = _http.PostAsync(_missionTextUrl, body).GetAwaiter().GetResult();
             if (!response.IsSuccessStatusCode)
             {

--- a/src/BlocksBeyondTheStars.GameServer/IGameLogger.cs
+++ b/src/BlocksBeyondTheStars.GameServer/IGameLogger.cs
@@ -9,6 +9,8 @@ public interface IGameLogger
 }
 
 /// <summary>Writes timestamped log lines to the console (and optionally a log file).</summary>
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA1001:Types that own disposable fields should be disposable",
+    Justification = "Process-lifetime logger; the optional log file uses AutoFlush and its handle is released when the host process exits. Making it IDisposable would force a dispose obligation on every long-lived call site without benefit.")]
 public sealed class ConsoleGameLogger : IGameLogger
 {
     private readonly object _gate = new();

--- a/src/BlocksBeyondTheStars.Launcher/SplashForm.cs
+++ b/src/BlocksBeyondTheStars.Launcher/SplashForm.cs
@@ -217,7 +217,7 @@ internal sealed class SplashForm : Form
             titleFont = new Font("Segoe UI Semibold", next, FontStyle.Bold, GraphicsUnit.Pixel);
         }
 
-        var centre = new StringFormat(StringFormatFlags.NoWrap)
+        using var centre = new StringFormat(StringFormatFlags.NoWrap)
         {
             Alignment = StringAlignment.Center,
             LineAlignment = StringAlignment.Center,

--- a/src/BlocksBeyondTheStars.Networking/Transport/WebSocketServerTransport.cs
+++ b/src/BlocksBeyondTheStars.Networking/Transport/WebSocketServerTransport.cs
@@ -15,6 +15,8 @@ namespace BlocksBeyondTheStars.Networking.Transport;
 /// </summary>
 public sealed class WebSocketServerTransport : IServerTransport
 {
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA1001:Types that own disposable fields should be disposable",
+        Justification = "Per-connection holder; the socket is torn down when the receive loop ends or the listener stops, and SendLock is used only for WaitAsync/Release (no WaitHandle is ever allocated), so there is nothing requiring deterministic disposal.")]
     private sealed class Client
     {
         public WebSocket Socket = null!;
@@ -106,7 +108,9 @@ public sealed class WebSocketServerTransport : IServerTransport
                         break;
                     }
 
+#pragma warning disable VSTHRD103 // MemoryStream.Write is an in-memory copy with nothing to await.
                     ms.Write(buffer, 0, result.Count);
+#pragma warning restore VSTHRD103
                 }
                 while (!result.EndOfMessage);
 

--- a/src/BlocksBeyondTheStars.Persistence/BugReportPaths.cs
+++ b/src/BlocksBeyondTheStars.Persistence/BugReportPaths.cs
@@ -14,7 +14,7 @@ public static class BugReportPaths
     /// (historically <c>&lt;world&gt;/bumps</c>).</param>
     /// <param name="startDirectory">Where to begin the upward search; defaults to the running
     /// executable's base directory.</param>
-    public static string Resolve(string perWorldFallback, string startDirectory = null)
+    public static string Resolve(string perWorldFallback, string? startDirectory = null)
     {
         var repoRoot = FindRepositoryRoot(startDirectory ?? System.AppContext.BaseDirectory);
         return repoRoot != null
@@ -25,7 +25,7 @@ public static class BugReportPaths
     /// <summary>Walks up from <paramref name="startDirectory"/> looking for the repository root — the nearest
     /// ancestor that contains a <c>.git</c> entry (a <c>BlocksBeyondTheStars.sln</c> is accepted as a secondary
     /// marker). Returns null when none is found within a bounded number of levels.</summary>
-    public static string FindRepositoryRoot(string startDirectory)
+    public static string? FindRepositoryRoot(string startDirectory)
     {
         if (string.IsNullOrEmpty(startDirectory))
         {

--- a/src/BlocksBeyondTheStars.Tools/Program.cs
+++ b/src/BlocksBeyondTheStars.Tools/Program.cs
@@ -59,7 +59,7 @@ static void RequireArgs(string[] args, int count, string usage)
 {
     if (args.Length < count)
     {
-        throw new ArgumentException($"Usage: {usage}");
+        throw new ArgumentException($"Usage: {usage}", nameof(args));
     }
 }
 

--- a/tests/BlocksBeyondTheStars.Tests/BumpTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/BumpTests.cs
@@ -22,10 +22,10 @@ public sealed class BumpTests : IDisposable
     // The server may route bumps to a shared <repo>/bugreports/server folder (when tests run inside the
     // working tree), so each test uses a unique world name and only ever touches its own files.
     private readonly string _world = "bumpworld_" + Guid.NewGuid().ToString("N");
-    private string _bumpDir;
-    private SqliteWorldRepository _repo;
-    private LoopbackServerTransport _st;
-    private LoopbackClientTransport _client;
+    private string _bumpDir = null!;
+    private SqliteWorldRepository _repo = null!;
+    private LoopbackServerTransport _st = null!;
+    private LoopbackClientTransport _client = null!;
 
     public BumpTests()
     {

--- a/tests/BlocksBeyondTheStars.Tests/SettlementGenerationTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/SettlementGenerationTests.cs
@@ -137,6 +137,4 @@ public sealed class SettlementGenerationTests
         // Town-style tiers are multi-storey; village-style are single-storey huts (shorter).
         Assert.True(town.Height > village.Height);
     }
-
-    public void Dispose() { }
 }

--- a/tests/BlocksBeyondTheStars.Tests/WorldOptionsTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/WorldOptionsTests.cs
@@ -194,7 +194,7 @@ public sealed class WorldOptionsTests : IDisposable
 
         var exoticKeys = _content.Planets.Values.Where(p => p.Exotic).Select(p => p.Key).ToHashSet();
         Assert.NotEmpty(exoticKeys); // the data flags exist
-        Assert.DoesNotContain(galaxy.AllBodies(), b => exoticKeys.Contains(b.PlanetType));
+        Assert.DoesNotContain(galaxy.AllBodies(), b => exoticKeys.Contains(b.PlanetType ?? string.Empty));
     }
 
     [Fact]
@@ -202,7 +202,7 @@ public sealed class WorldOptionsTests : IDisposable
     {
         var exoticKeys = _content.Planets.Values.Where(p => p.Exotic).Select(p => p.Key).ToHashSet();
         int Count(Frequency f) => new UniverseGenerator(42, new WorldDescription { StarSystemCount = 16, ExoticWorlds = f }, _content)
-            .Generate().AllBodies().Count(b => exoticKeys.Contains(b.PlanetType));
+            .Generate().AllBodies().Count(b => exoticKeys.Contains(b.PlanetType ?? string.Empty));
 
         Assert.True(Count(Frequency.Frequent) > Count(Frequency.Normal),
             "Frequent exotic worlds must produce more exotic planets than Normal.");


### PR DESCRIPTION
Resolves the 129 real warnings surfaced by the Roslyn analyzers (built-in CA + Meziantou + VS.Threading) that are already enabled on `main`. **No behaviour change** — annotations, `using`, explicit fire-and-forget discards, and justified suppressions for intentional patterns.

## What changed
- **Nullability (CS86xx, ~95):** `NetworkClient` events (all raised via `?.Invoke`), optional `= null` parameter defaults, lazily-initialised fields, graceful-null returns.
- **Async correctness (VSTHRD/MA0134):** the three background AI `Task.Run` calls marked explicit fire-and-forget (`_ =`); `VSTHRD002` suppressed with justification on the intentionally synchronous AI/feedback HTTP paths (background threads, no `SynchronizationContext`); `VSTHRD103` false positive on an in-memory `MemoryStream` write suppressed.
- **Dispose hygiene (CA2000/CA1001):** `using` for short-lived `StringContent`/`StringFormat`; `CA1001` documented on the process-lifetime `GameServer`/logger and the per-connection WebSocket client holder.
- **Tests:** empty `Dispose` removed, nullable test fixtures, `nameof` param on an `ArgumentException`.

## Verification
- `dotnet build` → **0 warnings, 0 errors**
- `dotnet test` → **683 + 12 tests green**

Note: client `Plugins/*.dll` are gitignored and regenerated by `sync-client-libs.ps1`; the Unity client should be rebuilt to pick up the `Client.Core` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)