### PR TITLE
ci(release): strip Burst _DoNotShip folder + mirror installers to itch.io

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -220,3 +220,14 @@ jobs:
             artifacts/installer/*.msi
             artifacts/installer/*Portable.zip
           generate_release_notes: true
+
+      # Mirror the same three installers to itch.io (jumavegames/blocks-beyond-the-stars) via butler — each
+      # artifact to its own channel (windows-setup / windows-msi / windows-portable), stamped with the release
+      # version. Runs after the GitHub Release so a butler hiccup never blocks the GitHub publish. The itch.io
+      # API key is the BUTLER_API_KEY repo secret; the script auto-downloads butler.
+      - name: Publish to itch.io (butler)
+        if: startsWith(github.ref, 'refs/tags/')
+        shell: pwsh
+        env:
+          BUTLER_API_KEY: ${{ secrets.BUTLER_API_KEY }}
+        run: ./scripts/publish-itch.ps1 -Version ${{ needs.build-player.outputs.version }}

--- a/docs/developer/DEVELOPER.md
+++ b/docs/developer/DEVELOPER.md
@@ -152,11 +152,38 @@ The workflow has two jobs:
 2. **Package + release (Windows)** — builds the launcher, downloads the player, and runs
    `publish-client-installer.ps1 -Msi` (with `vpk` pinned to the vendored Velopack version) to produce and
    attach three assets to a published GitHub Release: **`…-win-Setup.exe`** (per-user, no admin),
-   **`…-win.msi`** (machine-wide, for IT/MDM) and **`…-win-Portable.zip`**.
+   **`…-win.msi`** (machine-wide, for IT/MDM) and **`…-win-Portable.zip`**. The same three assets are then
+   mirrored to **itch.io** (see below).
 
 The workflow triggers **only** on tag pushes and manual dispatch (never `pull_request`), so the Unity license
 secrets (`UNITY_LICENSE`/`UNITY_EMAIL`/`UNITY_PASSWORD`) are never exposed — safe even with a public repo. A
 manual *Run workflow* dispatch builds and packages a `0.1.0-dev` test artifact but does not publish a Release.
+
+> **Note:** `publish-client-installer.ps1` deletes Unity's developer-only `*_DoNotShip` (Burst AOT debug
+> symbols) and `*_BackUpThisFolder_ButDontShipItWithYourGame` (IL2CPP backup) folders from the player before
+> packing, so they never end up inside the shipped installers. They are regenerated on the next Unity build.
+
+### Mirroring releases to itch.io
+
+After the GitHub Release is published, the same job pushes the three installers to the itch.io page
+[`jumavegames/blocks-beyond-the-stars`](https://jumavegames.itch.io/blocks-beyond-the-stars) via
+[butler](https://itch.io/docs/butler/) (`scripts/publish-itch.ps1`). Each artifact goes to its own channel,
+stamped with the release version (`--userversion`):
+
+| Artifact          | itch.io channel    |
+| ----------------- | ------------------ |
+| `…-win-Setup.exe` | `windows-setup`    |
+| `…-win.msi`       | `windows-msi`      |
+| `…-win-Portable.zip` | `windows-portable` |
+
+Notes:
+
+- The upload runs **after** the GitHub Release step, so a butler hiccup can never block the GitHub publish.
+- butler authenticates with an itch.io API key stored as the **`BUTLER_API_KEY`** repository secret (Settings →
+  Secrets and variables → Actions). It is **never** committed — generate one at itch.io → *Settings → API keys*.
+- The script auto-downloads butler (win-x64) if it is not already on `PATH`, so it also works locally:
+  `$env:BUTLER_API_KEY = '…'; ./scripts/publish-itch.ps1 -Version 0.3.0` (run after `publish-client-installer.ps1`).
+- The `windows` prefix in each channel name tags the upload as a Windows download on the itch.io page.
 
 ### The git tag is the single source of truth for the version
 

--- a/scripts/publish-client-installer.ps1
+++ b/scripts/publish-client-installer.ps1
@@ -71,6 +71,17 @@ if (-not (Test-Path (Join-Path $build 'BlocksBeyondTheStars.Launcher.exe'))) {
     Write-Error "Launcher not found at '$build'. Re-run ./scripts/build-client.ps1 (it now builds the launcher)."
 }
 
+# Strip Unity's developer-only debug folders before packing. Their names literally end in "_DoNotShip"
+# (Burst AOT debug symbols) / "_BackUpThisFolder_ButDontShipItWithYourGame" (IL2CPP backup): they are
+# debugging aids that must never reach players and only bloat the installer. Safe to delete — Unity
+# regenerates them on the next build. This guards every pack output (Setup.exe, MSI, Portable.zip).
+foreach ($pattern in @('*_DoNotShip', '*_BackUpThisFolder_ButDontShipItWithYourGame')) {
+    Get-ChildItem -Path $build -Directory -Filter $pattern -ErrorAction SilentlyContinue | ForEach-Object {
+        Write-Host "Removing non-shippable folder: $($_.Name)" -ForegroundColor DarkGray
+        Remove-Item $_.FullName -Recurse -Force
+    }
+}
+
 # The installer icon (.ico). Regenerate from the game PNG via ./scripts/make-launcher-icon.ps1 if missing.
 $iconPath = Join-Path $repo 'src/BlocksBeyondTheStars.Launcher/app_icon.ico'
 if (-not (Test-Path $iconPath)) {

--- a/scripts/publish-itch.ps1
+++ b/scripts/publish-itch.ps1
@@ -1,0 +1,89 @@
+<#
+.SYNOPSIS
+  Publishes the packaged Windows installers (Setup.exe, MSI, Portable zip) to itch.io via butler.
+
+.DESCRIPTION
+  Pushes the artifacts produced by scripts/publish-client-installer.ps1 (in artifacts/installer) to the
+  itch.io page jumavegames/blocks-beyond-the-stars, one artifact per channel:
+
+    *Setup.exe     -> windows-setup     (per-user Velopack installer)
+    *.msi          -> windows-msi       (machine-wide WiX installer)
+    *Portable.zip  -> windows-portable  (no-install portable copy)
+
+  Each push is stamped with --userversion so itch.io shows the release version. butler reads the itch.io
+  API key from the BUTLER_API_KEY environment variable (set it locally, or as the BUTLER_API_KEY repo
+  secret in CI). butler is auto-downloaded (win-x64) into artifacts/butler if it is not already on PATH.
+
+.PARAMETER Version
+  SemVer for this release (the itch userversion). Default: read from PlayerSettings.bundleVersion in
+  ProjectSettings.asset (the single source of truth the release CI sets from the git tag).
+
+.PARAMETER InstallerDir
+  Folder holding the packed installers. Default: artifacts/installer (publish-client-installer.ps1's output).
+
+.PARAMETER Target
+  The itch.io target (<user>/<game>). Default: jumavegames/blocks-beyond-the-stars.
+
+.EXAMPLE
+  $env:BUTLER_API_KEY = '...'; ./scripts/publish-itch.ps1 -Version 0.3.0
+#>
+param(
+    [string] $Version = '',
+    [string] $InstallerDir = 'artifacts/installer',
+    [string] $Target = 'jumavegames/blocks-beyond-the-stars'
+)
+
+$ErrorActionPreference = 'Stop'
+$repo = Split-Path -Parent $PSScriptRoot
+$dir = Join-Path $repo $InstallerDir
+
+if ([string]::IsNullOrWhiteSpace($env:BUTLER_API_KEY)) {
+    Write-Error 'BUTLER_API_KEY is not set. Export your itch.io API key (itch.io -> Settings -> API keys) before running.'
+}
+if (-not (Test-Path $dir)) {
+    Write-Error "Installer folder not found at '$dir'. Run ./scripts/publish-client-installer.ps1 first."
+}
+
+# Derive the version unless one was given — same single source of truth as publish-client-installer.ps1.
+if ([string]::IsNullOrWhiteSpace($Version)) {
+    $projSettings = Get-Content (Join-Path $repo 'client/ProjectSettings/ProjectSettings.asset') -Raw
+    if ($projSettings -match '(?m)^\s*bundleVersion:\s*(\S+)') { $Version = $Matches[1] }
+    else { Write-Error 'Could not read bundleVersion from ProjectSettings.asset; pass -Version explicitly.' }
+}
+
+# Ensure butler is available; download the win-x64 build into a tool cache if it is not already on PATH.
+$butler = (Get-Command butler -ErrorAction SilentlyContinue).Source
+if (-not $butler) {
+    $toolDir = Join-Path $repo 'artifacts/butler'
+    $butler = Join-Path $toolDir 'butler.exe'
+    if (-not (Test-Path $butler)) {
+        Write-Host 'Downloading butler (itch.io CLI, win-x64) ...' -ForegroundColor Cyan
+        New-Item -ItemType Directory -Force $toolDir | Out-Null
+        $zip = Join-Path $toolDir 'butler.zip'
+        Invoke-WebRequest -Uri 'https://broth.itch.ovh/butler/windows-amd64/LATEST/archive/default' -OutFile $zip
+        Expand-Archive -Path $zip -DestinationPath $toolDir -Force
+        Remove-Item $zip -Force
+    }
+}
+& $butler version
+if ($LASTEXITCODE -ne 0) { Write-Error 'butler is not runnable.' }
+
+# Map each packed artifact to its itch.io channel. The "windows" in each channel name tags it as a Windows
+# download on the itch.io page.
+$pushes = @(
+    @{ Channel = 'windows-setup';    Filter = '*Setup.exe' },
+    @{ Channel = 'windows-msi';      Filter = '*.msi' },
+    @{ Channel = 'windows-portable'; Filter = '*Portable.zip' }
+)
+
+foreach ($p in $pushes) {
+    $file = Get-ChildItem $dir -Filter $p.Filter -ErrorAction SilentlyContinue |
+        Sort-Object LastWriteTimeUtc -Descending | Select-Object -First 1
+    if (-not $file) { Write-Error "No artifact matching '$($p.Filter)' in '$dir'." }
+    $channel = "${Target}:$($p.Channel)"
+    Write-Host "Pushing $($file.Name) -> $channel (v$Version)" -ForegroundColor Cyan
+    & $butler push $file.FullName $channel --userversion $Version
+    if ($LASTEXITCODE -ne 0) { Write-Error "butler push failed for $($file.Name)." }
+}
+
+Write-Host "All installers pushed to itch.io ($Target)." -ForegroundColor Green


### PR DESCRIPTION
## Summary
- **Strip non-shippable folders before packing:** `publish-client-installer.ps1` now deletes Unity's developer-only `*_DoNotShip` (Burst AOT debug symbols) and `*_BackUpThisFolder_ButDontShipItWithYourGame` (IL2CPP backup) folders from the player build before `vpk pack`, so they no longer bloat the Setup.exe / MSI / Portable.zip.
- **Mirror releases to itch.io:** new `scripts/publish-itch.ps1` + a `release.yml` step push the three installers to [`jumavegames/blocks-beyond-the-stars`](https://jumavegames.itch.io/blocks-beyond-the-stars) via butler — one channel each (`windows-setup` / `windows-msi` / `windows-portable`), stamped with `--userversion`. Runs **after** the GitHub Release so a butler hiccup can't block the GitHub publish.
- **Docs:** DEVELOPER.md release section documents the itch.io mirroring + the strip (no key exposed).

## Secrets / setup
- Uses a new **`BUTLER_API_KEY`** repo secret (already configured). Not committed anywhere.

## Notes
- butler is auto-downloaded (win-x64) if missing, so `publish-itch.ps1` also works locally.
- Takes effect on the **next** release tag (e.g. v0.3.1 / v0.4.0). v0.3.0 was already published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)