### PR TITLE
fix(ci): correct butler download host (broth.itch.zone)

### DIFF
--- a/scripts/publish-itch.ps1
+++ b/scripts/publish-itch.ps1
@@ -60,7 +60,7 @@ if (-not $butler) {
         Write-Host 'Downloading butler (itch.io CLI, win-x64) ...' -ForegroundColor Cyan
         New-Item -ItemType Directory -Force $toolDir | Out-Null
         $zip = Join-Path $toolDir 'butler.zip'
-        Invoke-WebRequest -Uri 'https://broth.itch.ovh/butler/windows-amd64/LATEST/archive/default' -OutFile $zip
+        Invoke-WebRequest -Uri 'https://broth.itch.zone/butler/windows-amd64/LATEST/archive/default' -OutFile $zip
         Expand-Archive -Path $zip -DestinationPath $toolDir -Force
         Remove-Item $zip -Force
     }


### PR DESCRIPTION
The v0.3.1 itch.io upload step failed with `No such host is known` — the butler CDN is `broth.itch.zone`, not `broth.itch.ovh`. One-character host fix in `publish-itch.ps1` so the auto-download resolves.

Validated by running the corrected script locally against the v0.3.1 installers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)