### PR TITLE
docs(readme): add Project Status (in-development / as-is) section

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,12 @@ and our short **[Code of Conduct](CODE_OF_CONDUCT.md)** (the gist: be kind to on
 > were consolidated and removed.)
 > Docs and code comments are **English**. In-game text is **bilingual (German + English)**.
 
+## Project Status
+
+Blocks Beyond the Stars is a free in-development game. Bugs, missing content and compatibility issues are expected. Multiplayer and server behavior may change between versions.
+
+The software is provided as-is under the terms of the license included in this repository.
+
 ## Guiding principle
 
 > **The Unity client is presentation and input. The .NET server is the truth of the game world.**


### PR DESCRIPTION
Adds a `## Project Status` section to the README, placed right after "About this project" and before "Guiding principle".

It states the game is free and in-development (bugs, missing content and compatibility issues expected; multiplayer/server behavior may change between versions) and that the software is provided as-is under the repository's license.

The existing lower `## Status` section (feature/completeness list) is intentionally left as-is — it serves a different purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)