### PR TITLE
feat(space): explosion stays, no landing animation after ship destruction

### DIFF
--- a/client/Assets/BlocksBeyondTheStars/Scripts/RespawnPrompt.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/RespawnPrompt.cs
@@ -18,8 +18,10 @@ namespace BlocksBeyondTheStars.Client
     {
         public GameBootstrap Game;
 
-        // Let the death flash / explosion be seen before the modal slides in.
+        // Let the death flash / explosion be seen before the modal slides in. On-foot death is a quick red wash;
+        // a ship blowing up in space gets longer so the full fireball + debris play out before the modal covers it.
         private const float ShowDelay = 1.1f;
+        private const float ShipShowDelay = 2.1f;
         private const float FadeIn = 0.4f;
         private const float BackdropAlpha = 0.82f;
 
@@ -32,6 +34,7 @@ namespace BlocksBeyondTheStars.Client
         private bool _armed;   // a death/destruction arrived; counting down to show
         private bool _shown;   // the modal is currently up
         private float _delay;
+        private float _showDelay = ShowDelay; // how long to let the death FX play before the modal (per death kind)
         private float _fade;
         private string _titleKey = "ui.death.title";
 
@@ -47,7 +50,7 @@ namespace BlocksBeyondTheStars.Client
             if (_armed && !_shown)
             {
                 _delay += Time.deltaTime;
-                if (_delay >= ShowDelay)
+                if (_delay >= _showDelay)
                 {
                     Show();
                 }
@@ -79,7 +82,7 @@ namespace BlocksBeyondTheStars.Client
         {
             if (m.Died)
             {
-                Arm("ui.death.title");
+                Arm("ui.death.title", ShowDelay);
             }
         }
 
@@ -87,11 +90,11 @@ namespace BlocksBeyondTheStars.Client
         {
             if (m.ShipDisabled)
             {
-                Arm("ui.death.ship_title");
+                Arm("ui.death.ship_title", ShipShowDelay);
             }
         }
 
-        private void Arm(string titleKey)
+        private void Arm(string titleKey, float showDelay)
         {
             if (_armed || _shown)
             {
@@ -99,6 +102,7 @@ namespace BlocksBeyondTheStars.Client
             }
 
             _titleKey = titleKey;
+            _showDelay = showDelay;
             _armed = true;
             _delay = 0f;
             // Set the gate immediately (synchronously with the event) so PlayerController / SpaceView hold

--- a/client/Assets/BlocksBeyondTheStars/Scripts/SpaceView.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/SpaceView.cs
@@ -135,6 +135,7 @@ namespace BlocksBeyondTheStars.Client
         private bool _combatSubscribed;
         private bool _hyperjumpSubscribed;
         private bool _hyperjumping; // a hyperspace jump is tearing down the view (warp covers it, no landing)
+        private bool _shipDestroyed; // the ship blew up in space — tear down at once (explosion stays, no landing descent)
 
         private readonly HashSet<string> _dropIds = new HashSet<string>(); // tracked ResourceDrop entities
         private readonly List<TractorBeam> _beams = new List<TractorBeam>();
@@ -242,12 +243,12 @@ namespace BlocksBeyondTheStars.Client
             // station board tears down immediately — no surface-landing descent. Otherwise fly the
             // landing sequence back down to the body we launched from, then tear down.
             // When the ship was destroyed, hold here (explosion + hidden hull stay on screen) until the
-            // player clicks "Weiter" on the destruction prompt — only then fly the recovery descent.
+            // player clicks "Weiter" on the destruction prompt — then tear down at once (no recovery descent).
             if (!Game.InSpace && !Game.AwaitingRespawnConfirm)
             {
-                if (_hyperjumping || _phase == Phase.Boarding || _enteringInterior)
+                if (_hyperjumping || _phase == Phase.Boarding || _enteringInterior || _shipDestroyed)
                 {
-                    Exit(); // jump / station dock / stepping inside the ship: no landing descent
+                    Exit(); // jump / station dock / stepping inside the ship / ship blown up: no landing descent
                     return;
                 }
 
@@ -2103,6 +2104,7 @@ namespace BlocksBeyondTheStars.Client
             HideLandMap();
             _boardSent = false;
             _hyperjumping = false;
+            _shipDestroyed = false;
             _eva = false;
             _enteringInterior = false;
             _landTargetId = null;
@@ -2209,6 +2211,7 @@ namespace BlocksBeyondTheStars.Client
             _active = false;
             _eva = false;
             _enteringInterior = false;
+            _shipDestroyed = false;
             _remotePlayers.Clear(); // their GameObjects are children of _root, destroyed with the scene
             _shake = 0f;
             _hitFlash = 0f;
@@ -2254,6 +2257,7 @@ namespace BlocksBeyondTheStars.Client
             SpawnShipExplosion(at); // the boom + screen flash are already played by ClientAudio / DeathFx
             _hitFlash = Mathf.Max(_hitFlash, 0.9f);
             _shake = Mathf.Max(_shake, 0.7f);
+            _shipDestroyed = true; // once the player confirms the death screen, tear down at once (no recovery descent)
 
             // Hide the doomed hull so the player sees the debris, not an intact ship flying the recovery descent.
             if (_ship != null)


### PR DESCRIPTION
## What
When the ship is destroyed in space, the player no longer gets a landing fly-away animation after the death screen — the flight view tears down at once and the world reveals via the loading veil. The existing particle explosion is kept but timed to play out fully before the death modal covers it.

## Why
After the "Das Schiff wurde zerstört" screen, the old recovery descent flew an *invisible* hull (renderers are hidden on destruction), so the camera chased nothing for ~2.2s. Requested: real explosion sequence + no landing animation afterwards.

## Changes (client-only presentation, no server / NetCodec change)
- **SpaceView.cs**: new `_shipDestroyed` flag, set in `OnSpaceClosedFx`, reset in `Enter()`/`Exit()`. The post-confirm landing gate now calls `Exit()` directly instead of `BeginLandingFlyAway()` when the ship blew up.
- **RespawnPrompt.cs**: per-death-kind show delay — on-foot death stays `1.1s`, ship destruction waits `2.1s` so the full fireball + debris (~1.4s fireball + 0.7s shake) play before the modal appears.

## Verification
Unity client scripts (MonoBehaviour) — compiled by Unity, not the .NET build; **needs a Unity client build to validate at runtime**. No server tests affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)