### PR TITLE
ci: PR build/test gate (warnings-as-errors, docs-only skip) + drop Raspberry Pi doc references

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,6 @@
 # Line-ending policy: normalize all text to LF in the repo AND keep LF in the
 # working tree (eol=lf overrides core.autocrlf). The repository is already
-# LF-only and the .NET server also runs on Linux / Raspberry Pi, so LF
+# LF-only and the .NET server also runs on Linux / ARM64, so LF
 # everywhere — including on Windows — is the consistent, drift-free choice.
 # Windows (Unity, .NET, Visual Studio, modern editors) handles LF fine.
 * text=auto eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,93 @@
+# Fast pull-request gate: builds the .NET projects and runs the headless xUnit suites.
+#
+# Triggered on every pull request and on direct pushes to main — NOT by tags (that is release.yml).
+# This never touches Unity: it builds and tests only the two headless suites that run on Linux —
+#   tests/BlocksBeyondTheStars.Tests        (.NET server/shared xUnit, no Unity)
+#   tests/BlocksBeyondTheStars.Client.Tests (real NetworkClient vs in-process GameServer, no Unity/sockets)
+# The Unity Edit/PlayMode suites need the editor and stay opt-in/local (see scripts/run-tests.ps1).
+#
+# We target the test projects directly (not the whole .sln) on purpose: the .sln also contains the
+# WinForms launcher (net8.0-windows), which cannot build on the Linux runner. Building the test
+# projects pulls in exactly their dependencies (server/shared/client.core) and nothing Windows-only.
+#
+# Warnings ARE enforced here: the build runs with -warnaserror so any analyzer/compiler warning fails
+# the PR, even though the local build keeps TreatWarningsAsErrors=false (Directory.Build.props) for a
+# friction-free dev loop. The tree currently builds clean (0 warnings), so this only guards regressions.
+#
+# Docs-only changes don't run this: paths-ignore skips the workflow when EVERY changed file matches a
+# doc pattern below (any code/content/workflow file in the diff makes it run as normal). Note: `data/**`
+# and `web/**` are intentionally NOT ignored — they feed tests (e.g. the en/de locale-parity test).
+#
+# CAVEAT if you make this a REQUIRED status check in branch protection: a skipped run reports no status,
+# so a docs-only PR would sit forever "Expected — Waiting for status". The standard fix is a tiny always-
+# running guard job that reports success; ask before wiring that up so we don't add noise prematurely.
+
+name: CI
+
+# NOTE: GitHub Actions does not support YAML anchors, so the doc paths are duplicated below — keep both
+# lists in sync if you edit them.
+on:
+  pull_request:
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'LICENSE*'
+      - 'NOTICES*'
+      - 'THIRD-PARTY*'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/pull_request_template.md'
+  push:
+    branches: [main]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'LICENSE*'
+      - 'NOTICES*'
+      - 'THIRD-PARTY*'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/pull_request_template.md'
+
+permissions:
+  contents: read
+
+# A newer push to the same PR/branch cancels the older still-running check.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-test:
+    name: Build + test (.NET, headless)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Restore
+        run: |
+          dotnet restore tests/BlocksBeyondTheStars.Tests/BlocksBeyondTheStars.Tests.csproj
+          dotnet restore tests/BlocksBeyondTheStars.Client.Tests/BlocksBeyondTheStars.Client.Tests.csproj
+
+      # -warnaserror promotes every compiler/analyzer warning to a build error for the PR gate.
+      - name: Build (treat warnings as errors)
+        run: |
+          dotnet build tests/BlocksBeyondTheStars.Tests/BlocksBeyondTheStars.Tests.csproj --no-restore -warnaserror
+          dotnet build tests/BlocksBeyondTheStars.Client.Tests/BlocksBeyondTheStars.Client.Tests.csproj --no-restore -warnaserror
+
+      - name: Test
+        run: |
+          dotnet test tests/BlocksBeyondTheStars.Tests/BlocksBeyondTheStars.Tests.csproj --no-build --logger "trx;LogFileName=server.trx" --results-directory TestResults
+          dotnet test tests/BlocksBeyondTheStars.Client.Tests/BlocksBeyondTheStars.Client.Tests.csproj --no-build --logger "trx;LogFileName=clientcore.trx" --results-directory TestResults
+
+      # Keep the .trx results even when a suite fails, so failures are inspectable from the run page.
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: TestResults/*.trx
+          if-no-files-found: ignore

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,11 @@ If you are a developer, we welcome pull requests.
 3. **Open a pull request** against `main` with a short description of the change and why.
    Small, focused PRs are easier to review and merge.
 
+Once the PR is open, [CI](.github/workflows/ci.yml) automatically builds and runs the headless
+.NET test suites on every push — and **treats warnings as errors**, so keep the build warning-clean.
+The Unity tiers aren't in CI; run `./scripts/run-tests.ps1 -Suites All` locally before a
+client-affecting change.
+
 ### A few rules that keep the project consistent
 
 These mirror [AGENTS.md](AGENTS.md) (the deeper contributor guide — please skim it):

--- a/TODO.md
+++ b/TODO.md
@@ -17,6 +17,17 @@ world-gen; SQLite persistence.
 
 ---
 
+### ★ Pull-request CI gate: build + headless tests, warnings-as-errors (2026-06-21) — ✅ workflow added, NOT yet committed
+New [.github/workflows/ci.yml](.github/workflows/ci.yml) runs on every `pull_request` + push to `main` (separate
+from the tag-only `release.yml`). On `ubuntu-latest`, **no Unity / no license**: restores, builds and tests the
+two headless suites directly — `tests/BlocksBeyondTheStars.Tests` (Dotnet) + `tests/BlocksBeyondTheStars.Client.Tests`
+(ClientCore) — the same default set as `run-tests.ps1`.
+- **Targets the test projects, not the `.sln`** — the solution's WinForms launcher (`net8.0-windows`) can't build on Linux.
+- **Warnings fail the PR** via `-warnaserror` (local build keeps `TreatWarningsAsErrors=false`; tree is currently 0-warning). `.trx` results uploaded as an artifact.
+- **Docs-only PRs skip CI** via `paths-ignore` (`**/*.md`, `docs/**`, licences, issue/PR templates); `data/**`/`web/**` stay un-ignored (they feed tests). Caveat: a skipped run reports no status, so if this becomes a *required* check, add an always-green guard job so docs-only PRs aren't blocked.
+- **Unity tiers (`UnityEdit`/`UnityPlay`) stay local** (need the Editor) — run `./scripts/run-tests.ps1 -Suites All` before client-affecting changes.
+- **Follow-up:** add the `Build + test (.NET, headless)` check as a required status check in `main` branch protection. Docs updated: [DEVELOPER.md](docs/developer/DEVELOPER.md) §Continuous integration, [CLIENT_TESTING.md](docs/developer/CLIENT_TESTING.md), [CONTRIBUTING.md](CONTRIBUTING.md).
+
 ### ★ Multi-planet marketing screenshots (planet-type variety) (2026-06-20) — ✅ code + .NET test green, NEEDS Unity client build + GPU capture run
 Extends the screenshot automation to shoot one **surface shot per planet type** (`surface_<key>.png`) so the gallery shows the world variety, not just the home world.
 - **New `--start-planet <key>` server CLI arg** ([ServerConfig.cs](src/BlocksBeyondTheStars.Shared/Configuration/ServerConfig.cs)) forces the spawn planet's type (the field existed; only the CLI plumb was missing). Covered by the existing CLI-parse test ([WorldOptionsTests.cs](tests/BlocksBeyondTheStars.Tests/WorldOptionsTests.cs) `CommandLine_ParsesWorldOptionOverrides`, green).

--- a/docs/developer/ARCHITECTURE.md
+++ b/docs/developer/ARCHITECTURE.md
@@ -188,7 +188,7 @@ One binary serves every topology:
 - **Singleplayer** — client spawns the bundled server on `127.0.0.1` via
   `LocalServerLauncher`; stops it on exit.
 - **LAN / dedicated** — run `BlocksBeyondTheStars.GameServer` directly (Windows, Linux x64,
-  Linux ARM64 / Raspberry Pi 5 — no rendering/physics on the server). Optional WebSocket
+  Linux ARM64 — no rendering/physics on the server). Optional WebSocket
   gateway on the gameplay port for browser clients. `BlocksBeyondTheStars.Api` provides admin +
   the client download/update feed.
 

--- a/docs/developer/CLIENT_TESTING.md
+++ b/docs/developer/CLIENT_TESTING.md
@@ -102,5 +102,8 @@ You can still run a single suite directly: `dotnet test tests/BlocksBeyondTheSta
   player build.
 - `com.unity.test-framework` is pinned in `client/Packages/manifest.json`; adjust the version if your Editor
   resolves a different one.
-- CI is intentionally **not** wired up yet — these run locally. Tier 1 (`Dotnet` + `ClientCore`) is the part
-  that would drop straight into a `dotnet test` CI job with no Unity license needed.
+- **CI runs Tier 1 on every pull request.** [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml)
+  builds and runs the two headless suites (`Dotnet` + `ClientCore`) on `ubuntu-latest` with **no Unity
+  license needed**, and fails the build on any warning (`-warnaserror`). The Unity tiers (`UnityEdit` /
+  `UnityPlay`) stay **local-only** — they need the Editor — so run `./scripts/run-tests.ps1 -Suites All`
+  yourself before a client-affecting change. See [DEVELOPER.md](DEVELOPER.md#continuous-integration-pull-requests).

--- a/docs/developer/DEVELOPER.md
+++ b/docs/developer/DEVELOPER.md
@@ -39,6 +39,44 @@ the default `6000.4.9f1` path). The client is tested against the **real** server
 the `Client.Core` split, and the per-tier prerequisites are documented in
 [CLIENT_TESTING.md](CLIENT_TESTING.md).
 
+## Continuous integration (pull requests)
+
+Every pull request (and every direct push to `main`) is gated by
+[`.github/workflows/ci.yml`](../../.github/workflows/ci.yml). It runs on `ubuntu-latest` and is fast and
+free — **no Unity, no license** — because it only exercises the two headless .NET suites:
+
+```
+tests/BlocksBeyondTheStars.Tests        # Dotnet  — server/shared xUnit
+tests/BlocksBeyondTheStars.Client.Tests # ClientCore — real NetworkClient ↔ in-process GameServer
+```
+
+These are the same two suites `run-tests.ps1` runs by default. Two deliberate choices:
+
+- **It targets the test projects directly, not `BlocksBeyondTheStars.sln`.** The solution also contains the
+  WinForms launcher (`net8.0-windows`), which cannot build on the Linux runner; building the test projects
+  pulls in exactly their dependencies (server/shared/`Client.Core`) and nothing Windows-only.
+- **Warnings fail the PR.** The build step runs with **`-warnaserror`**, so any compiler or analyzer warning
+  breaks the check — even though the local build keeps `TreatWarningsAsErrors=false`
+  ([Directory.Build.props](../../Directory.Build.props)) for a friction-free dev loop. The tree currently
+  builds clean (0 warnings), so this only guards against regressions. The `.trx` results are uploaded as a
+  run artifact for inspection.
+- **Docs-only changes skip CI.** A `paths-ignore` list (Markdown, `docs/**`, licences, issue/PR templates)
+  means the workflow does **not** run when *every* changed file is documentation — no point burning a runner
+  on a typo fix. Any code/content file in the diff makes it run as normal; `data/**` and `web/**` are
+  deliberately **not** ignored because they feed tests (e.g. the en/de locale-parity test).
+
+> **Caveat for a required check:** GitHub reports *no* status for a skipped run, so if you make this a
+> required status check, a docs-only PR will wait forever on it. The standard fix is a tiny always-running
+> guard job that reports success — wire that up at the same time you mark the check required.
+
+The **Unity** suites (`UnityEdit` / `UnityPlay`) are **not** in CI — they need the Editor and stay local/opt-in
+(run them with `./scripts/run-tests.ps1 -Suites All` before a client-affecting change). The release build
+([`release.yml`](../../.github/workflows/release.yml)) is a **separate** workflow that triggers only on tags;
+it does not run tests, so the PR gate is where correctness is checked before merge.
+
+> To make CI a hard merge requirement, add the **`Build + test (.NET, headless)`** check as a required status
+> check in the `main` branch-protection rule (Settings → Branches).
+
 ## Building the Windows client
 
 One command produces a fully self-contained singleplayer/multiplayer client:
@@ -268,7 +306,7 @@ fallback text everywhere. Setup details: [SELF_HOSTING.md](SELF_HOSTING.md) §8;
 ## Self-hosting / dedicated server packages
 
 ```powershell
-./scripts/publish-server.ps1     # win-x64, linux-x64, linux-arm64 (Raspberry Pi 5)
+./scripts/publish-server.ps1     # win-x64, linux-x64, linux-arm64
 ```
 
 Produces self-contained single-file packages under `artifacts/` (no .NET runtime needed on

--- a/docs/developer/SELF_HOSTING.md
+++ b/docs/developer/SELF_HOSTING.md
@@ -1,7 +1,7 @@
 # Self-Hosting a Blocks Beyond the Stars Server
 
 Blocks Beyond the Stars is designed so players can host their own server on a Windows PC, a Linux box,
-a VPS, or a Raspberry Pi 5 — without installing .NET (the packages are self-contained).
+or a VPS — without installing .NET (the packages are self-contained).
 
 ## 1. Get a server package
 
@@ -11,7 +11,7 @@ Download or build a package for your platform:
 |---|---|
 | Windows x64 | `blocks-beyond-the-stars-server-win-x64.zip` |
 | Linux x64 | `blocks-beyond-the-stars-server-linux-x64.zip` |
-| Linux ARM64 / Raspberry Pi 5 | `blocks-beyond-the-stars-server-linux-arm64.zip` |
+| Linux ARM64 | `blocks-beyond-the-stars-server-linux-arm64.zip` |
 
 Build them yourself from a checkout with the .NET 8 SDK:
 
@@ -34,8 +34,8 @@ Build them yourself from a checkout with the .NET 8 SDK:
 5. Friends connect to your IP on the gameplay port.
 ```
 
-On a Raspberry Pi 5, prefer an SSD over a microSD for the world database to reduce wear
-and improve autosave performance.
+On low-power ARM64 boards, prefer an SSD over a microSD/eMMC for the world database to
+reduce wear and improve autosave performance.
 
 ## 3. Configuration (`config/server.json`)
 

--- a/docs/developer/adr/0001-authoritative-dotnet-server.md
+++ b/docs/developer/adr/0001-authoritative-dotnet-server.md
@@ -7,7 +7,7 @@
 ## Context
 
 Blocks Beyond the Stars must be a 3D Windows game that becomes multiplayer-capable and self-hostable
-(including on a Raspberry Pi 5) without a painful rewrite. We must decide where game truth
+(including on low-power Linux ARM64 hardware) without a painful rewrite. We must decide where game truth
 lives, what runs the server, and how data is stored and exchanged.
 
 ## Decision
@@ -15,7 +15,7 @@ lives, what runs the server, and how data is stored and exchanged.
 1. **The server is authoritative; the client is presentation + input.** The Unity client
    sends *intents*; the .NET server validates them and broadcasts authoritative *state*.
 2. **The server is a standalone .NET 8 process — no Unity runtime.** This keeps it
-   lightweight enough for ARM64 / Raspberry Pi 5 and free of rendering/physics-engine
+   lightweight enough for Linux ARM64 and free of rendering/physics-engine
    dependencies.
 3. **Singleplayer = the same server in-process** (loopback transport), so there is a
    single game-logic code path.

--- a/docs/developer/adr/0010-velopack-distribution-and-self-host-portal.md
+++ b/docs/developer/adr/0010-velopack-distribution-and-self-host-portal.md
@@ -21,7 +21,7 @@ client to its players.
    (ASP.NET Core minimal API) exposes `/portal` (a landing page with the one-click download and
    the update-feed URL), `/download` (the latest Velopack `Setup.exe`) and `/updates` (the static
    update feed under `<install>/clients`).
-4. **Self-contained, no .NET install required** on the host (Windows / Linux / Raspberry Pi 5).
+4. **Self-contained, no .NET install required** on the host (Windows / Linux x64 / Linux ARM64).
 
 ## Consequences
 

--- a/scripts/publish-server.ps1
+++ b/scripts/publish-server.ps1
@@ -4,7 +4,7 @@
 
 .DESCRIPTION
   Produces self-contained, single-file builds (no .NET install needed on the host) for
-  Windows x64, Linux x64 and Linux ARM64 (Raspberry Pi 5), bundles the data/ content and
+  Windows x64, Linux x64 and Linux ARM64, bundles the data/ content and
   a default config, then zips each package into artifacts/.
 
 .EXAMPLE

--- a/scripts/publish-server.sh
+++ b/scripts/publish-server.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Publishes the BlocksBeyondTheStars dedicated server + admin UI as self-hosting packages
-# (self-contained, single-file) for Windows x64, Linux x64 and Linux ARM64 (Pi 5).
+# (self-contained, single-file) for Windows x64, Linux x64 and Linux ARM64.
 #
 # Usage:
 #   ./scripts/publish-server.sh                 # all three runtimes

--- a/src/BlocksBeyondTheStars.GameServer/Program.cs
+++ b/src/BlocksBeyondTheStars.GameServer/Program.cs
@@ -5,7 +5,7 @@ using BlocksBeyondTheStars.Shared.Configuration;
 using BlocksBeyondTheStars.Shared.Content;
 
 // BlocksBeyondTheStars dedicated game server — standalone .NET host (no Unity runtime), so it runs
-// on Windows, Linux x64 and Linux ARM64 / Raspberry Pi 5 (technical requirements §3.2, §9).
+// on Windows, Linux x64 and Linux ARM64 (technical requirements §3.2, §9).
 
 string installDir = AppContext.BaseDirectory;
 string configPath = Path.Combine(installDir, "config", "server.json");


### PR DESCRIPTION
Adds a pull-request CI gate and bundles a concurrent docs cleanup (combined per author request).

## CI gate — `.github/workflows/ci.yml`
- Runs on every `pull_request` + push to `main`, on `ubuntu-latest`, **no Unity / no license**.
- Builds + tests the two headless suites (`BlocksBeyondTheStars.Tests` + `BlocksBeyondTheStars.Client.Tests`) — the same default set as `run-tests.ps1`.
- Targets the test projects directly (not the `.sln`) because the WinForms launcher (`net8.0-windows`) can't build on Linux.
- **Warnings fail the PR** via `-warnaserror` (local build keeps `TreatWarningsAsErrors=false`; tree is currently 0-warning). `.trx` results uploaded as an artifact.
- **Docs-only PRs skip CI** via `paths-ignore` (`**/*.md`, `docs/**`, licences, issue/PR templates); `data/**`/`web/**` stay un-ignored (they feed tests).
- Separate from the tag-only `release.yml`, which is unchanged and does not run tests.
- Follow-up: to make this a required status check, add an always-green guard job (a skipped run reports no status, blocking docs-only PRs).

Docs updated: DEVELOPER.md (§Continuous integration), CLIENT_TESTING.md, CONTRIBUTING.md, TODO.md.

## Bundled docs cleanup (other worker)
- Drop Raspberry Pi references in favour of generic Linux ARM64 across docs, build scripts and ADRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)