### PR TITLE
docs: drop Raspberry Pi references in favor of generic Linux ARM64

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,6 @@
 # Line-ending policy: normalize all text to LF in the repo AND keep LF in the
 # working tree (eol=lf overrides core.autocrlf). The repository is already
-# LF-only and the .NET server also runs on Linux / Raspberry Pi, so LF
+# LF-only and the .NET server also runs on Linux / ARM64, so LF
 # everywhere — including on Windows — is the consistent, drift-free choice.
 # Windows (Unity, .NET, Visual Studio, modern editors) handles LF fine.
 * text=auto eol=lf

--- a/docs/developer/ARCHITECTURE.md
+++ b/docs/developer/ARCHITECTURE.md
@@ -188,7 +188,7 @@ One binary serves every topology:
 - **Singleplayer** — client spawns the bundled server on `127.0.0.1` via
   `LocalServerLauncher`; stops it on exit.
 - **LAN / dedicated** — run `BlocksBeyondTheStars.GameServer` directly (Windows, Linux x64,
-  Linux ARM64 / Raspberry Pi 5 — no rendering/physics on the server). Optional WebSocket
+  Linux ARM64 — no rendering/physics on the server). Optional WebSocket
   gateway on the gameplay port for browser clients. `BlocksBeyondTheStars.Api` provides admin +
   the client download/update feed.
 

--- a/docs/developer/DEVELOPER.md
+++ b/docs/developer/DEVELOPER.md
@@ -268,7 +268,7 @@ fallback text everywhere. Setup details: [SELF_HOSTING.md](SELF_HOSTING.md) §8;
 ## Self-hosting / dedicated server packages
 
 ```powershell
-./scripts/publish-server.ps1     # win-x64, linux-x64, linux-arm64 (Raspberry Pi 5)
+./scripts/publish-server.ps1     # win-x64, linux-x64, linux-arm64
 ```
 
 Produces self-contained single-file packages under `artifacts/` (no .NET runtime needed on

--- a/docs/developer/SELF_HOSTING.md
+++ b/docs/developer/SELF_HOSTING.md
@@ -1,7 +1,7 @@
 # Self-Hosting a Blocks Beyond the Stars Server
 
 Blocks Beyond the Stars is designed so players can host their own server on a Windows PC, a Linux box,
-a VPS, or a Raspberry Pi 5 — without installing .NET (the packages are self-contained).
+or a VPS — without installing .NET (the packages are self-contained).
 
 ## 1. Get a server package
 
@@ -11,7 +11,7 @@ Download or build a package for your platform:
 |---|---|
 | Windows x64 | `blocks-beyond-the-stars-server-win-x64.zip` |
 | Linux x64 | `blocks-beyond-the-stars-server-linux-x64.zip` |
-| Linux ARM64 / Raspberry Pi 5 | `blocks-beyond-the-stars-server-linux-arm64.zip` |
+| Linux ARM64 | `blocks-beyond-the-stars-server-linux-arm64.zip` |
 
 Build them yourself from a checkout with the .NET 8 SDK:
 
@@ -34,8 +34,8 @@ Build them yourself from a checkout with the .NET 8 SDK:
 5. Friends connect to your IP on the gameplay port.
 ```
 
-On a Raspberry Pi 5, prefer an SSD over a microSD for the world database to reduce wear
-and improve autosave performance.
+On low-power ARM64 boards, prefer an SSD over a microSD/eMMC for the world database to
+reduce wear and improve autosave performance.
 
 ## 3. Configuration (`config/server.json`)
 

--- a/docs/developer/adr/0001-authoritative-dotnet-server.md
+++ b/docs/developer/adr/0001-authoritative-dotnet-server.md
@@ -7,7 +7,7 @@
 ## Context
 
 Blocks Beyond the Stars must be a 3D Windows game that becomes multiplayer-capable and self-hostable
-(including on a Raspberry Pi 5) without a painful rewrite. We must decide where game truth
+(including on low-power Linux ARM64 hardware) without a painful rewrite. We must decide where game truth
 lives, what runs the server, and how data is stored and exchanged.
 
 ## Decision
@@ -15,7 +15,7 @@ lives, what runs the server, and how data is stored and exchanged.
 1. **The server is authoritative; the client is presentation + input.** The Unity client
    sends *intents*; the .NET server validates them and broadcasts authoritative *state*.
 2. **The server is a standalone .NET 8 process — no Unity runtime.** This keeps it
-   lightweight enough for ARM64 / Raspberry Pi 5 and free of rendering/physics-engine
+   lightweight enough for Linux ARM64 and free of rendering/physics-engine
    dependencies.
 3. **Singleplayer = the same server in-process** (loopback transport), so there is a
    single game-logic code path.

--- a/docs/developer/adr/0010-velopack-distribution-and-self-host-portal.md
+++ b/docs/developer/adr/0010-velopack-distribution-and-self-host-portal.md
@@ -21,7 +21,7 @@ client to its players.
    (ASP.NET Core minimal API) exposes `/portal` (a landing page with the one-click download and
    the update-feed URL), `/download` (the latest Velopack `Setup.exe`) and `/updates` (the static
    update feed under `<install>/clients`).
-4. **Self-contained, no .NET install required** on the host (Windows / Linux / Raspberry Pi 5).
+4. **Self-contained, no .NET install required** on the host (Windows / Linux x64 / Linux ARM64).
 
 ## Consequences
 

--- a/scripts/publish-server.ps1
+++ b/scripts/publish-server.ps1
@@ -4,7 +4,7 @@
 
 .DESCRIPTION
   Produces self-contained, single-file builds (no .NET install needed on the host) for
-  Windows x64, Linux x64 and Linux ARM64 (Raspberry Pi 5), bundles the data/ content and
+  Windows x64, Linux x64 and Linux ARM64, bundles the data/ content and
   a default config, then zips each package into artifacts/.
 
 .EXAMPLE

--- a/scripts/publish-server.sh
+++ b/scripts/publish-server.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Publishes the BlocksBeyondTheStars dedicated server + admin UI as self-hosting packages
-# (self-contained, single-file) for Windows x64, Linux x64 and Linux ARM64 (Pi 5).
+# (self-contained, single-file) for Windows x64, Linux x64 and Linux ARM64.
 #
 # Usage:
 #   ./scripts/publish-server.sh                 # all three runtimes

--- a/src/BlocksBeyondTheStars.GameServer/Program.cs
+++ b/src/BlocksBeyondTheStars.GameServer/Program.cs
@@ -5,7 +5,7 @@ using BlocksBeyondTheStars.Shared.Configuration;
 using BlocksBeyondTheStars.Shared.Content;
 
 // BlocksBeyondTheStars dedicated game server — standalone .NET host (no Unity runtime), so it runs
-// on Windows, Linux x64 and Linux ARM64 / Raspberry Pi 5 (technical requirements §3.2, §9).
+// on Windows, Linux x64 and Linux ARM64 (technical requirements §3.2, §9).
 
 string installDir = AppContext.BaseDirectory;
 string configPath = Path.Combine(installDir, "config", "server.json");


### PR DESCRIPTION
Removes the Raspberry Pi 5 wording across docs, build scripts and ADRs, replacing it with the generic **Linux ARM64** the server actually targets. No functional change — the `linux-arm64` package and runtime support are unchanged; the Pi was only ever an example host.

### Touched
- `docs/developer/SELF_HOSTING.md` — intro, package table, and the SSD-vs-microSD note (now "low-power ARM64 boards")
- `docs/developer/DEVELOPER.md`, `docs/developer/ARCHITECTURE.md`
- `docs/developer/adr/0001-…`, `adr/0010-…`
- `scripts/publish-server.ps1`, `scripts/publish-server.sh`
- `src/BlocksBeyondTheStars.GameServer/Program.cs` (header comment)
- `.gitattributes` (comment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)