### PR TITLE
ci: make docs-only skip safe for a required status check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,38 +14,20 @@
 # the PR, even though the local build keeps TreatWarningsAsErrors=false (Directory.Build.props) for a
 # friction-free dev loop. The tree currently builds clean (0 warnings), so this only guards regressions.
 #
-# Docs-only changes don't run this: paths-ignore skips the workflow when EVERY changed file matches a
-# doc pattern below (any code/content/workflow file in the diff makes it run as normal). Note: `data/**`
-# and `web/**` are intentionally NOT ignored — they feed tests (e.g. the en/de locale-parity test).
-#
-# CAVEAT if you make this a REQUIRED status check in branch protection: a skipped run reports no status,
-# so a docs-only PR would sit forever "Expected — Waiting for status". The standard fix is a tiny always-
-# running guard job that reports success; ask before wiring that up so we don't add noise prematurely.
+# REQUIRED-CHECK SAFE docs-only skip: rather than skipping the whole workflow with paths-ignore (which
+# would leave a *required* check stuck on "Expected — Waiting for status" for a docs-only PR), the
+# workflow always runs and a `changes` job decides whether the heavy `build-test` job runs. On a
+# docs-only PR `build-test` is skipped via its `if:`, and GitHub counts a skipped required job as a pass —
+# so the `Build + test (.NET, headless)` check still reports green and never blocks a docs PR. Any
+# code/content file in the diff makes it run for real. `data/**` and `web/**` count as code (they feed
+# tests, e.g. the en/de locale-parity test), so they are NOT in the doc-only exclusions below.
 
 name: CI
 
-# NOTE: GitHub Actions does not support YAML anchors, so the doc paths are duplicated below — keep both
-# lists in sync if you edit them.
 on:
   pull_request:
-    paths-ignore:
-      - '**/*.md'
-      - 'docs/**'
-      - 'LICENSE*'
-      - 'NOTICES*'
-      - 'THIRD-PARTY*'
-      - '.github/ISSUE_TEMPLATE/**'
-      - '.github/pull_request_template.md'
   push:
     branches: [main]
-    paths-ignore:
-      - '**/*.md'
-      - 'docs/**'
-      - 'LICENSE*'
-      - 'NOTICES*'
-      - 'THIRD-PARTY*'
-      - '.github/ISSUE_TEMPLATE/**'
-      - '.github/pull_request_template.md'
 
 permissions:
   contents: read
@@ -56,8 +38,37 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Decides whether the diff contains anything other than documentation. Only meaningful for PRs;
+  # direct pushes to main always build (see build-test's `if:`), so the filter step is PR-only.
+  changes:
+    name: Detect code changes
+    runs-on: ubuntu-latest
+    outputs:
+      nondocs: ${{ steps.filter.outputs.nondocs }}
+    steps:
+      - uses: dorny/paths-filter@v3
+        id: filter
+        if: github.event_name == 'pull_request'
+        with:
+          # picomatch array semantics: the positive `**/*` matches every changed file, the `!` lines
+          # subtract the doc paths — so `nondocs` is true iff at least one NON-doc file changed.
+          filters: |
+            nondocs:
+              - '**/*'
+              - '!**/*.md'
+              - '!docs/**'
+              - '!LICENSE*'
+              - '!NOTICES*'
+              - '!THIRD-PARTY*'
+              - '!.github/ISSUE_TEMPLATE/**'
+              - '!.github/pull_request_template.md'
+
   build-test:
     name: Build + test (.NET, headless)
+    needs: changes
+    # Run for any push to main, or for a PR that touched at least one non-doc file. A docs-only PR
+    # skips this job; a skipped required check counts as passing, so docs PRs are never blocked.
+    if: github.event_name != 'pull_request' || needs.changes.outputs.nondocs == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/TODO.md
+++ b/TODO.md
@@ -17,16 +17,16 @@ world-gen; SQLite persistence.
 
 ---
 
-### ★ Pull-request CI gate: build + headless tests, warnings-as-errors (2026-06-21) — ✅ workflow added, NOT yet committed
+### ★ Pull-request CI gate: build + headless tests, warnings-as-errors (2026-06-21) — ✅ merged to main (PR #16 c86858e); required-check guard added
 New [.github/workflows/ci.yml](.github/workflows/ci.yml) runs on every `pull_request` + push to `main` (separate
 from the tag-only `release.yml`). On `ubuntu-latest`, **no Unity / no license**: restores, builds and tests the
 two headless suites directly — `tests/BlocksBeyondTheStars.Tests` (Dotnet) + `tests/BlocksBeyondTheStars.Client.Tests`
 (ClientCore) — the same default set as `run-tests.ps1`.
 - **Targets the test projects, not the `.sln`** — the solution's WinForms launcher (`net8.0-windows`) can't build on Linux.
 - **Warnings fail the PR** via `-warnaserror` (local build keeps `TreatWarningsAsErrors=false`; tree is currently 0-warning). `.trx` results uploaded as an artifact.
-- **Docs-only PRs skip CI** via `paths-ignore` (`**/*.md`, `docs/**`, licences, issue/PR templates); `data/**`/`web/**` stay un-ignored (they feed tests). Caveat: a skipped run reports no status, so if this becomes a *required* check, add an always-green guard job so docs-only PRs aren't blocked.
+- **Docs-only PRs skip the build but stay green** — a `changes` job (`dorny/paths-filter`) gates the `build-test` job; on a docs-only PR (`**/*.md`, `docs/**`, licences, issue/PR templates) `build-test` is skipped and a skipped *required* job counts as a pass, so it never blocks. `data/**`/`web/**` count as code (they feed tests). This makes the check **safe to mark required** (unlike a plain `paths-ignore` skip, which would stall a required check).
 - **Unity tiers (`UnityEdit`/`UnityPlay`) stay local** (need the Editor) — run `./scripts/run-tests.ps1 -Suites All` before client-affecting changes.
-- **Follow-up:** add the `Build + test (.NET, headless)` check as a required status check in `main` branch protection. Docs updated: [DEVELOPER.md](docs/developer/DEVELOPER.md) §Continuous integration, [CLIENT_TESTING.md](docs/developer/CLIENT_TESTING.md), [CONTRIBUTING.md](CONTRIBUTING.md).
+- **Follow-up (manual, repo settings):** mark **`Build + test (.NET, headless)`** as a required status check in `main` branch protection (the `Detect code changes` helper does NOT need to be required). Docs: [DEVELOPER.md](docs/developer/DEVELOPER.md) §Continuous integration, [CLIENT_TESTING.md](docs/developer/CLIENT_TESTING.md), [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ### ★ Multi-planet marketing screenshots (planet-type variety) (2026-06-20) — ✅ code + .NET test green, NEEDS Unity client build + GPU capture run
 Extends the screenshot automation to shoot one **surface shot per planet type** (`surface_<key>.png`) so the gallery shows the world variety, not just the home world.

--- a/docs/developer/DEVELOPER.md
+++ b/docs/developer/DEVELOPER.md
@@ -60,14 +60,18 @@ These are the same two suites `run-tests.ps1` runs by default. Two deliberate ch
   ([Directory.Build.props](../../Directory.Build.props)) for a friction-free dev loop. The tree currently
   builds clean (0 warnings), so this only guards against regressions. The `.trx` results are uploaded as a
   run artifact for inspection.
-- **Docs-only changes skip CI.** A `paths-ignore` list (Markdown, `docs/**`, licences, issue/PR templates)
-  means the workflow does **not** run when *every* changed file is documentation — no point burning a runner
-  on a typo fix. Any code/content file in the diff makes it run as normal; `data/**` and `web/**` are
-  deliberately **not** ignored because they feed tests (e.g. the en/de locale-parity test).
+- **Docs-only changes skip the build — without blocking the PR.** A small `changes` job
+  ([`dorny/paths-filter`](https://github.com/dorny/paths-filter)) decides whether the diff touches anything
+  other than docs (Markdown, `docs/**`, licences, issue/PR templates). If it is docs-only, the heavy
+  `build-test` job is skipped via its `if:`. The workflow still **runs** (so the check always reports), and a
+  *skipped* required job counts as a pass — so the gate stays green on a docs PR instead of stalling. Any
+  code/content file makes it build for real; `data/**` and `web/**` count as code (they feed tests, e.g. the
+  en/de locale-parity test), so they are **not** in the doc-only exclusions.
 
-> **Caveat for a required check:** GitHub reports *no* status for a skipped run, so if you make this a
-> required status check, a docs-only PR will wait forever on it. The standard fix is a tiny always-running
-> guard job that reports success — wire that up at the same time you mark the check required.
+This is **safe to mark as a required status check** in the `main` branch-protection rule: require
+**`Build + test (.NET, headless)`** (not the `Detect code changes` helper). Because the workflow always runs
+and the build-test check always reports (green/red/skipped-as-pass), a docs-only PR is never left waiting on a
+missing status — the usual failure mode of a plain `paths-ignore` skip.
 
 The **Unity** suites (`UnityEdit` / `UnityPlay`) are **not** in CI — they need the Editor and stay local/opt-in
 (run them with `./scripts/run-tests.ps1 -Suites All` before a client-affecting change). The release build


### PR DESCRIPTION
Follow-up to #16. Lets `Build + test (.NET, headless)` be marked as a **required** status check without a docs-only PR getting stuck on a missing status.

## Change
- Drops the workflow-level `paths-ignore` (a skipped workflow leaves a required check waiting forever).
- Adds a `changes` job ([`dorny/paths-filter`](https://github.com/dorny/paths-filter)) that detects whether the diff touches anything other than docs.
- The `build-test` job now runs `if:` it's a push to main **or** a PR with non-doc changes. A docs-only PR skips `build-test` — and a *skipped required job counts as a pass*, so the gate stays green.
- `data/**` and `web/**` count as code (they feed tests, e.g. locale-parity), so they still build.

## After merge (manual repo setting)
Mark **`Build + test (.NET, headless)`** as a required status check in `main` branch protection (the `Detect code changes` helper need not be required).

Docs updated: DEVELOPER.md §Continuous integration, TODO.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)