### PR TITLE
feat(multiplayer): raise default player cap from 4 to 12

### DIFF
--- a/client/Assets/BlocksBeyondTheStars/Scripts/UiSaveSelect.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/UiSaveSelect.cs
@@ -29,7 +29,7 @@ namespace BlocksBeyondTheStars.Client
             // Host mode ("Host Game" on the main menu): the same picker — any singleplayer save can be
             // hosted, "open to LAN" style — plus a host bar (max players + optional join password).
             bool host = shell.HostMode;
-            int[] maxPlayers = { 4 };
+            int[] maxPlayers = { 12 };
             string[] hostPass = { "" };
             void Launch(string world, bool unlockAll = false, bool allShips = false, bool kit = false, WorldCreationOptions options = null)
             {

--- a/docs/developer/SELF_HOSTING.md
+++ b/docs/developer/SELF_HOSTING.md
@@ -47,7 +47,7 @@ Created on first run; editable directly or through the admin UI.
 | `worldName` | Save folder under `saves/` | `world_001` |
 | `gameplayPort` | UDP port for the game (open/forward this) | `31415` |
 | `adminPort` | HTTP port for the admin UI | `31416` |
-| `maxPlayers` | Connection cap | `4` |
+| `maxPlayers` | Connection cap | `12` |
 | `serverPassword` | Required to join (empty = none) | `""` |
 | `whitelistEnabled` / `whitelist` | Restrict who may join | `false` / `[]` |
 | `adminPlayers` | Player names granted the Admin role on join (CLI: `--admins "a,b"`) | `[]` |

--- a/src/BlocksBeyondTheStars.GameServer/GameServerSpace.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerSpace.cs
@@ -61,7 +61,16 @@ public sealed partial class GameServer
             _ => (4, 8),
         };
         int baseCount = lo + PadRng(locationId).Next(hi - lo + 1);
-        return baseCount * 2; // double the landing spots per world (kept consistent across both consumers)
+        int count = baseCount * 2; // double the landing spots per world (kept consistent across both consumers)
+
+        // Full-size planets must offer at least one pad per player, so a busy server with PersonalLandingZones
+        // doesn't run out of free pads and cluster everyone onto pad 0 (spawn fallback). Moons/asteroids keep
+        // their deliberately small set — players don't start there and en-masse landings on tiny bodies are rare.
+        if (cls != WorldConstants.WorldSizeClass.Asteroid && cls != WorldConstants.WorldSizeClass.Moon)
+        {
+            count = System.Math.Max(count, _config.MaxPlayers);
+        }
+        return count;
     }
 
     /// <summary>(Re)builds the active world's deterministic pad set and hands it to worldgen for terrain

--- a/src/BlocksBeyondTheStars.Shared/Configuration/ServerConfig.cs
+++ b/src/BlocksBeyondTheStars.Shared/Configuration/ServerConfig.cs
@@ -25,7 +25,7 @@ public sealed class ServerConfig
     /// <summary>WebSocket bind host ("localhost"/LAN ip for safety, "+" for all interfaces).</summary>
     public string WebSocketBindAddress { get; set; } = "localhost";
 
-    public int MaxPlayers { get; set; } = 4;
+    public int MaxPlayers { get; set; } = 12;
     public string ServerPassword { get; set; } = string.Empty;
     public bool WhitelistEnabled { get; set; }
     public List<string> Whitelist { get; set; } = new();


### PR DESCRIPTION
## What

The multiplayer cap of **4** was only a *default*, not an architectural limit — the stack already supports up to 16 players (the host slider goes 2–16 and the transport is built from `config.MaxPlayers`). This raises the default to **12** and scales landing-pad supply to match.

## Changes

- **`ServerConfig.MaxPlayers`** default `4 → 12` — new worlds allow 12 players out of the box.
- **Host bar (`UiSaveSelect`)** default `4 → 12`; the stepper still spans 2–16.
- **`SELF_HOSTING.md`** documents the new default.
- **`PadCountFor`** floors full-planet pad count to `MaxPlayers` (`Math.Max`), so every player gets their own landing pad under `PersonalLandingZones` (default on) instead of clustering on pad 0. Moons/asteroids keep their deliberately small set — players don't start there.

## Notes

- Server-side only; no NetCodec/protocol change. Transport ceiling stays 16.
- `UiSaveSelect` is Unity client code → needs a Unity client build for the new host-bar default to appear in-game.

## Verification

- `dotnet test` — **683 passed, 0 failed**.
- Clean rebuild — **0 warnings, 0 errors** (Roslyn analyzers active).

🤖 Generated with [Claude Code](https://claude.com/claude-code)