### PR TITLE
docs: mandate local test/warning/Unity-build verification after changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,24 @@ build output (the `.exe` timestamp is not reliable). The full build guide — pi
 freshness verification and the known "works in the Editor, broken in the build" pitfalls — is in
 [docs/developer/DEVELOPER.md](docs/developer/DEVELOPER.md).
 
+## Local verification after changes (mandatory)
+
+After finishing a set of local changes — before reporting done and before committing — run this chain so
+problems are caught locally instead of at release time:
+
+1. **Tests** — `dotnet test` for the affected suite(s) (`BlocksBeyondTheStars.Tests` for server/shared,
+   `BlocksBeyondTheStars.Client.Tests` for client-core). They must be green.
+2. **Warning check** — a clean rebuild (`dotnet build --no-incremental`) and confirm **0 warnings / 0 errors**.
+   The Roslyn analyzers are on and CI builds with `-warnaserror`, so a warning fails CI. Don't rely on the
+   `dotnet test -v minimal` output — it hides warnings.
+3. **Local Unity build when client (Unity) code changed** — **PR CI never builds Unity** (it is .NET-only);
+   the Unity player is only built on a release tag / manual dispatch by
+   [.github/workflows/release.yml](.github/workflows/release.yml). So whenever a `client/Assets/**` file
+   changed, run `./scripts/build-client.ps1` locally. This catches Unity-only compile failures (e.g. the
+   `CS0246` "works in the Editor, broken in the build" trap) **and** surfaces generated/synced files that
+   must be committed (synced libs under `client/Assets/.../Plugins`, `.meta` files, etc.). Pure
+   server/shared/docs changes don't need it.
+
 ## Releases & versioning
 
 Releases are built in the cloud by [.github/workflows/release.yml](.github/workflows/release.yml) — never

--- a/docs/developer/DEVELOPER.md
+++ b/docs/developer/DEVELOPER.md
@@ -81,6 +81,36 @@ it does not run tests, so the PR gate is where correctness is checked before mer
 > To make CI a hard merge requirement, add the **`Build + test (.NET, headless)`** check as a required status
 > check in the `main` branch-protection rule (Settings → Branches).
 
+## Local verification after changes (mandatory)
+
+Because the PR gate is **.NET-only** (see above), some classes of breakage are invisible to CI until a release
+tag is cut. Run this chain locally after finishing a set of changes — before committing — so they are caught
+early:
+
+1. **Tests** — `dotnet test` for the affected suite(s) (`BlocksBeyondTheStars.Tests` for server/shared,
+   `BlocksBeyondTheStars.Client.Tests` for client-core), all green.
+2. **Warning check** — a clean rebuild and confirm **0 warnings / 0 errors**:
+
+   ```powershell
+   dotnet build src/BlocksBeyondTheStars.GameServer/BlocksBeyondTheStars.GameServer.csproj --no-incremental
+   ```
+
+   The analyzers are on and CI builds with `-warnaserror`, so a warning fails the PR even though the local
+   build keeps `TreatWarningsAsErrors=false`. Don't trust `dotnet test -v minimal` — it hides warnings.
+3. **Local Unity build when client code changed** — the Unity player is **never** built by PR CI; only
+   [`release.yml`](../../.github/workflows/release.yml) builds it (on a tag / manual dispatch). So whenever a
+   `client/Assets/**` file changed, run:
+
+   ```powershell
+   ./scripts/build-client.ps1
+   ```
+
+   This catches Unity-only compile failures (the `CS0246` "works in the Editor, broken in the build" trap —
+   see [Troubleshooting](#troubleshooting-works-in-the-editor-silently-broken-in-the-build)) **and** surfaces
+   generated/synced files that must be committed (synced libs, `.meta` files). Confirm freshness via the
+   `BlocksBeyondTheStars.Client.dll` timestamp (see [Verifying a build is actually fresh](#verifying-a-build-is-actually-fresh)).
+   Pure server/shared/docs changes don't need this step.
+
 ## Building the Windows client
 
 One command produces a fully self-contained singleplayer/multiplayer client:


### PR DESCRIPTION
## What

Documents the local close-out chain to run after finishing a set of changes, in **AGENTS.md** (new "Local verification after changes" section) and **docs/developer/DEVELOPER.md** (after the CI section).

## Why

PR CI is **.NET-only** — it never builds the Unity client (only [release.yml](.github/workflows/release.yml) does, on a tag). So a client-side compile failure or a generated/synced file that must be committed is invisible until a release is cut. The documented chain catches it locally:

1. `dotnet test` for the affected suite(s) — green.
2. Clean rebuild → **0 warnings / 0 errors** (CI uses `-warnaserror`).
3. **Local `./scripts/build-client.ps1` whenever `client/Assets/**` changed** — catches Unity-only compile fails and surfaces files that must be committed. Pure server/shared/docs changes skip it.

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)