### PR TITLE
style: reformat with dotnet format; enable Format CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,9 +103,23 @@ jobs:
           path: TestResults/*.trx
           if-no-files-found: ignore
 
-  # NOTE: a `dotnet format --verify-no-changes` gate is intentionally NOT here yet. The tree currently has
-  # ~1873 pre-existing WHITESPACE (indentation) violations across ~65 files, so the check would fail on day
-  # one. Enforcing it needs a separate, tree-wide reformat commit first (done when no other work is in
-  # flight, since it touches hot files like GameServer.cs / WorldGeneration.cs). BlocksBeyondTheStars.CI.slnf
-  # is kept for that: `dotnet format BlocksBeyondTheStars.CI.slnf` (it excludes the Windows-only launcher so
-  # it also runs on Linux). See TODO.md.
+  # Verifies C# code style/formatting (whitespace, using-order, object-initializer line breaks, …) per
+  # .editorconfig. Runs against BlocksBeyondTheStars.CI.slnf, a solution filter listing every project EXCEPT
+  # the Windows-only WinForms launcher, so the whole set loads on the Linux runner. Line endings are LF here
+  # (.gitattributes eol=lf + .editorconfig end_of_line=lf agree), so the check is consistent on every fresh
+  # checkout. Gated like build-test so docs-only PRs skip it (a skipped required job still counts as passing).
+  format:
+    name: Format (dotnet format)
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.nondocs == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: dotnet format --verify-no-changes
+        run: dotnet format BlocksBeyondTheStars.CI.slnf --verify-no-changes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,11 +112,11 @@ problems are caught locally instead of at release time:
 2. **Warning check** — a clean rebuild (`dotnet build --no-incremental`) and confirm **0 warnings / 0 errors**.
    The Roslyn analyzers are on and CI builds with `-warnaserror`, so a warning fails CI. Don't rely on the
    `dotnet test -v minimal` output — it hides warnings.
-3. **Lint (non-.NET)** — match the PR checks so they don't fail in CI: if you touched `ai-backend/`,
-   `uvx ruff check ai-backend`; if you touched `web/`, `node --check` the changed `.js`; if you touched
-   `.github/workflows/`, `actionlint -shellcheck=`. (The C# side is covered by the `-warnaserror` build in
-   step 2. `dotnet format` is **not** a CI gate yet — see TODO.md — but if you add new C# keep it tidy;
-   `dotnet format BlocksBeyondTheStars.CI.slnf` excludes the Windows-only launcher so it runs on any OS.)
+3. **Format + lint** — match the PR checks so they don't fail in CI:
+   - `dotnet format BlocksBeyondTheStars.CI.slnf --verify-no-changes` (C# style; the `.slnf` excludes the
+     Windows-only launcher so it runs on any OS). Drop `--verify-no-changes` to auto-fix.
+   - If you touched `ai-backend/`: `uvx ruff check ai-backend`. If you touched `web/`: `node --check` the
+     changed `.js`. If you touched `.github/workflows/`: `actionlint -shellcheck=`.
 4. **Local Unity build when client (Unity) code changed** — **PR CI never builds Unity** (it is .NET-only);
    the Unity player is only built on a release tag / manual dispatch by
    [.github/workflows/release.yml](.github/workflows/release.yml). So whenever a `client/Assets/**` file
@@ -163,9 +163,9 @@ built (blocked by the Windows-only UnityWebBrowser/CEF engine).
 - The author is JAM Software; follow sensible, consistent C# conventions.
 - **Automated checks on every PR** (see [docs/developer/DEVELOPER.md](docs/developer/DEVELOPER.md) §CI):
   `ci.yml` builds + tests with `-warnaserror` (Roslyn/Meziantou/VS.Threading analyzers as errors = the C#
-  syntax/static-analysis gate); `lint.yml` runs ruff (Python), `node --check` (web JS) and actionlint
-  (workflows); `codeql.yml` does security/quality scanning. Keep them green. (A `dotnet format` gate is not
-  enforced yet — the tree needs a one-off reformat first; see TODO.md.)
+  syntax/static-analysis gate) **and** runs `dotnet format --verify-no-changes` (C# style); `lint.yml` runs
+  ruff (Python), `node --check` (web JS) and actionlint (workflows); `codeql.yml` does security/quality
+  scanning. Keep them green — run the equivalents locally before pushing (next section).
 
 ## Git workflow (mandatory)
 

--- a/TODO.md
+++ b/TODO.md
@@ -22,9 +22,12 @@ Extends the PR gate beyond build+test (C# is already syntax/static-analysis-chec
 - **[lint.yml](.github/workflows/lint.yml)**: ruff (Python ai-backend, already clean), `node --check` (web JS parse), actionlint 1.7.12 (workflows, ShellCheck off). All verified green in CI.
 - **[codeql.yml](.github/workflows/codeql.yml)**: CodeQL security+quality for csharp (build-mode none → also covers Unity client C#), javascript-typescript, python, actions. Advanced-setup workflow (GITHUB_TOKEN has security-events:write; API default-setup PUT 404'd on token scope).
 - **Fixed a latent config bug:** `.editorconfig` had `end_of_line = crlf` while `.gitattributes` enforces `eol=lf` → any `dotnet format` would fail on every fresh (LF) checkout. Set `.editorconfig` to `lf`. Also fixed 3 using-order violations (NetCodec.cs, SqliteWorldRepository.cs, InventoryTests.cs).
-- **`dotnet format` gate NOT added** — a full restore-backed scan found **~1873 pre-existing WHITESPACE/indentation violations across ~65 files** (WorldGeneration.cs 743, GameServer.cs 611, Tests, generators …). A blocking check would be red on day one. [BlocksBeyondTheStars.CI.slnf](BlocksBeyondTheStars.CI.slnf) (Launcher excluded → runs on Linux) is kept for it.
-- Docs: [DEVELOPER.md](docs/developer/DEVELOPER.md) §CI (lint/CodeQL + deferred-format note), [AGENTS.md](AGENTS.md) (LF policy + verification chain).
-- **Follow-up 1 (own PR, tree quiet):** run `dotnet format BlocksBeyondTheStars.CI.slnf` to normalize the ~1873 whitespace issues, then add the `Format (dotnet format)` gate to ci.yml. **Follow-up 2:** optionally mark lint/CodeQL/format as required checks (today only `Build + test (.NET, headless)` is required).
+- Docs: [DEVELOPER.md](docs/developer/DEVELOPER.md) §CI (format/lint/CodeQL), [AGENTS.md](AGENTS.md) (LF policy + verification chain).
+
+### ★ Codebase reformat + activate `Format (dotnet format)` gate (2026-06-21) — ✅ done (follow-up to #22)
+- Ran `dotnet format BlocksBeyondTheStars.CI.slnf` over the tree: **60 files, formatting-only** (indentation + object-initializer/argument line breaks; `git diff -w` confirms zero logic change). Resolved the ~1873 pre-existing whitespace violations.
+- Re-added the **`Format (dotnet format)`** job to [ci.yml](.github/workflows/ci.yml) (gated by the `changes` job like build-test). Now green because the tree is clean.
+- **Follow-up (optional):** mark `Format (dotnet format)` / lint / CodeQL as required checks too (today only `Build + test (.NET, headless)` is required).
 
 ### ★ Pull-request CI gate: build + headless tests, warnings-as-errors (2026-06-21) — ✅ merged to main (PR #16 c86858e); required-check guard added
 New [.github/workflows/ci.yml](.github/workflows/ci.yml) runs on every `pull_request` + push to `main` (separate

--- a/docs/developer/DEVELOPER.md
+++ b/docs/developer/DEVELOPER.md
@@ -82,10 +82,17 @@ it does not run tests, so the PR gate is where correctness is checked before mer
 > The `Detect code changes` helper is intentionally **not** required. If you add another always-skippable
 > gate, only require the job that always reports.
 
-### Other PR checks: lint + CodeQL
+### Other PR checks: format, lint, CodeQL
 
-Beyond build+test, two more workflows run on PRs:
+Beyond build+test, three more gates run on PRs:
 
+- **`Format (dotnet format)`** — a second job in [`ci.yml`](../../.github/workflows/ci.yml) runs
+  `dotnet format --verify-no-changes` against [`BlocksBeyondTheStars.CI.slnf`](../../BlocksBeyondTheStars.CI.slnf),
+  a solution filter listing every project **except** the Windows-only launcher (so the set loads on Linux). It
+  enforces `.editorconfig` style: indentation, `using` ordering, object-initializer line breaks, etc. **Line
+  endings must be LF** — this only works because `.gitattributes` (`eol=lf`) and `.editorconfig`
+  (`end_of_line = lf`) agree; a CRLF setting would fail it on every fresh checkout. Gated by the same `changes`
+  job, so docs-only PRs skip it. Run `dotnet format BlocksBeyondTheStars.CI.slnf` to auto-fix before pushing.
 - **[`lint.yml`](../../.github/workflows/lint.yml)** — the non-.NET languages: **ruff** for the Python
   `ai-backend`, **`node --check`** (parse-only, zero-config) for the browser JS under `web/`, and
   **actionlint** (ShellCheck disabled → pure workflow-syntax) for the workflow YAML.
@@ -95,26 +102,24 @@ Beyond build+test, two more workflows run on PRs:
   **Security → Code scanning**. This is the *advanced setup* (a committed workflow) rather than the API default
   setup, because the workflow's `GITHUB_TOKEN` already has `security-events: write` (the API PUT needs a PAT).
 
-The C# side itself is already syntax/static-analysis-checked by the build (`-warnaserror` runs the Roslyn +
-Meziantou + VS.Threading analyzers as errors), so it needs no extra linter.
+The C# *compile/static-analysis* gate is the `-warnaserror` build (Roslyn + Meziantou + VS.Threading analyzers
+as errors); `Format` adds pure style on top.
 
-Run the lint equivalents locally before pushing (mirrors [AGENTS.md](../../AGENTS.md) §Local verification):
+Run the equivalents locally before pushing (mirrors [AGENTS.md](../../AGENTS.md) §Local verification):
 
 ```powershell
+dotnet format BlocksBeyondTheStars.CI.slnf --verify-no-changes                            # C# style/format
 uvx ruff check ai-backend                                                                # Python (uv is a project dep)
 Get-ChildItem web -Recurse -Filter *.js | ForEach-Object { node --check $_.FullName }     # web JS syntax
 ```
 
-Only `Build + test (.NET, headless)` is *required* to merge today; lint/CodeQL are advisory until you add
-them to branch protection too.
+Only `Build + test (.NET, headless)` is *required* to merge today; format/lint/CodeQL are advisory until you
+add them to branch protection too.
 
-> **Not enforced yet — `dotnet format`.** A `dotnet format --verify-no-changes` gate would be the natural C#
-> style check, and [`BlocksBeyondTheStars.CI.slnf`](../../BlocksBeyondTheStars.CI.slnf) (every project except
-> the Windows-only launcher, so it loads on Linux) exists for it. But the tree currently has ~1873 pre-existing
-> whitespace/indentation violations across ~65 files, so the check would fail immediately. Enforcing it needs a
-> one-off tree-wide `dotnet format` reformat commit first — run when no other work is in flight, since it
-> touches hot files (GameServer.cs, WorldGeneration.cs). The LF line-ending fix that makes the check viable is
-> already in place (`.gitattributes eol=lf` + `.editorconfig end_of_line = lf` now agree). Tracked in TODO.md.
+> **Heads-up for Windows devs:** `dotnet format --verify-no-changes` reads the working-tree bytes, so if an
+> old checkout still has CRLF in some files (from before `.gitattributes eol=lf` landed) it can report
+> line-ending diffs locally that CI (a fresh LF checkout) never sees. Re-normalize once with
+> `git add --renormalize . ; git checkout -- .` if that happens.
 
 ## Local verification after changes (mandatory)
 

--- a/src/BlocksBeyondTheStars.Client.Core/ClientWorld.cs
+++ b/src/BlocksBeyondTheStars.Client.Core/ClientWorld.cs
@@ -181,27 +181,27 @@ namespace BlocksBeyondTheStars.Client
             var origin = WorldConstants.ChunkOrigin(coord);
             int nsz = WorldConstants.ChunkSize;
             for (int x = 0; x < nsz; x++)
-            for (int y = 0; y < nsz; y++)
-            for (int z = 0; z < nsz; z++)
-            {
-                var id = chunk.Get(x, y, z);
-                var pos = new Vector3i(origin.X + x, origin.Y + y, origin.Z + z);
-                int rgb = 0;
-                if (!id.IsAir)
-                {
-                    var (_, glow) = chunk.GetModifier(x, y, z);
-                    rgb = glow != 0 ? glow : (_blockLightColor != null ? _blockLightColor(id.Value) : 0);
-                }
+                for (int y = 0; y < nsz; y++)
+                    for (int z = 0; z < nsz; z++)
+                    {
+                        var id = chunk.Get(x, y, z);
+                        var pos = new Vector3i(origin.X + x, origin.Y + y, origin.Z + z);
+                        int rgb = 0;
+                        if (!id.IsAir)
+                        {
+                            var (_, glow) = chunk.GetModifier(x, y, z);
+                            rgb = glow != 0 ? glow : (_blockLightColor != null ? _blockLightColor(id.Value) : 0);
+                        }
 
-                if (rgb != 0)
-                {
-                    _lightSources[pos] = rgb;
-                }
-                else
-                {
-                    _lightSources.Remove(pos);
-                }
-            }
+                        if (rgb != 0)
+                        {
+                            _lightSources[pos] = rgb;
+                        }
+                        else
+                        {
+                            _lightSources.Remove(pos);
+                        }
+                    }
         }
     }
 }

--- a/src/BlocksBeyondTheStars.Client.Core/NetworkClient.cs
+++ b/src/BlocksBeyondTheStars.Client.Core/NetworkClient.cs
@@ -217,8 +217,13 @@ namespace BlocksBeyondTheStars.Client
             string? targetPlayer = null, float x = 0f, float y = 0f, float z = 0f)
             => Send(new AdminCommandIntent
             {
-                Command = command, StringArg = stringArg, IntArg = intArg,
-                TargetPlayer = targetPlayer, X = x, Y = y, Z = z,
+                Command = command,
+                StringArg = stringArg,
+                IntArg = intArg,
+                TargetPlayer = targetPlayer,
+                X = x,
+                Y = y,
+                Z = z,
             });
 
         public void SendSelectHotbar(int slot) => Send(new SelectHotbarIntent { Slot = slot });

--- a/src/BlocksBeyondTheStars.GameServer/GameServer.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServer.cs
@@ -1246,19 +1246,19 @@ public sealed partial class GameServer
             // taller vertical span (esp. below) is still covered so digging down never outruns the terrain.
             var pending = new List<(ChunkCoord Coord, int DistSq)>();
             for (int dy = -3; dy <= 2; dy++)
-            for (int dx = -radius; dx <= radius; dx++)
-            for (int dz = -radius; dz <= radius; dz++)
-            {
-                // Canonicalize longitude so chunks just west of the seam (center.X+dx < 0) stream as the
-                // wrapped chunk from the far side — the player can see across X = 0 ≡ X = Circumference.
-                var coord = WorldConstants.CanonicalChunk(new ChunkCoord(center.X + dx, center.Y + dy, center.Z + dz), _world.Circumference);
-                if (session.SentChunks.Contains(coord))
-                {
-                    continue;
-                }
+                for (int dx = -radius; dx <= radius; dx++)
+                    for (int dz = -radius; dz <= radius; dz++)
+                    {
+                        // Canonicalize longitude so chunks just west of the seam (center.X+dx < 0) stream as the
+                        // wrapped chunk from the far side — the player can see across X = 0 ≡ X = Circumference.
+                        var coord = WorldConstants.CanonicalChunk(new ChunkCoord(center.X + dx, center.Y + dy, center.Z + dz), _world.Circumference);
+                        if (session.SentChunks.Contains(coord))
+                        {
+                            continue;
+                        }
 
-                pending.Add((coord, dx * dx + dy * dy + dz * dz));
-            }
+                        pending.Add((coord, dx * dx + dy * dy + dz * dz));
+                    }
 
             pending.Sort((a, b) => a.DistSq.CompareTo(b.DistSq));
 
@@ -2116,30 +2116,30 @@ public sealed partial class GameServer
     private void BreakArea(PlayerSession session, Vector3i center, int radius, MaterialPool pool)
     {
         for (int dx = -radius; dx <= radius; dx++)
-        for (int dy = -radius; dy <= radius; dy++)
-        for (int dz = -radius; dz <= radius; dz++)
-        {
-            if (dx == 0 && dy == 0 && dz == 0)
-            {
-                continue;
-            }
+            for (int dy = -radius; dy <= radius; dy++)
+                for (int dz = -radius; dz <= radius; dz++)
+                {
+                    if (dx == 0 && dy == 0 && dz == 0)
+                    {
+                        continue;
+                    }
 
-            var p = new Vector3i(center.X + dx, center.Y + dy, center.Z + dz);
-            var b = _world.GetBlock(p);
-            if (b.IsAir || IsShipBlock(p) || IsSettlementBlock(p) || IsStationBlock(p)
-                || IsBaseProtected(p, session.State.PlayerId, session.State.IsAdmin))
-            {
-                continue;
-            }
+                    var p = new Vector3i(center.X + dx, center.Y + dy, center.Z + dz);
+                    var b = _world.GetBlock(p);
+                    if (b.IsAir || IsShipBlock(p) || IsSettlementBlock(p) || IsStationBlock(p)
+                        || IsBaseProtected(p, session.State.PlayerId, session.State.IsAdmin))
+                    {
+                        continue;
+                    }
 
-            var d = _world.Definition(b);
-            if (d is null || !d.Mineable)
-            {
-                continue;
-            }
+                    var d = _world.Definition(b);
+                    if (d is null || !d.Mineable)
+                    {
+                        continue;
+                    }
 
-            BreakBlockAt(session, p, d, pool);
-        }
+                    BreakBlockAt(session, p, d, pool);
+                }
     }
 
     private void HandlePlace(PlayerSession session, PlaceBlockIntent place)
@@ -2682,20 +2682,20 @@ public sealed partial class GameServer
         switch (cmd.Command?.ToLowerInvariant())
         {
             case "give_item":
-            {
-                if (_content.GetItem(cmd.StringArg ?? string.Empty) is null)
                 {
-                    Reject(session, "admin", "Unknown item.");
-                    return;
-                }
+                    if (_content.GetItem(cmd.StringArg ?? string.Empty) is null)
+                    {
+                        Reject(session, "admin", "Unknown item.");
+                        return;
+                    }
 
-                var target = FindSessionByName(cmd.TargetPlayer) ?? session;
-                int amount = System.Math.Max(1, cmd.IntArg);
-                new MaterialPool(_content, target.State, _ship).Add(cmd.StringArg!, amount);
-                SendInventory(target);
-                CheatLog(p, $"gave {amount} {cmd.StringArg} to {target.State.Name}");
-                break;
-            }
+                    var target = FindSessionByName(cmd.TargetPlayer) ?? session;
+                    int amount = System.Math.Max(1, cmd.IntArg);
+                    new MaterialPool(_content, target.State, _ship).Add(cmd.StringArg!, amount);
+                    SendInventory(target);
+                    CheatLog(p, $"gave {amount} {cmd.StringArg} to {target.State.Name}");
+                    break;
+                }
 
             case "teleport_to_location":
                 p.Position = new Vector3f(cmd.X, cmd.Y, cmd.Z);
@@ -2704,19 +2704,19 @@ public sealed partial class GameServer
                 break;
 
             case "teleport_to_player":
-            {
-                var target = FindSessionByName(cmd.TargetPlayer);
-                if (target is null)
                 {
-                    Reject(session, "admin", "Target player not found.");
-                    return;
-                }
+                    var target = FindSessionByName(cmd.TargetPlayer);
+                    if (target is null)
+                    {
+                        Reject(session, "admin", "Target player not found.");
+                        return;
+                    }
 
-                p.Position = target.State.Position;
-                SendPlayerState(session);
-                CheatLog(p, $"teleported to player {target.State.Name}");
-                break;
-            }
+                    p.Position = target.State.Position;
+                    SendPlayerState(session);
+                    CheatLog(p, $"teleported to player {target.State.Name}");
+                    break;
+                }
 
             case "set_time":
                 _timeOfDay = cmd.StringArg ?? _timeOfDay;
@@ -2750,12 +2750,12 @@ public sealed partial class GameServer
 
             // ---- Story QA (P8 telemetry): jump around the arc for testing ----
             case "advance_story":
-            {
-                int beats = AdminAdvanceStory(cmd.IntArg);
-                Send(session, new ServerMessage { Text = $"Story advanced — beats revealed: {beats}." });
-                CheatLog(p, $"advanced story by {System.Math.Max(1, cmd.IntArg)} (beats {beats})");
-                break;
-            }
+                {
+                    int beats = AdminAdvanceStory(cmd.IntArg);
+                    Send(session, new ServerMessage { Text = $"Story advanced — beats revealed: {beats}." });
+                    CheatLog(p, $"advanced story by {System.Math.Max(1, cmd.IntArg)} (beats {beats})");
+                    break;
+                }
 
             case "reveal_finale":
                 AdminRevealFinale();
@@ -2769,55 +2769,55 @@ public sealed partial class GameServer
                 break;
 
             case "story_status":
-            {
-                var snap = StorySnapshot;
-                Send(session, new ServerMessage
                 {
-                    Text = $"Story '{snap.StoryId}': fragments={snap.Fragments}, kills={snap.Kills}, " +
-                           $"milestones={snap.Milestones}, beats={snap.BeatsRevealed}/{(_story?.Beats.Count ?? 0)}, " +
-                           $"finaleRevealed={_storyState.GuardianSystemRevealed}, defeated={snap.Defeated}",
-                });
-                break;
-            }
+                    var snap = StorySnapshot;
+                    Send(session, new ServerMessage
+                    {
+                        Text = $"Story '{snap.StoryId}': fragments={snap.Fragments}, kills={snap.Kills}, " +
+                               $"milestones={snap.Milestones}, beats={snap.BeatsRevealed}/{(_story?.Beats.Count ?? 0)}, " +
+                               $"finaleRevealed={_storyState.GuardianSystemRevealed}, defeated={snap.Defeated}",
+                    });
+                    break;
+                }
 
             // ---- Finale QA: fit a ship module (e.g. the jump generator), reveal all lore, or drop into the core ----
             case "grant_module":
-            {
-                var key = cmd.StringArg ?? string.Empty;
-                if (_ship is null)
                 {
-                    Reject(session, "admin", "You have no active ship to fit a module to.");
-                    return;
-                }
+                    var key = cmd.StringArg ?? string.Empty;
+                    if (_ship is null)
+                    {
+                        Reject(session, "admin", "You have no active ship to fit a module to.");
+                        return;
+                    }
 
-                if (_content.GetShipModule(key) is null)
-                {
-                    Reject(session, "admin", "Unknown ship module.");
-                    return;
-                }
+                    if (_content.GetShipModule(key) is null)
+                    {
+                        Reject(session, "admin", "Unknown ship module.");
+                        return;
+                    }
 
-                if (!_ship.HasModule(key))
-                {
-                    _ship.Modules.Add(key);
-                    ResizeCargo(_ship);
-                    RecomputeShipCombatStats();
-                    _repo.SaveShip(ShipSaveKey(p.PlayerId), _ship);
-                    SendShipCombatStatus(session);
-                    SendPlayerState(session);
-                }
+                    if (!_ship.HasModule(key))
+                    {
+                        _ship.Modules.Add(key);
+                        ResizeCargo(_ship);
+                        RecomputeShipCombatStats();
+                        _repo.SaveShip(ShipSaveKey(p.PlayerId), _ship);
+                        SendShipCombatStatus(session);
+                        SendPlayerState(session);
+                    }
 
-                Send(session, new ServerMessage { Text = $"Ship module fitted: {key}" });
-                CheatLog(p, $"fitted ship module {key}");
-                break;
-            }
+                    Send(session, new ServerMessage { Text = $"Ship module fitted: {key}" });
+                    CheatLog(p, $"fitted ship module {key}");
+                    break;
+                }
 
             case "reveal_lore":
-            {
-                int n = AdminRevealAllLore(session);
-                Send(session, new ServerMessage { Text = $"Revealed all story lore ({n} fragments + every memory)." });
-                CheatLog(p, "revealed all story lore");
-                break;
-            }
+                {
+                    int n = AdminRevealAllLore(session);
+                    Send(session, new ServerMessage { Text = $"Revealed all story lore ({n} fragments + every memory)." });
+                    CheatLog(p, "revealed all story lore");
+                    break;
+                }
 
             case "goto_core":
                 AdminGotoCore(session);

--- a/src/BlocksBeyondTheStars.GameServer/GameServerBeacons.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerBeacons.cs
@@ -51,7 +51,9 @@ public sealed partial class GameServer
         _repo.SaveBeacon(new StoredBeacon
         {
             Planet = _world.LocationId,
-            X = pos.X, Y = pos.Y, Z = pos.Z,
+            X = pos.X,
+            Y = pos.Y,
+            Z = pos.Z,
             Label = clean,
             OwnerId = session.State.PlayerId,
         });
@@ -105,7 +107,9 @@ public sealed partial class GameServer
         _repo.SaveBeacon(new StoredBeacon
         {
             Planet = _world.LocationId,
-            X = pos.X, Y = pos.Y, Z = pos.Z,
+            X = pos.X,
+            Y = pos.Y,
+            Z = pos.Z,
             Label = beacon.Label,
             OwnerId = beacon.OwnerId,
         });

--- a/src/BlocksBeyondTheStars.GameServer/GameServerBeam.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerBeam.cs
@@ -57,7 +57,9 @@ public sealed partial class GameServer
         _repo.SaveBeam(new StoredBeam
         {
             Planet = _world.LocationId,
-            X = pos.X, Y = pos.Y, Z = pos.Z,
+            X = pos.X,
+            Y = pos.Y,
+            Z = pos.Z,
             Name = clean,
             OwnerId = session.State.PlayerId,
         });
@@ -104,7 +106,9 @@ public sealed partial class GameServer
         _repo.SaveBeam(new StoredBeam
         {
             Planet = _world.LocationId,
-            X = beam.Cell.X, Y = beam.Cell.Y, Z = beam.Cell.Z,
+            X = beam.Cell.X,
+            Y = beam.Cell.Y,
+            Z = beam.Cell.Z,
             Name = beam.Name,
             OwnerId = beam.OwnerId,
         });
@@ -161,8 +165,12 @@ public sealed partial class GameServer
         Send(session, new BeamTeleported { X = to.X, Y = to.Y, Z = to.Z }); // snap the body + arrival effect
         BroadcastToWorld(new BeamFx
         {
-            FromX = from.X, FromY = from.Y, FromZ = from.Z,
-            ToX = to.X, ToY = to.Y, ToZ = to.Z,
+            FromX = from.X,
+            FromY = from.Y,
+            FromZ = from.Z,
+            ToX = to.X,
+            ToY = to.Y,
+            ToZ = to.Z,
         });
 
         string label = string.IsNullOrEmpty(target.Name) ? "beam block" : target.Name;

--- a/src/BlocksBeyondTheStars.GameServer/GameServerBump.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerBump.cs
@@ -56,8 +56,13 @@ public sealed partial class GameServer
                 s.History.Add(new BumpSample
                 {
                     T = Math.Round(_uptime, 1),
-                    X = p.Position.X, Y = p.Position.Y, Z = p.Position.Z,
-                    Health = p.Health, Oxygen = p.Oxygen, Energy = p.SuitEnergy, Hunger = p.Hunger,
+                    X = p.Position.X,
+                    Y = p.Position.Y,
+                    Z = p.Position.Z,
+                    Health = p.Health,
+                    Oxygen = p.Oxygen,
+                    Energy = p.SuitEnergy,
+                    Hunger = p.Hunger,
                     Aboard = p.AboardShip,
                 });
 
@@ -126,16 +131,27 @@ public sealed partial class GameServer
             {
                 instanceId = instance.Id,
                 kind = instance.Kind,
-                shipX = sp.X, shipY = sp.Y, shipZ = sp.Z, yaw = pose.Yaw, eva = pose.Eva,
+                shipX = sp.X,
+                shipY = sp.Y,
+                shipZ = sp.Z,
+                yaw = pose.Yaw,
+                eva = pose.Eva,
                 entities = instance.Entities
                     .OrderBy(e => e.Position.DistanceSquared(sp))
                     .Take(40)
                     .Select(e => new
                     {
-                        e.Id, kind = e.Kind.ToString(), e.Name, e.Hostile, species = e.SpeciesId,
-                        e.Hull, e.HullMax,
+                        e.Id,
+                        kind = e.Kind.ToString(),
+                        e.Name,
+                        e.Hostile,
+                        species = e.SpeciesId,
+                        e.Hull,
+                        e.HullMax,
                         dist = (float)Math.Sqrt(e.Position.DistanceSquared(sp)),
-                        x = e.Position.X, y = e.Position.Y, z = e.Position.Z,
+                        x = e.Position.X,
+                        y = e.Position.Y,
+                        z = e.Position.Z,
                     }).ToList(),
             };
         }
@@ -144,35 +160,35 @@ public sealed partial class GameServer
             // Detailed non-air blocks in a tight box...
             int px = (int)Math.Floor(p.Position.X), py = (int)Math.Floor(p.Position.Y), pz = (int)Math.Floor(p.Position.Z);
             for (int dx = -4; dx <= 4; dx++)
-            for (int dy = -2; dy <= 4; dy++)
-            for (int dz = -4; dz <= 4; dz++)
-            {
-                var id = _world.GetBlock(new Vector3i(px + dx, py + dy, pz + dz));
-                if (id.IsAir)
-                {
-                    continue;
-                }
+                for (int dy = -2; dy <= 4; dy++)
+                    for (int dz = -4; dz <= 4; dz++)
+                    {
+                        var id = _world.GetBlock(new Vector3i(px + dx, py + dy, pz + dz));
+                        if (id.IsAir)
+                        {
+                            continue;
+                        }
 
-                blocks.Add(new { x = px + dx, y = py + dy, z = pz + dz, block = _content.BlockById(id)?.Key ?? id.Value.ToString() });
-            }
+                        blocks.Add(new { x = px + dx, y = py + dy, z = pz + dz, block = _content.BlockById(id)?.Key ?? id.Value.ToString() });
+                    }
 
             // ...plus a wider, compact census (block-type → count) so terrain + voxel flora composition
             // (trees/leaves/planted crops) is captured without listing every cell. NB: small client-side
             // billboard undergrowth is procedural and not server voxel data, so it can't appear here.
             var tally = new Dictionary<string, int>();
             for (int dx = -12; dx <= 12; dx++)
-            for (int dz = -12; dz <= 12; dz++)
-            for (int dy = -4; dy <= 8; dy++)
-            {
-                var id = _world.GetBlock(new Vector3i(px + dx, py + dy, pz + dz));
-                if (id.IsAir)
-                {
-                    continue;
-                }
+                for (int dz = -12; dz <= 12; dz++)
+                    for (int dy = -4; dy <= 8; dy++)
+                    {
+                        var id = _world.GetBlock(new Vector3i(px + dx, py + dy, pz + dz));
+                        if (id.IsAir)
+                        {
+                            continue;
+                        }
 
-                string key = _content.BlockById(id)?.Key ?? id.Value.ToString();
-                tally[key] = tally.TryGetValue(key, out var n) ? n + 1 : 1;
-            }
+                        string key = _content.BlockById(id)?.Key ?? id.Value.ToString();
+                        tally[key] = tally.TryGetValue(key, out var n) ? n + 1 : 1;
+                    }
 
             census = tally.OrderByDescending(kv => kv.Value)
                 .Select(kv => (object)new { block = kv.Key, count = kv.Value }).ToList();
@@ -210,13 +226,30 @@ public sealed partial class GameServer
                 location = new { system = systemName, planet = planetName, activeLocationId = _meta.ActiveLocationId, planetType = _meta.DefaultPlanetType },
                 player = new
                 {
-                    p.PlayerId, p.Name,
-                    x = p.Position.X, y = p.Position.Y, z = p.Position.Z, p.Yaw, p.Pitch,
-                    p.Health, p.Oxygen, energy = p.SuitEnergy, p.Hunger,
-                    aboardShip = p.AboardShip, station = CurrentStationName(p.PlayerId),
-                    currentLocation = p.CurrentLocationId, inEva = p.InEva, aboveAtmosphere = p.AboveAtmosphere, inSpace,
-                    role = p.Role.ToString(), p.GodMode, p.Fly, p.Stealthed,
-                    selectedHotbarSlot = p.SelectedHotbarSlot, inventory, rations,
+                    p.PlayerId,
+                    p.Name,
+                    x = p.Position.X,
+                    y = p.Position.Y,
+                    z = p.Position.Z,
+                    p.Yaw,
+                    p.Pitch,
+                    p.Health,
+                    p.Oxygen,
+                    energy = p.SuitEnergy,
+                    p.Hunger,
+                    aboardShip = p.AboardShip,
+                    station = CurrentStationName(p.PlayerId),
+                    currentLocation = p.CurrentLocationId,
+                    inEva = p.InEva,
+                    aboveAtmosphere = p.AboveAtmosphere,
+                    inSpace,
+                    role = p.Role.ToString(),
+                    p.GodMode,
+                    p.Fly,
+                    p.Stealthed,
+                    selectedHotbarSlot = p.SelectedHotbarSlot,
+                    inventory,
+                    rations,
                 },
                 environment = BuildEnvironment(p.Position), // the player's local biome weather
                 ship = new { _ship.ShipType, _ship.Hull, hullMax = _shipHullMax, _ship.Shield, shieldMax = _shipShieldMax, modules = _ship.Modules },

--- a/src/BlocksBeyondTheStars.GameServer/GameServerCreatures.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerCreatures.cs
@@ -689,14 +689,14 @@ public sealed partial class GameServer
 
         int x = (int)System.Math.Floor(at.X), y = (int)System.Math.Floor(at.Y), z = (int)System.Math.Floor(at.Z);
         for (int dx = -r; dx <= r; dx++)
-        for (int dz = -r; dz <= r; dz++)
-        for (int dy = -1; dy <= 1; dy++)
-        {
-            if (_world.GetBlock(new Vector3i(x + dx, y + dy, z + dz)).Value == _creatureWaterId)
-            {
-                return true;
-            }
-        }
+            for (int dz = -r; dz <= r; dz++)
+                for (int dy = -1; dy <= 1; dy++)
+                {
+                    if (_world.GetBlock(new Vector3i(x + dx, y + dy, z + dz)).Value == _creatureWaterId)
+                    {
+                        return true;
+                    }
+                }
 
         return false;
     }

--- a/src/BlocksBeyondTheStars.GameServer/GameServerEnemies.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerEnemies.cs
@@ -150,25 +150,55 @@ public sealed partial class GameServer
     private static readonly LocomotionProfile RobotProfile = new()
     {
         Style = LocomotionStyle.Prowler,
-        CruiseSpeed = EnemyWanderSpeed, BurstSpeed = EnemyHuntSpeed, Accel = 3.0f, TurnRate = 1.8f,
-        HoldMin = 3.0f, HoldMax = 7.0f, PauseChance = 0.5f, PauseMin = 1.0f, PauseMax = 2.5f,
-        WeaveAmp = 0.12f, WeaveFreq = 0.8f, VertAmp = 0f, VertFreq = 0f,
+        CruiseSpeed = EnemyWanderSpeed,
+        BurstSpeed = EnemyHuntSpeed,
+        Accel = 3.0f,
+        TurnRate = 1.8f,
+        HoldMin = 3.0f,
+        HoldMax = 7.0f,
+        PauseChance = 0.5f,
+        PauseMin = 1.0f,
+        PauseMax = 2.5f,
+        WeaveAmp = 0.12f,
+        WeaveFreq = 0.8f,
+        VertAmp = 0f,
+        VertFreq = 0f,
     };
 
     private static readonly LocomotionProfile ToughRobotProfile = new()
     {
         Style = LocomotionStyle.Prowler,
-        CruiseSpeed = EnemyWanderSpeed, BurstSpeed = EnemyToughHuntSpeed, Accel = 3.4f, TurnRate = 2.0f,
-        HoldMin = 3.0f, HoldMax = 7.0f, PauseChance = 0.45f, PauseMin = 0.8f, PauseMax = 2.0f,
-        WeaveAmp = 0.12f, WeaveFreq = 0.8f, VertAmp = 0f, VertFreq = 0f,
+        CruiseSpeed = EnemyWanderSpeed,
+        BurstSpeed = EnemyToughHuntSpeed,
+        Accel = 3.4f,
+        TurnRate = 2.0f,
+        HoldMin = 3.0f,
+        HoldMax = 7.0f,
+        PauseChance = 0.45f,
+        PauseMin = 0.8f,
+        PauseMax = 2.0f,
+        WeaveAmp = 0.12f,
+        WeaveFreq = 0.8f,
+        VertAmp = 0f,
+        VertFreq = 0f,
     };
 
     private static readonly LocomotionProfile DroneProfile = new()
     {
         Style = LocomotionStyle.Glider,
-        CruiseSpeed = EnemyWanderSpeed * 1.3f, BurstSpeed = EnemyHuntSpeed, Accel = 5.0f, TurnRate = 3.5f,
-        HoldMin = 2.0f, HoldMax = 4.5f, PauseChance = 0.25f, PauseMin = 0.6f, PauseMax = 1.5f,
-        WeaveAmp = 0.25f, WeaveFreq = 1.1f, VertAmp = 0.6f, VertFreq = 1.4f, // hover bob
+        CruiseSpeed = EnemyWanderSpeed * 1.3f,
+        BurstSpeed = EnemyHuntSpeed,
+        Accel = 5.0f,
+        TurnRate = 3.5f,
+        HoldMin = 2.0f,
+        HoldMax = 4.5f,
+        PauseChance = 0.25f,
+        PauseMin = 0.6f,
+        PauseMax = 1.5f,
+        WeaveAmp = 0.25f,
+        WeaveFreq = 1.1f,
+        VertAmp = 0.6f,
+        VertFreq = 1.4f, // hover bob
     };
 
     private const float DroneStandoff = 7f;     // a hunting drone hovers this far from the player rather than ramming

--- a/src/BlocksBeyondTheStars.GameServer/GameServerGadgets.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerGadgets.cs
@@ -173,48 +173,48 @@ public sealed partial class GameServer
             (int)System.Math.Floor(target.X), (int)System.Math.Floor(target.Y), (int)System.Math.Floor(target.Z)), _world.Circumference);
 
         for (int dx = -BlasterRadius; dx <= BlasterRadius; dx++)
-        for (int dy = -BlasterRadius; dy <= BlasterRadius; dy++)
-        for (int dz = -BlasterRadius; dz <= BlasterRadius; dz++)
-        {
-            if (dx * dx + dy * dy + dz * dz > BlasterRadius * BlasterRadius)
-            {
-                continue; // carve a sphere, not a cube
-            }
+            for (int dy = -BlasterRadius; dy <= BlasterRadius; dy++)
+                for (int dz = -BlasterRadius; dz <= BlasterRadius; dz++)
+                {
+                    if (dx * dx + dy * dy + dz * dz > BlasterRadius * BlasterRadius)
+                    {
+                        continue; // carve a sphere, not a cube
+                    }
 
-            var p = WorldConstants.CanonicalBlock(new Vector3i(center.X + dx, center.Y + dy, center.Z + dz), _world.Circumference);
-            var b = _world.GetBlock(p);
-            if (b.IsAir || IsShipBlock(p) || IsSettlementBlock(p) || IsStationBlock(p)
-                || IsBaseProtected(p, session.State.PlayerId, session.State.IsAdmin))
-            {
-                continue;
-            }
+                    var p = WorldConstants.CanonicalBlock(new Vector3i(center.X + dx, center.Y + dy, center.Z + dz), _world.Circumference);
+                    var b = _world.GetBlock(p);
+                    if (b.IsAir || IsShipBlock(p) || IsSettlementBlock(p) || IsStationBlock(p)
+                        || IsBaseProtected(p, session.State.PlayerId, session.State.IsAdmin))
+                    {
+                        continue;
+                    }
 
-            var d = _world.Definition(b);
-            if (d is null || !d.Mineable)
-            {
-                continue; // leave bedrock / indestructible blocks intact
-            }
+                    var d = _world.Definition(b);
+                    if (d is null || !d.Mineable)
+                    {
+                        continue; // leave bedrock / indestructible blocks intact
+                    }
 
-            _world.SetBlock(p, BlockId.Air);
-            _miningProgress.Remove(p);
-            BroadcastToWorld(new BlockChanged { X = p.X, Y = p.Y, Z = p.Z, Block = BlockId.AirValue });
-            if (d.Key == "radio_beacon")
-            {
-                RemoveBeaconAt(p); // don't orphan a blasted beacon's label/marker (item 37)
-            }
-            if (d.Key == "base_core")
-            {
-                RemoveBaseAt(p); // don't orphan a blasted base's claim/marker (Grundstein)
-            }
-            if (d.Key == "beam_block")
-            {
-                RemoveBeamAt(p); // don't orphan a blasted beam block's name/marker (teleporter pad)
-            }
-            if (IsFluid(b.Value) || HasFluidNeighbor(p))
-            {
-                OnFluidRemoved(p); // a hole opened in/under water or lava refills
-            }
-        }
+                    _world.SetBlock(p, BlockId.Air);
+                    _miningProgress.Remove(p);
+                    BroadcastToWorld(new BlockChanged { X = p.X, Y = p.Y, Z = p.Z, Block = BlockId.AirValue });
+                    if (d.Key == "radio_beacon")
+                    {
+                        RemoveBeaconAt(p); // don't orphan a blasted beacon's label/marker (item 37)
+                    }
+                    if (d.Key == "base_core")
+                    {
+                        RemoveBaseAt(p); // don't orphan a blasted base's claim/marker (Grundstein)
+                    }
+                    if (d.Key == "beam_block")
+                    {
+                        RemoveBeamAt(p); // don't orphan a blasted beam block's name/marker (teleporter pad)
+                    }
+                    if (IsFluid(b.Value) || HasFluidNeighbor(p))
+                    {
+                        OnFluidRemoved(p); // a hole opened in/under water or lava refills
+                    }
+                }
     }
 
     /// <summary>Terrain scanner (Feature 40): scans a sphere around the player for valuable blocks (ores,
@@ -238,34 +238,37 @@ public sealed partial class GameServer
 
         var hits = new List<(Vector3i Pos, ushort Block, int DistSq)>();
         for (int dx = -radius; dx <= radius; dx++)
-        for (int dy = -radius; dy <= radius; dy++)
-        for (int dz = -radius; dz <= radius; dz++)
-        {
-            int distSq = dx * dx + dy * dy + dz * dz;
-            if (distSq > radius * radius)
-            {
-                continue; // a pulse sphere, not a cube
-            }
+            for (int dy = -radius; dy <= radius; dy++)
+                for (int dz = -radius; dz <= radius; dz++)
+                {
+                    int distSq = dx * dx + dy * dy + dz * dz;
+                    if (distSq > radius * radius)
+                    {
+                        continue; // a pulse sphere, not a cube
+                    }
 
-            var cell = WorldConstants.CanonicalBlock(new Vector3i(centre.X + dx, centre.Y + dy, centre.Z + dz), _world.Circumference);
-            var b = _world.GetBlock(cell);
-            if (b.IsAir)
-            {
-                continue;
-            }
+                    var cell = WorldConstants.CanonicalBlock(new Vector3i(centre.X + dx, centre.Y + dy, centre.Z + dz), _world.Circumference);
+                    var b = _world.GetBlock(cell);
+                    if (b.IsAir)
+                    {
+                        continue;
+                    }
 
-            if (IsValuableBlock(_world.Definition(b)?.Key))
-            {
-                hits.Add((cell, b.Value, distSq));
-            }
-        }
+                    if (IsValuableBlock(_world.Definition(b)?.Key))
+                    {
+                        hits.Add((cell, b.Value, distSq));
+                    }
+                }
 
         // Nearest finds first; cap so an ore-rich world doesn't flood the message.
         hits.Sort((a, b2) => a.DistSq.CompareTo(b2.DistSq));
         int n = System.Math.Min(hits.Count, ScannerMaxHits);
         var result = new OreScanResult
         {
-            X = new int[n], Y = new int[n], Z = new int[n], Block = new ushort[n],
+            X = new int[n],
+            Y = new int[n],
+            Z = new int[n],
+            Block = new ushort[n],
             Seconds = ScannerSeconds,
         };
         for (int i = 0; i < n; i++)

--- a/src/BlocksBeyondTheStars.GameServer/GameServerNpcs.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerNpcs.cs
@@ -26,10 +26,19 @@ public sealed partial class GameServer
     private static readonly LocomotionProfile NpcProfile = new()
     {
         Style = LocomotionStyle.Grazer,
-        CruiseSpeed = 0.7f, BurstSpeed = 0.9f, Accel = 2.5f, TurnRate = 3.0f,
-        HoldMin = 1.2f, HoldMax = 3.0f,
-        PauseChance = 0.6f, PauseMin = 2.0f, PauseMax = 5.0f,
-        WeaveAmp = 0.15f, WeaveFreq = 1.0f, VertAmp = 0f, VertFreq = 0f,
+        CruiseSpeed = 0.7f,
+        BurstSpeed = 0.9f,
+        Accel = 2.5f,
+        TurnRate = 3.0f,
+        HoldMin = 1.2f,
+        HoldMax = 3.0f,
+        PauseChance = 0.6f,
+        PauseMin = 2.0f,
+        PauseMax = 5.0f,
+        WeaveAmp = 0.15f,
+        WeaveFreq = 1.0f,
+        VertAmp = 0f,
+        VertFreq = 0f,
     };
 
     /// <summary>A settlement inhabitant. Lives only on the server; the client sees a <c>NetNpc</c>.</summary>

--- a/src/BlocksBeyondTheStars.GameServer/GameServerSettlements.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerSettlements.cs
@@ -201,8 +201,14 @@ public sealed partial class GameServer
             string name = UniqueName(SettlementDisplayName(tier, ruined, ir), usedNames);
             placed.Add(new PlacedSettlement
             {
-                Structure = structure, Origin = origin, GroundY = groundY,
-                Tier = tier, Ruined = ruined, OnIsland = onIsland, Name = name, Rng = ir,
+                Structure = structure,
+                Origin = origin,
+                GroundY = groundY,
+                Tier = tier,
+                Ruined = ruined,
+                OnIsland = onIsland,
+                Name = name,
+                Rng = ir,
             });
             reserved.Add((origin.X + structure.Width / 2, origin.Z + structure.Length / 2,
                 structure.Width / 2 + 1, structure.Length / 2 + 1));
@@ -283,35 +289,35 @@ public sealed partial class GameServer
         // 1) Clear any terrain occupying the build volume above the foundation, so a hill never buries the
         //    buildings (the structure's own air cells are otherwise left as whatever was there).
         for (int x = 0; x < s.Width; x++)
-        for (int z = 0; z < s.Length; z++)
-        for (int y = 1; y < s.Height; y++)
-        {
-            _world.SetBlock(new Vector3i(origin.X + x, gy + y, origin.Z + z), BlockId.Air);
-        }
+            for (int z = 0; z < s.Length; z++)
+                for (int y = 1; y < s.Height; y++)
+                {
+                    _world.SetBlock(new Vector3i(origin.X + x, gy + y, origin.Z + z), BlockId.Air);
+                }
 
         // 2) Flatten a foundation slab at ground level across the footprint (so it sits flush).
         if (!foundationId.IsAir)
         {
             for (int x = 0; x < s.Width; x++)
-            for (int z = 0; z < s.Length; z++)
-            {
-                _world.SetBlock(new Vector3i(origin.X + x, gy, origin.Z + z), foundationId);
-            }
+                for (int z = 0; z < s.Length; z++)
+                {
+                    _world.SetBlock(new Vector3i(origin.X + x, gy, origin.Z + z), foundationId);
+                }
         }
 
         // 3) Stamp the structure above the foundation (y=0 of the structure is the foundation row).
         for (int x = 0; x < s.Width; x++)
-        for (int y = 0; y < s.Height; y++)
-        for (int z = 0; z < s.Length; z++)
-        {
-            ushort b = s.Get(x, y, z);
-            if (b != 0)
-            {
-                var (tint, glow) = s.GetModifier(x, y, z);
-                _world.SetBlock(new Vector3i(origin.X + x, gy + y, origin.Z + z),
-                    new BlockId(b), tint, glow, s.GetShape(x, y, z));
-            }
-        }
+            for (int y = 0; y < s.Height; y++)
+                for (int z = 0; z < s.Length; z++)
+                {
+                    ushort b = s.Get(x, y, z);
+                    if (b != 0)
+                    {
+                        var (tint, glow) = s.GetModifier(x, y, z);
+                        _world.SetBlock(new Vector3i(origin.X + x, gy + y, origin.Z + z),
+                            new BlockId(b), tint, glow, s.GetShape(x, y, z));
+                    }
+                }
     }
 
     // --- placement allocator -------------------------------------------------------------------------------
@@ -584,7 +590,14 @@ public sealed partial class GameServer
 
     private static string Roman(int n) => n switch
     {
-        2 => "II", 3 => "III", 4 => "IV", 5 => "V", 6 => "VI", 7 => "VII", 8 => "VIII", 9 => "IX",
+        2 => "II",
+        3 => "III",
+        4 => "IV",
+        5 => "V",
+        6 => "VI",
+        7 => "VII",
+        8 => "VIII",
+        9 => "IX",
         _ => n.ToString(),
     };
 

--- a/src/BlocksBeyondTheStars.GameServer/GameServerShipStructure.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerShipStructure.cs
@@ -129,12 +129,16 @@ public sealed partial class GameServer
             PlayerId = ownerId,
             StructureId = s.Id,
             Removed = removed,
-            OriginX = rec.Origin.X, OriginY = rec.Origin.Y, OriginZ = rec.Origin.Z,
+            OriginX = rec.Origin.X,
+            OriginY = rec.Origin.Y,
+            OriginZ = rec.Origin.Z,
             // A landed NPC trader has no session; resolve its hull tint from the trader registry instead.
             Hull = ownerId.StartsWith("npc:", System.StringComparison.Ordinal)
                 ? NpcLandedHull(ownerId)
                 : FindSessionByPlayerId(ownerId)?.HullColor ?? 0,
-            Width = s.Width, Height = s.Height, Length = s.Length,
+            Width = s.Width,
+            Height = s.Height,
+            Length = s.Length,
         };
 
         if (!removed)
@@ -176,11 +180,11 @@ public sealed partial class GameServer
         // Re-stream the affected chunks to everyone on this world so stale hull blocks vanish client-side.
         var seen = new HashSet<ChunkCoord>();
         for (int x = min.X; x <= max.X; x += WorldConstants.ChunkSize)
-        for (int y = min.Y; y <= max.Y; y += WorldConstants.ChunkSize)
-        for (int z = min.Z; z <= max.Z; z += WorldConstants.ChunkSize)
-        {
-            seen.Add(WorldConstants.CanonicalChunk(WorldConstants.WorldToChunk(new Vector3i(x, y, z)), _world.Circumference));
-        }
+            for (int y = min.Y; y <= max.Y; y += WorldConstants.ChunkSize)
+                for (int z = min.Z; z <= max.Z; z += WorldConstants.ChunkSize)
+                {
+                    seen.Add(WorldConstants.CanonicalChunk(WorldConstants.WorldToChunk(new Vector3i(x, y, z)), _world.Circumference));
+                }
 
         seen.Add(WorldConstants.CanonicalChunk(WorldConstants.WorldToChunk(max), _world.Circumference));
         foreach (var session in JoinedInActiveWorld())
@@ -231,7 +235,10 @@ public sealed partial class GameServer
         {
             Stations = _stations.Select(s => new NetShipStation
             {
-                Type = s.Type, X = s.Pos.X, Y = s.Pos.Y, Z = s.Pos.Z,
+                Type = s.Type,
+                X = s.Pos.X,
+                Y = s.Pos.Y,
+                Z = s.Pos.Z,
             }).ToArray(),
         });
     }

--- a/src/BlocksBeyondTheStars.GameServer/GameServerSpaceStations.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerSpaceStations.cs
@@ -440,17 +440,17 @@ public sealed partial class GameServer
         _repo.RunInTransaction(() =>
         {
             for (int x = 0; x < structure.Width; x++)
-            for (int y = 0; y < structure.Height; y++)
-            for (int z = 0; z < structure.Length; z++)
-            {
-                ushort b = structure.Get(x, y, z);
-                if (b != 0)
-                {
-                    var (tint, glow) = structure.GetModifier(x, y, z);
-                    _world.SetBlock(new Vector3i(station.Origin.X + x, station.Origin.Y + y, station.Origin.Z + z),
-                        new BlockId(b), tint, glow, structure.GetShape(x, y, z));
-                }
-            }
+                for (int y = 0; y < structure.Height; y++)
+                    for (int z = 0; z < structure.Length; z++)
+                    {
+                        ushort b = structure.Get(x, y, z);
+                        if (b != 0)
+                        {
+                            var (tint, glow) = structure.GetModifier(x, y, z);
+                            _world.SetBlock(new Vector3i(station.Origin.X + x, station.Origin.Y + y, station.Origin.Z + z),
+                                new BlockId(b), tint, glow, structure.GetShape(x, y, z));
+                        }
+                    }
         });
 
         station.Markers.Clear();
@@ -481,10 +481,10 @@ public sealed partial class GameServer
         {
             var sp = station.Spawn.ToBlock();
             for (int dx = -1; dx <= 1; dx++)
-            for (int dz = -1; dz <= 1; dz++)
-            {
-                _world.SetBlock(new Vector3i(sp.X + dx, sp.Y - 1, sp.Z + dz), hull); // floor pad
-            }
+                for (int dz = -1; dz <= 1; dz++)
+                {
+                    _world.SetBlock(new Vector3i(sp.X + dx, sp.Y - 1, sp.Z + dz), hull); // floor pad
+                }
 
             _world.SetBlock(sp, BlockId.Air);                                   // stand-in space
             _world.SetBlock(new Vector3i(sp.X, sp.Y + 1, sp.Z), BlockId.Air);   // headroom

--- a/src/BlocksBeyondTheStars.GameServer/GameServerSpaceStructure.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerSpaceStructure.cs
@@ -193,14 +193,14 @@ public sealed partial class GameServer
             // Guarantee a flush, solid floor across the footprint (fills layout gaps) so the player never
             // falls out of the walkable interior — mirrors the old stamped-ship floor guarantee.
             for (int fx = 0; fx < layout.Width; fx++)
-            for (int fz = 0; fz < layout.Length; fz++)
-            {
-                var fp = new Vector3i(fx, 0, fz);
-                if (s.Get(fp).IsAir)
+                for (int fz = 0; fz < layout.Length; fz++)
                 {
-                    s.Set(fp, wall);
+                    var fp = new Vector3i(fx, 0, fz);
+                    if (s.Get(fp).IsAir)
+                    {
+                        s.Set(fp, wall);
+                    }
                 }
-            }
 
             FinishShipStructure(s, persistEdits);
             return s;
@@ -215,27 +215,27 @@ public sealed partial class GameServer
         s.Height = height + 1;
         s.Length = halfZ * 2 + 1;
         for (int x = 0; x <= halfX * 2; x++)
-        for (int y = 0; y <= height; y++)
-        for (int z = 0; z <= halfZ * 2; z++)
-        {
-            bool shell = x == 0 || x == halfX * 2 || y == 0 || y == height || z == 0 || z == halfZ * 2;
-            if (!shell)
-            {
-                continue; // hollow interior
-            }
+            for (int y = 0; y <= height; y++)
+                for (int z = 0; z <= halfZ * 2; z++)
+                {
+                    bool shell = x == 0 || x == halfX * 2 || y == 0 || y == height || z == 0 || z == halfZ * 2;
+                    if (!shell)
+                    {
+                        continue; // hollow interior
+                    }
 
-            bool door = z == 0 && (x == halfX - 1 || x == halfX || x == halfX + 1) && (y == 1 || y == 2);
-            if (door)
-            {
-                continue; // rear hatch opening (a slide door fills it, see DoorCells below)
-            }
+                    bool door = z == 0 && (x == halfX - 1 || x == halfX || x == halfX + 1) && (y == 1 || y == 2);
+                    if (door)
+                    {
+                        continue; // rear hatch opening (a slide door fills it, see DoorCells below)
+                    }
 
-            // Window panes at eye height: a band along the front (+Z) and both side walls (matching the
-            // old stamped box ship), so the cabin has proper windows to see out of.
-            bool frontWin = z == halfZ * 2 && y == 2 && x > 0 && x < halfX * 2;
-            bool sideWin = (x == 0 || x == halfX * 2) && y == 2 && z > 0 && z < halfZ * 2;
-            s.Set(new Vector3i(x, y, z), frontWin || sideWin ? glass : wall);
-        }
+                    // Window panes at eye height: a band along the front (+Z) and both side walls (matching the
+                    // old stamped box ship), so the cabin has proper windows to see out of.
+                    bool frontWin = z == halfZ * 2 && y == 2 && x > 0 && x < halfX * 2;
+                    bool sideWin = (x == 0 || x == halfX * 2) && y == 2 && z > 0 && z < halfZ * 2;
+                    s.Set(new Vector3i(x, y, z), frontWin || sideWin ? glass : wall);
+                }
 
         // The rear hatch gets a real door (server-authoritative slide door at the opening's centre column).
         s.DoorCells.Add(new Vector3i(halfX, 1, 0));
@@ -345,14 +345,14 @@ public sealed partial class GameServer
             }
 
             for (int x = cell.X - 1; x <= cell.X + 1; x++)
-            for (int z = cell.Z - 1; z <= cell.Z + 1; z++)
-            {
-                var p = new Vector3i(x, cell.Y - 1, z);
-                if (!s.Get(p).IsAir)
+                for (int z = cell.Z - 1; z <= cell.Z + 1; z++)
                 {
-                    s.Set(p, accent.NumericId);
+                    var p = new Vector3i(x, cell.Y - 1, z);
+                    if (!s.Get(p).IsAir)
+                    {
+                        s.Set(p, accent.NumericId);
+                    }
                 }
-            }
         }
     }
 
@@ -462,7 +462,11 @@ public sealed partial class GameServer
 
             BroadcastToInstance(instance, new StructureBlockChanged
             {
-                StructureId = s.Id, X = pos.X, Y = pos.Y, Z = pos.Z, Block = BlockId.AirValue,
+                StructureId = s.Id,
+                X = pos.X,
+                Y = pos.Y,
+                Z = pos.Z,
+                Block = BlockId.AirValue,
             });
 
             // A fully mined-out asteroid is gone — remove its body + paired entity (the field respawns later).
@@ -531,7 +535,11 @@ public sealed partial class GameServer
 
         BroadcastToInstance(instance, new StructureBlockChanged
         {
-            StructureId = s.Id, X = pos.X, Y = pos.Y, Z = pos.Z, Block = blockDef.NumericId.Value,
+            StructureId = s.Id,
+            X = pos.X,
+            Y = pos.Y,
+            Z = pos.Z,
+            Block = blockDef.NumericId.Value,
         });
 
         // item 20 S4: building a hull + airlock around a station core commissions it (boardable + on the map);
@@ -610,7 +618,11 @@ public sealed partial class GameServer
 
             BroadcastToWorld(new StructureBlockChanged
             {
-                StructureId = s.Id, X = pos.X, Y = pos.Y, Z = pos.Z, Block = BlockId.AirValue,
+                StructureId = s.Id,
+                X = pos.X,
+                Y = pos.Y,
+                Z = pos.Z,
+                Block = BlockId.AirValue,
             });
             return;
         }
@@ -672,7 +684,11 @@ public sealed partial class GameServer
         _repo.SetStructureBlock(s.Id, pos, blockDef.NumericId.Value);
         BroadcastToWorld(new StructureBlockChanged
         {
-            StructureId = s.Id, X = pos.X, Y = pos.Y, Z = pos.Z, Block = blockDef.NumericId.Value,
+            StructureId = s.Id,
+            X = pos.X,
+            Y = pos.Y,
+            Z = pos.Z,
+            Block = blockDef.NumericId.Value,
         });
     }
 
@@ -792,24 +808,24 @@ public sealed partial class GameServer
         int r = AsteroidVoxelRadius;
         int rSq = r * r;
         for (int x = -r; x <= r; x++)
-        for (int y = -r; y <= r; y++)
-        for (int z = -r; z <= r; z++)
-        {
-            int dSq = x * x + y * y + z * z;
-            if (dSq > rSq)
-            {
-                continue; // carve to a rough sphere
-            }
+            for (int y = -r; y <= r; y++)
+                for (int z = -r; z <= r; z++)
+                {
+                    int dSq = x * x + y * y + z * z;
+                    if (dSq > rSq)
+                    {
+                        continue; // carve to a rough sphere
+                    }
 
-            // A titanium core, an iron/copper shell, a little stone — a deterministic veined mix.
-            BlockId block;
-            if (dSq <= 1) { block = titanium; }
-            else if (((x + y + z) & 3) == 0) { block = copper; }
-            else if (((x + y + z) & 1) == 0) { block = stone; }
-            else { block = iron; }
+                    // A titanium core, an iron/copper shell, a little stone — a deterministic veined mix.
+                    BlockId block;
+                    if (dSq <= 1) { block = titanium; }
+                    else if (((x + y + z) & 3) == 0) { block = copper; }
+                    else if (((x + y + z) & 1) == 0) { block = stone; }
+                    else { block = iron; }
 
-            s.Set(new Vector3i(x, y, z), block);
-        }
+                    s.Set(new Vector3i(x, y, z), block);
+                }
 
         s.Width = s.Height = s.Length = r * 2 + 1;
         return s;
@@ -878,7 +894,11 @@ public sealed partial class GameServer
             s.Set(c, BlockId.Air);
             BroadcastToInstance(instance, new StructureBlockChanged
             {
-                StructureId = s.Id, X = c.X, Y = c.Y, Z = c.Z, Block = BlockId.AirValue,
+                StructureId = s.Id,
+                X = c.X,
+                Y = c.Y,
+                Z = c.Z,
+                Block = BlockId.AirValue,
             });
         }
     }

--- a/src/BlocksBeyondTheStars.GameServer/GameServerSpaceTraders.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerSpaceTraders.cs
@@ -732,7 +732,13 @@ public sealed partial class GameServer
 
             msg ??= new ShipTransitFx
             {
-                PlayerId = lt.OwnerId, Name = lt.Name, X = at.X, Y = at.Y, Z = at.Z, Landing = landing, Hull = lt.HullRgb,
+                PlayerId = lt.OwnerId,
+                Name = lt.Name,
+                X = at.X,
+                Y = at.Y,
+                Z = at.Z,
+                Landing = landing,
+                Hull = lt.HullRgb,
             };
             design ??= BuildNpcShipStructure(lt.StructureId, lt.ShipType);
             SendShipDesign(session, design, "ship_remote");

--- a/src/BlocksBeyondTheStars.GameServer/GameServerStoryFinale.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerStoryFinale.cs
@@ -170,24 +170,24 @@ public sealed partial class GameServer
         // plated floor.
         const int R = 5;
         for (int dx = -R; dx <= R; dx++)
-        for (int dz = -R; dz <= R; dz++)
-        for (int dy = -1; dy <= 6; dy++)
-        {
-            var p = new Vector3i(WorldConstants.WrapX(ax + dx, _world.Circumference), floorY + dy, az + dz);
-            bool wall = dx == -R || dx == R || dz == -R || dz == R;
-            if (dy == -1)
-            {
-                _world.SetBlock(p, floorBlk); // plated walkable floor
-            }
-            else if (dy == 6 || wall)
-            {
-                _world.SetBlock(p, shell);
-            }
-            else
-            {
-                _world.SetBlock(p, BlockId.Air);
-            }
-        }
+            for (int dz = -R; dz <= R; dz++)
+                for (int dy = -1; dy <= 6; dy++)
+                {
+                    var p = new Vector3i(WorldConstants.WrapX(ax + dx, _world.Circumference), floorY + dy, az + dz);
+                    bool wall = dx == -R || dx == R || dz == -R || dz == R;
+                    if (dy == -1)
+                    {
+                        _world.SetBlock(p, floorBlk); // plated walkable floor
+                    }
+                    else if (dy == 6 || wall)
+                    {
+                        _world.SetBlock(p, shell);
+                    }
+                    else
+                    {
+                        _world.SetBlock(p, BlockId.Air);
+                    }
+                }
 
         // Glow strips: red lights set into the middle of each wall at eye level.
         if (!core.IsAir)
@@ -201,10 +201,10 @@ public sealed partial class GameServer
         // The dormant core: a glowing red heart on a plated pedestal, framed by four metal pillars and glass
         // windows — the terminal the player breaches (centre of the chamber).
         for (int dx = -1; dx <= 1; dx++)
-        for (int dz = -1; dz <= 1; dz++)
-        {
-            _world.SetBlock(new Vector3i(WorldConstants.WrapX(ax + dx, _world.Circumference), floorY, az + dz), frame);
-        }
+            for (int dz = -1; dz <= 1; dz++)
+            {
+                _world.SetBlock(new Vector3i(WorldConstants.WrapX(ax + dx, _world.Circumference), floorY, az + dz), frame);
+            }
 
         if (!core.IsAir)
         {
@@ -237,26 +237,26 @@ public sealed partial class GameServer
         // +Z wall so you drop onto open floor (not onto the core) and walk in to the heart.
         int shaftZ = az + 3;
         for (int dy = floorY + 6; dy <= surfaceY + 1; dy++)
-        for (int dx = -1; dx <= 1; dx++)
-        for (int dz = -1; dz <= 1; dz++)
-        {
-            _world.SetBlock(new Vector3i(WorldConstants.WrapX(ax + dx, _world.Circumference), dy, shaftZ + dz), BlockId.Air);
-        }
+            for (int dx = -1; dx <= 1; dx++)
+                for (int dz = -1; dz <= 1; dz++)
+                {
+                    _world.SetBlock(new Vector3i(WorldConstants.WrapX(ax + dx, _world.Circumference), dy, shaftZ + dz), BlockId.Air);
+                }
 
         // A low ring of plating around the shaft mouth so the opening reads as the core's maw from the surface.
         for (int dx = -2; dx <= 2; dx++)
-        for (int dz = -2; dz <= 2; dz++)
-        {
-            if (System.Math.Abs(dx) != 2 && System.Math.Abs(dz) != 2)
+            for (int dz = -2; dz <= 2; dz++)
             {
-                continue;
-            }
+                if (System.Math.Abs(dx) != 2 && System.Math.Abs(dz) != 2)
+                {
+                    continue;
+                }
 
-            int rx = WorldConstants.WrapX(ax + dx, _world.Circumference);
-            int ry = _generator.SurfaceHeight(planet, rx, shaftZ + dz);
-            _world.SetBlock(new Vector3i(rx, ry + 1, shaftZ + dz), shell);
-            _world.SetBlock(new Vector3i(rx, ry + 2, shaftZ + dz), shell);
-        }
+                int rx = WorldConstants.WrapX(ax + dx, _world.Circumference);
+                int ry = _generator.SurfaceHeight(planet, rx, shaftZ + dz);
+                _world.SetBlock(new Vector3i(rx, ry + 1, shaftZ + dz), shell);
+                _world.SetBlock(new Vector3i(rx, ry + 2, shaftZ + dz), shell);
+            }
 
         _log.Info($"Stamped the Guardian core chamber on '{_world.LocationId}' at ({ax},{floorY},{az}).");
     }

--- a/src/BlocksBeyondTheStars.GameServer/GameServerVaults.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerVaults.cs
@@ -83,23 +83,23 @@ public sealed partial class GameServer
 
         // Chamber: a 9×9 outer shell (7×7 inside), 4 air-high, deepslate walls/floor/ceiling.
         for (int dx = -4; dx <= 4; dx++)
-        for (int dz = -4; dz <= 4; dz++)
-        for (int dy = -1; dy <= 4; dy++)
-        {
-            var p = new Vector3i(WorldConstants.WrapX(ax + dx, _world.Circumference), floorY + dy, az + dz);
-            bool isShell = dx is -4 or 4 || dz is -4 or 4 || dy is -1 or 4;
-            _world.SetBlock(p, isShell ? shell : BlockId.Air);
-        }
+            for (int dz = -4; dz <= 4; dz++)
+                for (int dy = -1; dy <= 4; dy++)
+                {
+                    var p = new Vector3i(WorldConstants.WrapX(ax + dx, _world.Circumference), floorY + dy, az + dz);
+                    bool isShell = dx is -4 or 4 || dz is -4 or 4 || dy is -1 or 4;
+                    _world.SetBlock(p, isShell ? shell : BlockId.Air);
+                }
 
         // Shaft: a 2×2 drop from the surface into the chamber's ceiling corner (the way in — bring a jetpack
         // or dig steps back out).
         for (int dy = floorY + 4; dy <= surfaceY + 1; dy++)
         {
             for (int dx = -1; dx <= 0; dx++)
-            for (int dz = -1; dz <= 0; dz++)
-            {
-                _world.SetBlock(new Vector3i(WorldConstants.WrapX(ax + dx, _world.Circumference), dy, az + dz), BlockId.Air);
-            }
+                for (int dz = -1; dz <= 0; dz++)
+                {
+                    _world.SetBlock(new Vector3i(WorldConstants.WrapX(ax + dx, _world.Circumference), dy, az + dz), BlockId.Air);
+                }
         }
 
         // Surface hint: a broken ring of weathered pillars (1–2 tall, some missing) around the shaft mouth.

--- a/src/BlocksBeyondTheStars.GameServer/GameServerWrecks.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerWrecks.cs
@@ -105,15 +105,15 @@ public sealed partial class GameServer
 
         // Stamp only the wreck's solid blocks (breaches stay as the existing terrain/air).
         for (int x = 0; x < structure.Width; x++)
-        for (int y = 0; y < structure.Height; y++)
-        for (int z = 0; z < structure.Length; z++)
-        {
-            ushort b = structure.Get(x, y, z);
-            if (b != 0)
-            {
-                _world.SetBlock(new Vector3i(ax + x, baseY + y, az + z), new BlockId(b));
-            }
-        }
+            for (int y = 0; y < structure.Height; y++)
+                for (int z = 0; z < structure.Length; z++)
+                {
+                    ushort b = structure.Get(x, y, z);
+                    if (b != 0)
+                    {
+                        _world.SetBlock(new Vector3i(ax + x, baseY + y, az + z), new BlockId(b));
+                    }
+                }
 
         _wreck = structure;
         _wreckName = WreckDisplayName(structure.Origin, design, rng);
@@ -275,28 +275,28 @@ public sealed partial class GameServer
         }
 
         for (int x = 0; x < _wreck.Width; x++)
-        for (int y = 0; y < _wreck.Height; y++)
-        for (int z = 0; z < _wreck.Length; z++)
-        {
-            ushort intact = _wreck.IntactAt(x, y, z);
-            if (intact == 0)
-            {
-                continue;
-            }
+            for (int y = 0; y < _wreck.Height; y++)
+                for (int z = 0; z < _wreck.Length; z++)
+                {
+                    ushort intact = _wreck.IntactAt(x, y, z);
+                    if (intact == 0)
+                    {
+                        continue;
+                    }
 
-            // The wreck anchor sits at a raw offset that can be negative; the actual blocks live in the
-            // canonical longitude space, so emit canonical breach positions (matches what the client renders).
-            var world = WorldConstants.CanonicalBlock(new Vector3i(_wreckOrigin.X + x, _wreckOrigin.Y + y, _wreckOrigin.Z + z), _world.Circumference);
-            if (_world.GetBlock(world).Value == intact)
-            {
-                continue;
-            }
+                    // The wreck anchor sits at a raw offset that can be negative; the actual blocks live in the
+                    // canonical longitude space, so emit canonical breach positions (matches what the client renders).
+                    var world = WorldConstants.CanonicalBlock(new Vector3i(_wreckOrigin.X + x, _wreckOrigin.Y + y, _wreckOrigin.Z + z), _world.Circumference);
+                    if (_world.GetBlock(world).Value == intact)
+                    {
+                        continue;
+                    }
 
-            if (_content.BlockById(new BlockId(intact)) is { } required)
-            {
-                yield return (world, required);
-            }
-        }
+                    if (_content.BlockById(new BlockId(intact)) is { } required)
+                    {
+                        yield return (world, required);
+                    }
+                }
     }
 
     private bool TryGetWreckRepairTarget(Vector3i world, out BlockDefinition required)

--- a/src/BlocksBeyondTheStars.Shared/Definitions/LocomotionController.cs
+++ b/src/BlocksBeyondTheStars.Shared/Definitions/LocomotionController.cs
@@ -206,15 +206,15 @@ public static class LocomotionController
         // base table per style: (cruiseFrac, burstFrac, turn, holdMin, holdMax, pauseChance, pauseMin, pauseMax, weaveAmp, weaveFreq, vertAmp, vertFreq)
         var b = sp.LocoStyle switch
         {
-            LocomotionStyle.Grazer    => (0.55f, 1.2f, 2.2f, 1.2f, 2.5f, 0.65f, 1.5f, 4.0f, 0.25f, 1.4f, 0f,    0f),
-            LocomotionStyle.Darter    => (1.00f, 1.6f, 4.5f, 0.5f, 1.4f, 0.55f, 0.4f, 1.2f, 0.35f, 2.6f, 0f,    0f),
-            LocomotionStyle.Prowler   => (0.60f, 1.4f, 2.4f, 2.0f, 4.0f, 0.45f, 1.0f, 2.5f, 0.15f, 1.0f, 0f,    0f),
-            LocomotionStyle.Hopper    => (0.90f, 1.3f, 3.0f, 0.5f, 1.0f, 0.55f, 0.5f, 1.2f, 0.10f, 1.0f, 0.55f, 3.0f),
-            LocomotionStyle.Drifter   => (0.50f, 1.0f, 1.2f, 2.5f, 5.0f, 0.25f, 1.5f, 3.5f, 0.40f, 0.6f, 0.25f, 0.8f),
-            LocomotionStyle.Slitherer => (0.80f, 1.2f, 2.6f, 2.0f, 4.5f, 0.15f, 0.8f, 2.0f, 0.60f, 2.2f, 0f,    0f),
-            LocomotionStyle.Glider    => (0.90f, 1.3f, 1.4f, 3.0f, 6.0f, 0.10f, 1.0f, 2.5f, 0.30f, 0.7f, 1.0f,  0.5f),
-            LocomotionStyle.Schooler  => (0.85f, 1.3f, 2.8f, 1.5f, 3.5f, 0.20f, 0.5f, 1.5f, 0.20f, 1.4f, 0.3f,  0.9f),
-            _                         => (0.85f, 1.3f, 2.0f, 2.5f, 5.0f, 0.20f, 0.6f, 1.5f, 0.18f, 1.2f, 0f,    0f), // Strider
+            LocomotionStyle.Grazer => (0.55f, 1.2f, 2.2f, 1.2f, 2.5f, 0.65f, 1.5f, 4.0f, 0.25f, 1.4f, 0f, 0f),
+            LocomotionStyle.Darter => (1.00f, 1.6f, 4.5f, 0.5f, 1.4f, 0.55f, 0.4f, 1.2f, 0.35f, 2.6f, 0f, 0f),
+            LocomotionStyle.Prowler => (0.60f, 1.4f, 2.4f, 2.0f, 4.0f, 0.45f, 1.0f, 2.5f, 0.15f, 1.0f, 0f, 0f),
+            LocomotionStyle.Hopper => (0.90f, 1.3f, 3.0f, 0.5f, 1.0f, 0.55f, 0.5f, 1.2f, 0.10f, 1.0f, 0.55f, 3.0f),
+            LocomotionStyle.Drifter => (0.50f, 1.0f, 1.2f, 2.5f, 5.0f, 0.25f, 1.5f, 3.5f, 0.40f, 0.6f, 0.25f, 0.8f),
+            LocomotionStyle.Slitherer => (0.80f, 1.2f, 2.6f, 2.0f, 4.5f, 0.15f, 0.8f, 2.0f, 0.60f, 2.2f, 0f, 0f),
+            LocomotionStyle.Glider => (0.90f, 1.3f, 1.4f, 3.0f, 6.0f, 0.10f, 1.0f, 2.5f, 0.30f, 0.7f, 1.0f, 0.5f),
+            LocomotionStyle.Schooler => (0.85f, 1.3f, 2.8f, 1.5f, 3.5f, 0.20f, 0.5f, 1.5f, 0.20f, 1.4f, 0.3f, 0.9f),
+            _ => (0.85f, 1.3f, 2.0f, 2.5f, 5.0f, 0.20f, 0.6f, 1.5f, 0.18f, 1.2f, 0f, 0f), // Strider
         };
 
         uint h = (uint)StableHash(sp.Id);

--- a/src/BlocksBeyondTheStars.WorldGeneration/SettlementGenerator.cs
+++ b/src/BlocksBeyondTheStars.WorldGeneration/SettlementGenerator.cs
@@ -218,65 +218,65 @@ public static class SettlementGenerator
         int buildings = 0;
         int plotIndex = 0;
         for (int cxp = 0; cxp < cols; cxp++)
-        for (int czp = 0; czp < rows; czp++)
-        {
-            // A village occasionally leaves a plot as an open square; a town fills them densely. The
-            // first plot is always built (so it carries the vendor / a guaranteed ruin loot cache).
-            bool skip = !town && plotIndex > 0 && rng.NextDouble() < 0.18;
-            if (skip)
+            for (int czp = 0; czp < rows; czp++)
             {
+                // A village occasionally leaves a plot as an open square; a town fills them densely. The
+                // first plot is always built (so it carries the vendor / a guaranteed ruin loot cache).
+                bool skip = !town && plotIndex > 0 && rng.NextDouble() < 0.18;
+                if (skip)
+                {
+                    plotIndex++;
+                    continue;
+                }
+
+                // Per-building variety: footprint, storeys, roof, door side, accent band.
+                int fp = Building - rng.Next(0, 3);                     // 4..6
+                int storeys = town ? (plotIndex == 0 ? floors : 1 + rng.Next(0, floors)) : 1;
+                int doorSide = rng.Next(0, 4);
+                // Desert settlements favour flat (adobe) roofs; elsewhere alien + half of houses are pitched.
+                int roofStyle = (!desert && (alien || rng.NextDouble() < 0.5)) ? 1 : 0;
+                int off = (Building - fp) / 2;
+                int ox = cxp * Plot + 1 + off;
+                int oz = czp * Plot + 1 + off;
+
+                StampBuilding(Set, ox, oz, fp, storeys, wall, accent, glass, ladder, doorSide, roofStyle, rng, ruined);
+                buildings++;
+
+                // A lamp post + a small garden beside the door, so streets feel inhabited.
+                DecorateAround(Set, ox, oz, fp, doorSide, lamp, flora, alien, rng);
+
+                // Interaction / spawn marker at the building's interior floor centre.
+                var centre = new Vector3i(ox + fp / 2, 1, oz + fp / 2);
+                if (!ruined)
+                {
+                    string role = plotIndex switch
+                    {
+                        0 => "vendor",
+                        1 => "mission_board",
+                        _ => "npc",
+                    };
+                    markers.Add(new SettlementMarker(role, centre));
+
+                    // A real door fills this building's doorway: a sci-fi slider for towns/cities, a hinged
+                    // door for villages/hamlets. Placed on the lower door column; the server probes the gap to
+                    // centre + size the door. (Ruins are abandoned — their doorways stay open.)
+                    int mid = fp / 2, w0 = System.Math.Max(1, mid - 1);
+                    var doorCell = doorSide switch
+                    {
+                        0 => new Vector3i(ox + w0, 1, oz),
+                        1 => new Vector3i(ox + w0, 1, oz + fp - 1),
+                        2 => new Vector3i(ox, 1, oz + w0),
+                        _ => new Vector3i(ox + fp - 1, 1, oz + w0),
+                    };
+                    markers.Add(new SettlementMarker(town ? "door_slide" : "door_hinge", doorCell));
+                }
+                else if (plotIndex == 0 || rng.NextDouble() < 0.6)
+                {
+                    markers.Add(new SettlementMarker("loot", centre)); // ruins: scavenge instead of services
+                }
+
                 plotIndex++;
-                continue;
             }
-
-            // Per-building variety: footprint, storeys, roof, door side, accent band.
-            int fp = Building - rng.Next(0, 3);                     // 4..6
-            int storeys = town ? (plotIndex == 0 ? floors : 1 + rng.Next(0, floors)) : 1;
-            int doorSide = rng.Next(0, 4);
-            // Desert settlements favour flat (adobe) roofs; elsewhere alien + half of houses are pitched.
-            int roofStyle = (!desert && (alien || rng.NextDouble() < 0.5)) ? 1 : 0;
-            int off = (Building - fp) / 2;
-            int ox = cxp * Plot + 1 + off;
-            int oz = czp * Plot + 1 + off;
-
-            StampBuilding(Set, ox, oz, fp, storeys, wall, accent, glass, ladder, doorSide, roofStyle, rng, ruined);
-            buildings++;
-
-            // A lamp post + a small garden beside the door, so streets feel inhabited.
-            DecorateAround(Set, ox, oz, fp, doorSide, lamp, flora, alien, rng);
-
-            // Interaction / spawn marker at the building's interior floor centre.
-            var centre = new Vector3i(ox + fp / 2, 1, oz + fp / 2);
-            if (!ruined)
-            {
-                string role = plotIndex switch
-                {
-                    0 => "vendor",
-                    1 => "mission_board",
-                    _ => "npc",
-                };
-                markers.Add(new SettlementMarker(role, centre));
-
-                // A real door fills this building's doorway: a sci-fi slider for towns/cities, a hinged
-                // door for villages/hamlets. Placed on the lower door column; the server probes the gap to
-                // centre + size the door. (Ruins are abandoned — their doorways stay open.)
-                int mid = fp / 2, w0 = System.Math.Max(1, mid - 1);
-                var doorCell = doorSide switch
-                {
-                    0 => new Vector3i(ox + w0, 1, oz),
-                    1 => new Vector3i(ox + w0, 1, oz + fp - 1),
-                    2 => new Vector3i(ox, 1, oz + w0),
-                    _ => new Vector3i(ox + fp - 1, 1, oz + w0),
-                };
-                markers.Add(new SettlementMarker(town ? "door_slide" : "door_hinge", doorCell));
-            }
-            else if (plotIndex == 0 || rng.NextDouble() < 0.6)
-            {
-                markers.Add(new SettlementMarker("loot", centre)); // ruins: scavenge instead of services
-            }
-
-            plotIndex++;
-        }
 
         // A central feature (well / plaza / monument) on the middle lane.
         if (!ruined)
@@ -294,25 +294,25 @@ public static class SettlementGenerator
         if (ruined)
         {
             for (int x = 0; x < w; x++)
-            for (int y = 0; y < h; y++)
-            for (int z = 0; z < l; z++)
-            {
-                if (blocks[(x * h + y) * l + z] != 0 && rng.NextDouble() < 0.35)
-                {
-                    Set(x, y, z, 0); // collapsed / missing
-                }
-            }
+                for (int y = 0; y < h; y++)
+                    for (int z = 0; z < l; z++)
+                    {
+                        if (blocks[(x * h + y) * l + z] != 0 && rng.NextDouble() < 0.35)
+                        {
+                            Set(x, y, z, 0); // collapsed / missing
+                        }
+                    }
 
             if (flora != 0)
             {
                 for (int x = 1; x < w - 1; x++)
-                for (int z = 1; z < l - 1; z++)
-                {
-                    if (blocks[(x * h + 0) * l + z] != 0 && rng.NextDouble() < 0.08)
+                    for (int z = 1; z < l - 1; z++)
                     {
-                        Set(x, 1, z, flora); // overgrowth on intact ground
+                        if (blocks[(x * h + 0) * l + z] != 0 && rng.NextDouble() < 0.08)
+                        {
+                            Set(x, 1, z, flora); // overgrowth on intact ground
+                        }
                     }
-                }
             }
         }
 
@@ -326,29 +326,29 @@ public static class SettlementGenerator
     {
         int height = storeys * FloorH;
         for (int x = 0; x < fp; x++)
-        for (int y = 0; y <= height; y++)
-        for (int z = 0; z < fp; z++)
-        {
-            bool shell = x == 0 || x == fp - 1 || z == 0 || z == fp - 1 || y == 0 || y == height;
-            bool interFloor = y > 0 && y < height && (y % FloorH == 0); // storey decks
+            for (int y = 0; y <= height; y++)
+                for (int z = 0; z < fp; z++)
+                {
+                    bool shell = x == 0 || x == fp - 1 || z == 0 || z == fp - 1 || y == 0 || y == height;
+                    bool interFloor = y > 0 && y < height && (y % FloorH == 0); // storey decks
 
-            if (shell)
-            {
-                bool sideWall = x == 0 || x == fp - 1 || z == 0 || z == fp - 1;
-                bool window = sideWall && (y % FloorH == 2) && x > 0 && x < fp - 1 && z > 0 && z < fp - 1;
-                bool band = sideWall && (y % FloorH == 1); // accent stripe at each storey base
-                ushort b = window ? glass : (band && accent != 0 ? accent : wall);
-                set(ox + x, y, oz + z, b);
-            }
-            else if (interFloor)
-            {
-                set(ox + x, y, oz + z, wall); // floor between storeys
-            }
-            else
-            {
-                set(ox + x, y, oz + z, 0); // hollow room
-            }
-        }
+                    if (shell)
+                    {
+                        bool sideWall = x == 0 || x == fp - 1 || z == 0 || z == fp - 1;
+                        bool window = sideWall && (y % FloorH == 2) && x > 0 && x < fp - 1 && z > 0 && z < fp - 1;
+                        bool band = sideWall && (y % FloorH == 1); // accent stripe at each storey base
+                        ushort b = window ? glass : (band && accent != 0 ? accent : wall);
+                        set(ox + x, y, oz + z, b);
+                    }
+                    else if (interFloor)
+                    {
+                        set(ox + x, y, oz + z, wall); // floor between storeys
+                    }
+                    else
+                    {
+                        set(ox + x, y, oz + z, 0); // hollow room
+                    }
+                }
 
         // Door: a 2-wide, 3-tall gap on the chosen wall at ground level so the player fits through
         // comfortably (a 1-wide / 2-tall opening was too tight to walk through).
@@ -356,16 +356,16 @@ public static class SettlementGenerator
         int w0 = System.Math.Max(1, mid - 1), w1 = mid; // two columns, kept inside the corners
         int dy1 = 1, dy2 = System.Math.Min(height - 1, 3); // up to 3 tall, never into the ceiling
         for (int w = w0; w <= w1; w++)
-        for (int y = dy1; y <= dy2; y++)
-        {
-            switch (doorSide)
+            for (int y = dy1; y <= dy2; y++)
             {
-                case 0: set(ox + w, y, oz, 0); break;             // -Z
-                case 1: set(ox + w, y, oz + fp - 1, 0); break;    // +Z
-                case 2: set(ox, y, oz + w, 0); break;             // -X
-                default: set(ox + fp - 1, y, oz + w, 0); break;   // +X
+                switch (doorSide)
+                {
+                    case 0: set(ox + w, y, oz, 0); break;             // -Z
+                    case 1: set(ox + w, y, oz + fp - 1, 0); break;    // +Z
+                    case 2: set(ox, y, oz + w, 0); break;             // -X
+                    default: set(ox + fp - 1, y, oz + w, 0); break;   // +X
+                }
             }
-        }
 
         // Vertical access between storeys: a hole through each deck + a full-height ladder in a corner.
         if (storeys > 1)
@@ -420,14 +420,14 @@ public static class SettlementGenerator
             }
 
             for (int x = x0; x <= x1; x++)
-            for (int z = z0; z <= z1; z++)
-            {
-                bool edge = x == x0 || x == x1 || z == z0 || z == z1;
-                if (edge || r == levels)
+                for (int z = z0; z <= z1; z++)
                 {
-                    set(x, y, z, wall);
+                    bool edge = x == x0 || x == x1 || z == z0 || z == z1;
+                    if (edge || r == levels)
+                    {
+                        set(x, y, z, wall);
+                    }
                 }
-            }
         }
     }
 
@@ -496,22 +496,22 @@ public static class SettlementGenerator
 
         // A 3×3 paved plaza.
         for (int dx = -1; dx <= 1; dx++)
-        for (int dz = -1; dz <= 1; dz++)
-        {
-            set(cx + dx, 0, cz + dz, floor);
-        }
+            for (int dz = -1; dz <= 1; dz++)
+            {
+                set(cx + dx, 0, cz + dz, floor);
+            }
 
         switch (kind)
         {
             case 0: // Well: a ring of accent with water in the middle.
                 for (int dx = -1; dx <= 1; dx++)
-                for (int dz = -1; dz <= 1; dz++)
-                {
-                    if (dx != 0 || dz != 0)
+                    for (int dz = -1; dz <= 1; dz++)
                     {
-                        set(cx + dx, 1, cz + dz, accent);
+                        if (dx != 0 || dz != 0)
+                        {
+                            set(cx + dx, 1, cz + dz, accent);
+                        }
                     }
-                }
 
                 if (water != 0)
                 {

--- a/src/BlocksBeyondTheStars.WorldGeneration/StationGenerator.cs
+++ b/src/BlocksBeyondTheStars.WorldGeneration/StationGenerator.cs
@@ -476,20 +476,20 @@ public static class StationGenerator
     {
         int viewTop = rh >= 8 ? 4 : 3; // a taller glazed band on the big rooms
         for (int x = 0; x < rw; x++)
-        for (int y = 0; y < rh; y++)
-        for (int z = 0; z < rl; z++)
-        {
-            bool shell = x == 0 || x == rw - 1 || y == 0 || y == rh - 1 || z == 0 || z == rl - 1;
-            if (!shell)
-            {
-                set(o.X + x, o.Y + y, o.Z + z, 0); // hollow interior
-                continue;
-            }
+            for (int y = 0; y < rh; y++)
+                for (int z = 0; z < rl; z++)
+                {
+                    bool shell = x == 0 || x == rw - 1 || y == 0 || y == rh - 1 || z == 0 || z == rl - 1;
+                    if (!shell)
+                    {
+                        set(o.X + x, o.Y + y, o.Z + z, 0); // hollow interior
+                        continue;
+                    }
 
-            bool sideWall = x == 0 || x == rw - 1 || z == 0 || z == rl - 1;
-            bool viewport = sideWall && y >= 2 && y <= viewTop && x > 0 && x < rw - 1 && z > 0 && z < rl - 1;
-            set(o.X + x, o.Y + y, o.Z + z, viewport ? glass : hull);
-        }
+                    bool sideWall = x == 0 || x == rw - 1 || z == 0 || z == rl - 1;
+                    bool viewport = sideWall && y >= 2 && y <= viewTop && x > 0 && x < rw - 1 && z > 0 && z < rl - 1;
+                    set(o.X + x, o.Y + y, o.Z + z, viewport ? glass : hull);
+                }
 
         if (round)
         {
@@ -497,14 +497,14 @@ public static class StationGenerator
             // rounding still reads at scale; the diagonal fill (i + j ≤ depth + 1) leaves no dead pockets.
             int depth = rw >= 10 ? 2 : 1;
             for (int i = 1; i <= depth; i++)
-            for (int j = 1; j <= depth + 1 - i; j++)
-            for (int y = 1; y <= rh - 2; y++)
-            {
-                set(o.X + i, o.Y + y, o.Z + j, hull);
-                set(o.X + i, o.Y + y, o.Z + rl - 1 - j, hull);
-                set(o.X + rw - 1 - i, o.Y + y, o.Z + j, hull);
-                set(o.X + rw - 1 - i, o.Y + y, o.Z + rl - 1 - j, hull);
-            }
+                for (int j = 1; j <= depth + 1 - i; j++)
+                    for (int y = 1; y <= rh - 2; y++)
+                    {
+                        set(o.X + i, o.Y + y, o.Z + j, hull);
+                        set(o.X + i, o.Y + y, o.Z + rl - 1 - j, hull);
+                        set(o.X + rw - 1 - i, o.Y + y, o.Z + j, hull);
+                        set(o.X + rw - 1 - i, o.Y + y, o.Z + rl - 1 - j, hull);
+                    }
         }
     }
 
@@ -525,21 +525,21 @@ public static class StationGenerator
 
         int cx = rw / 2, cz = rl / 2; // door/shaft centre columns to keep clear
         for (int lx = 2; lx <= rw - 3; lx++)
-        for (int lz = 2; lz <= rl - 3; lz++)
-        {
-            if (lx == cx || lz == cz)
+            for (int lz = 2; lz <= rl - 3; lz++)
             {
-                continue; // never the door/shaft line
-            }
+                if (lx == cx || lz == cz)
+                {
+                    continue; // never the door/shaft line
+                }
 
-            int wx = o.X + lx, wy = o.Y + 1, wz = o.Z + lz;
-            // Empty cell (no furniture) standing on a hull floor block → a clean interior spot for a plant.
-            if (get(wx, wy, wz) == 0 && get(wx, wy - 1, wz) == hull)
-            {
-                set(wx, wy, wz, plant);
-                return;
+                int wx = o.X + lx, wy = o.Y + 1, wz = o.Z + lz;
+                // Empty cell (no furniture) standing on a hull floor block → a clean interior spot for a plant.
+                if (get(wx, wy, wz) == 0 && get(wx, wy - 1, wz) == hull)
+                {
+                    set(wx, wy, wz, plant);
+                    return;
+                }
             }
-        }
     }
 
     /// <summary>
@@ -736,23 +736,23 @@ public static class StationGenerator
     {
         int span = (dirX != 0 ? rl : rw) - 2;
         for (int step = 1; step <= 2; step++)
-        for (int s = 1; s <= span; s++)
-        for (int y = o.Y + 2; y <= o.Y + 3; y++)
-        {
-            int x, z;
-            if (dirX != 0)
-            {
-                x = (dirX > 0 ? o.X + rw - 1 : o.X) + dirX * step;
-                z = o.Z + s;
-            }
-            else
-            {
-                z = (dirZ > 0 ? o.Z + rl - 1 : o.Z) + dirZ * step;
-                x = o.X + s;
-            }
+            for (int s = 1; s <= span; s++)
+                for (int y = o.Y + 2; y <= o.Y + 3; y++)
+                {
+                    int x, z;
+                    if (dirX != 0)
+                    {
+                        x = (dirX > 0 ? o.X + rw - 1 : o.X) + dirX * step;
+                        z = o.Z + s;
+                    }
+                    else
+                    {
+                        z = (dirZ > 0 ? o.Z + rl - 1 : o.Z) + dirZ * step;
+                        x = o.X + s;
+                    }
 
-            set(x, y, z, (s + step) % 2 == 0 ? glass : dark);
-        }
+                    set(x, y, z, (s + step) % 2 == 0 ? glass : dark);
+                }
     }
 
     /// <summary>A short antenna mast with a beacon tip on a module roof.</summary>
@@ -782,14 +782,14 @@ public static class StationGenerator
             }
 
             for (int x = x0; x <= x1; x++)
-            for (int z = z0; z <= z1; z++)
-            {
-                bool edge = x == x0 || x == x1 || z == z0 || z == z1;
-                if (edge || r == MarginTop - 1)
+                for (int z = z0; z <= z1; z++)
                 {
-                    set(x, y, z, r == MarginTop - 1 ? light : shell); // glowing apex
+                    bool edge = x == x0 || x == x1 || z == z0 || z == z1;
+                    if (edge || r == MarginTop - 1)
+                    {
+                        set(x, y, z, r == MarginTop - 1 ? light : shell); // glowing apex
+                    }
                 }
-            }
         }
     }
 
@@ -802,13 +802,13 @@ public static class StationGenerator
         {
             int x = o.X + rw - 1, zc = o.Z + rl / 2;
             for (int y = o.Y + 1; y <= top; y++)
-            for (int dz = -1; dz <= 0; dz++) set(x, y, zc + dz, 0);
+                for (int dz = -1; dz <= 0; dz++) set(x, y, zc + dz, 0);
         }
         else if (dir.Z > 0)
         {
             int z = o.Z + rl - 1, xc = o.X + rw / 2;
             for (int y = o.Y + 1; y <= top; y++)
-            for (int dx = -1; dx <= 0; dx++) set(xc + dx, y, z, 0);
+                for (int dx = -1; dx <= 0; dx++) set(xc + dx, y, z, 0);
         }
     }
 
@@ -820,19 +820,19 @@ public static class StationGenerator
         {
             int x = o.X + rw - 1;
             for (int y = o.Y + 1; y <= o.Y + rh - 2; y++)
-            for (int z = o.Z + 1; z <= o.Z + rl - 2; z++)
-            {
-                set(x, y, z, 0);
-            }
+                for (int z = o.Z + 1; z <= o.Z + rl - 2; z++)
+                {
+                    set(x, y, z, 0);
+                }
         }
         else if (dir.Z > 0)
         {
             int z = o.Z + rl - 1;
             for (int y = o.Y + 1; y <= o.Y + rh - 2; y++)
-            for (int x = o.X + 1; x <= o.X + rw - 2; x++)
-            {
-                set(x, y, z, 0);
-            }
+                for (int x = o.X + 1; x <= o.X + rw - 2; x++)
+                {
+                    set(x, y, z, 0);
+                }
         }
     }
 
@@ -842,10 +842,10 @@ public static class StationGenerator
         int size = rw >= 9 ? 3 : 2;
         int y = o.Y + rh - 1;
         for (int dx = 0; dx < size; dx++)
-        for (int dz = 0; dz < size; dz++)
-        {
-            set(o.X + rw / 2 + dx - (size - 2), y, o.Z + rl / 2 + dz - (size - 2), 0);
-        }
+            for (int dz = 0; dz < size; dz++)
+            {
+                set(o.X + rw / 2 + dx - (size - 2), y, o.Z + rl / 2 + dz - (size - 2), 0);
+            }
     }
 
     /// <summary>Glazes the outer -Z wall of a hangar room with an energy field (the docking mouth):
@@ -855,9 +855,9 @@ public static class StationGenerator
     {
         int top = System.Math.Min(o.Y + (rh >= 8 ? 5 : 3), o.Y + rh - 2);
         for (int x = o.X + 1; x < o.X + rw - 1; x++)
-        for (int y = o.Y + 1; y <= top; y++)
-        {
-            set(x, y, o.Z, field);
-        }
+            for (int y = o.Y + 1; y <= top; y++)
+            {
+                set(x, y, o.Z, field);
+            }
     }
 }

--- a/src/BlocksBeyondTheStars.WorldGeneration/WorldGenerator.cs
+++ b/src/BlocksBeyondTheStars.WorldGeneration/WorldGenerator.cs
@@ -90,36 +90,36 @@ public sealed class WorldGenerator
         var origin = WorldConstants.ChunkOrigin(coord);
         int cs = WorldConstants.ChunkSize;
         for (int lx = 0; lx < cs; lx++)
-        for (int lz = 0; lz < cs; lz++)
-        {
-            int worldX = origin.X + lx;
-            int worldZ = origin.Z + lz;
-            if (PadSurfaceAt(worldX, worldZ) is not int padY)
+            for (int lz = 0; lz < cs; lz++)
             {
-                continue;
-            }
+                int worldX = origin.X + lx;
+                int worldZ = origin.Z + lz;
+                if (PadSurfaceAt(worldX, worldZ) is not int padY)
+                {
+                    continue;
+                }
 
-            int biomeIndex = biomes.Count <= 1 ? 0 : BiomeIndex(seed, worldX, worldZ, biomes.Count, _circumference);
-            var surfaceId = biomes[biomeIndex].Surface;
-            var subSurfaceId = biomes[biomeIndex].Sub;
+                int biomeIndex = biomes.Count <= 1 ? 0 : BiomeIndex(seed, worldX, worldZ, biomes.Count, _circumference);
+                var surfaceId = biomes[biomeIndex].Surface;
+                var subSurfaceId = biomes[biomeIndex].Sub;
 
-            for (int ly = 0; ly < cs; ly++)
-            {
-                int worldY = origin.Y + ly;
-                if (worldY > padY)
+                for (int ly = 0; ly < cs; ly++)
                 {
-                    chunk.Set(lx, ly, lz, BlockId.Air); // shear off anything above the pad level
-                }
-                else if (worldY == padY)
-                {
-                    chunk.Set(lx, ly, lz, surfaceId); // a natural, level pad surface
-                }
-                else if (worldY >= padY - PadFoundationDepth && chunk.Get(lx, ly, lz).IsAir)
-                {
-                    chunk.Set(lx, ly, lz, subSurfaceId); // plug caves directly under the pad
+                    int worldY = origin.Y + ly;
+                    if (worldY > padY)
+                    {
+                        chunk.Set(lx, ly, lz, BlockId.Air); // shear off anything above the pad level
+                    }
+                    else if (worldY == padY)
+                    {
+                        chunk.Set(lx, ly, lz, surfaceId); // a natural, level pad surface
+                    }
+                    else if (worldY >= padY - PadFoundationDepth && chunk.Get(lx, ly, lz).IsAir)
+                    {
+                        chunk.Set(lx, ly, lz, subSurfaceId); // plug caves directly under the pad
+                    }
                 }
             }
-        }
     }
 
     // World options (creation-time, from the save's WorldDescription): global factors on top of the
@@ -274,59 +274,59 @@ public sealed class WorldGenerator
                 return h * amp * 0.75; // gentle rolling hills
 
             case "mountains":
-            {
-                double r = h * 0.25 + Ridge(h) * 0.75; // sharp, rugged
-                if (r > 0)
                 {
-                    r = System.Math.Pow(r, 1.35); // W-R1 crest sharpening: flatter mid-slopes, prouder peaks
-                }
+                    double r = h * 0.25 + Ridge(h) * 0.75; // sharp, rugged
+                    if (r > 0)
+                    {
+                        r = System.Math.Pow(r, 1.35); // W-R1 crest sharpening: flatter mid-slopes, prouder peaks
+                    }
 
-                return r * amp * 1.9;
-            }
+                    return r * amp * 1.9;
+                }
 
             case "canyons":
-            {
-                double r = h * 0.35 + Ridge(h) * 0.65;
-                if (r < 0)
                 {
-                    r = -System.Math.Pow(-r, 0.8); // W-R1: broader, deeper canyon floors below the mesatops
-                }
+                    double r = h * 0.35 + Ridge(h) * 0.65;
+                    if (r < 0)
+                    {
+                        r = -System.Math.Pow(-r, 0.8); // W-R1: broader, deeper canyon floors below the mesatops
+                    }
 
-                return r * amp * 1.4; // deep ridged canyons + mesatops
-            }
+                    return r * amp * 1.4; // deep ridged canyons + mesatops
+                }
 
             case "mesa":
-            {
-                // Terraced plateaus: quantise the height into flat decks separated by sharp cliffs, with a little
-                // roll on each deck so the tops aren't dead flat.
-                double raw = h * amp * 1.15;
-                double step = System.Math.Max(3.0, amp * 0.30);
-                double deck = System.Math.Floor(raw / step) * step;
-                double roll = FbmT(seed + 0x3E5A, worldX, worldZ, planet.TerrainScale * 0.5, octaves: 2);
-                return deck + (roll - 0.5) * 2.0; // ±2-block texture on each deck
-            }
-
-            case "dunes":
-            {
-                // Parallel wind-blown ridges: a ridged mid-frequency field laid over a gentle base.
-                double d = FbmT(seed + 0x0D0E, worldX, worldZ, planet.TerrainScale * 0.45, octaves: 2);
-                double ridged = 1.0 - System.Math.Abs(d * 2.0 - 1.0); // 0..1 dune crests
-                return h * amp * 0.25 + ridged * amp * 0.85;
-            }
-
-            case "spires":
-            {
-                // Mostly flat ground studded with sparse tall thin spikes (crystal needles / alien towers).
-                double basep = h * amp * 0.22;
-                double mask = FbmT(seed + 0x591E, worldX, worldZ, planet.TerrainScale * 0.4, octaves: 2);
-                if (mask > 0.72)
                 {
-                    double t = (mask - 0.72) / 0.28; // 0..1 toward the spike centre
-                    return basep + t * t * amp * 2.6;
+                    // Terraced plateaus: quantise the height into flat decks separated by sharp cliffs, with a little
+                    // roll on each deck so the tops aren't dead flat.
+                    double raw = h * amp * 1.15;
+                    double step = System.Math.Max(3.0, amp * 0.30);
+                    double deck = System.Math.Floor(raw / step) * step;
+                    double roll = FbmT(seed + 0x3E5A, worldX, worldZ, planet.TerrainScale * 0.5, octaves: 2);
+                    return deck + (roll - 0.5) * 2.0; // ±2-block texture on each deck
                 }
 
-                return basep;
-            }
+            case "dunes":
+                {
+                    // Parallel wind-blown ridges: a ridged mid-frequency field laid over a gentle base.
+                    double d = FbmT(seed + 0x0D0E, worldX, worldZ, planet.TerrainScale * 0.45, octaves: 2);
+                    double ridged = 1.0 - System.Math.Abs(d * 2.0 - 1.0); // 0..1 dune crests
+                    return h * amp * 0.25 + ridged * amp * 0.85;
+                }
+
+            case "spires":
+                {
+                    // Mostly flat ground studded with sparse tall thin spikes (crystal needles / alien towers).
+                    double basep = h * amp * 0.22;
+                    double mask = FbmT(seed + 0x591E, worldX, worldZ, planet.TerrainScale * 0.4, octaves: 2);
+                    if (mask > 0.72)
+                    {
+                        double t = (mask - 0.72) / 0.28; // 0..1 toward the spike centre
+                        return basep + t * t * amp * 2.6;
+                    }
+
+                    return basep;
+                }
 
             default:
                 return h * amp; // unknown style → plain base swell
@@ -761,180 +761,180 @@ public sealed class WorldGenerator
         var origin = WorldConstants.ChunkOrigin(coord);
 
         for (int lx = 0; lx < WorldConstants.ChunkSize; lx++)
-        for (int lz = 0; lz < WorldConstants.ChunkSize; lz++)
-        {
-            int worldX = origin.X + lx;
-            int worldZ = origin.Z + lz;
-            int surfaceY = SurfaceHeight(planet, worldX, worldZ);
-
-            // An upland pond carves a shallow bowl here (seabed below the terrain) and fills it with water up to
-            // the original surface (a pond flush with the surrounding ground), so the column reads as a swimmable
-            // pool. Normal columns leave seabed=surface and fill the sea up to the global level, unchanged.
-            int seabedY = surfaceY;
-            int waterTop = fluidLevel;
-            var columnFluid = fluidId;
-            bool pondHere = false;
-            if (ponds && surfaceY > fluidLevel)
+            for (int lz = 0; lz < WorldConstants.ChunkSize; lz++)
             {
-                int pondDepth = PondDepthAt(planet, seed, worldX, worldZ, pondThreshold);
-                if (pondDepth > 0)
+                int worldX = origin.X + lx;
+                int worldZ = origin.Z + lz;
+                int surfaceY = SurfaceHeight(planet, worldX, worldZ);
+
+                // An upland pond carves a shallow bowl here (seabed below the terrain) and fills it with water up to
+                // the original surface (a pond flush with the surrounding ground), so the column reads as a swimmable
+                // pool. Normal columns leave seabed=surface and fill the sea up to the global level, unchanged.
+                int seabedY = surfaceY;
+                int waterTop = fluidLevel;
+                var columnFluid = fluidId;
+                bool pondHere = false;
+                if (ponds && surfaceY > fluidLevel)
                 {
-                    seabedY = surfaceY - pondDepth;
-                    waterTop = surfaceY;
-                    columnFluid = seaWaterId;
-                    pondHere = true;
-                }
-            }
-
-            // Rivers: a winding river-line noise band carves a channel (deepest at the centre, tapering to the
-            // banks) and fills it with water flush to the surface — a meandering river across low/mid terrain.
-            // (Skipped where a pond already claimed the column. The old guard compared columnFluid to the sea
-            // fluid, which on a water world equals the column's default fluid — so rivers never carved.)
-            if (rivers && !pondHere && surfaceY > fluidLevel && surfaceY <= riverMaxY)
-            {
-                int depth = RiverDepthAt(planet, seed, worldX, worldZ);
-                if (depth >= 1)
-                {
-                    seabedY = surfaceY - depth;
-                    waterTop = surfaceY;
-                    columnFluid = seaWaterId;
-                }
-            }
-
-            // Per-column biome → surface/sub-surface blocks (single-biome worlds use index 0).
-            int biomeIndex = biomes.Count <= 1 ? 0 : BiomeIndex(seed, worldX, worldZ, biomes.Count, _circumference);
-            var biome = biomes[biomeIndex];
-            var surfaceId = biome.Surface;
-            var subSurfaceId = biome.Sub;
-
-            // Floating islands (item 21 V5): a per-column sky-island slab high above the surface — a grass-topped
-            // deck on a tapered rocky underbelly, scattered by a region mask, drifting in the air. The band is
-            // resolved by the shared helper so settlement placement can query the same island tops.
-            int islandTop = int.MinValue, islandBottom = int.MaxValue;
-            if (floatingIslands)
-            {
-                FloatingIslandBand(planet, worldX, worldZ, out islandTop, out islandBottom);
-            }
-
-            // Crater-floor metal clumps (item 33): on a cratered world, the top cells of a metal-bearing deep
-            // crater floor are exposed rare ore instead of regolith (only some craters, a few clumps each).
-            BlockId? craterMetal = (planet.Cratered || _crateredWorld)
-                ? CraterFloorMetal(planet, seed, worldX, worldZ) : (BlockId?)null;
-
-            for (int ly = 0; ly < WorldConstants.ChunkSize; ly++)
-            {
-                int worldY = origin.Y + ly;
-                if (worldY > seabedY)
-                {
-                    if (worldY <= waterTop)
+                    int pondDepth = PondDepthAt(planet, seed, worldX, worldZ, pondThreshold);
+                    if (pondDepth > 0)
                     {
-                        chunk.Set(lx, ly, lz, columnFluid); // sea fill in a basin, or an upland pond above it
-                    }
-                    else if (floatingIslands && worldY >= islandBottom && worldY <= islandTop)
-                    {
-                        // A sky island: grass-topped deck, sub-surface just under it, stone underbelly below.
-                        var ib = worldY == islandTop ? surfaceId : (worldY >= islandTop - 2 ? subSurfaceId : deepId);
-                        chunk.Set(lx, ly, lz, ib);
-                    }
-
-                    continue; // else air above the surface
-                }
-
-                int depth = seabedY - worldY;
-
-                // Unmineable world floor (B46/B?): solid bedrock at the very bottom of this world's deep
-                // foundation (no caves carved through it), with a boundary band just above — molten lava on real
-                // planets, basalt on airless moons/asteroids — so digging all the way down ends in lava/rock,
-                // never a void you can fall out of.
-                if (depth >= floorDepth)
-                {
-                    chunk.Set(lx, ly, lz, bedrockId);
-                    continue;
-                }
-
-                if (depth >= floorDepth - FloorBandThickness)
-                {
-                    chunk.Set(lx, ly, lz, floorBandId);
-                    continue;
-                }
-
-                // Carve caves below the surface layer (per-world cave frequency, item 21).
-                if (caveThreshold > 0.0 && depth > 1)
-                {
-                    double cave = ValueT(seed + 7777, worldX, worldY, worldZ, 22.0, 16.0, 22.0);
-                    if (cave > caveThreshold)
-                    {
-                        continue; // cave => air
+                        seabedY = surfaceY - pondDepth;
+                        waterTop = surfaceY;
+                        columnFluid = seaWaterId;
+                        pondHere = true;
                     }
                 }
 
-                BlockId block;
-                if (craterMetal.HasValue && depth <= 1)
+                // Rivers: a winding river-line noise band carves a channel (deepest at the centre, tapering to the
+                // banks) and fills it with water flush to the surface — a meandering river across low/mid terrain.
+                // (Skipped where a pond already claimed the column. The old guard compared columnFluid to the sea
+                // fluid, which on a water world equals the column's default fluid — so rivers never carved.)
+                if (rivers && !pondHere && surfaceY > fluidLevel && surfaceY <= riverMaxY)
                 {
-                    block = craterMetal.Value; // a rare-metal clump on the crater floor (top two cells)
-                }
-                else if (depth < planet.SurfaceDepth)
-                {
-                    block = depth == 0 ? surfaceId : subSurfaceId;
-                }
-                else
-                {
-                    // Deep crust turns to a dark basalt mantle below this world's mantle depth (item 21), so the
-                    // interior isn't one uniform stone column on every world. Ores still vein through it.
-                    var rock = depth >= mantleDepth ? mantleId : deepId;
-                    block = SelectOre(planet, seed, worldX, worldY, worldZ, depth, fallback: rock, oreRichness);
-
-                    if (block == rock && planet.DataCacheRarity > 0 && !dataCacheId.IsAir)
+                    int depth = RiverDepthAt(planet, seed, worldX, worldZ);
+                    if (depth >= 1)
                     {
-                        double r = Noise.Value01(seed + 4242, WorldConstants.WrapX(worldX, _circumference), worldY, Wz(worldZ));
-                        if (r < planet.DataCacheRarity)
+                        seabedY = surfaceY - depth;
+                        waterTop = surfaceY;
+                        columnFluid = seaWaterId;
+                    }
+                }
+
+                // Per-column biome → surface/sub-surface blocks (single-biome worlds use index 0).
+                int biomeIndex = biomes.Count <= 1 ? 0 : BiomeIndex(seed, worldX, worldZ, biomes.Count, _circumference);
+                var biome = biomes[biomeIndex];
+                var surfaceId = biome.Surface;
+                var subSurfaceId = biome.Sub;
+
+                // Floating islands (item 21 V5): a per-column sky-island slab high above the surface — a grass-topped
+                // deck on a tapered rocky underbelly, scattered by a region mask, drifting in the air. The band is
+                // resolved by the shared helper so settlement placement can query the same island tops.
+                int islandTop = int.MinValue, islandBottom = int.MaxValue;
+                if (floatingIslands)
+                {
+                    FloatingIslandBand(planet, worldX, worldZ, out islandTop, out islandBottom);
+                }
+
+                // Crater-floor metal clumps (item 33): on a cratered world, the top cells of a metal-bearing deep
+                // crater floor are exposed rare ore instead of regolith (only some craters, a few clumps each).
+                BlockId? craterMetal = (planet.Cratered || _crateredWorld)
+                    ? CraterFloorMetal(planet, seed, worldX, worldZ) : (BlockId?)null;
+
+                for (int ly = 0; ly < WorldConstants.ChunkSize; ly++)
+                {
+                    int worldY = origin.Y + ly;
+                    if (worldY > seabedY)
+                    {
+                        if (worldY <= waterTop)
                         {
-                            block = dataCacheId;
+                            chunk.Set(lx, ly, lz, columnFluid); // sea fill in a basin, or an upland pond above it
+                        }
+                        else if (floatingIslands && worldY >= islandBottom && worldY <= islandTop)
+                        {
+                            // A sky island: grass-topped deck, sub-surface just under it, stone underbelly below.
+                            var ib = worldY == islandTop ? surfaceId : (worldY >= islandTop - 2 ? subSurfaceId : deepId);
+                            chunk.Set(lx, ly, lz, ib);
+                        }
+
+                        continue; // else air above the surface
+                    }
+
+                    int depth = seabedY - worldY;
+
+                    // Unmineable world floor (B46/B?): solid bedrock at the very bottom of this world's deep
+                    // foundation (no caves carved through it), with a boundary band just above — molten lava on real
+                    // planets, basalt on airless moons/asteroids — so digging all the way down ends in lava/rock,
+                    // never a void you can fall out of.
+                    if (depth >= floorDepth)
+                    {
+                        chunk.Set(lx, ly, lz, bedrockId);
+                        continue;
+                    }
+
+                    if (depth >= floorDepth - FloorBandThickness)
+                    {
+                        chunk.Set(lx, ly, lz, floorBandId);
+                        continue;
+                    }
+
+                    // Carve caves below the surface layer (per-world cave frequency, item 21).
+                    if (caveThreshold > 0.0 && depth > 1)
+                    {
+                        double cave = ValueT(seed + 7777, worldX, worldY, worldZ, 22.0, 16.0, 22.0);
+                        if (cave > caveThreshold)
+                        {
+                            continue; // cave => air
                         }
                     }
+
+                    BlockId block;
+                    if (craterMetal.HasValue && depth <= 1)
+                    {
+                        block = craterMetal.Value; // a rare-metal clump on the crater floor (top two cells)
+                    }
+                    else if (depth < planet.SurfaceDepth)
+                    {
+                        block = depth == 0 ? surfaceId : subSurfaceId;
+                    }
+                    else
+                    {
+                        // Deep crust turns to a dark basalt mantle below this world's mantle depth (item 21), so the
+                        // interior isn't one uniform stone column on every world. Ores still vein through it.
+                        var rock = depth >= mantleDepth ? mantleId : deepId;
+                        block = SelectOre(planet, seed, worldX, worldY, worldZ, depth, fallback: rock, oreRichness);
+
+                        if (block == rock && planet.DataCacheRarity > 0 && !dataCacheId.IsAir)
+                        {
+                            double r = Noise.Value01(seed + 4242, WorldConstants.WrapX(worldX, _circumference), worldY, Wz(worldZ));
+                            if (r < planet.DataCacheRarity)
+                            {
+                                block = dataCacheId;
+                            }
+                        }
+                    }
+
+                    chunk.Set(lx, ly, lz, block);
                 }
 
-                chunk.Set(lx, ly, lz, block);
-            }
-
-            // Surface flora: one plant in the air cell directly above the surface (bounded — one per column,
-            // no spreading), chosen by biome surface + a density roll. Columns that lie under the sea grow
-            // aquatic flora instead (kelp + lily pads); land plants don't grow underwater.
-            if (flora && seabedY + 1 > waterTop)
-            {
-                var floraId = FloraForSurface(planet, biome, seed, worldX, worldZ);
-                int fy = seabedY + 1;
-                int fly = fy - origin.Y;
-                // Local density is modulated by a vegetation-richness mask (lush forest floors / meadows vs
-                // sparse open ground) + the per-biome density, so undergrowth gathers into thickets instead
-                // of an even sprinkle — and the same forest the trees cluster in is also carpeted with plants.
-                double localFloraDensity = LocalFloraDensity(planet, biome, floraDensity, seed, worldX, worldZ);
-                if (!floraId.IsAir && fly >= 0 && fly < WorldConstants.ChunkSize
-                    && Noise.Value01(seed + 9001, WorldConstants.WrapX(worldX, _circumference), 7, Wz(worldZ)) < localFloraDensity)
+                // Surface flora: one plant in the air cell directly above the surface (bounded — one per column,
+                // no spreading), chosen by biome surface + a density roll. Columns that lie under the sea grow
+                // aquatic flora instead (kelp + lily pads); land plants don't grow underwater.
+                if (flora && seabedY + 1 > waterTop)
                 {
-                    chunk.Set(lx, fly, lz, floraId);
+                    var floraId = FloraForSurface(planet, biome, seed, worldX, worldZ);
+                    int fy = seabedY + 1;
+                    int fly = fy - origin.Y;
+                    // Local density is modulated by a vegetation-richness mask (lush forest floors / meadows vs
+                    // sparse open ground) + the per-biome density, so undergrowth gathers into thickets instead
+                    // of an even sprinkle — and the same forest the trees cluster in is also carpeted with plants.
+                    double localFloraDensity = LocalFloraDensity(planet, biome, floraDensity, seed, worldX, worldZ);
+                    if (!floraId.IsAir && fly >= 0 && fly < WorldConstants.ChunkSize
+                        && Noise.Value01(seed + 9001, WorldConstants.WrapX(worldX, _circumference), 7, Wz(worldZ)) < localFloraDensity)
+                    {
+                        chunk.Set(lx, fly, lz, floraId);
+                    }
                 }
-            }
-            else if (waterFlora && seabedY + 1 <= waterTop)
-            {
-                // Submerged column — the sea or an upland pond grows seabed plants / lily pads, not land flora.
-                StampWaterFlora(chunk, origin, lx, lz, seed, worldX, worldZ, seabedY, waterTop,
-                    kelpId, lilyId, coralId, seagrassId, floraDensity);
-            }
-
-            // Sky islands grow their own surface flora on top — a floating meadow, not a bare slab.
-            if (flora && islandTop != int.MinValue)
-            {
-                var isleFlora = FloraForSurface(planet, biome, seed, worldX, worldZ);
-                int ify = islandTop + 1 - origin.Y;
-                double isleDensity = LocalFloraDensity(planet, biome, floraDensity, seed, worldX, worldZ);
-                if (!isleFlora.IsAir && ify >= 0 && ify < WorldConstants.ChunkSize
-                    && Noise.Value01(seed + 9002, WorldConstants.WrapX(worldX, _circumference), 7, Wz(worldZ)) < isleDensity)
+                else if (waterFlora && seabedY + 1 <= waterTop)
                 {
-                    chunk.Set(lx, ify, lz, isleFlora);
+                    // Submerged column — the sea or an upland pond grows seabed plants / lily pads, not land flora.
+                    StampWaterFlora(chunk, origin, lx, lz, seed, worldX, worldZ, seabedY, waterTop,
+                        kelpId, lilyId, coralId, seagrassId, floraDensity);
+                }
+
+                // Sky islands grow their own surface flora on top — a floating meadow, not a bare slab.
+                if (flora && islandTop != int.MinValue)
+                {
+                    var isleFlora = FloraForSurface(planet, biome, seed, worldX, worldZ);
+                    int ify = islandTop + 1 - origin.Y;
+                    double isleDensity = LocalFloraDensity(planet, biome, floraDensity, seed, worldX, worldZ);
+                    if (!isleFlora.IsAir && ify >= 0 && ify < WorldConstants.ChunkSize
+                        && Noise.Value01(seed + 9002, WorldConstants.WrapX(worldX, _circumference), 7, Wz(worldZ)) < isleDensity)
+                    {
+                        chunk.Set(lx, ify, lz, isleFlora);
+                    }
                 }
             }
-        }
 
         if (trees)
         {
@@ -999,102 +999,102 @@ public sealed class WorldGenerator
         // Margin 6 so the widest feature (a stone circle, radius ~4) generates identically from either side
         // of a chunk edge.
         for (int wx = origin.X - 6; wx < origin.X + cs + 6; wx++)
-        for (int wz = origin.Z - 6; wz < origin.Z + cs + 6; wz++)
-        {
-            int cx = WorldConstants.WrapX(wx, _circumference);
-
-            // One roll per column per prop kind (distinct salts), all rare — these are scattered accents.
-            bool boulder = !boulderId.IsAir && Noise.Value01(seed + 0xB01D, cx, 29, Wz(wz)) < 0.0012;
-            bool shard = !crystalId.IsAir && Noise.Value01(seed + 0xC57A, cx, 31, Wz(wz)) < 0.0008;
-            bool deadTree = !deadLogId.IsAir && Noise.Value01(seed + 0xDEAD, cx, 37, Wz(wz)) < 0.0009;
-            // Small POIs (W-R3, blocks-only): lone monoliths + broken stone circles, rarer than the props —
-            // landmark finds with a data cache at the base/centre worth detouring for.
-            bool monolith = !boulderId.IsAir && Noise.Value01(seed + 0x3057, cx, 43, Wz(wz)) < 0.00018;
-            bool circle = !boulderId.IsAir && Noise.Value01(seed + 0xC1AC, cx, 47, Wz(wz)) < 0.00007;
-            if (!boulder && !shard && !deadTree && !monolith && !circle)
+            for (int wz = origin.Z - 6; wz < origin.Z + cs + 6; wz++)
             {
-                continue;
-            }
+                int cx = WorldConstants.WrapX(wx, _circumference);
 
-            int sy = SurfaceHeight(planet, wx, wz);
-            if (sy + 1 <= fluidLevel || SurfacePondDepth(planet, wx, wz) > 0 || SurfaceRiverDepth(planet, wx, wz) > 0)
-            {
-                continue; // dry ground only
-            }
-
-            int h1 = (int)(Noise.Value01(seed + 0x5E7D, cx, 41, Wz(wz)) * 997); // per-column shape hash
-            var cacheId = _content.GetBlock("data_cache")?.NumericId ?? BlockId.Air;
-
-            if (monolith)
-            {
-                // A lone weathered monolith, 5–7 tall, with a data cache leaning at its base.
-                int height = 5 + h1 % 3;
-                for (int dy = 1; dy <= height; dy++)
+                // One roll per column per prop kind (distinct salts), all rare — these are scattered accents.
+                bool boulder = !boulderId.IsAir && Noise.Value01(seed + 0xB01D, cx, 29, Wz(wz)) < 0.0012;
+                bool shard = !crystalId.IsAir && Noise.Value01(seed + 0xC57A, cx, 31, Wz(wz)) < 0.0008;
+                bool deadTree = !deadLogId.IsAir && Noise.Value01(seed + 0xDEAD, cx, 37, Wz(wz)) < 0.0009;
+                // Small POIs (W-R3, blocks-only): lone monoliths + broken stone circles, rarer than the props —
+                // landmark finds with a data cache at the base/centre worth detouring for.
+                bool monolith = !boulderId.IsAir && Noise.Value01(seed + 0x3057, cx, 43, Wz(wz)) < 0.00018;
+                bool circle = !boulderId.IsAir && Noise.Value01(seed + 0xC1AC, cx, 47, Wz(wz)) < 0.00007;
+                if (!boulder && !shard && !deadTree && !monolith && !circle)
                 {
-                    SetCell(wx, sy + dy, wz, boulderId);
+                    continue;
                 }
 
-                if (!cacheId.IsAir)
+                int sy = SurfaceHeight(planet, wx, wz);
+                if (sy + 1 <= fluidLevel || SurfacePondDepth(planet, wx, wz) > 0 || SurfaceRiverDepth(planet, wx, wz) > 0)
                 {
-                    SetCell(wx + 1, sy + 1, wz, cacheId);
+                    continue; // dry ground only
                 }
-            }
-            else if (circle)
-            {
-                // A broken stone circle: pillars on a radius-4 ring (some collapsed), a data cache at the
-                // centre. Each pillar grounds on its own column so the ring follows the terrain.
-                (int X, int Z)[] ring = { (4, 0), (3, 3), (0, 4), (-3, 3), (-4, 0), (-3, -3), (0, -4), (3, -3) };
-                for (int r = 0; r < ring.Length; r++)
+
+                int h1 = (int)(Noise.Value01(seed + 0x5E7D, cx, 41, Wz(wz)) * 997); // per-column shape hash
+                var cacheId = _content.GetBlock("data_cache")?.NumericId ?? BlockId.Air;
+
+                if (monolith)
                 {
-                    if (((h1 >> r) & 1) == 0 && r % 3 == 2)
+                    // A lone weathered monolith, 5–7 tall, with a data cache leaning at its base.
+                    int height = 5 + h1 % 3;
+                    for (int dy = 1; dy <= height; dy++)
                     {
-                        continue; // the odd collapsed pillar
+                        SetCell(wx, sy + dy, wz, boulderId);
                     }
 
-                    int px = wx + ring[r].X, pz = wz + ring[r].Z;
-                    int py = SurfaceHeight(planet, px, pz);
-                    int ph = 2 + ((h1 >> r) & 1);
-                    for (int dy = 1; dy <= ph; dy++)
+                    if (!cacheId.IsAir)
                     {
-                        SetCell(px, py + dy, pz, boulderId);
+                        SetCell(wx + 1, sy + 1, wz, cacheId);
                     }
                 }
+                else if (circle)
+                {
+                    // A broken stone circle: pillars on a radius-4 ring (some collapsed), a data cache at the
+                    // centre. Each pillar grounds on its own column so the ring follows the terrain.
+                    (int X, int Z)[] ring = { (4, 0), (3, 3), (0, 4), (-3, 3), (-4, 0), (-3, -3), (0, -4), (3, -3) };
+                    for (int r = 0; r < ring.Length; r++)
+                    {
+                        if (((h1 >> r) & 1) == 0 && r % 3 == 2)
+                        {
+                            continue; // the odd collapsed pillar
+                        }
 
-                if (!cacheId.IsAir)
-                {
-                    SetCell(wx, sy + 1, wz, cacheId);
-                }
-            }
-            else if (boulder)
-            {
-                // An irregular 2–4 block boulder cluster of the world's own rock.
-                SetCell(wx, sy + 1, wz, boulderId);
-                if ((h1 & 1) == 0) SetCell(wx + 1, sy + 1, wz, boulderId);
-                if ((h1 & 2) == 0) SetCell(wx, sy + 1, wz + 1, boulderId);
-                if ((h1 & 12) == 0) SetCell(wx, sy + 2, wz, boulderId); // the odd two-tall rock
-            }
-            else if (shard)
-            {
-                // A jutting crystal shard, 1–3 blocks tall (taller ones rarer).
-                int height = 1 + h1 % 3;
-                for (int dy = 1; dy <= height; dy++)
-                {
-                    SetCell(wx, sy + dy, wz, crystalId);
-                }
-            }
-            else if (deadTree)
-            {
-                // A bare dead trunk (3–5 tall) with a single stub branch near the top — no leaves.
-                int height = 3 + h1 % 3;
-                for (int dy = 1; dy <= height; dy++)
-                {
-                    SetCell(wx, sy + dy, wz, deadLogId);
-                }
+                        int px = wx + ring[r].X, pz = wz + ring[r].Z;
+                        int py = SurfaceHeight(planet, px, pz);
+                        int ph = 2 + ((h1 >> r) & 1);
+                        for (int dy = 1; dy <= ph; dy++)
+                        {
+                            SetCell(px, py + dy, pz, boulderId);
+                        }
+                    }
 
-                int bx = (h1 & 4) == 0 ? 1 : -1;
-                SetCell(wx + bx, sy + height - 1, wz, deadLogId);
+                    if (!cacheId.IsAir)
+                    {
+                        SetCell(wx, sy + 1, wz, cacheId);
+                    }
+                }
+                else if (boulder)
+                {
+                    // An irregular 2–4 block boulder cluster of the world's own rock.
+                    SetCell(wx, sy + 1, wz, boulderId);
+                    if ((h1 & 1) == 0) SetCell(wx + 1, sy + 1, wz, boulderId);
+                    if ((h1 & 2) == 0) SetCell(wx, sy + 1, wz + 1, boulderId);
+                    if ((h1 & 12) == 0) SetCell(wx, sy + 2, wz, boulderId); // the odd two-tall rock
+                }
+                else if (shard)
+                {
+                    // A jutting crystal shard, 1–3 blocks tall (taller ones rarer).
+                    int height = 1 + h1 % 3;
+                    for (int dy = 1; dy <= height; dy++)
+                    {
+                        SetCell(wx, sy + dy, wz, crystalId);
+                    }
+                }
+                else if (deadTree)
+                {
+                    // A bare dead trunk (3–5 tall) with a single stub branch near the top — no leaves.
+                    int height = 3 + h1 % 3;
+                    for (int dy = 1; dy <= height; dy++)
+                    {
+                        SetCell(wx, sy + dy, wz, deadLogId);
+                    }
+
+                    int bx = (h1 & 4) == 0 ? 1 : -1;
+                    SetCell(wx + bx, sy + height - 1, wz, deadLogId);
+                }
             }
-        }
     }
 
     /// <summary>Stamps sparse geyser/vent marker blocks on the surface (item 21 follow-up): the topmost ground
@@ -1107,25 +1107,25 @@ public sealed class WorldGenerator
         const double density = 0.0015; // per-column chance (rare — geysers are scattered landmarks)
 
         for (int wx = origin.X; wx < origin.X + cs; wx++)
-        for (int wz = origin.Z; wz < origin.Z + cs; wz++)
-        {
-            if (Noise.Value01(seed + 0x6E7A, WorldConstants.WrapX(wx, _circumference), 23, Wz(wz)) >= density)
+            for (int wz = origin.Z; wz < origin.Z + cs; wz++)
             {
-                continue;
-            }
+                if (Noise.Value01(seed + 0x6E7A, WorldConstants.WrapX(wx, _circumference), 23, Wz(wz)) >= density)
+                {
+                    continue;
+                }
 
-            int sy = SurfaceHeight(planet, wx, wz);
-            if (sy + 1 <= fluidLevel || SurfacePondDepth(planet, wx, wz) > 0 || SurfaceRiverDepth(planet, wx, wz) > 0)
-            {
-                continue; // a vent needs open ground (not a sea/pond column)
-            }
+                int sy = SurfaceHeight(planet, wx, wz);
+                if (sy + 1 <= fluidLevel || SurfacePondDepth(planet, wx, wz) > 0 || SurfaceRiverDepth(planet, wx, wz) > 0)
+                {
+                    continue; // a vent needs open ground (not a sea/pond column)
+                }
 
-            int ly = sy - origin.Y;
-            if (ly >= 0 && ly < cs)
-            {
-                chunk.Set(wx - origin.X, ly, wz - origin.Z, ventId); // the surface cell becomes a vent
+                int ly = sy - origin.Y;
+                if (ly >= 0 && ly < cs)
+                {
+                    chunk.Set(wx - origin.X, ly, wz - origin.Z, ventId); // the surface cell becomes a vent
+                }
             }
-        }
     }
 
     /// <summary>Stamps towering giant mushrooms (a fibrous stem + a domed cap) on a fungal world's mycelium
@@ -1156,53 +1156,53 @@ public sealed class WorldGenerator
         }
 
         for (int wx = origin.X - maxCapR; wx < origin.X + cs + maxCapR; wx++)
-        for (int wz = origin.Z - maxCapR; wz < origin.Z + cs + maxCapR; wz++)
-        {
-            if (Noise.Value01(seed + 0x5340, WorldConstants.WrapX(wx, _circumference), 17, Wz(wz)) >= density)
+            for (int wz = origin.Z - maxCapR; wz < origin.Z + cs + maxCapR; wz++)
             {
-                continue;
-            }
-
-            var surf = biomes[biomes.Count <= 1 ? 0 : BiomeIndex(seed, wx, wz, biomes.Count, _circumference)].Surface;
-            if (surf != myceliumId)
-            {
-                continue; // only on mycelium ground
-            }
-
-            int sy = SurfaceHeight(planet, wx, wz);
-            if (sy + 1 <= fluidLevel || SurfacePondDepth(planet, wx, wz) > 0 || SurfaceRiverDepth(planet, wx, wz) > 0)
-            {
-                continue; // not in water
-            }
-
-            // Per-mushroom size (loosely-coupled stem height + cap): a shared bell factor with independent
-            // jitter on each, so a fungal grove reads as a mix of small and towering capped fungi.
-            double sizeF = SizeFactor(seed + 0x53410, wx, wz, 0.30);  // overall size, ±30% (bell)
-            double hJit = SizeFactor(seed + 0x53411, wx, wz, 0.12);  // independent stem-height jitter
-            double cJit = SizeFactor(seed + 0x53412, wx, wz, 0.12);  // independent cap jitter
-            int height = System.Math.Clamp((int)System.Math.Round(7.0 * sizeF * hJit), 4, 12);   // ~5..9 before
-            int capR = System.Math.Clamp((int)System.Math.Round(3.0 * sizeF * cJit), 2, maxCapR); // 2..4
-            int topY = sy + height;
-            for (int ty = sy + 1; ty <= topY; ty++)
-            {
-                SetCell(wx, ty, wz, stemId, overwrite: true);
-            }
-
-            // A domed cap: shrinking discs stacked above the stem top (taller dome for bigger caps).
-            int capLayers = capR - 1;
-            for (int dy = 0; dy <= capLayers; dy++)
-            {
-                int rr = capR - dy;
-                for (int dx = -rr; dx <= rr; dx++)
-                for (int dz = -rr; dz <= rr; dz++)
+                if (Noise.Value01(seed + 0x5340, WorldConstants.WrapX(wx, _circumference), 17, Wz(wz)) >= density)
                 {
-                    if (dx * dx + dz * dz <= rr * rr + 1)
-                    {
-                        SetCell(wx + dx, topY + dy, wz + dz, capId, overwrite: false);
-                    }
+                    continue;
+                }
+
+                var surf = biomes[biomes.Count <= 1 ? 0 : BiomeIndex(seed, wx, wz, biomes.Count, _circumference)].Surface;
+                if (surf != myceliumId)
+                {
+                    continue; // only on mycelium ground
+                }
+
+                int sy = SurfaceHeight(planet, wx, wz);
+                if (sy + 1 <= fluidLevel || SurfacePondDepth(planet, wx, wz) > 0 || SurfaceRiverDepth(planet, wx, wz) > 0)
+                {
+                    continue; // not in water
+                }
+
+                // Per-mushroom size (loosely-coupled stem height + cap): a shared bell factor with independent
+                // jitter on each, so a fungal grove reads as a mix of small and towering capped fungi.
+                double sizeF = SizeFactor(seed + 0x53410, wx, wz, 0.30);  // overall size, ±30% (bell)
+                double hJit = SizeFactor(seed + 0x53411, wx, wz, 0.12);  // independent stem-height jitter
+                double cJit = SizeFactor(seed + 0x53412, wx, wz, 0.12);  // independent cap jitter
+                int height = System.Math.Clamp((int)System.Math.Round(7.0 * sizeF * hJit), 4, 12);   // ~5..9 before
+                int capR = System.Math.Clamp((int)System.Math.Round(3.0 * sizeF * cJit), 2, maxCapR); // 2..4
+                int topY = sy + height;
+                for (int ty = sy + 1; ty <= topY; ty++)
+                {
+                    SetCell(wx, ty, wz, stemId, overwrite: true);
+                }
+
+                // A domed cap: shrinking discs stacked above the stem top (taller dome for bigger caps).
+                int capLayers = capR - 1;
+                for (int dy = 0; dy <= capLayers; dy++)
+                {
+                    int rr = capR - dy;
+                    for (int dx = -rr; dx <= rr; dx++)
+                        for (int dz = -rr; dz <= rr; dz++)
+                        {
+                            if (dx * dx + dz * dz <= rr * rr + 1)
+                            {
+                                SetCell(wx + dx, topY + dy, wz + dz, capId, overwrite: false);
+                            }
+                        }
                 }
             }
-        }
     }
 
     /// <summary>A deterministic per-instance size factor centred on 1.0 (a "bell" — the average of two
@@ -1253,63 +1253,63 @@ public sealed class WorldGenerator
         }
 
         for (int wx = origin.X - maxCrown; wx < origin.X + cs + maxCrown; wx++)
-        for (int wz = origin.Z - maxCrown; wz < origin.Z + cs + maxCrown; wz++)
-        {
-            var biome = biomes[biomes.Count <= 1 ? 0 : BiomeIndex(seed, wx, wz, biomes.Count, _circumference)];
-
-            // FORESTS: a low-frequency mask gathers trees into real groves/woods. Inside a forest patch the
-            // density is ~9x, on the fringe ~2x, the open land between almost bare — scaled by the biome's
-            // (and its theme's) tree density so savanna stays sparse, jungle dense, fungal/crystal treeless.
-            double forest = FbmT(seed + 0xF07E57, wx, wz, planet.TerrainScale * 2.0, octaves: 3);
-            double localDensity = density * biome.TreeMul * biome.Theme.TreeMul
-                * (forest > 0.62 ? 9.0 : forest > 0.52 ? 2.0 : 0.15);
-            if (localDensity <= 0.0
-                || Noise.Value01(seed + 5150, WorldConstants.WrapX(wx, _circumference), 11, Wz(wz)) >= localDensity)
+            for (int wz = origin.Z - maxCrown; wz < origin.Z + cs + maxCrown; wz++)
             {
-                continue;
-            }
+                var biome = biomes[biomes.Count <= 1 ? 0 : BiomeIndex(seed, wx, wz, biomes.Count, _circumference)];
 
-            // Pick a grove kind from the biome theme's tree palette (one kind per low-frequency patch).
-            var kind = PickTreeKind(biome.Theme.Trees, seed, wx, wz, planet.TerrainScale);
-            if (kind == TreeKind.None)
-            {
-                continue; // this theme grows no trees here (e.g. fungal → giant mushrooms instead)
-            }
+                // FORESTS: a low-frequency mask gathers trees into real groves/woods. Inside a forest patch the
+                // density is ~9x, on the fringe ~2x, the open land between almost bare — scaled by the biome's
+                // (and its theme's) tree density so savanna stays sparse, jungle dense, fungal/crystal treeless.
+                double forest = FbmT(seed + 0xF07E57, wx, wz, planet.TerrainScale * 2.0, octaves: 3);
+                double localDensity = density * biome.TreeMul * biome.Theme.TreeMul
+                    * (forest > 0.62 ? 9.0 : forest > 0.52 ? 2.0 : 0.15);
+                if (localDensity <= 0.0
+                    || Noise.Value01(seed + 5150, WorldConstants.WrapX(wx, _circumference), 11, Wz(wz)) >= localDensity)
+                {
+                    continue;
+                }
 
-            var surf = biome.Surface;
-            bool earthy = surf == grassId || surf == dirtId || surf == mudId;
-            bool sandyOk = surf == sandId && (kind == TreeKind.Palm || kind == TreeKind.Dead); // palms/dead snags on sand
-            if (!earthy && !sandyOk)
-            {
-                continue;
-            }
+                // Pick a grove kind from the biome theme's tree palette (one kind per low-frequency patch).
+                var kind = PickTreeKind(biome.Theme.Trees, seed, wx, wz, planet.TerrainScale);
+                if (kind == TreeKind.None)
+                {
+                    continue; // this theme grows no trees here (e.g. fungal → giant mushrooms instead)
+                }
 
-            int sy = SurfaceHeight(planet, wx, wz);
-            if (sy + 1 <= fluidLevel)
-            {
-                continue; // not in the sea
-            }
+                var surf = biome.Surface;
+                bool earthy = surf == grassId || surf == dirtId || surf == mudId;
+                bool sandyOk = surf == sandId && (kind == TreeKind.Palm || kind == TreeKind.Dead); // palms/dead snags on sand
+                if (!earthy && !sandyOk)
+                {
+                    continue;
+                }
 
-            if (SurfacePondDepth(planet, wx, wz) > 0 || SurfaceRiverDepth(planet, wx, wz) > 0)
-            {
-                continue; // B35: an upland pond/lake or a river here — a tree would stand in the water
-            }
+                int sy = SurfaceHeight(planet, wx, wz);
+                if (sy + 1 <= fluidLevel)
+                {
+                    continue; // not in the sea
+                }
 
-            // Per-tree size (loosely-coupled height + crown): a shared bell factor sets the overall scale,
-            // with a smaller independent jitter on each so trunk height and crown width still vary apart.
-            double sizeF = SizeFactor(seed + 0x71EE5, wx, wz, 0.30);              // overall tree size, ±30% (bell)
-            double hJit = SizeFactor(seed + 0x71EE6, wx, wz, 0.12);              // independent height jitter
-            double cJit = SizeFactor(seed + 0x71EE7, wx, wz, 0.12);              // independent crown jitter
+                if (SurfacePondDepth(planet, wx, wz) > 0 || SurfaceRiverDepth(planet, wx, wz) > 0)
+                {
+                    continue; // B35: an upland pond/lake or a river here — a tree would stand in the water
+                }
 
-            switch (kind)
-            {
-                case TreeKind.Conifer: BuildConifer(wx, sy, wz, sizeF, hJit, cJit, logId, pineId, SetCell); break;
-                case TreeKind.Palm:    BuildPalm(wx, sy, wz, sizeF, hJit, cJit, logId, palmId, SetCell); break;
-                case TreeKind.Jungle:  BuildJungle(wx, sy, wz, sizeF, hJit, cJit, logId, leafId, SetCell); break;
-                case TreeKind.Dead:    BuildDead(wx, sy, wz, sizeF, hJit, logId, SetCell); break;
-                default:               BuildBroadleaf(wx, sy, wz, sizeF, hJit, cJit, logId, leafId, SetCell); break;
+                // Per-tree size (loosely-coupled height + crown): a shared bell factor sets the overall scale,
+                // with a smaller independent jitter on each so trunk height and crown width still vary apart.
+                double sizeF = SizeFactor(seed + 0x71EE5, wx, wz, 0.30);              // overall tree size, ±30% (bell)
+                double hJit = SizeFactor(seed + 0x71EE6, wx, wz, 0.12);              // independent height jitter
+                double cJit = SizeFactor(seed + 0x71EE7, wx, wz, 0.12);              // independent crown jitter
+
+                switch (kind)
+                {
+                    case TreeKind.Conifer: BuildConifer(wx, sy, wz, sizeF, hJit, cJit, logId, pineId, SetCell); break;
+                    case TreeKind.Palm: BuildPalm(wx, sy, wz, sizeF, hJit, cJit, logId, palmId, SetCell); break;
+                    case TreeKind.Jungle: BuildJungle(wx, sy, wz, sizeF, hJit, cJit, logId, leafId, SetCell); break;
+                    case TreeKind.Dead: BuildDead(wx, sy, wz, sizeF, hJit, logId, SetCell); break;
+                    default: BuildBroadleaf(wx, sy, wz, sizeF, hJit, cJit, logId, leafId, SetCell); break;
+                }
             }
-        }
     }
 
     /// <summary>Picks one tree archetype for this column from the theme's palette. A low-frequency grove mask
@@ -1378,14 +1378,14 @@ public sealed class WorldGenerator
         }
 
         for (int dy = -1; dy <= crownR; dy++)
-        for (int dx = -crownR; dx <= crownR; dx++)
-        for (int dz = -crownR; dz <= crownR; dz++)
-        {
-            if (dx * dx + dz * dz + dy * dy <= crownR * crownR + 1)
-            {
-                set(wx + dx, topY + dy, wz + dz, leafId, false);
-            }
-        }
+            for (int dx = -crownR; dx <= crownR; dx++)
+                for (int dz = -crownR; dz <= crownR; dz++)
+                {
+                    if (dx * dx + dz * dz + dy * dy <= crownR * crownR + 1)
+                    {
+                        set(wx + dx, topY + dy, wz + dz, leafId, false);
+                    }
+                }
     }
 
     /// <summary>A rainforest giant: very tall trunk under a broad, deep canopy.</summary>
@@ -1401,14 +1401,14 @@ public sealed class WorldGenerator
         }
 
         for (int dy = -2; dy <= crownR; dy++)
-        for (int dx = -crownR; dx <= crownR; dx++)
-        for (int dz = -crownR; dz <= crownR; dz++)
-        {
-            if (dx * dx + dz * dz + dy * dy <= crownR * crownR + 2)
-            {
-                set(wx + dx, topY + dy, wz + dz, leafId, false);
-            }
-        }
+            for (int dx = -crownR; dx <= crownR; dx++)
+                for (int dz = -crownR; dz <= crownR; dz++)
+                {
+                    if (dx * dx + dz * dz + dy * dy <= crownR * crownR + 2)
+                    {
+                        set(wx + dx, topY + dy, wz + dz, leafId, false);
+                    }
+                }
     }
 
     /// <summary>A boreal conifer: tall narrow trunk under a layered conical needle crown tapering to a tip.</summary>
@@ -1430,13 +1430,13 @@ public sealed class WorldGenerator
             double f = (double)(tip - y) / (tip - crownStart); // wide at the base, ~0 near the tip
             int r = System.Math.Clamp((int)System.Math.Round(baseR * f), 0, baseR);
             for (int dx = -r; dx <= r; dx++)
-            for (int dz = -r; dz <= r; dz++)
-            {
-                if (dx * dx + dz * dz <= r * r + 1)
+                for (int dz = -r; dz <= r; dz++)
                 {
-                    set(wx + dx, y, wz + dz, leafId, false);
+                    if (dx * dx + dz * dz <= r * r + 1)
+                    {
+                        set(wx + dx, y, wz + dz, leafId, false);
+                    }
                 }
-            }
         }
 
         set(wx, tip, wz, leafId, false); // pointed tip

--- a/src/BlocksBeyondTheStars.WorldGeneration/WreckGenerator.cs
+++ b/src/BlocksBeyondTheStars.WorldGeneration/WreckGenerator.cs
@@ -119,54 +119,54 @@ public static class WreckGenerator
 
         // 1) Intact hull: a hollow shell with a viewport band (the repair target).
         for (int x = 0; x < w; x++)
-        for (int y = 0; y < h; y++)
-        for (int z = 0; z < l; z++)
-        {
-            bool shell = x == 0 || x == w - 1 || y == 0 || y == h - 1 || z == 0 || z == l - 1;
-            if (!shell)
-            {
-                continue;
-            }
+            for (int y = 0; y < h; y++)
+                for (int z = 0; z < l; z++)
+                {
+                    bool shell = x == 0 || x == w - 1 || y == 0 || y == h - 1 || z == 0 || z == l - 1;
+                    if (!shell)
+                    {
+                        continue;
+                    }
 
-            bool sideWall = x == 0 || x == w - 1 || z == 0 || z == l - 1;
-            bool viewport = sideWall && y == 2 && x > 0 && x < w - 1 && z > 0 && z < l - 1;
-            intact[(x * h + y) * l + z] = viewport ? glass : hull;
-        }
+                    bool sideWall = x == 0 || x == w - 1 || z == 0 || z == l - 1;
+                    bool viewport = sideWall && y == 2 && x > 0 && x < w - 1 && z > 0 && z < l - 1;
+                    intact[(x * h + y) * l + z] = viewport ? glass : hull;
+                }
 
         // 2) Decay: copy the intact hull, then punch breaches + scorch.
         var blocks = (ushort[])intact.Clone();
         for (int x = 0; x < w; x++)
-        for (int y = 0; y < h; y++)
-        for (int z = 0; z < l; z++)
-        {
-            int i = (x * h + y) * l + z;
-            if (intact[i] == 0)
-            {
-                continue;
-            }
+            for (int y = 0; y < h; y++)
+                for (int z = 0; z < l; z++)
+                {
+                    int i = (x * h + y) * l + z;
+                    if (intact[i] == 0)
+                    {
+                        continue;
+                    }
 
-            double r = rng.NextDouble();
-            if (r < 0.30)
-            {
-                blocks[i] = 0;               // breach
-            }
-            else if (r < 0.38 && scorch != 0)
-            {
-                blocks[i] = scorch;          // scorched plating
-            }
-        }
+                    double r = rng.NextDouble();
+                    if (r < 0.30)
+                    {
+                        blocks[i] = 0;               // breach
+                    }
+                    else if (r < 0.38 && scorch != 0)
+                    {
+                        blocks[i] = scorch;          // scorched plating
+                    }
+                }
 
         // Always tear a big gash in one wall (the crash impact) so the wreck is open to enter.
         int gx = w / 2;
         for (int y = 1; y <= System.Math.Min(3, h - 2); y++)
-        for (int dx = -1; dx <= 1; dx++)
-        {
-            int x = gx + dx;
-            if (x > 0 && x < w - 1)
+            for (int dx = -1; dx <= 1; dx++)
             {
-                blocks[(x * h + y) * l + 0] = 0;
+                int x = gx + dx;
+                if (x > 0 && x < w - 1)
+                {
+                    blocks[(x * h + y) * l + 0] = 0;
+                }
             }
-        }
 
         // 3) Markers inside: loot caches, a recoverable module, and (sometimes) a data terminal.
         var markers = new List<WreckMarker>();

--- a/tests/BlocksBeyondTheStars.Tests/CreativeModeTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/CreativeModeTests.cs
@@ -27,7 +27,10 @@ public sealed class CreativeModeTests : IDisposable
         var st = new LoopbackServerTransport(new LoopbackLink());
         var config = new ServerConfig
         {
-            WorldName = name, Seed = 1, AutoSaveIntervalMinutes = 9999, PlaceStarterShip = true,
+            WorldName = name,
+            Seed = 1,
+            AutoSaveIntervalMinutes = 9999,
+            PlaceStarterShip = true,
             CreativeUnlockAllBlueprints = creative,
             CreativeStartAllShips = creative,
             CreativeStarterKit = creative,

--- a/tests/BlocksBeyondTheStars.Tests/DoorTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/DoorTests.cs
@@ -33,9 +33,13 @@ public sealed class DoorTests : IDisposable
         var st = new LoopbackServerTransport(new LoopbackLink());
         var config = new ServerConfig
         {
-            WorldName = "door_" + seed, Seed = seed, StartPlanet = "jungle",
-            AutoSaveIntervalMinutes = 9999, PlaceStarterShip = false,
-            PlaceSettlements = true, PlaceWrecks = false,
+            WorldName = "door_" + seed,
+            Seed = seed,
+            StartPlanet = "jungle",
+            AutoSaveIntervalMinutes = 9999,
+            PlaceStarterShip = false,
+            PlaceSettlements = true,
+            PlaceWrecks = false,
         };
         var server = new SvGameServer(config, _content, st, repo);
         server.Start();

--- a/tests/BlocksBeyondTheStars.Tests/EnemyMovementTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/EnemyMovementTests.cs
@@ -37,8 +37,14 @@ public sealed class EnemyMovementTests : IDisposable
         var st = new LoopbackServerTransport(new LoopbackLink());
         var config = new ServerConfig
         {
-            WorldName = world, Seed = 9, StartPlanet = "rocky", AutoSaveIntervalMinutes = 9999,
-            PlaceStarterShip = false, PlaceSettlements = false, PlaceWrecks = false, ViewDistanceChunks = 1,
+            WorldName = world,
+            Seed = 9,
+            StartPlanet = "rocky",
+            AutoSaveIntervalMinutes = 9999,
+            PlaceStarterShip = false,
+            PlaceSettlements = false,
+            PlaceWrecks = false,
+            ViewDistanceChunks = 1,
         };
         config.Rules.FreeSpaceFlight = true;
         config.Rules.SpaceCombat = SpaceCombatMode.PvE; // hostile NPCs only spawn with combat enabled

--- a/tests/BlocksBeyondTheStars.Tests/FloraTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/FloraTests.cs
@@ -162,8 +162,11 @@ public sealed class FloraTests : IDisposable
             var st = new LoopbackServerTransport(new LoopbackLink());
             var config = new ServerConfig
             {
-                WorldName = "floratox", Seed = 7, AutoSaveIntervalMinutes = 9999,
-                PlaceStarterShip = false, StartPlanet = "jungle", // a flora world
+                WorldName = "floratox",
+                Seed = 7,
+                AutoSaveIntervalMinutes = 9999,
+                PlaceStarterShip = false,
+                StartPlanet = "jungle", // a flora world
             };
             var server = new SvGameServer(config, _content, st, repo);
             server.Start();
@@ -202,13 +205,13 @@ public sealed class FloraTests : IDisposable
 
         int found = 0;
         for (int x = 0; x < 48; x++)
-        for (int z = 0; z < 48; z++)
-        {
-            if (floraIds.Contains(BlockAboveSurface(gen, planet, x, z)))
+            for (int z = 0; z < 48; z++)
             {
-                found++;
+                if (floraIds.Contains(BlockAboveSurface(gen, planet, x, z)))
+                {
+                    found++;
+                }
             }
-        }
 
         Assert.True(found > 0, "Expected a flora planet to seed at least one flora block across a 48x48 area.");
     }
@@ -221,10 +224,10 @@ public sealed class FloraTests : IDisposable
         var floraIds = FloraIds();
 
         for (int x = 0; x < 24; x++)
-        for (int z = 0; z < 24; z++)
-        {
-            Assert.DoesNotContain(BlockAboveSurface(gen, planet, x, z), floraIds);
-        }
+            for (int z = 0; z < 24; z++)
+            {
+                Assert.DoesNotContain(BlockAboveSurface(gen, planet, x, z), floraIds);
+            }
     }
 
     [Fact]

--- a/tests/BlocksBeyondTheStars.Tests/FloraVarietyTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/FloraVarietyTests.cs
@@ -96,22 +96,22 @@ public sealed class FloraVarietyTests
 
         var counts = new Dictionary<ushort, int>();
         for (int cx = 0; cx < chunksXZ; cx++)
-        for (int cz = 0; cz < chunksXZ; cz++)
-        for (int cy = cyLo; cy <= cyHi; cy++)
-        {
-            var coord = WorldConstants.WorldToChunk(new Vector3i(cx * cs, cy * cs, cz * cs));
-            var chunk = gen.Generate(planet, coord);
-            for (int lx = 0; lx < cs; lx++)
-            for (int ly = 0; ly < cs; ly++)
-            for (int lz = 0; lz < cs; lz++)
-            {
-                ushort id = chunk.Get(lx, ly, lz).Value;
-                if (id != 0)
+            for (int cz = 0; cz < chunksXZ; cz++)
+                for (int cy = cyLo; cy <= cyHi; cy++)
                 {
-                    counts[id] = counts.TryGetValue(id, out var c) ? c + 1 : 1;
+                    var coord = WorldConstants.WorldToChunk(new Vector3i(cx * cs, cy * cs, cz * cs));
+                    var chunk = gen.Generate(planet, coord);
+                    for (int lx = 0; lx < cs; lx++)
+                        for (int ly = 0; ly < cs; ly++)
+                            for (int lz = 0; lz < cs; lz++)
+                            {
+                                ushort id = chunk.Get(lx, ly, lz).Value;
+                                if (id != 0)
+                                {
+                                    counts[id] = counts.TryGetValue(id, out var c) ? c + 1 : 1;
+                                }
+                            }
                 }
-            }
-        }
 
         return counts;
     }

--- a/tests/BlocksBeyondTheStars.Tests/FluidTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/FluidTests.cs
@@ -83,14 +83,14 @@ public sealed class FluidTests : IDisposable
 
             // A stone basin (floor at y0) filled with a 9x9x3 body of static "sea" water (y0+1..y0+3).
             for (int x = -4; x <= 4; x++)
-            for (int z = -4; z <= 4; z++)
-            {
-                server.World.SetBlock(new Vector3i(x, y0, z), stone);
-                for (int y = y0 + 1; y <= y0 + 3; y++)
+                for (int z = -4; z <= 4; z++)
                 {
-                    server.World.SetBlock(new Vector3i(x, y, z), water);
+                    server.World.SetBlock(new Vector3i(x, y0, z), stone);
+                    for (int y = y0 + 1; y <= y0 + 3; y++)
+                    {
+                        server.World.SetBlock(new Vector3i(x, y, z), water);
+                    }
                 }
-            }
 
             var p = server.AddLocalPlayer("Miner");
             p.State.Position = new Vector3f(0.5f, y0 + 5f, 0.5f);
@@ -182,10 +182,10 @@ public sealed class FluidTests : IDisposable
             var stone = _content.GetBlock("stone")!.NumericId;
             int y = 130;
             for (int x = -3; x <= 3; x++)
-            for (int z = -3; z <= 3; z++)
-            {
-                server.World.SetBlock(new Vector3i(x, y - 1, z), stone);
-            }
+                for (int z = -3; z <= 3; z++)
+                {
+                    server.World.SetBlock(new Vector3i(x, y - 1, z), stone);
+                }
 
             server.PlaceFluidSource("water", 0, y, 0);
             for (int i = 0; i < 6; i++)

--- a/tests/BlocksBeyondTheStars.Tests/GadgetTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/GadgetTests.cs
@@ -28,8 +28,11 @@ public sealed class GadgetTests : IDisposable
         var st = new LoopbackServerTransport(new LoopbackLink());
         var config = new ServerConfig
         {
-            WorldName = "gadget", Seed = 3, StartPlanet = "rocky",
-            AutoSaveIntervalMinutes = 9999, PlaceStarterShip = false,
+            WorldName = "gadget",
+            Seed = 3,
+            StartPlanet = "rocky",
+            AutoSaveIntervalMinutes = 9999,
+            PlaceStarterShip = false,
         };
         var server = new SvGameServer(config, _content, st, repo);
         server.Start();
@@ -79,11 +82,11 @@ public sealed class GadgetTests : IDisposable
             var stone = _content.GetBlock("stone")!.NumericId;
             var center = new Vector3i(12, 40, 12);
             for (int dx = -2; dx <= 2; dx++)
-            for (int dy = -2; dy <= 2; dy++)
-            for (int dz = -2; dz <= 2; dz++)
-            {
-                server.World.SetBlock(new Vector3i(center.X + dx, center.Y + dy, center.Z + dz), stone);
-            }
+                for (int dy = -2; dy <= 2; dy++)
+                    for (int dz = -2; dz <= 2; dz++)
+                    {
+                        server.World.SetBlock(new Vector3i(center.X + dx, center.Y + dy, center.Z + dz), stone);
+                    }
 
             int stoneBefore = p.State.Inventory.CountOf("stone");
 

--- a/tests/BlocksBeyondTheStars.Tests/GameServerCouplingTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/GameServerCouplingTests.cs
@@ -35,8 +35,12 @@ public sealed class GameServerCouplingTests : IDisposable
             var st = new LoopbackServerTransport(new LoopbackLink());
             var config = new ServerConfig
             {
-                WorldName = name, Seed = seed, StartPlanet = "rocky",
-                AutoSaveIntervalMinutes = 9999, PlaceStarterShip = false, PlaceWrecks = true,
+                WorldName = name,
+                Seed = seed,
+                StartPlanet = "rocky",
+                AutoSaveIntervalMinutes = 9999,
+                PlaceStarterShip = false,
+                PlaceWrecks = true,
             };
             config.Rules.MachineWreckCoupling = coupling;
             var server = new SvGameServer(config, _content, st, repo);

--- a/tests/BlocksBeyondTheStars.Tests/GameServerFinaleTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/GameServerFinaleTests.cs
@@ -30,8 +30,11 @@ public sealed class GameServerFinaleTests : IDisposable
         var st = new LoopbackServerTransport(new LoopbackLink());
         var config = new ServerConfig
         {
-            WorldName = "rocky", Seed = 4242, StartPlanet = "rocky",
-            AutoSaveIntervalMinutes = 9999, PlaceStarterShip = false,
+            WorldName = "rocky",
+            Seed = 4242,
+            StartPlanet = "rocky",
+            AutoSaveIntervalMinutes = 9999,
+            PlaceStarterShip = false,
         };
         var server = new SvGameServer(config, _content, st, repo);
         server.Start();

--- a/tests/BlocksBeyondTheStars.Tests/GameServerStoryCombatTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/GameServerStoryCombatTests.cs
@@ -30,8 +30,11 @@ public sealed class GameServerStoryCombatTests : IDisposable
         var st = new LoopbackServerTransport(new LoopbackLink());
         var config = new ServerConfig
         {
-            WorldName = planet, Seed = 4242, StartPlanet = planet,
-            AutoSaveIntervalMinutes = 9999, PlaceStarterShip = false,
+            WorldName = planet,
+            Seed = 4242,
+            StartPlanet = planet,
+            AutoSaveIntervalMinutes = 9999,
+            PlaceStarterShip = false,
         };
         var server = new SvGameServer(config, _content, st, repo);
         server.Start(); // default rules: Survival + PlanetEnemies Normal

--- a/tests/BlocksBeyondTheStars.Tests/GameServerStoryP7P8Tests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/GameServerStoryP7P8Tests.cs
@@ -28,8 +28,11 @@ public sealed class GameServerStoryP7P8Tests : IDisposable
         var st = new LoopbackServerTransport(new LoopbackLink());
         var config = new ServerConfig
         {
-            WorldName = "rocky", Seed = 4242, StartPlanet = "rocky",
-            AutoSaveIntervalMinutes = 9999, PlaceStarterShip = false,
+            WorldName = "rocky",
+            Seed = 4242,
+            StartPlanet = "rocky",
+            AutoSaveIntervalMinutes = 9999,
+            PlaceStarterShip = false,
         };
         rules?.Invoke(config.Rules);
         var server = new SvGameServer(config, _content, st, repo);

--- a/tests/BlocksBeyondTheStars.Tests/LandableAsteroidTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/LandableAsteroidTests.cs
@@ -48,22 +48,22 @@ public sealed class LandableAsteroidTests : IDisposable
 
         int crystalSurface = 0;
         for (int x = 0; x < 24; x++)
-        for (int z = 0; z < 24; z++)
-        {
-            int y = gen.SurfaceHeight(ast, x, z);
-            var coord = WorldConstants.WorldToChunk(new Vector3i(x, y, z));
-            var origin = WorldConstants.ChunkOrigin(coord);
-            var chunk = gen.Generate(ast, coord);
-            if (chunk.Get(x - origin.X, y - origin.Y, z - origin.Z).Value == crystal) crystalSurface++;
-
-            int ay = y + 1;
-            if (ay - origin.Y is >= 0 and < WorldConstants.ChunkSize)
+            for (int z = 0; z < 24; z++)
             {
-                ushort above = chunk.Get(x - origin.X, ay - origin.Y, z - origin.Z).Value;
-                Assert.NotEqual(floraPlant, above);   // no flora on a barren asteroid
-                Assert.NotEqual(floraCrystal, above);
+                int y = gen.SurfaceHeight(ast, x, z);
+                var coord = WorldConstants.WorldToChunk(new Vector3i(x, y, z));
+                var origin = WorldConstants.ChunkOrigin(coord);
+                var chunk = gen.Generate(ast, coord);
+                if (chunk.Get(x - origin.X, y - origin.Y, z - origin.Z).Value == crystal) crystalSurface++;
+
+                int ay = y + 1;
+                if (ay - origin.Y is >= 0 and < WorldConstants.ChunkSize)
+                {
+                    ushort above = chunk.Get(x - origin.X, ay - origin.Y, z - origin.Z).Value;
+                    Assert.NotEqual(floraPlant, above);   // no flora on a barren asteroid
+                    Assert.NotEqual(floraCrystal, above);
+                }
             }
-        }
 
         Assert.True(crystalSurface > 0, "Expected a crystalline asteroid surface.");
     }
@@ -119,8 +119,11 @@ public sealed class LandableAsteroidTests : IDisposable
         var st = new LoopbackServerTransport(new LoopbackLink());
         var config = new ServerConfig
         {
-            WorldName = "ast", Seed = 7, StartPlanet = "asteroid",
-            AutoSaveIntervalMinutes = 9999, PlaceStarterShip = false,
+            WorldName = "ast",
+            Seed = 7,
+            StartPlanet = "asteroid",
+            AutoSaveIntervalMinutes = 9999,
+            PlaceStarterShip = false,
         };
         var server = new SvGameServer(config, _content, st, repo);
         server.Start();
@@ -152,8 +155,11 @@ public sealed class LandableAsteroidTests : IDisposable
             var st1 = new LoopbackServerTransport(new LoopbackLink());
             var config1 = new ServerConfig
             {
-                WorldName = "ast_persist", Seed = 11, StartPlanet = "asteroid",
-                AutoSaveIntervalMinutes = 9999, PlaceStarterShip = false,
+                WorldName = "ast_persist",
+                Seed = 11,
+                StartPlanet = "asteroid",
+                AutoSaveIntervalMinutes = 9999,
+                PlaceStarterShip = false,
             };
             var s1 = new SvGameServer(config1, _content, st1, repo1);
             s1.Start();
@@ -188,8 +194,11 @@ public sealed class LandableAsteroidTests : IDisposable
         var st2 = new LoopbackServerTransport(new LoopbackLink());
         var config2 = new ServerConfig
         {
-            WorldName = "ast_persist", Seed = 11, StartPlanet = "asteroid",
-            AutoSaveIntervalMinutes = 9999, PlaceStarterShip = false,
+            WorldName = "ast_persist",
+            Seed = 11,
+            StartPlanet = "asteroid",
+            AutoSaveIntervalMinutes = 9999,
+            PlaceStarterShip = false,
         };
         var s2 = new SvGameServer(config2, _content, st2, repo2);
         s2.Start();

--- a/tests/BlocksBeyondTheStars.Tests/LlmStagesTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/LlmStagesTests.cs
@@ -67,9 +67,14 @@ public sealed class LlmStagesTests : IDisposable
             var st = new LoopbackServerTransport(new LoopbackLink());
             var config = new ServerConfig
             {
-                WorldName = $"l_{seed}", Seed = seed, StartPlanet = "jungle",
-                AutoSaveIntervalMinutes = 9999, PlaceStarterShip = false,
-                PlaceSettlements = true, PlaceWrecks = false, AiLevel = level,
+                WorldName = $"l_{seed}",
+                Seed = seed,
+                StartPlanet = "jungle",
+                AutoSaveIntervalMinutes = 9999,
+                PlaceStarterShip = false,
+                PlaceSettlements = true,
+                PlaceWrecks = false,
+                AiLevel = level,
             };
             var server = new SvGameServer(config, _content, st, repo, logger: null, aiProvider: provider);
             server.Start();
@@ -125,7 +130,9 @@ public sealed class LlmStagesTests : IDisposable
             string npcKey = $"settle_{(uint)WorldGenerator.StableHash(server.SettlementName) % 100000u}:vendor";
             p.State.NpcMemory[npcKey] = new NpcRelationship
             {
-                Name = "Old Mira", Role = "vendor", Value = 25,
+                Name = "Old Mira",
+                Role = "vendor",
+                Value = 25,
                 Log =
                 {
                     new NpcInteraction { Kind = NpcInteractionKind.Trade },

--- a/tests/BlocksBeyondTheStars.Tests/LocomotionControllerTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/LocomotionControllerTests.cs
@@ -14,9 +14,19 @@ public sealed class LocomotionControllerTests
     private static LocomotionProfile Roamer(float cruise = 2f, float accel = 4f, float turn = 3f) => new()
     {
         Style = LocomotionStyle.Strider,
-        CruiseSpeed = cruise, BurstSpeed = cruise, Accel = accel, TurnRate = turn,
-        HoldMin = 2f, HoldMax = 2f, PauseChance = 0f, PauseMin = 1f, PauseMax = 1f,
-        WeaveAmp = 0f, WeaveFreq = 0f, VertAmp = 0f, VertFreq = 0f,
+        CruiseSpeed = cruise,
+        BurstSpeed = cruise,
+        Accel = accel,
+        TurnRate = turn,
+        HoldMin = 2f,
+        HoldMax = 2f,
+        PauseChance = 0f,
+        PauseMin = 1f,
+        PauseMax = 1f,
+        WeaveAmp = 0f,
+        WeaveFreq = 0f,
+        VertAmp = 0f,
+        VertFreq = 0f,
     };
 
     [Fact]

--- a/tests/BlocksBeyondTheStars.Tests/MiningTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/MiningTests.cs
@@ -87,25 +87,25 @@ public sealed class MiningTests : IDisposable
             var stone = _content.GetBlock("stone")!.NumericId;
             var center = new Vector3i(0, 64, 0);
             for (int dx = -1; dx <= 1; dx++)
-            for (int dy = -1; dy <= 1; dy++)
-            for (int dz = -1; dz <= 1; dz++)
-            {
-                server.World.SetBlock(new Vector3i(center.X + dx, center.Y + dy, center.Z + dz), stone);
-            }
+                for (int dy = -1; dy <= 1; dy++)
+                    for (int dz = -1; dz <= 1; dz++)
+                    {
+                        server.World.SetBlock(new Vector3i(center.X + dx, center.Y + dy, center.Z + dz), stone);
+                    }
 
             server.MineBlock("Miner", center.X, center.Y, center.Z);
 
             // The centre + its whole 3x3x3 neighbourhood are cleared in one go.
             int solid = 0;
             for (int dx = -1; dx <= 1; dx++)
-            for (int dy = -1; dy <= 1; dy++)
-            for (int dz = -1; dz <= 1; dz++)
-            {
-                if (!server.World.GetBlock(new Vector3i(center.X + dx, center.Y + dy, center.Z + dz)).IsAir)
-                {
-                    solid++;
-                }
-            }
+                for (int dy = -1; dy <= 1; dy++)
+                    for (int dz = -1; dz <= 1; dz++)
+                    {
+                        if (!server.World.GetBlock(new Vector3i(center.X + dx, center.Y + dy, center.Z + dz)).IsAir)
+                        {
+                            solid++;
+                        }
+                    }
 
             Assert.Equal(0, solid);
         }

--- a/tests/BlocksBeyondTheStars.Tests/MissionBoardTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/MissionBoardTests.cs
@@ -31,9 +31,13 @@ public sealed class MissionBoardTests : IDisposable
         var st = new LoopbackServerTransport(new LoopbackLink());
         var config = new ServerConfig
         {
-            WorldName = "board_" + seed, Seed = seed, StartPlanet = "jungle",
-            AutoSaveIntervalMinutes = 9999, PlaceStarterShip = false,
-            PlaceSettlements = true, PlaceWrecks = false,
+            WorldName = "board_" + seed,
+            Seed = seed,
+            StartPlanet = "jungle",
+            AutoSaveIntervalMinutes = 9999,
+            PlaceStarterShip = false,
+            PlaceSettlements = true,
+            PlaceWrecks = false,
         };
         var server = new SvGameServer(config, _content, st, repo);
         server.Start();

--- a/tests/BlocksBeyondTheStars.Tests/NpcGreetingTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/NpcGreetingTests.cs
@@ -94,9 +94,14 @@ public sealed class NpcGreetingTests : IDisposable
             var st = new LoopbackServerTransport(new LoopbackLink());
             var config = new ServerConfig
             {
-                WorldName = $"g_{seed}", Seed = seed, StartPlanet = "jungle",
-                AutoSaveIntervalMinutes = 9999, PlaceStarterShip = false,
-                PlaceSettlements = true, PlaceWrecks = false, AiLevel = level,
+                WorldName = $"g_{seed}",
+                Seed = seed,
+                StartPlanet = "jungle",
+                AutoSaveIntervalMinutes = 9999,
+                PlaceStarterShip = false,
+                PlaceSettlements = true,
+                PlaceWrecks = false,
+                AiLevel = level,
             };
             var server = new SvGameServer(config, _content, st, repo, logger: null, aiProvider: provider);
             server.Start();

--- a/tests/BlocksBeyondTheStars.Tests/OxygenTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/OxygenTests.cs
@@ -31,9 +31,13 @@ public sealed class OxygenTests : IDisposable
         var st = new LoopbackServerTransport(new LoopbackLink());
         var config = new ServerConfig
         {
-            WorldName = "oxy", Seed = 7, StartPlanet = "rocky", // rocky = toxic atmosphere → oxygen matters
-            AutoSaveIntervalMinutes = 9999, PlaceStarterShip = true,
-            PlaceSettlements = false, PlaceWrecks = false,
+            WorldName = "oxy",
+            Seed = 7,
+            StartPlanet = "rocky", // rocky = toxic atmosphere → oxygen matters
+            AutoSaveIntervalMinutes = 9999,
+            PlaceStarterShip = true,
+            PlaceSettlements = false,
+            PlaceWrecks = false,
         };
         var server = new SvGameServer(config, _content, st, repo);
         server.Start();
@@ -49,9 +53,13 @@ public sealed class OxygenTests : IDisposable
             var st = new LoopbackServerTransport(new LoopbackLink());
             var config = new ServerConfig
             {
-                WorldName = "oxyswim", Seed = 7, StartPlanet = "jungle", // breathable atmosphere
-                AutoSaveIntervalMinutes = 9999, PlaceStarterShip = true, // a ship so AboardShip is tracked
-                PlaceSettlements = false, PlaceWrecks = false,
+                WorldName = "oxyswim",
+                Seed = 7,
+                StartPlanet = "jungle", // breathable atmosphere
+                AutoSaveIntervalMinutes = 9999,
+                PlaceStarterShip = true, // a ship so AboardShip is tracked
+                PlaceSettlements = false,
+                PlaceWrecks = false,
             };
             var server = new SvGameServer(config, _content, st, repo);
             server.Start();
@@ -66,11 +74,11 @@ public sealed class OxygenTests : IDisposable
             var stone = _content.GetBlock("stone")!.NumericId;
             int cx = 240, cz = 240, floorY = 100;
             for (int x = cx - 3; x <= cx + 3; x++)
-            for (int z = cz - 3; z <= cz + 3; z++)
-            {
-                server.World.SetBlock(new Vector3i(x, floorY, z), stone);
-                for (int y = floorY + 1; y <= floorY + 8; y++) server.World.SetBlock(new Vector3i(x, y, z), water);
-            }
+                for (int z = cz - 3; z <= cz + 3; z++)
+                {
+                    server.World.SetBlock(new Vector3i(x, floorY, z), stone);
+                    for (int y = floorY + 1; y <= floorY + 8; y++) server.World.SetBlock(new Vector3i(x, y, z), water);
+                }
 
             var abovePool = new Vector3f(cx + 0.5f, floorY + 14f, cz + 0.5f); // dry air above the pool
             var dive = new Vector3f(cx + 0.5f, floorY + 3f, cz + 0.5f);       // chest-deep in the pool

--- a/tests/BlocksBeyondTheStars.Tests/PlaytimeTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/PlaytimeTests.cs
@@ -29,9 +29,13 @@ public sealed class PlaytimeTests : IDisposable
         var st = new LoopbackServerTransport(new LoopbackLink());
         var config = new ServerConfig
         {
-            WorldName = world, Seed = 7, StartPlanet = "rocky",
-            AutoSaveIntervalMinutes = 9999, PlaceStarterShip = true,
-            PlaceSettlements = false, PlaceWrecks = false,
+            WorldName = world,
+            Seed = 7,
+            StartPlanet = "rocky",
+            AutoSaveIntervalMinutes = 9999,
+            PlaceStarterShip = true,
+            PlaceSettlements = false,
+            PlaceWrecks = false,
         };
         var server = new SvGameServer(config, _content, st, repo);
         server.Start();

--- a/tests/BlocksBeyondTheStars.Tests/SettlementGenerationTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/SettlementGenerationTests.cs
@@ -27,11 +27,11 @@ public sealed class SettlementGenerationTests
         Assert.Equal(a.Length, b.Length);
         Assert.Equal(a.BuildingCount, b.BuildingCount);
         for (int x = 0; x < a.Width; x++)
-        for (int y = 0; y < a.Height; y++)
-        for (int z = 0; z < a.Length; z++)
-        {
-            Assert.Equal(a.Get(x, y, z), b.Get(x, y, z));
-        }
+            for (int y = 0; y < a.Height; y++)
+                for (int z = 0; z < a.Length; z++)
+                {
+                    Assert.Equal(a.Get(x, y, z), b.Get(x, y, z));
+                }
     }
 
     [Fact]
@@ -49,11 +49,11 @@ public sealed class SettlementGenerationTests
         // Built from the biome material (mud), not iron.
         bool usesMud = false;
         for (int x = 0; x < s.Width && !usesMud; x++)
-        for (int y = 0; y < s.Height; y++)
-        for (int z = 0; z < s.Length; z++)
-        {
-            if (s.Get(x, y, z) == mud) { usesMud = true; break; }
-        }
+            for (int y = 0; y < s.Height; y++)
+                for (int z = 0; z < s.Length; z++)
+                {
+                    if (s.Get(x, y, z) == mud) { usesMud = true; break; }
+                }
 
         Assert.True(usesMud, "A village should be built from its biome surface block.");
     }
@@ -68,11 +68,11 @@ public sealed class SettlementGenerationTests
         Assert.Equal("town", s.Tier);
         bool hasLadder = false;
         for (int x = 0; x < s.Width && !hasLadder; x++)
-        for (int y = 0; y < s.Height; y++)
-        for (int z = 0; z < s.Length; z++)
-        {
-            if (s.Get(x, y, z) == ladder) { hasLadder = true; break; }
-        }
+            for (int y = 0; y < s.Height; y++)
+                for (int z = 0; z < s.Length; z++)
+                {
+                    if (s.Get(x, y, z) == ladder) { hasLadder = true; break; }
+                }
 
         Assert.True(hasLadder, "A multi-storey town building must have a ladder between floors.");
     }
@@ -111,11 +111,11 @@ public sealed class SettlementGenerationTests
 
         int interiorAir = 0;
         for (int x = 1; x < s.Width - 1; x++)
-        for (int y = 1; y < s.Height - 1; y++)
-        for (int z = 1; z < s.Length - 1; z++)
-        {
-            if (s.Get(x, y, z) == air) interiorAir++;
-        }
+            for (int y = 1; y < s.Height - 1; y++)
+                for (int z = 1; z < s.Length - 1; z++)
+                {
+                    if (s.Get(x, y, z) == air) interiorAir++;
+                }
 
         Assert.True(interiorAir > 0, "Buildings must be hollow (enterable rooms).");
         Assert.True(s.BuildingCount >= 1);

--- a/tests/BlocksBeyondTheStars.Tests/SettlementNpcTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/SettlementNpcTests.cs
@@ -32,9 +32,13 @@ public sealed class SettlementNpcTests : IDisposable
         var st = new LoopbackServerTransport(new LoopbackLink());
         var config = new ServerConfig
         {
-            WorldName = "npc_" + seed, Seed = seed, StartPlanet = planet,
-            AutoSaveIntervalMinutes = 9999, PlaceStarterShip = false,
-            PlaceSettlements = true, PlaceWrecks = false,
+            WorldName = "npc_" + seed,
+            Seed = seed,
+            StartPlanet = planet,
+            AutoSaveIntervalMinutes = 9999,
+            PlaceStarterShip = false,
+            PlaceSettlements = true,
+            PlaceWrecks = false,
         };
         var server = new SvGameServer(config, _content, st, repo);
         server.Start();

--- a/tests/BlocksBeyondTheStars.Tests/SettlementOverhaulTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/SettlementOverhaulTests.cs
@@ -33,9 +33,13 @@ public sealed class SettlementOverhaulTests : IDisposable
         var st = new LoopbackServerTransport(new LoopbackLink());
         var config = new ServerConfig
         {
-            WorldName = planet + seed, Seed = seed, StartPlanet = planet,
-            AutoSaveIntervalMinutes = 9999, PlaceStarterShip = false,
-            PlaceSettlements = true, PlaceWrecks = false,
+            WorldName = planet + seed,
+            Seed = seed,
+            StartPlanet = planet,
+            AutoSaveIntervalMinutes = 9999,
+            PlaceStarterShip = false,
+            PlaceSettlements = true,
+            PlaceWrecks = false,
         };
         var server = new SvGameServer(config, _content, st, repo);
         server.Start();
@@ -102,11 +106,11 @@ public sealed class SettlementOverhaulTests : IDisposable
                 checkedAMultiWorld = true;
                 int circ = server.World.Circumference;
                 for (int a = 0; a < list.Count; a++)
-                for (int b = a + 1; b < list.Count; b++)
-                {
-                    Assert.False(RectsOverlap(list[a], list[b], circ),
-                        $"seed {seed}: two settlement footprints overlap.");
-                }
+                    for (int b = a + 1; b < list.Count; b++)
+                    {
+                        Assert.False(RectsOverlap(list[a], list[b], circ),
+                            $"seed {seed}: two settlement footprints overlap.");
+                    }
             }
         }
 

--- a/tests/BlocksBeyondTheStars.Tests/SettlementStampTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/SettlementStampTests.cs
@@ -31,8 +31,12 @@ public sealed class SettlementStampTests : IDisposable
         var st = new LoopbackServerTransport(new LoopbackLink());
         var config = new ServerConfig
         {
-            WorldName = planet + seed, Seed = seed, StartPlanet = planet,
-            AutoSaveIntervalMinutes = 9999, PlaceStarterShip = false, PlaceSettlements = true,
+            WorldName = planet + seed,
+            Seed = seed,
+            StartPlanet = planet,
+            AutoSaveIntervalMinutes = 9999,
+            PlaceStarterShip = false,
+            PlaceSettlements = true,
         };
         var server = new SvGameServer(config, _content, st, repo);
         server.Start();
@@ -111,14 +115,14 @@ public sealed class SettlementStampTests : IDisposable
 
             bool solidNearby = false;
             for (int dx = -4; dx <= 4 && !solidNearby; dx++)
-            for (int dy = -1; dy <= 4 && !solidNearby; dy++)
-            for (int dz = -4; dz <= 4 && !solidNearby; dz++)
-            {
-                if (!server.World.GetBlock(new Vector3i(basePos.X + dx, basePos.Y + dy, basePos.Z + dz)).IsAir)
-                {
-                    solidNearby = true;
-                }
-            }
+                for (int dy = -1; dy <= 4 && !solidNearby; dy++)
+                    for (int dz = -4; dz <= 4 && !solidNearby; dz++)
+                    {
+                        if (!server.World.GetBlock(new Vector3i(basePos.X + dx, basePos.Y + dy, basePos.Z + dz)).IsAir)
+                        {
+                            solidNearby = true;
+                        }
+                    }
 
             Assert.True(solidNearby, "A stamped settlement should place solid blocks in the world.");
         }

--- a/tests/BlocksBeyondTheStars.Tests/ShipAiTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/ShipAiTests.cs
@@ -100,27 +100,27 @@ public sealed class ShipAiTests : IDisposable
         int topY = (int)Math.Ceiling(session.State.Position.Y);
         int mined = 0;
         for (int dx = -2; dx <= 2 && mined < 3; dx++)
-        for (int dz = -2; dz <= 2 && mined < 3; dz++)
-        for (int y = topY; y > topY - 7 && mined < 3; y--)
-        {
-            var pos = new Vector3i(px + dx, y, pz + dz);
-            if (server.World.GetBlock(pos).IsAir)
-            {
-                continue;
-            }
+            for (int dz = -2; dz <= 2 && mined < 3; dz++)
+                for (int y = topY; y > topY - 7 && mined < 3; y--)
+                {
+                    var pos = new Vector3i(px + dx, y, pz + dz);
+                    if (server.World.GetBlock(pos).IsAir)
+                    {
+                        continue;
+                    }
 
-            for (int hit = 0; hit < 12 && !server.World.GetBlock(pos).IsAir; hit++)
-            {
-                client.Send(NetCodec.Encode(new MineBlockIntent { X = pos.X, Y = pos.Y, Z = pos.Z }),
-                    DeliveryMode.ReliableOrdered);
-                server.Tick(0.1);
-            }
+                    for (int hit = 0; hit < 12 && !server.World.GetBlock(pos).IsAir; hit++)
+                    {
+                        client.Send(NetCodec.Encode(new MineBlockIntent { X = pos.X, Y = pos.Y, Z = pos.Z }),
+                            DeliveryMode.ReliableOrdered);
+                        server.Tick(0.1);
+                    }
 
-            if (server.World.GetBlock(pos).IsAir)
-            {
-                mined++;
-            }
-        }
+                    if (server.World.GetBlock(pos).IsAir)
+                    {
+                        mined++;
+                    }
+                }
 
         Assert.Equal(3, mined);
         client.Poll();

--- a/tests/BlocksBeyondTheStars.Tests/ShipRepairTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/ShipRepairTests.cs
@@ -30,7 +30,10 @@ public sealed class ShipRepairTests : IDisposable
         var st = new LoopbackServerTransport(new LoopbackLink());
         var config = new ServerConfig
         {
-            WorldName = "shiprepair", Seed = 1, AutoSaveIntervalMinutes = 9999, PlaceStarterShip = true,
+            WorldName = "shiprepair",
+            Seed = 1,
+            AutoSaveIntervalMinutes = 9999,
+            PlaceStarterShip = true,
         };
         var server = new SvGameServer(config, _content, st, repo);
         server.Start();

--- a/tests/BlocksBeyondTheStars.Tests/ShipStructureTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/ShipStructureTests.cs
@@ -57,8 +57,11 @@ public sealed class ShipStructureTests : IDisposable
             var st = new LoopbackServerTransport(new LoopbackLink());
             var config = new ServerConfig
             {
-                WorldName = "padflat", Seed = 1, StartPlanet = "jungle",
-                AutoSaveIntervalMinutes = 9999, PlaceStarterShip = true,
+                WorldName = "padflat",
+                Seed = 1,
+                StartPlanet = "jungle",
+                AutoSaveIntervalMinutes = 9999,
+                PlaceStarterShip = true,
             };
             var server = new SvGameServer(config, _content, st, repo);
             server.Start();
@@ -90,8 +93,11 @@ public sealed class ShipStructureTests : IDisposable
             var st = new LoopbackServerTransport(new LoopbackLink());
             var config = new ServerConfig
             {
-                WorldName = "wet_world", Seed = 1, StartPlanet = "jungle",
-                AutoSaveIntervalMinutes = 9999, PlaceStarterShip = true,
+                WorldName = "wet_world",
+                Seed = 1,
+                StartPlanet = "jungle",
+                AutoSaveIntervalMinutes = 9999,
+                PlaceStarterShip = true,
             };
             var server = new SvGameServer(config, _content, st, repo);
             server.Start();

--- a/tests/BlocksBeyondTheStars.Tests/SkylandsTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/SkylandsTests.cs
@@ -27,44 +27,44 @@ public sealed class SkylandsTests
         // SOLID island band higher up. Sample full chunk columns over the island altitude window.
         bool foundIsland = false;
         for (int cx = 0; cx < 12 && !foundIsland; cx++)
-        for (int cz = 0; cz < 12 && !foundIsland; cz++)
-        {
-            // The island band lives around BaseHeight+28 (±12 altitude jitter, ±~16 thickness) — chunk
-            // Y=5 covers world Y 80..95 for BaseHeight 56; chunk Y=4 covers 64..79.
-            foreach (int cy in new[] { 4, 5, 6 })
+            for (int cz = 0; cz < 12 && !foundIsland; cz++)
             {
-                var coord = new ChunkCoord(cx, cy, cz);
-                var chunk = gen.Generate(planet, coord);
-                var origin = WorldConstants.ChunkOrigin(coord);
-
-                for (int lx = 0; lx < WorldConstants.ChunkSize && !foundIsland; lx++)
-                for (int lz = 0; lz < WorldConstants.ChunkSize && !foundIsland; lz++)
+                // The island band lives around BaseHeight+28 (±12 altitude jitter, ±~16 thickness) — chunk
+                // Y=5 covers world Y 80..95 for BaseHeight 56; chunk Y=4 covers 64..79.
+                foreach (int cy in new[] { 4, 5, 6 })
                 {
-                    int wx = origin.X + lx, wz = origin.Z + lz;
-                    int surface = gen.SurfaceHeight(planet, wx, wz);
+                    var coord = new ChunkCoord(cx, cy, cz);
+                    var chunk = gen.Generate(planet, coord);
+                    var origin = WorldConstants.ChunkOrigin(coord);
 
-                    // Find a solid cell in this chunk column clearly ABOVE the terrain surface…
-                    for (int ly = 0; ly < WorldConstants.ChunkSize; ly++)
-                    {
-                        int wy = origin.Y + ly;
-                        if (wy <= surface + 6 || chunk.Get(lx, ly, lz).IsAir)
+                    for (int lx = 0; lx < WorldConstants.ChunkSize && !foundIsland; lx++)
+                        for (int lz = 0; lz < WorldConstants.ChunkSize && !foundIsland; lz++)
                         {
-                            continue;
-                        }
+                            int wx = origin.X + lx, wz = origin.Z + lz;
+                            int surface = gen.SurfaceHeight(planet, wx, wz);
 
-                        // …and verify there is an air gap between the ground and this island cell.
-                        var below = gen.Generate(planet, WorldConstants.WorldToChunk(new BlocksBeyondTheStars.Shared.Geometry.Vector3i(wx, surface + 2, wz)));
-                        var bo = WorldConstants.ChunkOrigin(WorldConstants.WorldToChunk(new BlocksBeyondTheStars.Shared.Geometry.Vector3i(wx, surface + 2, wz)));
-                        if (below.Get(wx - bo.X, surface + 2 - bo.Y, wz - bo.Z).IsAir)
-                        {
-                            foundIsland = true;
-                        }
+                            // Find a solid cell in this chunk column clearly ABOVE the terrain surface…
+                            for (int ly = 0; ly < WorldConstants.ChunkSize; ly++)
+                            {
+                                int wy = origin.Y + ly;
+                                if (wy <= surface + 6 || chunk.Get(lx, ly, lz).IsAir)
+                                {
+                                    continue;
+                                }
 
-                        break;
-                    }
+                                // …and verify there is an air gap between the ground and this island cell.
+                                var below = gen.Generate(planet, WorldConstants.WorldToChunk(new BlocksBeyondTheStars.Shared.Geometry.Vector3i(wx, surface + 2, wz)));
+                                var bo = WorldConstants.ChunkOrigin(WorldConstants.WorldToChunk(new BlocksBeyondTheStars.Shared.Geometry.Vector3i(wx, surface + 2, wz)));
+                                if (below.Get(wx - bo.X, surface + 2 - bo.Y, wz - bo.Z).IsAir)
+                                {
+                                    foundIsland = true;
+                                }
+
+                                break;
+                            }
+                        }
                 }
             }
-        }
 
         Assert.True(foundIsland, "expected at least one floating island (solid band above the surface with air below) in the scanned region");
     }
@@ -81,28 +81,28 @@ public sealed class SkylandsTests
         // a grove (many trunks), others are nearly bare. A uniform sprinkle would spread them evenly.
         int total = 0, maxPerChunk = 0, emptyChunks = 0, chunks = 0;
         for (int cx = 0; cx < 10; cx++)
-        for (int cz = 0; cz < 10; cz++)
-        {
-            int trunks = 0;
-            foreach (int cy in new[] { 3, 4, 5 }) // surface band for jungle BaseHeight 66
+            for (int cz = 0; cz < 10; cz++)
             {
-                var chunk = gen.Generate(planet, new ChunkCoord(cx, cy, cz));
-                for (int lx = 0; lx < WorldConstants.ChunkSize; lx++)
-                for (int ly = 0; ly < WorldConstants.ChunkSize; ly++)
-                for (int lz = 0; lz < WorldConstants.ChunkSize; lz++)
+                int trunks = 0;
+                foreach (int cy in new[] { 3, 4, 5 }) // surface band for jungle BaseHeight 66
                 {
-                    if (chunk.Get(lx, ly, lz) == logId)
-                    {
-                        trunks++;
-                    }
+                    var chunk = gen.Generate(planet, new ChunkCoord(cx, cy, cz));
+                    for (int lx = 0; lx < WorldConstants.ChunkSize; lx++)
+                        for (int ly = 0; ly < WorldConstants.ChunkSize; ly++)
+                            for (int lz = 0; lz < WorldConstants.ChunkSize; lz++)
+                            {
+                                if (chunk.Get(lx, ly, lz) == logId)
+                                {
+                                    trunks++;
+                                }
+                            }
                 }
-            }
 
-            chunks++;
-            total += trunks;
-            if (trunks == 0) emptyChunks++;
-            if (trunks > maxPerChunk) maxPerChunk = trunks;
-        }
+                chunks++;
+                total += trunks;
+                if (trunks == 0) emptyChunks++;
+                if (trunks > maxPerChunk) maxPerChunk = trunks;
+            }
 
         Assert.True(total > 60, $"a jungle region should hold plenty of trees (found {total} trunk cells in {chunks} chunk columns)");
         Assert.True(maxPerChunk >= 20, $"forests should form dense groves somewhere (densest chunk column: {maxPerChunk} trunk cells)");

--- a/tests/BlocksBeyondTheStars.Tests/SpaceCombatTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/SpaceCombatTests.cs
@@ -102,11 +102,11 @@ public sealed class SpaceCombatTests : IDisposable
             // Find a solid hull cell in the player's ship structure.
             int sx = -1, sy = -1, sz = -1;
             for (int x = 0; x < 24 && sx < 0; x++)
-            for (int y = 0; y < 24 && sx < 0; y++)
-            for (int z = 0; z < 24 && sx < 0; z++)
-            {
-                if (server.StructureBlockForTest("Pilot", x, y, z) != 0) { sx = x; sy = y; sz = z; }
-            }
+                for (int y = 0; y < 24 && sx < 0; y++)
+                    for (int z = 0; z < 24 && sx < 0; z++)
+                    {
+                        if (server.StructureBlockForTest("Pilot", x, y, z) != 0) { sx = x; sy = y; sz = z; }
+                    }
 
             Assert.True(sx >= 0, "the ship structure should have at least one solid cell");
 
@@ -134,11 +134,11 @@ public sealed class SpaceCombatTests : IDisposable
 
             int sx = -1, sy = -1, sz = -1;
             for (int x = 0; x < 24 && sx < 0; x++)
-            for (int y = 0; y < 24 && sx < 0; y++)
-            for (int z = 0; z < 24 && sx < 0; z++)
-            {
-                if (server.StructureBlockForTest("Pilot", x, y, z) != 0) { sx = x; sy = y; sz = z; }
-            }
+                for (int y = 0; y < 24 && sx < 0; y++)
+                    for (int z = 0; z < 24 && sx < 0; z++)
+                    {
+                        if (server.StructureBlockForTest("Pilot", x, y, z) != 0) { sx = x; sy = y; sz = z; }
+                    }
 
             server.HandleStructureEditForTest("Pilot",
                 new StructureEditIntent { StructureId = "ship:Pilot", X = sx, Y = sy, Z = sz, Mine = true });
@@ -257,11 +257,11 @@ public sealed class SpaceCombatTests : IDisposable
 
                 // Find a solid hull cell to mine and an adjacent air cell to build into.
                 for (int x = 0; x < 24 && sx < 0; x++)
-                for (int y = 0; y < 24 && sx < 0; y++)
-                for (int z = 0; z < 24 && sx < 0; z++)
-                {
-                    if (s1.StructureBlockForTest("Pilot", x, y, z) != 0) { sx = x; sy = y; sz = z; }
-                }
+                    for (int y = 0; y < 24 && sx < 0; y++)
+                        for (int z = 0; z < 24 && sx < 0; z++)
+                        {
+                            if (s1.StructureBlockForTest("Pilot", x, y, z) != 0) { sx = x; sy = y; sz = z; }
+                        }
 
                 Assert.True(sx >= 0, "the ship structure should have at least one solid cell");
 
@@ -311,15 +311,15 @@ public sealed class SpaceCombatTests : IDisposable
 
                 // Find an air cell adjacent to a solid hull cell (a buildable spot just outside the hull).
                 for (int x = 0; x < 24 && bx < 0; x++)
-                for (int y = 0; y < 24 && bx < 0; y++)
-                for (int z = 0; z < 24 && bx < 0; z++)
-                {
-                    if (s1.StructureBlockForTest("Pilot", x, y, z) != 0
-                        && s1.StructureBlockForTest("Pilot", x, y + 1, z) == 0)
-                    {
-                        bx = x; by = y + 1; bz = z;
-                    }
-                }
+                    for (int y = 0; y < 24 && bx < 0; y++)
+                        for (int z = 0; z < 24 && bx < 0; z++)
+                        {
+                            if (s1.StructureBlockForTest("Pilot", x, y, z) != 0
+                                && s1.StructureBlockForTest("Pilot", x, y + 1, z) == 0)
+                            {
+                                bx = x; by = y + 1; bz = z;
+                            }
+                        }
 
                 Assert.True(bx >= 0, "expected an empty cell above a hull cell");
                 s1.HandleStructureEditForTest("Pilot",
@@ -375,11 +375,11 @@ public sealed class SpaceCombatTests : IDisposable
 
             int sx = -1, sy = -1, sz = -1;
             for (int x = 0; x < 24 && sx < 0; x++)
-            for (int y = 0; y < 24 && sx < 0; y++)
-            for (int z = 0; z < 24 && sx < 0; z++)
-            {
-                if (server.StructureBlockForTest("Alice", x, y, z) != 0) { sx = x; sy = y; sz = z; }
-            }
+                for (int y = 0; y < 24 && sx < 0; y++)
+                    for (int z = 0; z < 24 && sx < 0; z++)
+                    {
+                        if (server.StructureBlockForTest("Alice", x, y, z) != 0) { sx = x; sy = y; sz = z; }
+                    }
 
             Assert.True(sx >= 0);
             server.HandleStructureEditForTest("Bob",

--- a/tests/BlocksBeyondTheStars.Tests/SpaceStationBoardingTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/SpaceStationBoardingTests.cs
@@ -92,14 +92,14 @@ public sealed class SpaceStationBoardingTests : IDisposable
             bool solidNearby = false;
             var pos = pilot.State.Position.ToBlock();
             for (int dx = -6; dx <= 6 && !solidNearby; dx++)
-            for (int dy = -2; dy <= 6 && !solidNearby; dy++)
-            for (int dz = -6; dz <= 6 && !solidNearby; dz++)
-            {
-                if (!server.World.GetBlock(new Vector3i(pos.X + dx, pos.Y + dy, pos.Z + dz)).IsAir)
-                {
-                    solidNearby = true;
-                }
-            }
+                for (int dy = -2; dy <= 6 && !solidNearby; dy++)
+                    for (int dz = -6; dz <= 6 && !solidNearby; dz++)
+                    {
+                        if (!server.World.GetBlock(new Vector3i(pos.X + dx, pos.Y + dy, pos.Z + dz)).IsAir)
+                        {
+                            solidNearby = true;
+                        }
+                    }
 
             Assert.True(solidNearby, $"Boarding {station.Name} should stamp real station blocks.");
         }

--- a/tests/BlocksBeyondTheStars.Tests/SpawnSafetyTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/SpawnSafetyTests.cs
@@ -34,9 +34,13 @@ public sealed class SpawnSafetyTests : IDisposable
         var st = new LoopbackServerTransport(new LoopbackLink());
         var config = new ServerConfig
         {
-            WorldName = "spawn", Seed = 12345, StartPlanet = "jungle",
-            AutoSaveIntervalMinutes = 9999, PlaceStarterShip = false,
-            PlaceSettlements = false, PlaceWrecks = false,
+            WorldName = "spawn",
+            Seed = 12345,
+            StartPlanet = "jungle",
+            AutoSaveIntervalMinutes = 9999,
+            PlaceStarterShip = false,
+            PlaceSettlements = false,
+            PlaceWrecks = false,
         };
         var server = new SvGameServer(config, _content, st, repo);
         server.Start();

--- a/tests/BlocksBeyondTheStars.Tests/StationGenerationTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/StationGenerationTests.cs
@@ -29,11 +29,11 @@ public sealed class StationGenerationTests
         Assert.Equal(a.Length, b.Length);
         Assert.Equal(a.Modules.Count, b.Modules.Count);
         for (int x = 0; x < a.Width; x++)
-        for (int y = 0; y < a.Height; y++)
-        for (int z = 0; z < a.Length; z++)
-        {
-            Assert.Equal(a.Get(x, y, z), b.Get(x, y, z));
-        }
+            for (int y = 0; y < a.Height; y++)
+                for (int z = 0; z < a.Length; z++)
+                {
+                    Assert.Equal(a.Get(x, y, z), b.Get(x, y, z));
+                }
     }
 
     [Fact]
@@ -67,11 +67,11 @@ public sealed class StationGenerationTests
         // There is plenty of solid hull overall.
         int solid = 0;
         for (int x = 0; x < s.Width; x++)
-        for (int y = 0; y < s.Height; y++)
-        for (int z = 0; z < s.Length; z++)
-        {
-            if (s.Get(x, y, z) != air) solid++;
-        }
+            for (int y = 0; y < s.Height; y++)
+                for (int z = 0; z < s.Length; z++)
+                {
+                    if (s.Get(x, y, z) != air) solid++;
+                }
 
         Assert.True(solid > 0, "A station must be built from solid blocks.");
     }
@@ -121,12 +121,12 @@ public sealed class StationGenerationTests
 
             int glazed = 0, holes = 0;
             for (int x = o.X + 1; x <= o.X + s.RoomW - 2; x++)
-            for (int y = o.Y + 1; y <= o.Y + mouthTop; y++)
-            {
-                ushort b = s.Get(x, y, o.Z);
-                if (b == field) glazed++;
-                else if (b == air) holes++;
-            }
+                for (int y = o.Y + 1; y <= o.Y + mouthTop; y++)
+                {
+                    ushort b = s.Get(x, y, o.Z);
+                    if (b == field) glazed++;
+                    else if (b == air) holes++;
+                }
 
             Assert.True(glazed > 0, $"Seed {seed}: hangar mouth should be glazed with a force field.");
             Assert.Equal(0, holes); // no open gap to the void anywhere in the mouth
@@ -276,11 +276,11 @@ public sealed class StationGenerationTests
 
             // Seed the flood from every cell on the bounding-box surface, then expand through air/plants.
             for (int x = 0; x < W; x++)
-            for (int y = 0; y < H; y++) { Visit(x, y, 0); Visit(x, y, L - 1); }
+                for (int y = 0; y < H; y++) { Visit(x, y, 0); Visit(x, y, L - 1); }
             for (int x = 0; x < W; x++)
-            for (int z = 0; z < L; z++) { Visit(x, 0, z); Visit(x, H - 1, z); }
+                for (int z = 0; z < L; z++) { Visit(x, 0, z); Visit(x, H - 1, z); }
             for (int y = 0; y < H; y++)
-            for (int z = 0; z < L; z++) { Visit(0, y, z); Visit(W - 1, y, z); }
+                for (int z = 0; z < L; z++) { Visit(0, y, z); Visit(W - 1, y, z); }
 
             int[] dx = { 1, -1, 0, 0, 0, 0 }, dy = { 0, 0, 1, -1, 0, 0 }, dz = { 0, 0, 0, 0, 1, -1 };
             while (stack.Count > 0)
@@ -290,16 +290,16 @@ public sealed class StationGenerationTests
             }
 
             for (int x = 0; x < W; x++)
-            for (int y = 0; y < H; y++)
-            for (int z = 0; z < L; z++)
-            {
-                if (s.Get(x, y, z) != plant) continue;
-                totalPlants++;
-                Assert.False(reached[Idx(x, y, z)],
-                    $"{tier} seed {seed * 1009 + 7}: plant at ({x},{y},{z}) is open to the void (see-through / walk-through).");
-                Assert.True(y > 0 && s.Get(x, y - 1, z) != 0,
-                    $"{tier} seed {seed * 1009 + 7}: plant at ({x},{y},{z}) does not stand on a solid block.");
-            }
+                for (int y = 0; y < H; y++)
+                    for (int z = 0; z < L; z++)
+                    {
+                        if (s.Get(x, y, z) != plant) continue;
+                        totalPlants++;
+                        Assert.False(reached[Idx(x, y, z)],
+                            $"{tier} seed {seed * 1009 + 7}: plant at ({x},{y},{z}) is open to the void (see-through / walk-through).");
+                        Assert.True(y > 0 && s.Get(x, y - 1, z) != 0,
+                            $"{tier} seed {seed * 1009 + 7}: plant at ({x},{y},{z}) does not stand on a solid block.");
+                    }
         }
 
         Assert.True(totalPlants > 0, $"Stations of tier '{tier}' should still be furnished with decorative plants.");

--- a/tests/BlocksBeyondTheStars.Tests/StructureInteractionTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/StructureInteractionTests.cs
@@ -31,9 +31,13 @@ public sealed class StructureInteractionTests : IDisposable
         var st = new LoopbackServerTransport(new LoopbackLink());
         var config = new ServerConfig
         {
-            WorldName = planet + "_" + seed, Seed = seed, StartPlanet = planet,
-            AutoSaveIntervalMinutes = 9999, PlaceStarterShip = false,
-            PlaceSettlements = settlements, PlaceWrecks = wrecks,
+            WorldName = planet + "_" + seed,
+            Seed = seed,
+            StartPlanet = planet,
+            AutoSaveIntervalMinutes = 9999,
+            PlaceStarterShip = false,
+            PlaceSettlements = settlements,
+            PlaceWrecks = wrecks,
         };
         var server = new SvGameServer(config, _content, st, repo);
         server.Start();

--- a/tests/BlocksBeyondTheStars.Tests/StructureTemplateTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/StructureTemplateTests.cs
@@ -24,8 +24,13 @@ public sealed class StructureTemplateTests
 
         var t = new StructureTemplate
         {
-            Key = "test_station", Name = "Test", Tier = "small", Kind = "station",
-            Width = 6, Height = 4, Length = 6,
+            Key = "test_station",
+            Name = "Test",
+            Tier = "small",
+            Kind = "station",
+            Width = 6,
+            Height = 4,
+            Length = 6,
             Cells = new List<TemplateCell>
             {
                 new() { X = 1, Y = 0, Z = 1, Kind = "block", Id = "iron_wall" },
@@ -52,8 +57,13 @@ public sealed class StructureTemplateTests
 
         var t = new StructureTemplate
         {
-            Key = "test_town", Name = "Test", Tier = "village", Kind = "settlement",
-            Width = 5, Height = 4, Length = 5,
+            Key = "test_town",
+            Name = "Test",
+            Tier = "village",
+            Kind = "settlement",
+            Width = 5,
+            Height = 4,
+            Length = 5,
             Cells = new List<TemplateCell>
             {
                 new() { X = 0, Y = 0, Z = 0, Kind = "block", Id = "stone" },
@@ -77,7 +87,12 @@ public sealed class StructureTemplateTests
         var c = Content();
         var t = new StructureTemplate
         {
-            Key = "tinted", Tier = "small", Kind = "station", Width = 3, Height = 2, Length = 3,
+            Key = "tinted",
+            Tier = "small",
+            Kind = "station",
+            Width = 3,
+            Height = 2,
+            Length = 3,
             Cells = new List<TemplateCell>
             {
                 new() { X = 1, Y = 0, Z = 1, Kind = "block", Id = "iron_wall", Tint = 0x3F6FB0, Glow = 0x00FFFF, Shape = 0x15 },
@@ -99,7 +114,12 @@ public sealed class StructureTemplateTests
         var c = Content();
         var t = new StructureTemplate
         {
-            Key = "tinted_town", Tier = "village", Kind = "settlement", Width = 3, Height = 2, Length = 3,
+            Key = "tinted_town",
+            Tier = "village",
+            Kind = "settlement",
+            Width = 3,
+            Height = 2,
+            Length = 3,
             Cells = new List<TemplateCell>
             {
                 new() { X = 2, Y = 1, Z = 2, Kind = "block", Id = "wood_log", Tint = 0xAA5500, Shape = 0x06 },

--- a/tests/BlocksBeyondTheStars.Tests/WorldGenerationTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/WorldGenerationTests.cs
@@ -48,35 +48,35 @@ public class WorldGenerationTests
         int minH = int.MaxValue, flat = 0, total = 0, metalCols = 0, surfaceCols = 0;
 
         for (int cx = 0; cx < 16; cx++)
-        for (int cz = 0; cz < 16; cz++)
-        {
-            var col = new ChunkData[5];
-            for (int cy = 0; cy < col.Length; cy++)
+            for (int cz = 0; cz < 16; cz++)
             {
-                col[cy] = gen.Generate(asteroid, new ChunkCoord(cx, cy, cz));
-            }
-
-            var origin = WorldConstants.ChunkOrigin(new ChunkCoord(cx, 0, cz));
-            for (int lx = 0; lx < cs; lx++)
-            for (int lz = 0; lz < cs; lz++)
-            {
-                int h = gen.SurfaceHeight(asteroid, origin.X + lx, origin.Z + lz);
-                minH = System.Math.Min(minH, h);
-                if (System.Math.Abs(h - baseH) <= 3) flat++;
-                total++;
-
-                for (int gy = col.Length * cs - 1; gy >= 0; gy--) // top solid cell = the exposed surface
+                var col = new ChunkData[5];
+                for (int cy = 0; cy < col.Length; cy++)
                 {
-                    var b = col[gy / cs].Get(lx, gy % cs, lz);
-                    if (!b.IsAir)
-                    {
-                        surfaceCols++;
-                        if (metals.Contains(b)) metalCols++;
-                        break;
-                    }
+                    col[cy] = gen.Generate(asteroid, new ChunkCoord(cx, cy, cz));
                 }
+
+                var origin = WorldConstants.ChunkOrigin(new ChunkCoord(cx, 0, cz));
+                for (int lx = 0; lx < cs; lx++)
+                    for (int lz = 0; lz < cs; lz++)
+                    {
+                        int h = gen.SurfaceHeight(asteroid, origin.X + lx, origin.Z + lz);
+                        minH = System.Math.Min(minH, h);
+                        if (System.Math.Abs(h - baseH) <= 3) flat++;
+                        total++;
+
+                        for (int gy = col.Length * cs - 1; gy >= 0; gy--) // top solid cell = the exposed surface
+                        {
+                            var b = col[gy / cs].Get(lx, gy % cs, lz);
+                            if (!b.IsAir)
+                            {
+                                surfaceCols++;
+                                if (metals.Contains(b)) metalCols++;
+                                break;
+                            }
+                        }
+                    }
             }
-        }
 
         Assert.True(baseH - minH >= 4, "craters dig pits below the flat regolith");
         Assert.True(flat > total / 4, "much of the surface is flat regolith between craters");
@@ -100,22 +100,22 @@ public class WorldGenerationTests
 
         int pondCells = 0;
         for (int cx = 0; cx < 16 && pondCells == 0; cx++)
-        for (int cz = 0; cz < 16 && pondCells == 0; cz++)
-        for (int cy = 0; cy <= 4; cy++)
-        {
-            var coord = new ChunkCoord(cx, cy, cz);
-            var chunk = gen.Generate(planet, coord);
-            var origin = WorldConstants.ChunkOrigin(coord);
-            for (int lx = 0; lx < cs; lx++)
-            for (int ly = 0; ly < cs; ly++)
-            for (int lz = 0; lz < cs; lz++)
-            {
-                if (origin.Y + ly > sea && chunk.Get(lx, ly, lz) == waterId)
+            for (int cz = 0; cz < 16 && pondCells == 0; cz++)
+                for (int cy = 0; cy <= 4; cy++)
                 {
-                    pondCells++;
+                    var coord = new ChunkCoord(cx, cy, cz);
+                    var chunk = gen.Generate(planet, coord);
+                    var origin = WorldConstants.ChunkOrigin(coord);
+                    for (int lx = 0; lx < cs; lx++)
+                        for (int ly = 0; ly < cs; ly++)
+                            for (int lz = 0; lz < cs; lz++)
+                            {
+                                if (origin.Y + ly > sea && chunk.Get(lx, ly, lz) == waterId)
+                                {
+                                    pondCells++;
+                                }
+                            }
                 }
-            }
-        }
 
         Assert.True(pondCells > 0, $"expected upland ponds (water above sea level {sea}) on a watery world");
     }
@@ -135,36 +135,36 @@ public class WorldGenerationTests
 
         int logs = 0, logsInWater = 0;
         for (int cx = 0; cx < 16; cx++)
-        for (int cz = 0; cz < 16; cz++)
-        {
-            // Generate the vertical column of chunks once so a trunk base at a chunk boundary can see the cell
-            // below it (in the chunk underneath).
-            var col = new ChunkData[6];
-            for (int cy = 0; cy < col.Length; cy++)
+            for (int cz = 0; cz < 16; cz++)
             {
-                col[cy] = gen.Generate(planet, new ChunkCoord(cx, cy, cz));
-            }
-
-            for (int cy = 0; cy < col.Length; cy++)
-            for (int lx = 0; lx < cs; lx++)
-            for (int ly = 0; ly < cs; ly++)
-            for (int lz = 0; lz < cs; lz++)
-            {
-                if (col[cy].Get(lx, ly, lz) != logId)
+                // Generate the vertical column of chunks once so a trunk base at a chunk boundary can see the cell
+                // below it (in the chunk underneath).
+                var col = new ChunkData[6];
+                for (int cy = 0; cy < col.Length; cy++)
                 {
-                    continue;
+                    col[cy] = gen.Generate(planet, new ChunkCoord(cx, cy, cz));
                 }
 
-                logs++;
-                var below = ly > 0 ? col[cy].Get(lx, ly - 1, lz)
-                          : cy > 0 ? col[cy - 1].Get(lx, cs - 1, lz)
-                          : BlockId.Air;
-                if (below == waterId)
-                {
-                    logsInWater++;
-                }
+                for (int cy = 0; cy < col.Length; cy++)
+                    for (int lx = 0; lx < cs; lx++)
+                        for (int ly = 0; ly < cs; ly++)
+                            for (int lz = 0; lz < cs; lz++)
+                            {
+                                if (col[cy].Get(lx, ly, lz) != logId)
+                                {
+                                    continue;
+                                }
+
+                                logs++;
+                                var below = ly > 0 ? col[cy].Get(lx, ly - 1, lz)
+                                          : cy > 0 ? col[cy - 1].Get(lx, cs - 1, lz)
+                                          : BlockId.Air;
+                                if (below == waterId)
+                                {
+                                    logsInWater++;
+                                }
+                            }
             }
-        }
 
         Assert.True(logs > 0, "expected the jungle world to grow trees (the test would be meaningless otherwise)");
         Assert.Equal(0, logsInWater);
@@ -182,17 +182,17 @@ public class WorldGenerationTests
 
         bool anyWet = false, anyDry = false;
         for (int x = 0; x < 400 && !(anyWet && anyDry); x += 3)
-        for (int z = -200; z < 200 && !(anyWet && anyDry); z += 7)
-        {
-            if (gen.IsSurfaceWater(planet, x, z))
+            for (int z = -200; z < 200 && !(anyWet && anyDry); z += 7)
             {
-                anyWet = true;
+                if (gen.IsSurfaceWater(planet, x, z))
+                {
+                    anyWet = true;
+                }
+                else
+                {
+                    anyDry = true;
+                }
             }
-            else
-            {
-                anyDry = true;
-            }
-        }
 
         Assert.True(anyWet, "expected some surface water (sea/pond) on a watery world");
         Assert.True(anyDry, "expected some dry land on a watery world (else ships could never land dry)");
@@ -344,15 +344,15 @@ public class WorldGenerationTests
     {
         int n = 0;
         for (int cx = 0; cx < 8; cx++)
-        for (int cz = 0; cz < 8; cz++)
-        for (int cy = 3; cy <= 5; cy++) // a wide span around typical sea levels (Y ≈ 48..95)
-        {
-            var chunk = gen.Generate(planet, new ChunkCoord(cx, cy, cz));
-            foreach (var b in chunk.RawBlocks)
-            {
-                if (b == block) n++;
-            }
-        }
+            for (int cz = 0; cz < 8; cz++)
+                for (int cy = 3; cy <= 5; cy++) // a wide span around typical sea levels (Y ≈ 48..95)
+                {
+                    var chunk = gen.Generate(planet, new ChunkCoord(cx, cy, cz));
+                    foreach (var b in chunk.RawBlocks)
+                    {
+                        if (b == block) n++;
+                    }
+                }
 
         return n;
     }
@@ -437,28 +437,28 @@ public class WorldGenerationTests
 
         int verified = 0;
         for (int wx = 0; wx < 512 && verified < 25; wx++)
-        for (int wz = 0; wz < 512 && verified < 25; wz++)
-        {
-            if (!gen.TryGetWaterSurface(planet, wx, wz, out int top, out int bed))
+            for (int wz = 0; wz < 512 && verified < 25; wz++)
             {
-                continue;
+                if (!gen.TryGetWaterSurface(planet, wx, wz, out int top, out int bed))
+                {
+                    continue;
+                }
+
+                Assert.True(top > bed, "a water column must have at least one water cell above the seabed");
+
+                // Every cell of the reported [seabed+1 .. top] span must be water or aquatic flora in the generated
+                // world — i.e. the helper points a swimmer at a genuine, fully-filled water body (the old surface+1
+                // probe sat in the air above flush ponds, which is what kept water creatures from ever spawning).
+                for (int y = bed + 1; y <= top; y++)
+                {
+                    var coord = new ChunkCoord(wx / cs, y / cs, wz / cs);
+                    var chunk = gen.Generate(planet, coord);
+                    ushort cell = chunk.Get(wx % cs, y % cs, wz % cs).Value;
+                    Assert.True(aquatic.Contains(cell), $"cell ({wx},{y},{wz}) in the reported water column should be water/aquatic flora");
+                }
+
+                verified++;
             }
-
-            Assert.True(top > bed, "a water column must have at least one water cell above the seabed");
-
-            // Every cell of the reported [seabed+1 .. top] span must be water or aquatic flora in the generated
-            // world — i.e. the helper points a swimmer at a genuine, fully-filled water body (the old surface+1
-            // probe sat in the air above flush ponds, which is what kept water creatures from ever spawning).
-            for (int y = bed + 1; y <= top; y++)
-            {
-                var coord = new ChunkCoord(wx / cs, y / cs, wz / cs);
-                var chunk = gen.Generate(planet, coord);
-                ushort cell = chunk.Get(wx % cs, y % cs, wz % cs).Value;
-                Assert.True(aquatic.Contains(cell), $"cell ({wx},{y},{wz}) in the reported water column should be water/aquatic flora");
-            }
-
-            verified++;
-        }
 
         Assert.True(verified > 0, "expected to find water columns on a watery world.");
     }
@@ -486,24 +486,24 @@ public class WorldGenerationTests
 
         int rivers = 0;
         for (int wx = 0; wx < 512 && rivers < 10; wx++)
-        for (int wz = 0; wz < 512 && rivers < 10; wz++)
-        {
-            int depth = gen.SurfaceRiverDepth(planet, wx, wz);
-            if (depth <= 0)
+            for (int wz = 0; wz < 512 && rivers < 10; wz++)
             {
-                continue;
+                int depth = gen.SurfaceRiverDepth(planet, wx, wz);
+                if (depth <= 0)
+                {
+                    continue;
+                }
+
+                int surfaceY = gen.SurfaceHeight(planet, wx, wz);
+                Assert.True(surfaceY > sea, "a river is carved above the global sea level");
+
+                // The channel is filled flush to the surface; the surface water cell must be water/aquatic flora.
+                var coord = new ChunkCoord(wx / cs, surfaceY / cs, wz / cs);
+                var chunk = gen.Generate(planet, coord);
+                ushort cell = chunk.Get(wx % cs, surfaceY % cs, wz % cs).Value;
+                Assert.True(aquatic.Contains(cell), $"river surface cell ({wx},{surfaceY},{wz}) should be water/aquatic flora");
+                rivers++;
             }
-
-            int surfaceY = gen.SurfaceHeight(planet, wx, wz);
-            Assert.True(surfaceY > sea, "a river is carved above the global sea level");
-
-            // The channel is filled flush to the surface; the surface water cell must be water/aquatic flora.
-            var coord = new ChunkCoord(wx / cs, surfaceY / cs, wz / cs);
-            var chunk = gen.Generate(planet, coord);
-            ushort cell = chunk.Get(wx % cs, surfaceY % cs, wz % cs).Value;
-            Assert.True(aquatic.Contains(cell), $"river surface cell ({wx},{surfaceY},{wz}) should be water/aquatic flora");
-            rivers++;
-        }
 
         Assert.True(rivers > 0, "a wet world should carve river channels.");
     }
@@ -522,19 +522,19 @@ public class WorldGenerationTests
 
         int rivers = 0;
         for (int wx = 0; wx < 512; wx++)
-        for (int wz = 0; wz < 512; wz++)
-        {
-            if (gen.SurfaceRiverDepth(planet, wx, wz) <= 0)
+            for (int wz = 0; wz < 512; wz++)
             {
-                continue;
-            }
+                if (gen.SurfaceRiverDepth(planet, wx, wz) <= 0)
+                {
+                    continue;
+                }
 
-            int slope = System.Math.Abs(gen.SurfaceHeight(planet, wx + 2, wz) - gen.SurfaceHeight(planet, wx - 2, wz))
-                      + System.Math.Abs(gen.SurfaceHeight(planet, wx, wz + 2) - gen.SurfaceHeight(planet, wx, wz - 2));
-            Assert.True(slope <= riverMaxSlope,
-                $"river column ({wx},{wz}) sits on a slope of {slope} (> {riverMaxSlope}) — it would leave a floating water wall");
-            rivers++;
-        }
+                int slope = System.Math.Abs(gen.SurfaceHeight(planet, wx + 2, wz) - gen.SurfaceHeight(planet, wx - 2, wz))
+                          + System.Math.Abs(gen.SurfaceHeight(planet, wx, wz + 2) - gen.SurfaceHeight(planet, wx, wz - 2));
+                Assert.True(slope <= riverMaxSlope,
+                    $"river column ({wx},{wz}) sits on a slope of {slope} (> {riverMaxSlope}) — it would leave a floating water wall");
+                rivers++;
+            }
 
         Assert.True(rivers > 0, "expected to find river columns on a watery world (else the gate erased all rivers).");
     }

--- a/tests/BlocksBeyondTheStars.Tests/WorldOptionsTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/WorldOptionsTests.cs
@@ -132,8 +132,12 @@ public sealed class WorldOptionsTests : IDisposable
         using var client = new LoopbackClientTransport(link);
         var config = new ServerConfig
         {
-            WorldName = "dead", Seed = 123456, StartPlanet = "jungle",
-            AutoSaveIntervalMinutes = 9999, ViewDistanceChunks = 1, PlaceStarterShip = false,
+            WorldName = "dead",
+            Seed = 123456,
+            StartPlanet = "jungle",
+            AutoSaveIntervalMinutes = 9999,
+            ViewDistanceChunks = 1,
+            PlaceStarterShip = false,
         };
         config.Rules.CreatureAbundance = AlienActivity.Off;
         var server = new SvGameServer(config, _content, serverTransport, repo);
@@ -223,19 +227,19 @@ public sealed class WorldOptionsTests : IDisposable
         bool HasFlora(WorldGenerator gen)
         {
             for (int cx = 0; cx < 3; cx++)
-            for (int cz = 0; cz < 3; cz++)
-            for (int cy = 3; cy <= 5; cy++)
-            {
-                var chunk = gen.Generate(planet, new BlocksBeyondTheStars.Shared.World.ChunkCoord(cx, cy, cz));
-                for (int i = 0; i < chunk.RawBlocks.Length; i++)
-                {
-                    var key = _content.BlockById(new BlocksBeyondTheStars.Shared.Primitives.BlockId(chunk.RawBlocks[i]))?.Key;
-                    if (key != null && (key.StartsWith("flora_", StringComparison.Ordinal) || key == "wood_log"))
+                for (int cz = 0; cz < 3; cz++)
+                    for (int cy = 3; cy <= 5; cy++)
                     {
-                        return true;
+                        var chunk = gen.Generate(planet, new BlocksBeyondTheStars.Shared.World.ChunkCoord(cx, cy, cz));
+                        for (int i = 0; i < chunk.RawBlocks.Length; i++)
+                        {
+                            var key = _content.BlockById(new BlocksBeyondTheStars.Shared.Primitives.BlockId(chunk.RawBlocks[i]))?.Key;
+                            if (key != null && (key.StartsWith("flora_", StringComparison.Ordinal) || key == "wood_log"))
+                            {
+                                return true;
+                            }
+                        }
                     }
-                }
-            }
 
             return false;
         }
@@ -256,8 +260,12 @@ public sealed class WorldOptionsTests : IDisposable
             var st = new LoopbackServerTransport(new LoopbackLink());
             var config = new ServerConfig
             {
-                WorldName = $"s_{seed}", Seed = seed, StartPlanet = "jungle",
-                AutoSaveIntervalMinutes = 9999, PlaceStarterShip = false, PlaceWrecks = false,
+                WorldName = $"s_{seed}",
+                Seed = seed,
+                StartPlanet = "jungle",
+                AutoSaveIntervalMinutes = 9999,
+                PlaceStarterShip = false,
+                PlaceWrecks = false,
             };
             var server = new SvGameServer(config, _content, st, repo);
             server.Start();
@@ -273,8 +281,12 @@ public sealed class WorldOptionsTests : IDisposable
             var st2 = new LoopbackServerTransport(new LoopbackLink());
             var offConfig = new ServerConfig
             {
-                WorldName = $"s_{seed}_off", Seed = seed, StartPlanet = "jungle",
-                AutoSaveIntervalMinutes = 9999, PlaceStarterShip = false, PlaceWrecks = false,
+                WorldName = $"s_{seed}_off",
+                Seed = seed,
+                StartPlanet = "jungle",
+                AutoSaveIntervalMinutes = 9999,
+                PlaceStarterShip = false,
+                PlaceWrecks = false,
             };
             offConfig.World.Settlements = Frequency.Off;
             var server2 = new SvGameServer(offConfig, _content, st2, repo2);

--- a/tests/BlocksBeyondTheStars.Tests/WreckGenerationTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/WreckGenerationTests.cs
@@ -26,11 +26,11 @@ public sealed class WreckGenerationTests
         Assert.Equal(a.Origin, b.Origin);
         Assert.Equal(a.BreachCount(), b.BreachCount());
         for (int x = 0; x < a.Width; x++)
-        for (int y = 0; y < a.Height; y++)
-        for (int z = 0; z < a.Length; z++)
-        {
-            Assert.Equal(a.Get(x, y, z), b.Get(x, y, z));
-        }
+            for (int y = 0; y < a.Height; y++)
+                for (int z = 0; z < a.Length; z++)
+                {
+                    Assert.Equal(a.Get(x, y, z), b.Get(x, y, z));
+                }
     }
 
     [Fact]
@@ -53,15 +53,15 @@ public sealed class WreckGenerationTests
 
         // Every breach is a cell the intact hull fills but the current blocks don't.
         for (int x = 0; x < w.Width; x++)
-        for (int y = 0; y < w.Height; y++)
-        for (int z = 0; z < w.Length; z++)
-        {
-            if (w.IsBreach(x, y, z))
-            {
-                Assert.NotEqual((ushort)0, w.IntactAt(x, y, z));
-                Assert.Equal((ushort)0, w.Get(x, y, z));
-            }
-        }
+            for (int y = 0; y < w.Height; y++)
+                for (int z = 0; z < w.Length; z++)
+                {
+                    if (w.IsBreach(x, y, z))
+                    {
+                        Assert.NotEqual((ushort)0, w.IntactAt(x, y, z));
+                        Assert.Equal((ushort)0, w.Get(x, y, z));
+                    }
+                }
     }
 
     [Fact]
@@ -94,10 +94,10 @@ public sealed class WreckGenerationTests
         // The -Z wall (z = 0) must have an opening near the centre (the crash gash).
         bool open = false;
         for (int x = 0; x < w.Width && !open; x++)
-        for (int y = 1; y < w.Height; y++)
-        {
-            if (w.IntactAt(x, y, 0) != 0 && w.Get(x, y, 0) == air) { open = true; break; }
-        }
+            for (int y = 1; y < w.Height; y++)
+            {
+                if (w.IntactAt(x, y, 0) != 0 && w.Get(x, y, 0) == air) { open = true; break; }
+            }
 
         Assert.True(open, "A wreck should be open enough to enter.");
     }

--- a/tests/BlocksBeyondTheStars.Tests/WreckStampTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/WreckStampTests.cs
@@ -30,9 +30,13 @@ public sealed class WreckStampTests : IDisposable
         var st = new LoopbackServerTransport(new LoopbackLink());
         var config = new ServerConfig
         {
-            WorldName = planet + "_" + seed, Seed = seed, StartPlanet = planet,
-            AutoSaveIntervalMinutes = 9999, PlaceStarterShip = false,
-            PlaceSettlements = false, PlaceWrecks = true,
+            WorldName = planet + "_" + seed,
+            Seed = seed,
+            StartPlanet = planet,
+            AutoSaveIntervalMinutes = 9999,
+            PlaceStarterShip = false,
+            PlaceSettlements = false,
+            PlaceWrecks = true,
         };
         var server = new SvGameServer(config, _content, st, repo);
         server.Start();
@@ -79,14 +83,14 @@ public sealed class WreckStampTests : IDisposable
 
             bool solidNearby = false;
             for (int dx = -5; dx <= 5 && !solidNearby; dx++)
-            for (int dy = -1; dy <= 5 && !solidNearby; dy++)
-            for (int dz = -5; dz <= 5 && !solidNearby; dz++)
-            {
-                if (!server.World.GetBlock(new Vector3i(basePos.X + dx, basePos.Y + dy, basePos.Z + dz)).IsAir)
-                {
-                    solidNearby = true;
-                }
-            }
+                for (int dy = -1; dy <= 5 && !solidNearby; dy++)
+                    for (int dz = -5; dz <= 5 && !solidNearby; dz++)
+                    {
+                        if (!server.World.GetBlock(new Vector3i(basePos.X + dx, basePos.Y + dy, basePos.Z + dz)).IsAir)
+                        {
+                            solidNearby = true;
+                        }
+                    }
 
             Assert.True(solidNearby, "A stamped wreck should place solid blocks in the world.");
         }
@@ -105,15 +109,15 @@ public sealed class WreckStampTests : IDisposable
 
             Vector3i? solid = null;
             for (int dx = -5; dx <= 5 && solid is null; dx++)
-            for (int dy = -1; dy <= 5 && solid is null; dy++)
-            for (int dz = -5; dz <= 5 && solid is null; dz++)
-            {
-                var c = new Vector3i(basePos.X + dx, basePos.Y + dy, basePos.Z + dz);
-                if (!server.World.GetBlock(c).IsAir)
-                {
-                    solid = c;
-                }
-            }
+                for (int dy = -1; dy <= 5 && solid is null; dy++)
+                    for (int dz = -5; dz <= 5 && solid is null; dz++)
+                    {
+                        var c = new Vector3i(basePos.X + dx, basePos.Y + dy, basePos.Z + dz);
+                        if (!server.World.GetBlock(c).IsAir)
+                        {
+                            solid = c;
+                        }
+                    }
 
             Assert.NotNull(solid);
             Assert.False(server.IsSettlementBlock(solid!.Value)); // wrecks aren't settlement-protected


### PR DESCRIPTION
Follow-up to #22. Clears the ~1873 pre-existing whitespace violations and turns on the `dotnet format` gate.

## Changes
- **`dotnet format BlocksBeyondTheStars.CI.slnf`** applied across the tree → **60 files, formatting-only**
  (indentation + object-initializer/argument line breaks). `git diff -w` confirms **zero logic change**;
  behaviour is identical, tests unchanged.
- **Re-added the `Format (dotnet format)` job** to `ci.yml`, gated by the same `changes` job as build-test
  (docs-only PRs skip it). Verified green against an LF checkout before pushing.

## Docs
DEVELOPER.md §CI (format now active + Windows CRLF heads-up), AGENTS.md (format in the verification chain),
TODO.md (reformat done).

## Note
Large diff, but purely mechanical formatting — review with **"Hide whitespace"** on (or `git diff -w`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)