### PR TITLE
docs: reflect format/lint/CodeQL as required status checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,7 +165,8 @@ built (blocked by the Windows-only UnityWebBrowser/CEF engine).
   `ci.yml` builds + tests with `-warnaserror` (Roslyn/Meziantou/VS.Threading analyzers as errors = the C#
   syntax/static-analysis gate) **and** runs `dotnet format --verify-no-changes` (C# style); `lint.yml` runs
   ruff (Python), `node --check` (web JS) and actionlint (workflows); `codeql.yml` does security/quality
-  scanning. Keep them green — run the equivalents locally before pushing (next section).
+  scanning. **All six are *required* status checks on `main`** — a PR can't merge until they pass — so run
+  the equivalents locally before pushing (next section).
 
 ## Git workflow (mandatory)
 
@@ -176,7 +177,9 @@ Every change ships through a **pull request**:
 2. **Commit on the branch** with a conventional-commit message, ending each message with the
    `Co-Authored-By: Claude …` trailer.
 3. **Push the branch and open a PR** (`gh pr create` with a clear title + body). Never push to `main` directly.
-4. **Merge via the PR** once checks pass (`gh pr merge`). Do not force-push or rewrite shared history on `main`.
+4. **Merge via the PR** once the required checks pass (`gh pr merge`). `main` requires 1 approval **and** the
+   six status checks (build+test, format, ruff, web-js, actionlint, CodeQL); an owner can `--admin`-override in
+   an emergency. Do not force-push or rewrite shared history on `main`.
 
 Other agents may share this clone, so **stage only your own files** (`git add <paths>` — never `git add -A`),
 and never sweep another worker's in-progress changes into your commit.

--- a/TODO.md
+++ b/TODO.md
@@ -27,7 +27,7 @@ Extends the PR gate beyond build+test (C# is already syntax/static-analysis-chec
 ### ★ Codebase reformat + activate `Format (dotnet format)` gate (2026-06-21) — ✅ done (follow-up to #22)
 - Ran `dotnet format BlocksBeyondTheStars.CI.slnf` over the tree: **60 files, formatting-only** (indentation + object-initializer/argument line breaks; `git diff -w` confirms zero logic change). Resolved the ~1873 pre-existing whitespace violations.
 - Re-added the **`Format (dotnet format)`** job to [ci.yml](.github/workflows/ci.yml) (gated by the `changes` job like build-test). Now green because the tree is clean.
-- **Follow-up (optional):** mark `Format (dotnet format)` / lint / CodeQL as required checks too (today only `Build + test (.NET, headless)` is required).
+- **All six checks now required** on `main` (2026-06-21): `Build + test (.NET, headless)`, `Format (dotnet format)`, `ruff (Python ai-backend)`, `web JS syntax (node --check)`, `actionlint (workflows)`, `CodeQL`. `strict` off, `enforce_admins` off (owner can `--admin`-override), 1 approval kept. Docs reflect this in [DEVELOPER.md](docs/developer/DEVELOPER.md) §CI + [AGENTS.md](AGENTS.md) §Git workflow.
 
 ### ★ Pull-request CI gate: build + headless tests, warnings-as-errors (2026-06-21) — ✅ merged to main (PR #16 c86858e); required-check guard added
 New [.github/workflows/ci.yml](.github/workflows/ci.yml) runs on every `pull_request` + push to `main` (separate

--- a/docs/developer/DEVELOPER.md
+++ b/docs/developer/DEVELOPER.md
@@ -68,19 +68,21 @@ These are the same two suites `run-tests.ps1` runs by default. Two deliberate ch
   code/content file makes it build for real; `data/**` and `web/**` count as code (they feed tests, e.g. the
   en/de locale-parity test), so they are **not** in the doc-only exclusions.
 
-This is **safe to mark as a required status check** in the `main` branch-protection rule: require
-**`Build + test (.NET, headless)`** (not the `Detect code changes` helper). Because the workflow always runs
-and the build-test check always reports (green/red/skipped-as-pass), a docs-only PR is never left waiting on a
-missing status — the usual failure mode of a plain `paths-ignore` skip.
+It is **safe as a required status check** — and is one: because the workflow always runs and the build-test
+check always reports (green/red/skipped-as-pass), a docs-only PR is never left waiting on a missing status, the
+usual failure mode of a plain `paths-ignore` skip. (Require the `Build + test (.NET, headless)` job, **not** the
+`Detect code changes` helper.)
 
 The **Unity** suites (`UnityEdit` / `UnityPlay`) are **not** in CI — they need the Editor and stay local/opt-in
 (run them with `./scripts/run-tests.ps1 -Suites All` before a client-affecting change). The release build
 ([`release.yml`](../../.github/workflows/release.yml)) is a **separate** workflow that triggers only on tags;
 it does not run tests, so the PR gate is where correctness is checked before merge.
 
-> **`Build + test (.NET, headless)` is a required status check** on `main` (configured in branch protection).
-> The `Detect code changes` helper is intentionally **not** required. If you add another always-skippable
-> gate, only require the job that always reports.
+> **Required status checks on `main`** (branch protection): `Build + test (.NET, headless)`,
+> `Format (dotnet format)`, `ruff (Python ai-backend)`, `web JS syntax (node --check)`, `actionlint (workflows)`
+> and `CodeQL` — all six must pass before merge. The `Detect code changes` helper is intentionally **not**
+> required (it's an always-skippable gate; only require jobs that always report). `strict` is off (no forced
+> rebase) and `enforce_admins` is off (an owner can still `gh pr merge --admin` in an emergency).
 
 ### Other PR checks: format, lint, CodeQL
 
@@ -113,8 +115,8 @@ uvx ruff check ai-backend                                                       
 Get-ChildItem web -Recurse -Filter *.js | ForEach-Object { node --check $_.FullName }     # web JS syntax
 ```
 
-Only `Build + test (.NET, headless)` is *required* to merge today; format/lint/CodeQL are advisory until you
-add them to branch protection too.
+**All of these are required status checks** on `main` (see the list above), so every PR must pass build+test,
+format, the three lint jobs and CodeQL before it can merge.
 
 > **Heads-up for Windows devs:** `dotnet format --verify-no-changes` reads the working-tree bytes, so if an
 > old checkout still has CRLF in some files (from before `.gitattributes eol=lf` landed) it can report


### PR DESCRIPTION
Docs-only follow-up: all six PR checks are now required on `main`. Updates DEVELOPER.md §CI, AGENTS.md and TODO.md. (Also exercises the docs-only skip path with the new required checks.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)