### PR TITLE
ci: fix docs-only skip detection (paths-filter never actually skipped)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,30 +38,37 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Decides whether the diff contains anything other than documentation. Only meaningful for PRs;
-  # direct pushes to main always build (see build-test's `if:`), so the filter step is PR-only.
+  # Decides whether the PR diff contains anything other than documentation. Only meaningful for PRs;
+  # direct pushes to main always build (see build-test's `if:`), so the detection step is PR-only.
   changes:
     name: Detect code changes
     runs-on: ubuntu-latest
     outputs:
-      nondocs: ${{ steps.filter.outputs.nondocs }}
+      nondocs: ${{ steps.detect.outputs.nondocs }}
     steps:
-      - uses: dorny/paths-filter@v3
-        id: filter
+      # Lists the PR's changed files via the API (no checkout needed) and sets nondocs=true if ANY file is
+      # not documentation. Doc-only PRs (Markdown, docs/**, licences, issue/PR templates) leave it false, so
+      # build-test/format skip and — a skipped required job counting as a pass — never block a docs PR.
+      # data/** and web/** are treated as code (they feed tests, e.g. the en/de locale-parity test).
+      # (Done with an explicit case match rather than dorny/paths-filter, whose `some` glob semantics made a
+      # `**/*` + `!doc` list always true.)
+      - name: Detect non-doc changes
+        id: detect
         if: github.event_name == 'pull_request'
-        with:
-          # picomatch array semantics: the positive `**/*` matches every changed file, the `!` lines
-          # subtract the doc paths — so `nondocs` is true iff at least one NON-doc file changed.
-          filters: |
-            nondocs:
-              - '**/*'
-              - '!**/*.md'
-              - '!docs/**'
-              - '!LICENSE*'
-              - '!NOTICES*'
-              - '!THIRD-PARTY*'
-              - '!.github/ISSUE_TEMPLATE/**'
-              - '!.github/pull_request_template.md'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          files="$(gh api --paginate "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" --jq '.[].filename')"
+          nondocs=false
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            case "$f" in
+              *.md|docs/*|LICENSE*|NOTICES*|THIRD-PARTY*|.github/ISSUE_TEMPLATE/*|.github/pull_request_template.md) ;;
+              *) nondocs=true; break ;;
+            esac
+          done <<< "$files"
+          echo "nondocs=$nondocs" >> "$GITHUB_OUTPUT"
+          echo "Changed files:"; printf '%s\n' "$files"; echo "nondocs=$nondocs"
 
   build-test:
     name: Build + test (.NET, headless)

--- a/docs/developer/DEVELOPER.md
+++ b/docs/developer/DEVELOPER.md
@@ -60,13 +60,14 @@ These are the same two suites `run-tests.ps1` runs by default. Two deliberate ch
   ([Directory.Build.props](../../Directory.Build.props)) for a friction-free dev loop. The tree currently
   builds clean (0 warnings), so this only guards against regressions. The `.trx` results are uploaded as a
   run artifact for inspection.
-- **Docs-only changes skip the build — without blocking the PR.** A small `changes` job
-  ([`dorny/paths-filter`](https://github.com/dorny/paths-filter)) decides whether the diff touches anything
-  other than docs (Markdown, `docs/**`, licences, issue/PR templates). If it is docs-only, the heavy
-  `build-test` job is skipped via its `if:`. The workflow still **runs** (so the check always reports), and a
-  *skipped* required job counts as a pass — so the gate stays green on a docs PR instead of stalling. Any
-  code/content file makes it build for real; `data/**` and `web/**` count as code (they feed tests, e.g. the
-  en/de locale-parity test), so they are **not** in the doc-only exclusions.
+- **Docs-only changes skip the build — without blocking the PR.** A small `changes` job lists the PR's
+  changed files (via the GitHub API) and sets `nondocs=true` if any file is not documentation (Markdown,
+  `docs/**`, licences, issue/PR templates). If it is docs-only, the heavy `build-test` and `format` jobs are
+  skipped via their `if:`. The workflow still **runs** (so the checks always report), and a *skipped* required
+  job counts as a pass — so the gates stay green on a docs PR instead of stalling. Any code/content file makes
+  it build for real; `data/**` and `web/**` count as code (they feed tests, e.g. the en/de locale-parity test).
+  (The detection is an explicit `case` match, not `dorny/paths-filter` — that action's `some`-glob semantics
+  made a `**/*` + `!doc` list evaluate true for every diff, so docs PRs never actually skipped.)
 
 It is **safe as a required status check** — and is one: because the workflow always runs and the build-test
 check always reports (green/red/skipped-as-pass), a docs-only PR is never left waiting on a missing status, the


### PR DESCRIPTION
PR #24 (docs-only) revealed that `build-test`/`format` ran anyway — the docs-only skip never worked.

## Cause
The `changes` job used `dorny/paths-filter` with a `['**/*', '!**/*.md', …]` list. The action's `some`-glob
semantics make `**/*` match every file, so `nondocs` was always `true`; the `!` lines didn't subtract.

## Fix
Replace it with an explicit GitHub-API file listing + `case` match: `nondocs=true` only if a changed file
is **not** Markdown / `docs/**` / licence / issue-PR-template. `data/**` and `web/**` stay code. Verified
locally (docs-only → false; code/workflow/data → true). Bonus: removes the Node-20-deprecated action.

The real docs-only skip will be proven by the next docs-only PR (this one changes ci.yml, so it correctly
builds for real).

🤖 Generated with [Claude Code](https://claude.com/claude-code)