### PR TITLE
feat(server): optional Docker image for the dedicated server

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,46 @@
+# Keep the Docker build context small and the image clean. The build only needs src/, data/ and the
+# Directory.Build.props / nuget config — everything below is irrelevant to a Linux server build.
+
+# The Unity client project is huge and Windows-only — never needed for the server image.
+client/
+
+# Build outputs / restore caches (the image restores + publishes fresh inside the SDK stage).
+**/bin/
+**/obj/
+artifacts/
+publish/
+TestResults/
+
+# Git + CI + editor/agent metadata.
+.git/
+.github/
+.idea/
+.vs/
+.claude/
+
+# Runtime data that must never bleed into an image layer.
+saves/
+backups/
+logs/
+*.db
+*.db-shm
+*.db-wal
+bugreports/
+
+# Python tooling + AI backend venvs (the image installs the AI backend deps fresh in its own venv).
+**/__pycache__/
+**/.venv/
+.ruff_cache/
+
+# Never bake a local .env (real LLM API keys etc.) into the image — it is mounted at runtime instead.
+# (.env.example keeps a different filename, so it is not matched here.)
+**/.env
+
+# Local scratch / logs.
+*.log
+marketing/
+plans/
+
+# Docs are not needed to build the binaries (kept out to shrink the context).
+docs/
+*.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,30 +38,37 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Decides whether the diff contains anything other than documentation. Only meaningful for PRs;
-  # direct pushes to main always build (see build-test's `if:`), so the filter step is PR-only.
+  # Decides whether the PR diff contains anything other than documentation. Only meaningful for PRs;
+  # direct pushes to main always build (see build-test's `if:`), so the detection step is PR-only.
   changes:
     name: Detect code changes
     runs-on: ubuntu-latest
     outputs:
-      nondocs: ${{ steps.filter.outputs.nondocs }}
+      nondocs: ${{ steps.detect.outputs.nondocs }}
     steps:
-      - uses: dorny/paths-filter@v3
-        id: filter
+      # Lists the PR's changed files via the API (no checkout needed) and sets nondocs=true if ANY file is
+      # not documentation. Doc-only PRs (Markdown, docs/**, licences, issue/PR templates) leave it false, so
+      # build-test/format skip and — a skipped required job counting as a pass — never block a docs PR.
+      # data/** and web/** are treated as code (they feed tests, e.g. the en/de locale-parity test).
+      # (Done with an explicit case match rather than dorny/paths-filter, whose `some` glob semantics made a
+      # `**/*` + `!doc` list always true.)
+      - name: Detect non-doc changes
+        id: detect
         if: github.event_name == 'pull_request'
-        with:
-          # picomatch array semantics: the positive `**/*` matches every changed file, the `!` lines
-          # subtract the doc paths — so `nondocs` is true iff at least one NON-doc file changed.
-          filters: |
-            nondocs:
-              - '**/*'
-              - '!**/*.md'
-              - '!docs/**'
-              - '!LICENSE*'
-              - '!NOTICES*'
-              - '!THIRD-PARTY*'
-              - '!.github/ISSUE_TEMPLATE/**'
-              - '!.github/pull_request_template.md'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          files="$(gh api --paginate "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" --jq '.[].filename')"
+          nondocs=false
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            case "$f" in
+              *.md|docs/*|LICENSE*|NOTICES*|THIRD-PARTY*|.github/ISSUE_TEMPLATE/*|.github/pull_request_template.md) ;;
+              *) nondocs=true; break ;;
+            esac
+          done <<< "$files"
+          echo "nondocs=$nondocs" >> "$GITHUB_OUTPUT"
+          echo "Changed files:"; printf '%s\n' "$files"; echo "nondocs=$nondocs"
 
   build-test:
     name: Build + test (.NET, headless)

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,93 @@
+# Dedicated-server Docker image (game server + admin/portal/download UI in one Linux container).
+#
+# Two entry points:
+#   * workflow_dispatch — build it by hand from the Actions tab (build-validate by default; set `push`
+#     to publish to GHCR).
+#   * workflow_call     — reused by release.yml so a tagged release also builds + pushes the image to
+#     GHCR (tagged with the release version and `latest`). See docs/developer/SELF_HOSTING.md §10.
+
+name: Docker
+
+on:
+  workflow_dispatch:
+    inputs:
+      push:
+        description: "Push the image to GHCR (ghcr.io). Leave off to only build/validate."
+        type: boolean
+        default: false
+      tag:
+        description: "Image tag to apply (e.g. dev, 0.1.0)."
+        type: string
+        default: dev
+      latest:
+        description: "Also tag the pushed image as :latest."
+        type: boolean
+        default: false
+      platforms:
+        description: "Target platforms."
+        type: string
+        default: linux/amd64
+  workflow_call:
+    inputs:
+      push:
+        type: boolean
+        default: false
+      tag:
+        type: string
+        default: dev
+      latest:
+        type: boolean
+        default: false
+      platforms:
+        type: string
+        default: linux/amd64
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: docker-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  image:
+    name: Build dedicated-server image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Build the image tag list. The owner is lowercased — GHCR repository names must be lowercase, but
+      # github.repository_owner can contain uppercase letters.
+      - name: Compute image name + tags
+        id: img
+        run: |
+          name="ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/blocks-beyond-the-stars-server"
+          {
+            echo "tags<<EOF"
+            echo "${name}:${{ inputs.tag }}"
+            if [ "${{ inputs.latest }}" = "true" ]; then echo "${name}:latest"; fi
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        if: ${{ inputs.push }}
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build (and optionally push)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: ${{ inputs.platforms }}
+          push: ${{ inputs.push }}
+          tags: ${{ steps.img.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,9 +13,10 @@
 #        UNITY_PASSWORD = your Unity account password
 #   3. Push a tag:  git tag v1.0.0 && git push origin v1.0.0
 #
-# Why two jobs: the Unity build runs in GameCI's Linux Docker image (Windows player cross-built
+# Why split jobs: the Unity build runs in GameCI's Linux Docker image (Windows player cross-built
 # with the Mono backend). The WinForms launcher needs the Windows Desktop SDK, so it is built on
-# a windows-latest runner and merged into the player afterwards.
+# a windows-latest runner and merged into the player afterwards. A third job builds the optional
+# dedicated-server Docker image (reusable docker.yml) and pushes it to GHCR on a tag.
 
 name: Release
 
@@ -161,6 +162,24 @@ jobs:
         with:
           name: player-windows
           path: player
+
+  # Optional dedicated-server Docker image. Reuses .github/workflows/docker.yml (workflow_call). It only
+  # needs the resolved version from build-player, NOT the Unity player, so it runs in parallel with package.
+  # The image is PUSHED to GHCR only on a real tag (multi-arch, tagged with the version + `latest`); a manual
+  # workflow_dispatch run just build-validates it — same publish gating as the GitHub Release / itch.io steps.
+  docker:
+    name: Dedicated-server image
+    needs: build-player
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/docker.yml
+    with:
+      push: ${{ startsWith(github.ref, 'refs/tags/') }}
+      latest: ${{ startsWith(github.ref, 'refs/tags/') }}
+      tag: ${{ needs.build-player.outputs.version }}
+      platforms: linux/amd64,linux/arm64
+    secrets: inherit
 
   package:
     name: Package + release (Windows)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,12 +134,17 @@ build a release locally for distribution. Cut one by pushing a SemVer tag:
 git tag v0.3.0 && git push origin v0.3.0
 ```
 
-That triggers two jobs: a GameCI Linux Docker job cross-builds the `StandaloneWindows64` player (Mono
+That triggers three jobs: a GameCI Linux Docker job cross-builds the `StandaloneWindows64` player (Mono
 backend), then a `windows-latest` job builds the launcher and runs `scripts/publish-client-installer.ps1 -Msi`
 to attach **Setup.exe** (per-user, no admin), the **WiX MSI** (machine-wide/IT) and **Portable.zip** to a
-published GitHub Release. The workflow runs *only* on tags / manual dispatch (never `pull_request`), so the
-Unity license secrets (`UNITY_LICENSE`/`UNITY_EMAIL`/`UNITY_PASSWORD`) are safe in a public repo. A manual
-*Run workflow* dispatch builds + packages a `0.1.0-dev` test artifact but does not publish.
+published GitHub Release. In parallel, a third job reuses [.github/workflows/docker.yml](.github/workflows/docker.yml)
+to build the optional **dedicated-server Docker image** and push it multi-arch (amd64+arm64) to **GHCR**
+(`ghcr.io/<owner>/blocks-beyond-the-stars-server:<version>` + `:latest`) — see
+[docs/developer/SELF_HOSTING.md](docs/developer/SELF_HOSTING.md) §10. The workflow runs *only* on tags / manual
+dispatch (never `pull_request`), so the Unity license secrets (`UNITY_LICENSE`/`UNITY_EMAIL`/`UNITY_PASSWORD`)
+are safe in a public repo. A manual *Run workflow* dispatch builds + packages a `0.1.0-dev` test artifact and
+build-validates the image, but publishes nothing (no Release, no itch.io push, no GHCR push). `docker.yml` can
+also be run on its own from the Actions tab to build/push the image ad-hoc.
 
 **The git tag is the single source of truth for the version.** It flows into GameCI `versioning: Custom` →
 `PlayerSettings.bundleVersion`, so the in-game UI (`AppShell.Version` is a property `=> Application.version`,

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,61 @@
+# syntax=docker/dockerfile:1
+#
+# Blocks Beyond the Stars — dedicated server image (OPTIONAL, not part of the normal GitHub release).
+# Runs the headless .NET game server + the admin/portal/download web UI in one container.
+# See docs/developer/SELF_HOSTING.md §10 for usage. Build context = repo root (the .dockerignore keeps
+# the huge Unity client/, bin/obj and .git out of the build).
+
+# ---- build ----
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+COPY . .
+
+# Publish the three headless server projects into one folder, framework-dependent (the runtime image
+# already ships the .NET + ASP.NET runtime). We publish the projects individually on purpose: the .sln
+# also contains the net8.0-windows WinForms launcher, which cannot build on Linux.
+RUN dotnet publish src/BlocksBeyondTheStars.GameServer/BlocksBeyondTheStars.GameServer.csproj -c Release -o /app \
+ && dotnet publish src/BlocksBeyondTheStars.Api/BlocksBeyondTheStars.Api.csproj               -c Release -o /app \
+ && dotnet publish src/BlocksBeyondTheStars.Tools/BlocksBeyondTheStars.Tools.csproj           -c Release -o /app \
+ && cp -r data /app/data
+
+# ---- runtime ----
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime
+
+# tini = a proper PID 1 (reaps zombies + forwards signals to the entrypoint). curl = best-effort download
+# of the Windows client installer from GitHub Releases so the portal's /download works. python3 + venv =
+# the optional AI text backend (baked in, but only STARTED when a .env is provided — see the entrypoint).
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends tini curl ca-certificates python3 python3-venv \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY --from=build /app ./
+
+# Optional AI text backend (NPC greetings / mission flavour / VEGA banter). It is installed into its own
+# venv so it never clashes with anything; it is only LAUNCHED at runtime when an ai-backend/.env exists (or
+# BBTS_AI_* is set). Note: this pulls LangChain/LangGraph, which makes the image noticeably larger.
+# The .dockerignore keeps any local ai-backend/.env (real keys) out of the build context.
+COPY ai-backend/ /app/ai-backend/
+RUN python3 -m venv /app/ai-backend/.venv \
+ && /app/ai-backend/.venv/bin/pip install --no-cache-dir --upgrade pip \
+ && /app/ai-backend/.venv/bin/pip install --no-cache-dir \
+      "fastapi>=0.110" "uvicorn>=0.29" "langchain>=0.3" "langchain-openai>=0.2" "langgraph>=0.2" "python-dotenv>=1.0"
+
+COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+# Default the admin UI/portal bind to all interfaces (the app's own default is loopback, which would be
+# unreachable from outside the container). ALWAYS pair a public admin port with BBS_ADMIN_PASSWORD.
+ENV BBS_ADMIN_BIND=0.0.0.0
+
+# 31415/udp native client · 31415/tcp browser WebSocket (when BBS_ENABLE_WEBSOCKET=true) · 31416/tcp admin+portal+download
+EXPOSE 31415/udp 31415/tcp 31416/tcp
+
+# saves/ = SQLite world + backups + logs + /bump bug reports (<world>/bumps) · config/ = server.json · clients/ = published installer
+VOLUME ["/app/saves", "/app/config", "/app/clients"]
+
+# Health = the public admin dashboard root (cheap static HTML, never password-gated unlike /api/*).
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+  CMD curl -fsS "http://127.0.0.1:${BBS_ADMIN_PORT:-31416}/" >/dev/null || exit 1
+
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [Screenshots](#screenshots) ·
 [About this project](#about-this-project) ·
 [Project Status](#project-status) ·
+[System requirements](#system-requirements) ·
 [Guiding principle](#guiding-principle) ·
 [Tech stack](#tech-stack) ·
 [Repository layout](#repository-layout) ·
@@ -130,6 +131,29 @@ Blocks Beyond the Stars is a free in-development game. Bugs, missing content and
 
 The software is provided as-is under the terms of the license included in this repository.
 
+## System requirements
+
+The **game client is Windows-only**, but the **server is cross-platform** — so a Linux/macOS machine,
+a NAS or a VPS (including via Docker) can host a world that Windows players join.
+
+**Game client (to play)**
+
+- **Windows 10/11 (64-bit).**
+- A GPU with DirectX 11+ support (Unity 6 / URP) and a few GB of free disk for the client + worlds.
+- The client always talks to a server: a local one started automatically in singleplayer / "Host
+  Game", or a remote dedicated server.
+
+**Dedicated server (to host)**
+
+- **OS-independent.** Self-contained packages (no .NET install needed) ship for **Windows x64,
+  Linux x64 and Linux ARM64**; build them with `scripts/publish-server.ps1` / `.sh`.
+- Or run the **Docker image** on any Docker host — Linux, macOS, Windows (Docker Desktop / WSL2), a
+  NAS or a VPS. Pull it from GHCR (`ghcr.io/marceld23/blocks-beyond-the-stars-server`) or build it
+  locally. See [SELF_HOSTING.md §10](docs/developer/SELF_HOSTING.md#10-running-in-docker).
+- Lightweight: **no GPU**, modest CPU/RAM. On low-power ARM64 boards prefer an SSD over a
+  microSD/eMMC for the world database.
+- From source you only need the **.NET 8 SDK** (see [Build, test, run](#build-test-run)).
+
 ## Guiding principle
 
 > **The Unity client is presentation and input. The .NET server is the truth of the game world.**
@@ -217,8 +241,10 @@ dotnet run --project src/BlocksBeyondTheStars.Tools -- backup saves world_001
 provider-agnostic via the OpenAI-compatible chat API — LM Studio / OpenAI / Claude, chosen by env)
 that writes mission texts and NPC/ship-AI dialogue. The game is fully playable without it — every
 AI text has a scripted, localized fallback, and the C# server validates everything the service
-returns. See [ai-backend/README.md](ai-backend/README.md) and
-[docs/developer/AI_MISSION_BACKEND.md](docs/developer/AI_MISSION_BACKEND.md).
+returns. It is also **bundled into the Docker image** and starts automatically when you mount its
+`.env` (otherwise no Python process runs). See [ai-backend/README.md](ai-backend/README.md),
+[docs/developer/AI_MISSION_BACKEND.md](docs/developer/AI_MISSION_BACKEND.md) and
+[SELF_HOSTING.md §10](docs/developer/SELF_HOSTING.md#10-running-in-docker).
 
 ### Self-hosting packages
 
@@ -227,6 +253,12 @@ returns. See [ai-backend/README.md](ai-backend/README.md) and
 ```
 Produces self-contained, single-file packages (no .NET install needed on the host) under
 `artifacts/`. On Linux/macOS use `scripts/publish-server.sh`.
+
+You can also run the server (game server + admin/portal/download UI, plus the optional bundled AI text
+backend) as a **Docker container** on any OS. Each tagged release publishes a multi-arch image to GHCR,
+so you can just pull it — `docker pull ghcr.io/marceld23/blocks-beyond-the-stars-server:latest` — or
+build it locally with `docker compose up -d`. See
+[docs/developer/SELF_HOSTING.md §10](docs/developer/SELF_HOSTING.md#10-running-in-docker).
 
 Players can also download and install the Windows client **from the running server's own web page**:
 `scripts/publish-client-installer.ps1` builds a [Velopack](https://velopack.io) installer + auto-update

--- a/TODO.md
+++ b/TODO.md
@@ -17,6 +17,29 @@ world-gen; SQLite persistence.
 
 ---
 
+### ★ Optional Docker image for the dedicated server (2026-06-21) — ✅ done (built + pushed to GHCR on each release)
+Ship the headless server **and** the admin/portal/download UI (and the optional AI backend) as one optional Linux
+container — runs on any OS (Linux/macOS/Windows-WSL2/NAS/VPS); the game client stays Windows-only.
+- **One image, asymmetric processes** under `tini` (PID 1): [`Dockerfile`](Dockerfile) + [`docker/entrypoint.sh`](docker/entrypoint.sh) +
+  [`docker-compose.yml`](docker-compose.yml). Game server = critical foreground process (gets the signal, saves the world);
+  admin API = best-effort auto-restarting sidecar. `docker stop` (SIGTERM) is translated to the **SIGINT** the server's
+  clean drain+save path listens for.
+- **AI backend bundled, opt-in start:** the Python `ai-backend` is baked into the image (own venv) but only **starts when
+  configured** — an `ai-backend/.env` mounted at `/app/ai-backend/.env` or `BBTS_AI_BASE_URL` set (override `BBS_AI_BACKEND=1/0`).
+  Listens on in-container `127.0.0.1:8077` (= server's default `aiBackendUrl`); enable use with `BBS_AI_LEVEL`. `.dockerignore`
+  excludes `**/.env` so local keys never bake into the image. (Adds LangChain/LangGraph → larger image.)
+- **Env-var config** (container channel): new `ServerConfig.ApplyEnvironment()` reads `BBS_*` vars; precedence
+  `server.json` < env < CLI. Wired into both the GameServer and the Api (`AdminService.LoadConfig`). 3 new tests (689 green).
+- **Client download** (`/download`): a Linux container can't build the Windows installer, so the entrypoint pulls the
+  latest `*Setup.exe` from GitHub Releases into `clients/` (best-effort, `BBS_FETCH_CLIENT`/`BBS_CLIENT_REPO`).
+- **`/bump` bug reports work from the container** unchanged: they fall back to `saves/<world>/bumps/`, which is on the
+  persisted `saves` volume (retrievable via the volume or `docker cp`).
+- **CI:** [`docker.yml`](.github/workflows/docker.yml) is a reusable workflow (`workflow_call`) invoked by
+  [`release.yml`](.github/workflows/release.yml) → tag builds + pushes multi-arch (amd64+arm64) to **GHCR**
+  (`ghcr.io/marceld23/blocks-beyond-the-stars-server:<version>`+`:latest`); also `workflow_dispatch` for ad-hoc builds.
+  Docs: [SELF_HOSTING.md §10](docs/developer/SELF_HOSTING.md) + `BBS_*` env-var table, README **System requirements**,
+  [DEVELOPER.md §CI](docs/developer/DEVELOPER.md), [AGENTS.md §Releases](AGENTS.md).
+
 ### ★ Syntax/lint + CodeQL checks across all languages (2026-06-21) — ✅ lint+CodeQL added & green (PR #22); dotnet format DEFERRED
 Extends the PR gate beyond build+test (C# is already syntax/static-analysis-checked by the `-warnaserror` build):
 - **[lint.yml](.github/workflows/lint.yml)**: ruff (Python ai-backend, already clean), `node --check` (web JS parse), actionlint 1.7.12 (workflows, ShellCheck off). All verified green in CI.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,47 @@
+# Blocks Beyond the Stars — dedicated server (OPTIONAL Docker setup; not part of the GitHub release).
+# One image, both processes (game server + admin/portal/download). See docs/developer/SELF_HOSTING.md §10.
+#
+#   docker compose up -d          # build + run in the background
+#   docker compose logs -f        # follow the server log
+#   docker compose down           # stop (sends SIGTERM -> clean world save)
+#
+# Config precedence is server.json < BBS_* env vars < CLI; in a container you normally use the env vars
+# below. ALWAYS set BBS_ADMIN_PASSWORD before exposing the admin port (31416) beyond your LAN.
+
+services:
+  server:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: blocks-beyond-the-stars-server:local
+    restart: unless-stopped
+    stop_grace_period: 60s        # give the world time to drain + save on SIGTERM
+    ports:
+      - "31415:31415/udp"          # native client (UDP)
+      - "31415:31415/tcp"          # browser client over WebSocket (only when BBS_ENABLE_WEBSOCKET=true)
+      - "127.0.0.1:31416:31416/tcp" # admin + portal + download — bound to localhost on the HOST by default
+    environment:
+      BBS_SERVER_NAME: "Blocks Beyond the Stars Server"
+      BBS_WORLD: "world_001"
+      BBS_MAX_PLAYERS: "12"
+      # BBS_PASSWORD: "join-secret"        # required to join the game (optional)
+      BBS_ADMIN_BIND: "0.0.0.0"            # inside the container; reach it via the host port mapping above
+      # BBS_ADMIN_PASSWORD: "change-me"    # REQUIRED before exposing 31416 publicly
+      # BBS_ENABLE_WEBSOCKET: "true"       # also accept browser clients on the gameplay port
+      BBS_FETCH_CLIENT: "1"                # pull the latest Windows installer from GitHub Releases for /download
+      # BBS_CLIENT_REPO: "marceld23/BlocksBeyondTheStars"
+      # --- Optional AI text backend (NPC greetings / mission flavour / VEGA banter) ---
+      # It is baked into the image but only STARTS when an ai-backend/.env is mounted (see volumes below)
+      # or BBTS_AI_BASE_URL is set here. Set BBS_AI_LEVEL so the game server actually uses it:
+      # BBS_AI_LEVEL: "Suggest"            # Off (default) | Suggest (AI missions as drafts) | Auto (published)
+    volumes:
+      - saves:/app/saves            # SQLite world + backups + logs + /bump bug reports (<world>/bumps)
+      - config:/app/config          # server.json (created on first run)
+      - clients:/app/clients        # published Windows installer the portal hands out
+      # Mount your AI config to enable the in-container LLM backend (copy ai-backend/.env.example -> .env):
+      # - ./ai-backend/.env:/app/ai-backend/.env:ro
+
+volumes:
+  saves:
+  config:
+  clients:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Container entrypoint for the Blocks Beyond the Stars dedicated server image.
+#
+# It runs the server processes in one container, asymmetrically (see docs/developer/SELF_HOSTING.md §10):
+#   * the GAME SERVER is the critical, foreground process — it receives the shutdown signal and saves the
+#     world on its way out;
+#   * the ADMIN API (dashboard + portal + client download) is a best-effort sidecar — if it dies it is
+#     restarted and never takes the game server (and the players on it) down with it.
+#   * the optional AI text backend (Python) is started ONLY when an ai-backend/.env is provided (or
+#     BBTS_AI_* is set); it too is a best-effort, auto-restarting sidecar.
+#
+# tini is PID 1 (see the Dockerfile ENTRYPOINT): it reaps zombies and forwards SIGTERM to this script.
+set -uo pipefail
+
+APP_DIR=/app
+CONFIG_DIR="$APP_DIR/config"
+CLIENTS_DIR="$APP_DIR/clients"
+SAVES_DIR="$APP_DIR/saves"
+mkdir -p "$CONFIG_DIR" "$CLIENTS_DIR" "$SAVES_DIR"
+
+log() { echo "[entrypoint] $*"; }
+
+# The admin UI/portal must be reachable from outside the container; the application's own default is
+# loopback. The Dockerfile sets BBS_ADMIN_BIND=0.0.0.0; re-export it here so it is in scope for both
+# child processes regardless of how the container was started.
+export BBS_ADMIN_BIND="${BBS_ADMIN_BIND:-0.0.0.0}"
+
+# --- best-effort: fetch the latest Windows client installer from GitHub Releases so /download works ---
+# A Linux container cannot build the Windows installer (that needs Unity + Windows), so the portal's
+# one-click download is populated from the published GitHub Release instead. Non-fatal: without it the
+# portal still runs and /download simply reports "no installer published yet".
+fetch_client() {
+  local repo="${BBS_CLIENT_REPO:-marceld23/BlocksBeyondTheStars}"
+  local api="https://api.github.com/repos/${repo}/releases/latest"
+  log "fetching latest client installer from ${repo} ..."
+
+  local url
+  url=$(curl -fsSL "$api" \
+        | grep -o '"browser_download_url":[ ]*"[^"]*Setup\.exe"' \
+        | head -n1 | sed 's/.*"\(https[^"]*\)"/\1/') || return 1
+  [ -n "$url" ] || { log "no *Setup.exe asset in the latest release"; return 1; }
+
+  local target="$CLIENTS_DIR/$(basename "$url")"
+  curl -fsSL "$url" -o "$target.partial" || return 1
+  mv -f "$target.partial" "$target"
+  log "client installer ready: $(basename "$target")"
+}
+
+if [ "${BBS_FETCH_CLIENT:-1}" = "1" ]; then
+  fetch_client || log "client download skipped (continuing without it)"
+else
+  log "BBS_FETCH_CLIENT=0 -> skipping client installer download"
+fi
+
+# --- admin API: best-effort sidecar, auto-restarted, never fatal to the container ---
+run_api() {
+  while true; do
+    "$APP_DIR/BlocksBeyondTheStars.Api"
+    log "admin API exited ($?); restarting in 5s"
+    sleep 5
+  done
+}
+run_api &
+API_SUPERVISOR_PID=$!
+
+# --- optional AI text backend (Python): started ONLY when configured ---
+# "Configured" = an ai-backend/.env file is present (mounted at runtime), or BBTS_AI_BASE_URL is set in
+# the environment. Set BBS_AI_BACKEND=1/0 to force it on/off regardless. Best-effort sidecar like the API.
+AI_DIR="$APP_DIR/ai-backend"
+AI_ENV="${BBS_AI_ENV_FILE:-$AI_DIR/.env}"
+AI_SUPERVISOR_PID=""
+start_ai="${BBS_AI_BACKEND:-auto}"
+if [ "$start_ai" = "auto" ]; then
+  if [ -s "$AI_ENV" ] || [ -n "${BBTS_AI_BASE_URL:-}" ]; then start_ai=1; else start_ai=0; fi
+fi
+
+if [ "$start_ai" = "1" ]; then
+  if [ -x "$AI_DIR/.venv/bin/uvicorn" ]; then
+    log "AI backend: configuration found -> starting on 127.0.0.1:8077 (set BBS_AI_LEVEL=Suggest|Auto to use it)"
+    run_ai() {
+      while true; do
+        # CWD = ai-backend so the app's load_dotenv() picks up ai-backend/.env.
+        ( cd "$AI_DIR" && exec .venv/bin/uvicorn app.main:app --host 127.0.0.1 --port 8077 )
+        log "AI backend exited ($?); restarting in 5s"
+        sleep 5
+      done
+    }
+    run_ai &
+    AI_SUPERVISOR_PID=$!
+  else
+    log "AI backend requested but not installed in this image; skipping"
+  fi
+else
+  log "AI backend: no .env at $AI_ENV and BBTS_AI_BASE_URL unset -> not starting"
+fi
+
+# --- game server: the critical foreground process ---
+"$APP_DIR/BlocksBeyondTheStars.GameServer" &
+SERVER_PID=$!
+log "game server started (pid $SERVER_PID); admin supervisor (pid $API_SUPERVISOR_PID)"
+
+# `docker stop` delivers SIGTERM, but the server's clean drain+save path is wired to SIGINT
+# (Console.CancelKeyPress). Translate TERM/INT into SIGINT for the server so the world is always saved.
+shutdown() {
+  log "shutdown requested -> SIGINT to game server (clean save)"
+  kill -INT "$SERVER_PID" 2>/dev/null || true
+}
+trap shutdown TERM INT
+
+# Wait for the game server to exit. A trapped signal interrupts `wait`, so loop until the process is
+# really gone (it is still draining + saving in the meantime).
+while :; do
+  wait "$SERVER_PID"
+  STATUS=$?
+  kill -0 "$SERVER_PID" 2>/dev/null || break
+done
+
+log "game server stopped (exit $STATUS); stopping sidecars"
+kill "$API_SUPERVISOR_PID" 2>/dev/null || true
+[ -n "$AI_SUPERVISOR_PID" ] && kill "$AI_SUPERVISOR_PID" 2>/dev/null || true
+exit "$STATUS"

--- a/docs/developer/DEVELOPER.md
+++ b/docs/developer/DEVELOPER.md
@@ -108,6 +108,13 @@ Beyond build+test, three more gates run on PRs:
 The C# *compile/static-analysis* gate is the `-warnaserror` build (Roslyn + Meziantou + VS.Threading analyzers
 as errors); `Format` adds pure style on top.
 
+- **[`docker.yml`](../../.github/workflows/docker.yml)** — builds the optional dedicated-server Docker image
+  (game server + admin/portal/download + the bundled, opt-in AI backend). It is a **reusable workflow**
+  (`workflow_call`) that `release.yml` invokes so a tagged release also builds and pushes the image multi-arch
+  (amd64+arm64) to **GHCR** (`:<version>` + `:latest`). It can also be run standalone from the Actions tab
+  (`workflow_dispatch`) — build-validate by default, opt-in `push` to GHCR. Not triggered by `pull_request`.
+  See [SELF_HOSTING.md §10](SELF_HOSTING.md#10-running-in-docker).
+
 Run the equivalents locally before pushing (mirrors [AGENTS.md](../../AGENTS.md) §Local verification):
 
 ```powershell

--- a/docs/developer/DEVELOPER.md
+++ b/docs/developer/DEVELOPER.md
@@ -60,13 +60,14 @@ These are the same two suites `run-tests.ps1` runs by default. Two deliberate ch
   ([Directory.Build.props](../../Directory.Build.props)) for a friction-free dev loop. The tree currently
   builds clean (0 warnings), so this only guards against regressions. The `.trx` results are uploaded as a
   run artifact for inspection.
-- **Docs-only changes skip the build — without blocking the PR.** A small `changes` job
-  ([`dorny/paths-filter`](https://github.com/dorny/paths-filter)) decides whether the diff touches anything
-  other than docs (Markdown, `docs/**`, licences, issue/PR templates). If it is docs-only, the heavy
-  `build-test` job is skipped via its `if:`. The workflow still **runs** (so the check always reports), and a
-  *skipped* required job counts as a pass — so the gate stays green on a docs PR instead of stalling. Any
-  code/content file makes it build for real; `data/**` and `web/**` count as code (they feed tests, e.g. the
-  en/de locale-parity test), so they are **not** in the doc-only exclusions.
+- **Docs-only changes skip the build — without blocking the PR.** A small `changes` job lists the PR's
+  changed files (via the GitHub API) and sets `nondocs=true` if any file is not documentation (Markdown,
+  `docs/**`, licences, issue/PR templates). If it is docs-only, the heavy `build-test` and `format` jobs are
+  skipped via their `if:`. The workflow still **runs** (so the checks always report), and a *skipped* required
+  job counts as a pass — so the gates stay green on a docs PR instead of stalling. Any code/content file makes
+  it build for real; `data/**` and `web/**` count as code (they feed tests, e.g. the en/de locale-parity test).
+  (The detection is an explicit `case` match, not `dorny/paths-filter` — that action's `some`-glob semantics
+  made a `**/*` + `!doc` list evaluate true for every diff, so docs PRs never actually skipped.)
 
 It is **safe as a required status check** — and is one: because the workflow always runs and the build-test
 check always reports (green/red/skipped-as-pass), a docs-only PR is never left waiting on a missing status, the

--- a/docs/developer/SELF_HOSTING.md
+++ b/docs/developer/SELF_HOSTING.md
@@ -62,6 +62,25 @@ Created on first run; editable directly or through the admin UI.
 | `aiLevel` | Optional AI text backend: `Off`, `Suggest` (AI missions land as drafts), `Auto` (published) — see §8 | `Off` |
 | `aiBackendUrl` | Base URL of the optional AI backend | `http://127.0.0.1:8077` |
 
+### Environment-variable overrides (containers)
+
+Every key above can also be set with a `BBS_*` environment variable, which is the natural way to
+configure the [Docker image](#10-running-in-docker). Precedence is **`server.json` < environment <
+command line**, so env vars override the file but the in-game host's CLI flags still win.
+
+| Variable | Maps to | Variable | Maps to |
+|---|---|---|---|
+| `BBS_SERVER_NAME` | `serverName` | `BBS_ADMIN_PASSWORD` | `adminPassword` |
+| `BBS_WORLD` | `worldName` | `BBS_ADMIN_BIND` | `adminBindAddress` |
+| `BBS_PORT` (`BBS_GAMEPLAY_PORT`) | `gameplayPort` | `BBS_ENABLE_WEBSOCKET` | `enableWebSocket` |
+| `BBS_ADMIN_PORT` | `adminPort` | `BBS_WEBSOCKET_BIND` | `webSocketBindAddress` |
+| `BBS_MAX_PLAYERS` | `maxPlayers` | `BBS_SAVES` | `savesRoot` |
+| `BBS_PASSWORD` (`BBS_SERVER_PASSWORD`) | `serverPassword` | `BBS_DATA` | `dataDir` |
+| `BBS_ADMINS` | `adminPlayers` (comma-separated) | `BBS_USERCONTENT` | `userContentDir` |
+| `BBS_SEED` | `seed` | `BBS_TICK_RATE` | `tickRate` |
+| `BBS_START_PLANET` | `startPlanet` | `BBS_VIEW_DISTANCE` | `viewDistanceChunks` |
+| `BBS_AI_LEVEL` | `aiLevel` | `BBS_AI_BACKEND_URL` | `aiBackendUrl` |
+
 ### Player names & name verification
 
 A player's name keys their server-side state (inventory, position, role). Two protections
@@ -157,6 +176,9 @@ admin-generated missions (`/ai <prompt>` in chat). The game is fully playable wi
 every AI text has a localized scripted fallback (DE+EN), and with `aiLevel = Off` (the
 default) the server never contacts the backend.
 
+> **Running in Docker?** The image bundles this backend and starts it automatically when you mount its
+> `.env` — you don't run the steps below by hand. See [§10 → Optional AI text backend](#optional-ai-text-backend-in-the-container).
+
 1. **Start the backend** (from a repo checkout; needs [uv](https://docs.astral.sh/uv/)):
 
    ```bash
@@ -233,3 +255,110 @@ is password-gated; `/portal`, `/download` and `/updates` stay public so players 
 
 Updates only apply to an *installed* client (not a dev/Editor or portable-zip run). Each published
 version must be higher than the last.
+
+## 10. Running in Docker
+
+The dedicated server (game server **and** admin/portal/download UI, plus the optional AI text backend)
+can run as a single Linux container. This is **optional**, but a tagged release **does** build and
+publish the image to the GitHub Container Registry (GHCR), so you can just pull it:
+
+```bash
+docker pull ghcr.io/marceld23/blocks-beyond-the-stars-server:latest   # or a :X.Y.Z version tag
+```
+
+You can also build it yourself (`docker compose build` / `docker build`) or trigger the standalone
+[`Docker`](../../.github/workflows/docker.yml) workflow from the Actions tab. The server is
+Linux x64+ARM64 native, so the container runs on Linux, macOS, Windows (Docker Desktop / WSL2), a NAS
+or a VPS. The **game client stays Windows-only** — the container hosts the server and hands the Windows
+installer out via `/download`.
+
+**One image, asymmetric processes.** [`Dockerfile`](../../Dockerfile) publishes the headless projects
+onto the .NET 8 ASP.NET runtime image and runs them through
+[`docker/entrypoint.sh`](../../docker/entrypoint.sh) under `tini` (PID 1). The split is deliberate:
+
+- the **game server** is the critical foreground process — it receives the shutdown signal and saves
+  the world before exiting;
+- the **admin API** is a best-effort sidecar — it auto-restarts and never takes the game server (and
+  the players on it) down with it;
+- the **AI text backend** (Python) is baked in but only started when you provide its `.env` (below) —
+  also a best-effort, auto-restarting sidecar.
+
+`docker stop` sends `SIGTERM`; the entrypoint translates that into the `SIGINT` the server's clean
+drain-and-save path listens for, so the world is always saved on shutdown (give it time with a
+`stop_grace_period`/`--stop-timeout` of ~60 s).
+
+### Quick start (Compose)
+
+```bash
+docker compose up -d        # build + run (see docker-compose.yml)
+docker compose logs -f      # follow the server log
+docker compose down         # SIGTERM -> clean world save, then stop
+```
+
+Configure with the `BBS_*` environment variables (see §3). At minimum set `BBS_ADMIN_PASSWORD` before
+exposing the admin port. Ports: **31415/udp** (native client), **31415/tcp** (browser WebSocket, only
+when `BBS_ENABLE_WEBSOCKET=true`), **31416/tcp** (admin + portal + download).
+
+### Or plain `docker run`
+
+```bash
+docker build -t bbts-server .
+docker run -d --name bbts \
+  -p 31415:31415/udp -p 31415:31415/tcp -p 127.0.0.1:31416:31416/tcp \
+  -e BBS_ADMIN_PASSWORD=change-me -e BBS_MAX_PLAYERS=12 \
+  -v bbts-saves:/app/saves -v bbts-config:/app/config -v bbts-clients:/app/clients \
+  --stop-timeout 60 bbts-server
+```
+
+### Volumes (what to persist)
+
+| Volume | Holds |
+|---|---|
+| `/app/saves` | SQLite world + `backups/` + `logs/` **and `/bump` bug reports** (`<world>/bumps/`) |
+| `/app/config` | `server.json` (created on first run; env vars override it) |
+| `/app/clients` | the published Windows installer the portal serves at `/download` |
+
+### Client download from the container
+
+A Linux container can't *build* the Windows installer, so on start the entrypoint pulls the newest
+`*Setup.exe` from the latest GitHub Release into `/app/clients` (best-effort; controlled by
+`BBS_FETCH_CLIENT=1`/`0` and `BBS_CLIENT_REPO`). The portal (`/portal`) and one-click `/download` then
+work as in §9. Without it the portal still runs and `/download` reports "no installer published yet";
+you can instead drop a `Setup.exe` into the `clients` volume yourself.
+
+### Bug reports (`/bump`) in a container
+
+The in-game **bug report / `/bump`** feature works unchanged from a container: the client sends the
+report (with its screenshot) over the network and the server writes a JSON snapshot (+ the JPG) to
+`saves/<world>/bumps/`. Because that lives on the **`saves` volume**, reports survive restarts and are
+retrievable from the host — browse the volume, or `docker cp bbts:/app/saves/<world>/bumps ./bumps`.
+(Reports only divert to a repo's `bugreports/server/` when the server runs from inside a git checkout,
+which a normal container is not.)
+
+### Optional AI text backend in the container
+
+The Python AI backend from §8 is **bundled into the image** (its own venv) but **only starts when you
+configure it** — otherwise no Python process runs. It is enabled when either:
+
+- an **`ai-backend/.env`** file is mounted into the container at `/app/ai-backend/.env` (the normal
+  way — copy [`ai-backend/.env.example`](../../ai-backend/.env.example) and fill in one provider), or
+- a **`BBTS_AI_BASE_URL`** environment variable is set on the container.
+
+Set `BBS_AI_BACKEND=1`/`0` to force it on/off explicitly. When it starts it listens on the in-container
+`127.0.0.1:8077`, which is the game server's default `aiBackendUrl` — so you only need to turn the
+server's usage on with **`BBS_AI_LEVEL=Suggest`** (AI missions as drafts) or **`Auto`** (published);
+any non-`Off` value also enables NPC greetings / board flavour / VEGA banter (see §8). With no `.env`
+and `BBS_AI_LEVEL=Off` (the defaults), the game is fully AI-free and no backend runs.
+
+```yaml
+# docker-compose.yml — enable the bundled AI backend
+services:
+  server:
+    environment:
+      BBS_AI_LEVEL: "Suggest"
+    volumes:
+      - ./ai-backend/.env:/app/ai-backend/.env:ro
+```
+
+> Bundling LangChain/LangGraph makes the image noticeably larger. The AI backend is still entirely
+> optional and the game runs identically without it; only the image size grows.

--- a/src/BlocksBeyondTheStars.Api/AdminService.cs
+++ b/src/BlocksBeyondTheStars.Api/AdminService.cs
@@ -55,7 +55,15 @@ public sealed class AdminService
         _configPath = Path.Combine(installDir, "config", "server.json");
     }
 
-    public ServerConfig LoadConfig() => ServerConfig.Load(_configPath);
+    public ServerConfig LoadConfig()
+    {
+        // Same precedence as the game server: server.json overlaid by BBS_* environment variables, so a
+        // containerised admin UI honours BBS_ADMIN_BIND / BBS_ADMIN_PORT / BBS_ADMIN_PASSWORD. Saving config
+        // (PUT /api/config) deserialises the request body instead, so env values are never written to disk.
+        var config = ServerConfig.Load(_configPath);
+        config.ApplyEnvironment();
+        return config;
+    }
 
     public void SaveConfig(ServerConfig config) => config.Save(_configPath);
 

--- a/src/BlocksBeyondTheStars.GameServer/Program.cs
+++ b/src/BlocksBeyondTheStars.GameServer/Program.cs
@@ -12,6 +12,10 @@ string configPath = Path.Combine(installDir, "config", "server.json");
 
 var config = ServerConfig.Load(configPath);
 
+// Configuration precedence: server.json < BBS_* environment variables < command line. The env layer
+// is the container channel (Docker/Compose), the CLI is what the in-game singleplayer host passes.
+var appliedEnv = config.ApplyEnvironment();
+
 // Command-line overrides (e.g. the client's local singleplayer host passes --port/--saves/--data).
 var appliedOverrides = config.ApplyCommandLine(args);
 
@@ -22,6 +26,11 @@ string? userContentDir = string.IsNullOrEmpty(config.UserContentDir)
     : (Path.IsPathRooted(config.UserContentDir) ? config.UserContentDir : Path.Combine(installDir, config.UserContentDir));
 
 var logger = new ConsoleGameLogger(Path.Combine(savesRoot, config.WorldName, "logs", "server.log"));
+
+if (appliedEnv.Count > 0)
+{
+    logger.Info($"Applied environment overrides: {string.Join(", ", appliedEnv)}.");
+}
 
 if (appliedOverrides.Count > 0)
 {

--- a/src/BlocksBeyondTheStars.Shared/Configuration/ServerConfig.cs
+++ b/src/BlocksBeyondTheStars.Shared/Configuration/ServerConfig.cs
@@ -374,6 +374,48 @@ public sealed class ServerConfig
         return applied;
     }
 
+    /// <summary>
+    /// Applies <c>BBS_*</c> environment-variable overrides onto this config — the configuration
+    /// channel used when running in a container (Docker/Compose/Kubernetes), where mounting a
+    /// <c>server.json</c> is awkward. Precedence is <c>server.json</c> &lt; environment &lt;
+    /// command-line, so call this after <see cref="Load"/> and before <see cref="ApplyCommandLine"/>.
+    /// Empty/unset variables are ignored; unparseable values are skipped. Returns the canonical
+    /// names of the keys that were applied.
+    /// </summary>
+    public IReadOnlyList<string> ApplyEnvironment()
+    {
+        var applied = new List<string>();
+
+        static string? Env(string name)
+        {
+            var v = Environment.GetEnvironmentVariable(name);
+            return string.IsNullOrEmpty(v) ? null : v;
+        }
+
+        if (Env("BBS_SERVER_NAME") is { } serverName) { ServerName = serverName; applied.Add("BBS_SERVER_NAME"); }
+        if (Env("BBS_WORLD") is { } world) { WorldName = world; applied.Add("BBS_WORLD"); }
+        if ((Env("BBS_PORT") ?? Env("BBS_GAMEPLAY_PORT")) is { } portStr && int.TryParse(portStr, out var port)) { GameplayPort = port; applied.Add("BBS_PORT"); }
+        if (Env("BBS_ADMIN_PORT") is { } adminPortStr && int.TryParse(adminPortStr, out var adminPort)) { AdminPort = adminPort; applied.Add("BBS_ADMIN_PORT"); }
+        if (Env("BBS_MAX_PLAYERS") is { } maxStr && int.TryParse(maxStr, out var max)) { MaxPlayers = max; applied.Add("BBS_MAX_PLAYERS"); }
+        if ((Env("BBS_PASSWORD") ?? Env("BBS_SERVER_PASSWORD")) is { } pw) { ServerPassword = pw; applied.Add("BBS_PASSWORD"); }
+        if (Env("BBS_ADMINS") is { } admins) { AdminPlayers = SplitNames(admins); applied.Add("BBS_ADMINS"); }
+        if (Env("BBS_ADMIN_PASSWORD") is { } adminPw) { AdminPassword = adminPw; applied.Add("BBS_ADMIN_PASSWORD"); }
+        if (Env("BBS_ADMIN_BIND") is { } adminBind) { AdminBindAddress = adminBind; applied.Add("BBS_ADMIN_BIND"); }
+        if (Env("BBS_ENABLE_WEBSOCKET") is { } wsStr && bool.TryParse(wsStr, out var ws)) { EnableWebSocket = ws; applied.Add("BBS_ENABLE_WEBSOCKET"); }
+        if (Env("BBS_WEBSOCKET_BIND") is { } wsBind) { WebSocketBindAddress = wsBind; applied.Add("BBS_WEBSOCKET_BIND"); }
+        if (Env("BBS_SAVES") is { } saves) { SavesRoot = saves; applied.Add("BBS_SAVES"); }
+        if (Env("BBS_DATA") is { } data) { DataDir = data; applied.Add("BBS_DATA"); }
+        if (Env("BBS_USERCONTENT") is { } userContent) { UserContentDir = userContent; applied.Add("BBS_USERCONTENT"); }
+        if (Env("BBS_SEED") is { } seedStr && long.TryParse(seedStr, out var seed)) { Seed = seed; applied.Add("BBS_SEED"); }
+        if (Env("BBS_START_PLANET") is { } startPlanet) { StartPlanet = startPlanet.Trim(); applied.Add("BBS_START_PLANET"); }
+        if (Env("BBS_TICK_RATE") is { } tickStr && int.TryParse(tickStr, out var tick)) { TickRate = tick; applied.Add("BBS_TICK_RATE"); }
+        if (Env("BBS_VIEW_DISTANCE") is { } vdStr && int.TryParse(vdStr, out var vd)) { ViewDistanceChunks = vd; applied.Add("BBS_VIEW_DISTANCE"); }
+        if (Env("BBS_AI_LEVEL") is { } aiStr && Enum.TryParse<AiLevel>(aiStr, ignoreCase: true, out var ai)) { AiLevel = ai; applied.Add("BBS_AI_LEVEL"); }
+        if (Env("BBS_AI_BACKEND_URL") is { } aiUrl) { AiBackendUrl = aiUrl; applied.Add("BBS_AI_BACKEND_URL"); }
+
+        return applied;
+    }
+
     /// <summary>Splits a comma-separated name list, trimming entries and dropping empties.</summary>
     private static List<string> SplitNames(string value)
         => value.Split(',').Select(n => n.Trim()).Where(n => n.Length > 0).ToList();

--- a/tests/BlocksBeyondTheStars.Tests/ServerConfigTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/ServerConfigTests.cs
@@ -121,4 +121,99 @@ public sealed class ServerConfigTests
         Assert.Empty(applied);
         Assert.Equal(defaultPort, config.GameplayPort);
     }
+
+    [Fact]
+    public void ApplyEnvironment_OverridesKnownKeys()
+    {
+        var vars = new Dictionary<string, string?>
+        {
+            ["BBS_PORT"] = "32000",
+            ["BBS_ADMIN_PORT"] = "32001",
+            ["BBS_MAX_PLAYERS"] = "8",
+            ["BBS_ADMIN_BIND"] = "0.0.0.0",
+            ["BBS_ADMIN_PASSWORD"] = "secret",
+            ["BBS_ENABLE_WEBSOCKET"] = "true",
+            ["BBS_ADMINS"] = "Alice, Bob",
+            ["BBS_WORLD"] = "dockerworld",
+            ["BBS_AI_LEVEL"] = "Suggest",
+        };
+
+        WithEnvironment(vars, () =>
+        {
+            var config = new ServerConfig();
+            var applied = config.ApplyEnvironment();
+
+            Assert.Equal(32000, config.GameplayPort);
+            Assert.Equal(32001, config.AdminPort);
+            Assert.Equal(8, config.MaxPlayers);
+            Assert.Equal("0.0.0.0", config.AdminBindAddress);
+            Assert.Equal("secret", config.AdminPassword);
+            Assert.True(config.EnableWebSocket);
+            Assert.Equal(new[] { "Alice", "Bob" }, config.AdminPlayers);
+            Assert.Equal("dockerworld", config.WorldName);
+            Assert.Equal(AiLevel.Suggest, config.AiLevel);
+            Assert.Contains("BBS_PORT", applied);
+            Assert.Contains("BBS_ADMIN_BIND", applied);
+            Assert.Contains("BBS_AI_LEVEL", applied);
+        });
+    }
+
+    [Fact]
+    public void ApplyEnvironment_IgnoresUnsetAndUnparseableValues()
+    {
+        var vars = new Dictionary<string, string?>
+        {
+            ["BBS_PORT"] = "notaport",
+            ["BBS_MAX_PLAYERS"] = "",
+        };
+
+        WithEnvironment(vars, () =>
+        {
+            var config = new ServerConfig();
+            int defaultPort = config.GameplayPort;
+            int defaultMax = config.MaxPlayers;
+
+            var applied = config.ApplyEnvironment();
+
+            Assert.Empty(applied);
+            Assert.Equal(defaultPort, config.GameplayPort);
+            Assert.Equal(defaultMax, config.MaxPlayers);
+        });
+    }
+
+    [Fact]
+    public void CommandLine_TakesPrecedenceOverEnvironment()
+    {
+        WithEnvironment(new Dictionary<string, string?> { ["BBS_PORT"] = "32000" }, () =>
+        {
+            var config = new ServerConfig();
+            config.ApplyEnvironment();          // env layer: 32000
+            config.ApplyCommandLine(new[] { "--port", "33000" }); // CLI layer wins
+
+            Assert.Equal(33000, config.GameplayPort);
+        });
+    }
+
+    /// <summary>Sets the given environment variables for the duration of <paramref name="body"/>, then restores them.</summary>
+    private static void WithEnvironment(Dictionary<string, string?> vars, Action body)
+    {
+        var previous = new Dictionary<string, string?>();
+        foreach (var (key, value) in vars)
+        {
+            previous[key] = Environment.GetEnvironmentVariable(key);
+            Environment.SetEnvironmentVariable(key, value);
+        }
+
+        try
+        {
+            body();
+        }
+        finally
+        {
+            foreach (var (key, value) in previous)
+            {
+                Environment.SetEnvironmentVariable(key, value);
+            }
+        }
+    }
 }


### PR DESCRIPTION
## What

Run the dedicated server as **one optional Linux container** — the game server, the admin/portal/download web UI, and (opt-in) the AI text backend. It runs on any OS (Linux, macOS, Windows/WSL2, NAS, VPS); the **game client stays Windows-only**.

## Highlights

- **One image, asymmetric processes** — [`Dockerfile`](Dockerfile) (multi-stage `sdk:8.0` → `aspnet:8.0`) + [`docker/entrypoint.sh`](docker/entrypoint.sh) under `tini` (PID 1). The **game server is the critical foreground process** (gets the signal, saves the world); the **admin API** and **AI backend** are best-effort, auto-restarting sidecars. `docker stop` (SIGTERM) is translated to the **SIGINT** the server's clean drain+save path listens for.
- **Env-var configuration** for containers — new `ServerConfig.ApplyEnvironment()` reads `BBS_*` vars (precedence `server.json` < env < CLI), wired into the game server and the admin API. +3 `ServerConfigTests`.
- **Built on release → GHCR** — [`docker.yml`](.github/workflows/docker.yml) is now a reusable workflow (`workflow_call` + `workflow_dispatch`); [`release.yml`](.github/workflows/release.yml) calls it so a tagged release builds + pushes the image multi-arch (amd64+arm64) to `ghcr.io/marceld23/blocks-beyond-the-stars-server:<version>` + `:latest`. A manual dispatch only build-validates.
- **AI backend bundled, opt-in start** — the Python `ai-backend` is baked into the image (own venv) but only **starts when configured**: an `ai-backend/.env` mounted at `/app/ai-backend/.env`, or `BBTS_AI_BASE_URL` set (force via `BBS_AI_BACKEND=1/0`). `.dockerignore` excludes `**/.env` so local keys never bake into the image. Enable usage with `BBS_AI_LEVEL`.
- **Client `/download`** — a Linux container can't build the Windows installer, so the entrypoint pulls the latest `*Setup.exe` from GitHub Releases into `clients/` (best-effort, `BBS_FETCH_CLIENT`/`BBS_CLIENT_REPO`).
- **`/bump` bug reports work unchanged** from a container — they land in `saves/<world>/bumps/` on the persisted `saves` volume.

## Docs

SELF_HOSTING §8 + new §10 (incl. `BBS_*` env table, GHCR pull, AI-in-container), README **System requirements** + Docker/GHCR notes, DEVELOPER §CI, AGENTS §Releases (two → three jobs), TODO.

## Verification

- `dotnet test` (server suite): **689 passing**, build `-warnaserror` **0 warnings**, `dotnet format --verify-no-changes` clean.
- All workflow/compose YAML well-formed; `entrypoint.sh` passes `bash -n`.
- **Local image build OK (400 MB)** + container smoke test: admin returns **200**, AI backend **off** without a `.env` / **on** with one (Uvicorn up on :8077), and `docker stop` performs the clean SIGTERM→SIGINT shutdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)