### PR TITLE
ci(security): pin Actions to SHAs, harden wiki esc, CodeQL -> security-extended

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
-          queries: security-and-quality
+          queries: security-extended
 
       - name: Analyze
         uses: github/codeql-action/analyze@v3

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -70,19 +70,19 @@ jobs:
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to GHCR
         if: ${{ inputs.push }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build (and optionally push)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/ruff-action@v3
+      - uses: astral-sh/ruff-action@4919ec5cf1f49eff0871dbcea0da843445b837e6 # v3
         with:
           args: "check"
           src: "ai-backend"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,7 +123,7 @@ jobs:
           echo "Injected feedback API key into the build."
 
       - name: Build Windows player
-        uses: game-ci/unity-builder@v4
+        uses: game-ci/unity-builder@1d4ee0697f193f54668e98961d79907911f4b4f2 # v4
         env:
           # Unity Personal needs all three: the .ulf contents + the account email & password.
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
@@ -232,7 +232,7 @@ jobs:
       # (verifiable from the run logs) but skips publishing.
       - name: Publish GitHub Release
         if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           files: |
             artifacts/installer/*Setup.exe

--- a/web/wiki/wiki.js
+++ b/web/wiki/wiki.js
@@ -43,7 +43,7 @@
   var blockByKey = {}; D.blocks.forEach(function (b) { blockByKey[b.key] = b; });
   function itemName(key) { var i = itemByKey[key]; return i ? L(i.nameKey) : key; }
 
-  function esc(s) { return String(s).replace(/[&<>]/g, function (c) { return { '&': '&amp;', '<': '&lt;', '>': '&gt;' }[c]; }); }
+  function esc(s) { return String(s).replace(/[&<>"']/g, function (c) { return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]; }); }
   function link(go, label) { return '<span class="link" data-go="' + esc(go) + '">' + esc(label) + '</span>'; }
   function itemLink(key, count) {
     var label = itemName(key) + (count ? ' ×' + count : '');


### PR DESCRIPTION
Addresses GitHub **Code scanning** findings (927 open alerts triaged).

## What & why
The CodeQL workflow ran the buildless `security-and-quality` suite, which produced ~689 note-level quality alerts plus false-positive errors that buried the real findings. Code quality is already enforced by the Roslyn analyzers (0 warnings in CI), so the quality queries were redundant noise.

## Changes
- **CodeQL suite** `security-and-quality` → `security-extended` ([codeql.yml](.github/workflows/codeql.yml)). Drops the ~689 quality `note`s and the 12 quality `error`s (all false-positive / by-design: `cs/invalid-string-formatting` on a localized `string.Format` whose `{0}` the buildless scan can't resolve; `cs/loss-of-precision` on intentional integer centering; `cs/unused-collection`). Keeps full security coverage. Existing alerts auto-dismiss on the next scan of `main`.
- **Pin 7 unpinned 3rd-party Actions to commit SHAs** (medium security, `actions/unpinned-tag`), tag preserved as a comment: `docker/{setup-qemu,setup-buildx,login,build-push}-action`, `game-ci/unity-builder`, `softprops/action-gh-release`, `astral-sh/ruff-action`.
- **Harden `esc()`** in [web/wiki/wiki.js](web/wiki/wiki.js) to also escape `"` and `'` (was `&<>` only) — it is used inside double-quoted HTML attributes, closing the 3 `js/incomplete-html-attribute-sanitization` findings.

## Validation
- `node --check web/wiki/wiki.js` passes.
- YAML edits are single-token `uses:` value swaps (indentation unchanged); all 7 pins verified present.
- No C# changes, so no behavioural/test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)