### PR TITLE
ci: bump first-party Actions to Node 24 majors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,10 +78,10 @@ jobs:
     if: github.event_name != 'pull_request' || needs.changes.outputs.nondocs == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '8.0.x'
 
@@ -104,7 +104,7 @@ jobs:
       # Keep the .trx results even when a suite fails, so failures are inspectable from the run page.
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: test-results
           path: TestResults/*.trx
@@ -121,10 +121,10 @@ jobs:
     if: github.event_name != 'pull_request' || needs.changes.outputs.nondocs == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '8.0.x'
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -43,16 +43,16 @@ jobs:
           - language: actions
             build-mode: none
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
           queries: security-extended
 
       - name: Analyze
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -55,7 +55,7 @@ jobs:
     name: Build dedicated-server image
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # Build the image tag list. The owner is lowercased — GHCR repository names must be lowercase, but
       # github.repository_owner can contain uppercase letters.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
     name: ruff (Python ai-backend)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: astral-sh/ruff-action@4919ec5cf1f49eff0871dbcea0da843445b837e6 # v3
         with:
           args: "check"
@@ -32,8 +32,8 @@ jobs:
     name: web JS syntax (node --check)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: '20'
       - name: node --check every web/*.js
@@ -54,7 +54,7 @@ jobs:
     name: actionlint (workflows)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Download + run actionlint
         run: |
           curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash | bash -s -- 1.7.12

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
     outputs:
       version: ${{ steps.ver.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # Version single source of truth: a tag push (vX.Y.Z) defines the version for the whole build —
       # in-game (Application.version), the launcher and the Velopack installers all derive from it. A manual
@@ -58,7 +58,7 @@ jobs:
           echo "Resolved build version: $v"
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '8.0.x'
 
@@ -81,7 +81,7 @@ jobs:
         run: ./scripts/publish-local-server.ps1 -Runtime win-x64
 
       - name: Cache Unity Library
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: client/Library
           key: Library-${{ hashFiles('client/Assets/**', 'client/Packages/**', 'client/ProjectSettings/**') }}
@@ -158,7 +158,7 @@ jobs:
           test "$baked" = "${{ steps.ver.outputs.version }}"
 
       - name: Upload player artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: player-windows
           path: player
@@ -186,10 +186,10 @@ jobs:
     needs: build-player
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '8.0.x'
 
@@ -205,7 +205,7 @@ jobs:
 
       # Download the player into the layout publish-client-installer.ps1 expects (its default -BuildDir).
       - name: Download player artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: player-windows
           path: client/Build/Windows


### PR DESCRIPTION
Silences the **Node 20 deprecation** warning on GitHub Actions runners (runners now default to Node 24 and flag actions that still bundle the node20 runtime). Follow-up to the security PR (#28).

Each first-party action bumped to its **lowest major that runs on node24** (verified via each action's `action.yml`):

| Action | from | to | note |
|---|---|---|---|
| actions/checkout | v4 | v5 | |
| actions/setup-dotnet | v4 | v5 | |
| actions/setup-node | v4 | v5 | |
| actions/cache | v4 | v5 | |
| actions/upload-artifact | v4 | **v6** | v5 is still node20 |
| actions/download-artifact | v4 | **v7** | v5/v6 are still node20 |
| github/codeql-action | v3 | v4 | also clears the "CodeQL Action v3 deprecated Dec 2026" notice |

Artifact usage is the simple single-named-artifact pattern (`name` + `path`, no wildcard/merge), so it stays compatible across the v4 artifact backend. The 3rd-party actions stay **SHA-pinned** and untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)