### PR TITLE
ci: re-pin 3rd-party Actions to Node 24 majors

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -70,19 +70,19 @@ jobs:
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
-      - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
-      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+      - uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
       - name: Log in to GHCR
         if: ${{ inputs.push }}
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build (and optionally push)
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: astral-sh/ruff-action@4919ec5cf1f49eff0871dbcea0da843445b837e6 # v3
+      - uses: astral-sh/ruff-action@0ce1b0bf8b818ef400413f810f8a11cdbda0034b # v4.0.0
         with:
           args: "check"
           src: "ai-backend"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -232,7 +232,7 @@ jobs:
       # (verifiable from the run logs) but skips publishing.
       - name: Publish GitHub Release
         if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3
         with:
           files: |
             artifacts/installer/*Setup.exe


### PR DESCRIPTION
Follow-up to #29. After bumping the first-party actions, the **SHA-pinned 3rd-party actions** turned out to still bundle node20 at the pinned versions — so the Node 20 warning persisted (notably `ruff-action`, which runs on every PR/push).

Re-pinned each to its lowest **node24** major (SHA-pinned, tag in comment, verified via `action.yml`):

| Action | from | to |
|---|---|---|
| astral-sh/ruff-action | v3 | **v4.0.0** (PR/push — lint) |
| docker/setup-qemu-action | v3 | v4 |
| docker/setup-buildx-action | v3 | v4 |
| docker/login-action | v3 | v4 |
| docker/build-push-action | v6 | v7 |
| softprops/action-gh-release | v2 | v3 |

**Deliberately excluded:** `game-ci/unity-builder` v4 → v5. v5 is node24 but a major Unity-builder bump that only runs on release tags (so it can't be validated by PR CI). Left for a separate, deliberate change. It is the only remaining node20 source, and only on release runs.

`ruff` is exercised by this PR's lint check; the docker/release actions run only on tags / `workflow_dispatch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)