### PR TITLE
ci: bump game-ci/unity-builder v4 -> v5 (Node 24)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,7 +123,7 @@ jobs:
           echo "Injected feedback API key into the build."
 
       - name: Build Windows player
-        uses: game-ci/unity-builder@1d4ee0697f193f54668e98961d79907911f4b4f2 # v4
+        uses: game-ci/unity-builder@d829bfc901f2347c8fe18898f06712b66916ef42 # v5
         env:
           # Unity Personal needs all three: the .ulf contents + the account email & password.
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}


### PR DESCRIPTION
Final node20 cleanup (follow-up to #29 / #32). `game-ci/unity-builder` was the last action still on the Node 20 runtime.

- `game-ci/unity-builder` v4 → **v5** (SHA-pinned `d829bfc…`), which ships the [Node.js 20 → 24 runtime update](https://github.com/game-ci/unity-builder/pull/827).

**Breaking-change review:** v5's breaking changes are confined to the **Cloud Runner / Orchestrator** path (S3 locking, plugin system, `Cli→PluginOptions` rename, legacy-CLI removal) — none of which this repo uses. Our build uses the standard hosted-runner inputs (`projectPath`, `unityVersion`, `targetPlatform`, `buildMethod`, `versioning`, `version`, `customParameters`, `allowDirtyBuild`), which are unchanged, so v5 is drop-in.

⚠️ `release.yml` only runs on **release tags**, so this can't be exercised by PR CI — it will be validated on the next real release. actionlint (PR-run) still checks the workflow syntax.

With this merged, **every** GitHub Action in the repo runs on Node 24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)