### PR TITLE
ci(codeql): compile C# (manual build mode) to fix low analysis quality

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,9 +4,15 @@
 # security_events scope, while the workflow's built-in GITHUB_TOKEN already has `security-events: write` — no
 # extra credentials. Findings land in the repo's Security → Code scanning tab (and enable Copilot Autofix).
 #
-# C# is analysed with build-mode: none (buildless) — it scans source without compiling, so it needs neither
-# the Unity editor nor the Windows-only Launcher, and it also covers the Unity client C# under client/Assets/
-# that the .NET build in ci.yml never touches. JS/TS, Python and Actions are buildless too.
+# C# is analysed in MANUAL build mode: it compiles BlocksBeyondTheStars.CI.slnf (every .NET project except the
+# Windows-only Launcher) so CodeQL gets full type/call resolution. Manual mode extracts only what the compiler
+# compiles, so the Unity client C# under client/Assets/ — which needs the Unity editor and isn't in any .csproj
+# we build — drops out of the C# scan. That trade is deliberate: the security-relevant code (GameServer,
+# Networking, Persistence, Api, Client.Core) is fully analysed, while the dropped Unity scripts are
+# MonoBehaviour rendering/UI with little security surface; their untrusted-input part (the wiki/minigames) is
+# JS and stays covered by the javascript-typescript analysis. The earlier buildless (build-mode: none) C# scan
+# left ~23% of calls unresolved (below CodeQL's 85% threshold → "low analysis quality"), risking false
+# positives / missed results. JS/TS, Python and Actions stay buildless (build-mode: none).
 
 name: CodeQL
 
@@ -35,7 +41,7 @@ jobs:
       matrix:
         include:
           - language: csharp
-            build-mode: none
+            build-mode: manual
           - language: javascript-typescript
             build-mode: none
           - language: python
@@ -45,12 +51,27 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      # C# only: the manual build below needs the .NET SDK. Skipped for the buildless languages.
+      - name: Set up .NET
+        if: matrix.language == 'csharp'
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '8.0.x'
+
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
           queries: security-extended
+
+      # Manual C# build so CodeQL traces the compiler and resolves all types/calls. CI.slnf is the same
+      # solution filter ci.yml uses (every project except the Windows-only WinForms launcher), so it builds
+      # on the Linux runner. No -warnaserror here: this gate is for security analysis, not style enforcement
+      # (ci.yml already enforces 0 warnings). Skipped for the buildless languages.
+      - name: Build C# (solution filter)
+        if: matrix.language == 'csharp'
+        run: dotnet build BlocksBeyondTheStars.CI.slnf -c Release
 
       - name: Analyze
         uses: github/codeql-action/analyze@v4

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -81,3 +81,4 @@ ones are marked, not deleted.
 - [0008 — Optional, offline-safe LLM backend](adr/0008-optional-offline-safe-llm-backend.md)
 - [0009 — Embedded browser for the in-game Wiki + Arcade](adr/0009-embedded-browser-wiki-arcade.md)
 - [0010 — Velopack distribution + self-host portal](adr/0010-velopack-distribution-and-self-host-portal.md)
+- [0011 — CodeQL code scanning strategy](adr/0011-codeql-security-scanning-strategy.md)

--- a/docs/developer/adr/0011-codeql-security-scanning-strategy.md
+++ b/docs/developer/adr/0011-codeql-security-scanning-strategy.md
@@ -1,0 +1,48 @@
+# ADR 0011 — CodeQL code scanning strategy
+
+- **Status:** Accepted
+- **Date:** 2026-06-21
+- **Context source:** [`.github/workflows/codeql.yml`](../../../.github/workflows/codeql.yml)
+
+## Context
+
+The repo runs GitHub CodeQL "advanced setup" as a committed workflow (`codeql.yml`) across C#,
+JavaScript/TypeScript, Python and GitHub Actions. Three things needed deciding: which query suite to
+run, how to analyse C# given that the codebase is split between headless .NET projects and a large
+Unity client, and how to treat that Unity client in the C# scan. An initial broad configuration
+produced ~900 mostly-stylistic alerts and a "Low C# analysis quality" diagnostic (only ~77 % of
+calls resolved, below CodeQL's 85 % threshold), which together obscured real findings.
+
+## Decision
+
+1. **Run the `security-extended` query suite, not `security-and-quality`.** The quality queries are
+   redundant here — code quality is already enforced by the Roslyn analyzers (`Directory.Build.props`:
+   `EnableNETAnalyzers` + Meziantou + VS.Threading, with `ci.yml` building `-warnaserror` at 0
+   warnings). The quality suite added ~689 note-level alerts (and false-positive errors such as
+   `cs/invalid-string-formatting` on localized `string.Format`) with no security value.
+2. **Analyse C# in `manual` build mode, compiling `BlocksBeyondTheStars.CI.slnf`.** Compiling the
+   solution lets CodeQL trace the compiler and fully resolve types and call targets on the
+   security-relevant code (`GameServer`, `Networking`, `Persistence`, `Api`, `Client.Core`). The
+   earlier buildless (`build-mode: none`) scan could not, because the Unity client references
+   `UnityEngine` assemblies that are absent without the editor.
+3. **The Unity client C# (`client/Assets/`) is out of scope for C# scanning, by construction.**
+   Manual build mode extracts only what the compiler compiles, and those ~43k lines compile only in
+   the Unity editor — so they drop out without an explicit `paths-ignore`. The trade is deliberate:
+   that code is `MonoBehaviour` rendering/UI with little security surface, and its one
+   untrusted-input area (the in-game wiki + minigames) is JavaScript, covered by the
+   `javascript-typescript` analysis. `CI.slnf` is the same filter `ci.yml` uses (every .NET project
+   except the Windows-only WinForms launcher), so it builds on the Linux runner.
+4. **All workflow Actions are version-pinned for supply-chain safety and the Node 20 runtime
+   deprecation.** First-party `actions/*` and `github/codeql-action` use their Node 24 major tags;
+   third-party actions (docker/*, game-ci/unity-builder, softprops/action-gh-release,
+   astral-sh/ruff-action) are pinned to a commit **SHA** with the version in a trailing comment.
+
+## Consequences
+
+- Security findings are low-noise and high-confidence; the C# CodeQL job costs ~2–3 min more because
+  it now compiles `CI.slnf`.
+- New .NET projects are scanned automatically once they are part of `CI.slnf`; Unity-only client
+  scripts are **not** CodeQL-scanned (accepted — low security surface, JS surface stays covered).
+- The C# build step uses no `-warnaserror`: this gate is for security analysis, and `ci.yml` already
+  enforces warnings-as-errors separately.
+- `codeql.yml` is the single source of truth for the scanning configuration; this ADR records *why*.


### PR DESCRIPTION
Fixes the **"Low C# analysis quality"** CodeQL diagnostic (call-target resolution **77%** vs the 85% threshold).

## Cause
The C# scan ran **buildless** (`build-mode: none`). The Unity client under `client/Assets/` (129 files, ~43k lines) calls `UnityEngine.*` APIs whose assemblies aren't present without the 6 GB editor, so ~23% of calls couldn't be resolved — dragging the metric below threshold and risking false positives / missed results.

## Change
Switch **C# to manual build mode** and compile [`BlocksBeyondTheStars.CI.slnf`](BlocksBeyondTheStars.CI.slnf) (the same solution filter `ci.yml` uses — every .NET project except the Windows-only launcher). CodeQL then traces the compiler and gets **full type/call resolution** on the security-relevant code: `GameServer`, `Networking`, `Persistence`, `Api`, `Client.Core` (`NetworkClient`/`ClientWorld`).

Manual mode extracts **only compiled code**, so the Unity `MonoBehaviour`/UI scripts drop out of the C# scan by construction (no explicit `paths-ignore` needed). That trade is deliberate — those scripts need the editor and carry little security surface; their one untrusted-input area (the in-game wiki/minigames) is **JS** and stays covered by the `javascript-typescript` analysis.

- csharp matrix entry: `build-mode: none` → `manual`
- adds a **csharp-only** `setup-dotnet` + `dotnet build CI.slnf -c Release` step (no `-warnaserror`: this is the security gate, `ci.yml` already enforces 0 warnings)
- JS/TS, Python, Actions stay buildless

## Validation
This PR's own **CodeQL (csharp)** check is the real test: it exercises the manual build + extraction. Merging only after it's green. (+~2–3 min to the csharp job.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)