### PR TITLE
ci(release): prepend the Docker pull command to release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -234,6 +234,22 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3
         with:
+          # `body` is PREPENDED to the auto-generated notes (GitHub API: generate_release_notes keeps a
+          # supplied body and appends the changelog after it). So the Docker pull lines show at the top,
+          # the generated changelog below. The image itself is pushed to GHCR by the `docker` job — it is
+          # NOT a release asset, so this is how it surfaces on the release page.
+          body: |
+            ### 🐳 Docker (dedicated server)
+
+            Run the dedicated server (game server + admin/portal/download UI, optional AI backend) on any OS with Docker:
+
+            ```bash
+            docker pull ghcr.io/marceld23/blocks-beyond-the-stars-server:${{ needs.build-player.outputs.version }}
+            # or the rolling tag:
+            docker pull ghcr.io/marceld23/blocks-beyond-the-stars-server:latest
+            ```
+
+            Setup & configuration: [SELF_HOSTING.md §10](https://github.com/marceld23/BlocksBeyondTheStars/blob/main/docs/developer/SELF_HOSTING.md#10-running-in-docker).
           files: |
             artifacts/installer/*Setup.exe
             artifacts/installer/*.msi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,7 +140,8 @@ to attach **Setup.exe** (per-user, no admin), the **WiX MSI** (machine-wide/IT) 
 published GitHub Release. In parallel, a third job reuses [.github/workflows/docker.yml](.github/workflows/docker.yml)
 to build the optional **dedicated-server Docker image** and push it multi-arch (amd64+arm64) to **GHCR**
 (`ghcr.io/<owner>/blocks-beyond-the-stars-server:<version>` + `:latest`) — see
-[docs/developer/SELF_HOSTING.md](docs/developer/SELF_HOSTING.md) §10. The workflow runs *only* on tags / manual
+[docs/developer/SELF_HOSTING.md](docs/developer/SELF_HOSTING.md) §10. The image is NOT a release asset (it lives
+in GHCR), so the published release notes are prepended with its `docker pull` command for discoverability. The workflow runs *only* on tags / manual
 dispatch (never `pull_request`), so the Unity license secrets (`UNITY_LICENSE`/`UNITY_EMAIL`/`UNITY_PASSWORD`)
 are safe in a public repo. A manual *Run workflow* dispatch builds + packages a `0.1.0-dev` test artifact and
 build-validates the image, but publishes nothing (no Release, no itch.io push, no GHCR push). `docker.yml` can


### PR DESCRIPTION
## What

The dedicated-server Docker image is pushed to **GHCR** (not attached as a release asset), so it didn't appear anywhere on the GitHub Release page. This adds a `docker pull` block to the **top of every release's notes** so users can discover it.

## How

In [release.yml](.github/workflows/release.yml), the `Publish GitHub Release` step now passes a `body`. With `generate_release_notes: true`, GitHub **prepends** the supplied body and **appends** the auto-generated changelog — so the release notes look like:

```
### 🐳 Docker (dedicated server)
docker pull ghcr.io/marceld23/blocks-beyond-the-stars-server:<version>
docker pull ghcr.io/marceld23/blocks-beyond-the-stars-server:latest
...

<auto-generated changelog>
```

The version comes from `needs.build-player.outputs.version`.

## Notes

- **Takes effect on the next tagged release**; no behavior change otherwise. This PR does **not** cut a release.
- The image is still not a release *asset* (download) — it lives in GHCR and is pulled. AGENTS.md §Releases updated to say so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)