### PR TITLE
docs(docker): local Docker Desktop test walkthrough + README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,8 +279,10 @@ Produces self-contained, single-file packages (no .NET install needed on the hos
 You can also run the server (game server + admin/portal/download UI, plus the optional bundled AI text
 backend) as a **Docker container** on any OS. Each tagged release publishes a multi-arch image to GHCR,
 so you can just pull it — `docker pull ghcr.io/marceld23/blocks-beyond-the-stars-server:latest` — or
-build it locally with `docker compose up -d`. See
-[docs/developer/SELF_HOSTING.md §10](docs/developer/SELF_HOSTING.md#10-running-in-docker).
+build it locally with `docker compose up -d`. The self-hosting guide has the full setup plus a
+step-by-step **local test in Docker Desktop**:
+[docs/developer/SELF_HOSTING.md §10](docs/developer/SELF_HOSTING.md#10-running-in-docker)
+([try it locally](docs/developer/SELF_HOSTING.md#try-it-locally-docker-desktop)).
 
 Players can also download and install the Windows client **from the running server's own web page**:
 `scripts/publish-client-installer.ps1` builds a [Velopack](https://velopack.io) installer + auto-update

--- a/docs/developer/SELF_HOSTING.md
+++ b/docs/developer/SELF_HOSTING.md
@@ -287,6 +287,34 @@ onto the .NET 8 ASP.NET runtime image and runs them through
 drain-and-save path listens for, so the world is always saved on shutdown (give it time with a
 `stop_grace_period`/`--stop-timeout` of ~60 s).
 
+### Try it locally (Docker Desktop)
+
+A quick end-to-end test on your own machine (Docker Desktop on Windows/macOS/Linux):
+
+1. **Run it** (throwaway — no volumes, so the world is discarded on `rm`):
+
+   ```bash
+   docker run -d --name bbts -p 31415:31415/udp -p 31416:31416/tcp \
+     -e BBS_ADMIN_PASSWORD=test123 -e BBS_SERVER_NAME="Local Test" \
+     ghcr.io/marceld23/blocks-beyond-the-stars-server:latest
+   ```
+
+   Docker pulls the image automatically. Add `-e BBS_FETCH_CLIENT=0` to skip the GitHub
+   client-installer download for a pure offline server test.
+
+2. **Check it's up** — open the admin dashboard at <http://localhost:31416/> and the public portal at
+   <http://localhost:31416/portal>. `BBS_ADMIN_PASSWORD` gates the `/api/*` calls (the dashboard
+   prompts for it); the dashboard/portal pages themselves are public.
+
+3. **Connect the game** — launch the Windows client → **Join** → host **`127.0.0.1`**, port **`31415`**.
+
+4. **Watch it** — `docker logs -f bbts`, or in **Docker Desktop → Containers → `bbts`** use the
+   **Logs / Inspect / Exec** tabs.
+
+5. **Stop cleanly** — `docker stop bbts` (SIGTERM → the world is saved), then `docker rm bbts`.
+
+For a test that survives restarts, add the named volumes shown under [Volumes](#volumes-what-to-persist).
+
 ### Quick start (Compose)
 
 ```bash


### PR DESCRIPTION
## What

Adds a focused **"Try it locally (Docker Desktop)"** walkthrough to [SELF_HOSTING.md §10](docs/developer/SELF_HOSTING.md#10-running-in-docker) and links it from the README, so testing the published GHCR image on your own machine is documented end-to-end.

The new subsection covers: pull + `docker run` the GHCR image, reach the admin dashboard/portal in a browser, connect the Windows client to `127.0.0.1:31415`, view logs in the Docker Desktop GUI, and stop cleanly (SIGTERM → world saved).

Docs-only; no code/behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)