### PR TITLE
fix(hud): hide planet-only compass + time-of-day panel during space flight

### DIFF
--- a/client/Assets/BlocksBeyondTheStars/Scripts/HudUi.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/HudUi.cs
@@ -702,6 +702,21 @@ namespace BlocksBeyondTheStars.Client
 
         private void RefreshCompass()
         {
+            // The round compass is on-foot/EVA navigation (north arrow, ship + waypoint + beacon blips). While
+            // piloting the ship you ARE the ship and the flight view draws its own radar, so hide it then; on an
+            // EVA it stays — the ship blip + distance is how you float your way back to the hull.
+            bool piloting = Game.SpaceViewActive && !Game.InEva;
+            var compassGo = _compassParent != null ? _compassParent.gameObject : null;
+            if (compassGo != null && compassGo.activeSelf == piloting)
+            {
+                compassGo.SetActive(!piloting);
+            }
+
+            if (piloting)
+            {
+                return;
+            }
+
             const float radius = 44f;
             PlaceBlip(_compassWp, Game.Waypoint.HasValue, Game.Waypoint ?? Vector3.zero, radius);
             PlaceBlip(_compassShip, Game.ShipPosition.HasValue, Game.ShipPosition ?? Vector3.zero, radius, out float dist);
@@ -745,7 +760,10 @@ namespace BlocksBeyondTheStars.Client
         private void RefreshTimeOfDay(BlocksBeyondTheStars.Shared.Localization.Localizer loc)
         {
             var env = Game.Environment;
-            if (env == null)
+            // Day/night clock, temperature and gravity are planet-surface readings — meaningless in space, both
+            // while piloting and on an EVA (no day/night cycle out there), so drop the whole panel there as well
+            // as when there's no environment yet.
+            if (env == null || Game.SpaceViewActive || Game.OnFootInSpace)
             {
                 _todText.transform.parent.gameObject.SetActive(false);
                 return;


### PR DESCRIPTION
## Problem
During space flight the on-foot HUD (`HudUi`) stays drawn underneath the `SpaceView` flight overlay. The hotbar and prompts already self-hide, but two **top-right** widgets were never gated for flight and kept showing planet-surface data that makes no sense while piloting:

- the round **compass** (north arrow, ship/waypoint/beacon blips)
- the **day/night + temperature + gravity** panel

## Fix (client-only)
- **Compass** — hidden while piloting (`SpaceViewActive && !InEva`). Kept on an **EVA**, where the ship blip + distance is how you float back to the hull.
- **Time-of-day panel** — hidden whenever in space (`SpaceViewActive || OnFootInSpace`); no day/night cycle out there.

Vitals and playtime panels are intentionally left unchanged. No server / NetCodec change.

## Verification
Needs a local Unity client build (touches `client/Assets`). In-game: flight → top-right clear; EVA → compass returns (clock stays hidden); on a planet → unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)