### PR TITLE
feat(client): automated in-game clip recorder (video + audio)

### DIFF
--- a/client/Assets/BlocksBeyondTheStars/Scripts/ClipDirector.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/ClipDirector.cs
@@ -1,0 +1,683 @@
+using System;
+using System.Collections;
+using System.IO;
+using UnityEngine;
+
+namespace BlocksBeyondTheStars.Client
+{
+    /// <summary>
+    /// Automated short-clip (video + audio) capture — the moving-picture sibling of
+    /// <see cref="ScreenshotDirector"/>. Launched with the <c>-captureClip</c> command-line flag (a built
+    /// player run), this self-installs, drives the client into a scene, then renders a deterministic offline
+    /// clip: it fixes <see cref="Time.captureFramerate"/> and, via <see cref="ClipFrameWriter"/>, writes one
+    /// PNG per frame plus a frame-synced WAV of the game audio. An external FFmpeg step (capture-clips.ps1)
+    /// muxes <c>frame_%05d.png</c> + <c>audio.wav</c> into an MP4 afterwards.
+    ///
+    /// ONE clip per run, selected from a JSON manifest (<c>-clipManifest &lt;path&gt; -clipName &lt;name&gt;</c>),
+    /// which keeps each run a single proven world start; capture-clips.ps1 loops the player over every clip.
+    /// With no manifest, a built-in default ("space_pan") is captured — the original P1 proof clip. Each clip
+    /// chooses its scene (space / surface / cockpit), HUD on/off, length/fps and a simple camera move; the
+    /// richer parametric camera moves and the server-lockstep for action clips come in later phases.
+    ///
+    /// Capture must run HEADED (a real audio device) — under <c>-batchmode -nographics</c> the audio is silent.
+    /// </summary>
+    public sealed class ClipDirector : MonoBehaviour
+    {
+        private const string WorldName = "ClipShots";
+        private const long DefaultSeed = 424242L;
+        private const int ClipWidth = 1920;
+        private const int ClipHeight = 1080;
+        private const float WorldLoadTimeout = 90f;
+        private const float ChunkSettle = 5f;          // let chunks mesh / the veil lower before rolling
+        private const float CaptureReadyTimeout = 14f; // surface: time to settle on solid, dry, alive ground
+
+        private string _lang = "en";
+        private long _seed = DefaultSeed;
+        private string _outDir;
+        private bool _headless;
+        private string _manifestPath;
+        private string _clipName;
+
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
+        private static void AutoInstall()
+        {
+            if (!ClipRequested(out var cfg))
+            {
+                return;
+            }
+
+            var go = new GameObject("ClipDirector");
+            DontDestroyOnLoad(go);
+            var d = go.AddComponent<ClipDirector>();
+            d._lang = cfg.lang;
+            d._outDir = cfg.outDir;
+            d._seed = cfg.seed;
+            d._headless = cfg.headless;
+            d._manifestPath = cfg.manifest;
+            d._clipName = cfg.clipName;
+        }
+
+        private struct Config
+        {
+            public string lang;
+            public string outDir;
+            public long seed;
+            public bool headless;
+            public string manifest;
+            public string clipName;
+        }
+
+        private static bool ClipRequested(out Config cfg)
+        {
+            cfg = new Config { lang = "en", seed = DefaultSeed };
+
+            var args = Environment.GetCommandLineArgs();
+            for (int i = 0; i < args.Length; i++)
+            {
+                string a = args[i];
+                if (string.Equals(a, "-captureClip", StringComparison.OrdinalIgnoreCase))
+                {
+                    cfg.headless = true;
+                }
+                else if (string.Equals(a, "-lang", StringComparison.OrdinalIgnoreCase) && i + 1 < args.Length)
+                {
+                    cfg.lang = args[i + 1];
+                }
+                else if (string.Equals(a, "-clipOut", StringComparison.OrdinalIgnoreCase) && i + 1 < args.Length)
+                {
+                    cfg.outDir = args[i + 1];
+                }
+                else if (string.Equals(a, "-clipManifest", StringComparison.OrdinalIgnoreCase) && i + 1 < args.Length)
+                {
+                    cfg.manifest = args[i + 1];
+                }
+                else if (string.Equals(a, "-clipName", StringComparison.OrdinalIgnoreCase) && i + 1 < args.Length)
+                {
+                    cfg.clipName = args[i + 1];
+                }
+                else if (string.Equals(a, "-seed", StringComparison.OrdinalIgnoreCase) && i + 1 < args.Length
+                         && long.TryParse(args[i + 1], out var s))
+                {
+                    cfg.seed = s;
+                }
+            }
+
+            bool on = cfg.headless;
+#if UNITY_EDITOR
+            if (!on && UnityEditor.EditorPrefs.GetBool("bbs_clip", false))
+            {
+                on = true;
+                cfg.lang = UnityEditor.EditorPrefs.GetString("bbs_clip_lang", "en");
+                UnityEditor.EditorPrefs.SetBool("bbs_clip", false); // consume it
+            }
+#endif
+            cfg.lang = cfg.lang == "de" ? "de" : "en";
+            return on;
+        }
+
+        /// <summary>The built-in clip when no manifest is supplied: the original P1 proof — a slow yaw pan in space.</summary>
+        private static ClipSpec DefaultClip() => new ClipSpec
+        {
+            name = "space_pan",
+            scene = "space",
+            lengthSeconds = 8f,
+            fps = 30,
+            hud = false,
+            camera = "yaw_sweep",
+            yawStart = -20f,
+            yawEnd = 20f,
+        };
+
+        private ClipSpec ResolveClip()
+        {
+            if (string.IsNullOrEmpty(_manifestPath))
+            {
+                return DefaultClip();
+            }
+
+            var manifest = ClipManifest.Load(_manifestPath);
+            if (manifest == null)
+            {
+                return null;
+            }
+
+            // No -clipName → the first clip in the manifest.
+            return string.IsNullOrEmpty(_clipName) ? manifest.clips[0] : manifest.Find(_clipName);
+        }
+
+        private void Start() => StartCoroutine(Run());
+
+        private IEnumerator Run()
+        {
+            Application.runInBackground = true; // keep rendering even if the window loses focus mid-capture
+            Screen.SetResolution(ClipWidth, ClipHeight, false);
+
+            var shell = FindAnyObjectByType<AppShell>();
+            if (shell == null)
+            {
+                Debug.LogError("[Clip] No AppShell in the scene.");
+                Quit(1);
+                yield break;
+            }
+
+            shell.Settings.Language = _lang;
+            shell.LoadLocalizer();
+
+            ClipSpec clip = ResolveClip();
+            if (clip == null)
+            {
+                Debug.LogError($"[Clip] clip '{_clipName}' not found in manifest '{_manifestPath}'. Aborting.");
+                Quit(1);
+                yield break;
+            }
+
+            string clipDir = Path.Combine(ResolveOutDir(), clip.name);
+            Debug.Log($"[Clip] lang={_lang} seed={_seed} clip={clip.name} scene={clip.scene} hud={clip.hud} out={clipDir}");
+
+            // Intro clip: film the boot chain itself (studio → splash → menu → New Game → loading), so it must
+            // record from the very first frame, BEFORE the menu — and it starts the world itself.
+            if (string.Equals(clip.scene, "intro", StringComparison.OrdinalIgnoreCase))
+            {
+                yield return RecordIntroClip(clip, clipDir, shell);
+                Debug.Log("[Clip] Done.");
+                Quit(0);
+                yield break;
+            }
+
+            // ONE world per run (proven path). Surface clips pin the world to a planet type. Enemies are forced
+            // off for every capture world so a clip never gets interrupted (or fast-forwarded) by hostiles —
+            // but world options only apply at CREATION, so delete any existing save first to force a fresh,
+            // peaceful world (otherwise a leftover save from an earlier run keeps its old, hostile settings).
+            yield return WaitForPhase(shell, ShellPhase.MainMenu, 30f);
+            string worldName = WorldName + "_" + clip.name;
+            LocalServerLauncher.DeleteWorld(worldName);
+            shell.StartSingleplayerWorld(worldName, _seed,
+                creativeUnlockAll: true, creativeAllShips: true, creativeKit: true,
+                worldOptions: CaptureWorldOptions(clip));
+
+            yield return WaitForPhase(shell, ShellPhase.InGame, WorldLoadTimeout);
+            var boot = shell.CurrentBoot;
+            if (boot == null || boot.Network == null)
+            {
+                Debug.LogError("[Clip] World did not start (bundled server missing?). Aborting.");
+                Quit(1);
+                yield break;
+            }
+
+            yield return WaitUntil(() => boot.WorldReady, WorldLoadTimeout);
+            yield return new WaitForSecondsRealtime(ChunkSettle);
+
+            // Reach the requested scene.
+            SpaceView space = null;
+            switch (clip.scene)
+            {
+                case "space":
+                case "land":
+                    boot.Network.SendEnterSpace();
+                    yield return WaitUntil(() => boot.InSpace, 25f);
+                    yield return new WaitForSecondsRealtime(ChunkSettle);
+                    space = FindAnyObjectByType<SpaceView>();
+                    break;
+
+                case "surface":
+                    bool ready = false;
+                    yield return PlaceOnSurface(boot, r => ready = r);
+                    if (!ready)
+                    {
+                        Debug.LogWarning($"[Clip] {clip.name}: no safe footing — recording the spawn view anyway.");
+                    }
+
+                    break;
+
+                // "cockpit" (and any unknown scene): a fresh world spawns the player INSIDE the ship cockpit on
+                // the surface, so the spawn view IS the cockpit — just settle, optionally open the menu, and record.
+                default:
+                    yield return new WaitForSecondsRealtime(ChunkSettle);
+                    if (clip.openMenu)
+                    {
+                        var menu = FindAnyObjectByType<GameMenu>();
+                        if (menu != null)
+                        {
+                            menu.SetMenuOpen(true);
+                            Cursor.visible = false; // the OS cursor isn't in the capture anyway
+                            yield return new WaitForSecondsRealtime(1f);
+                        }
+                    }
+
+                    break;
+            }
+
+            if (string.Equals(clip.scene, "land", StringComparison.OrdinalIgnoreCase) && space != null)
+            {
+                yield return RecordLandingClip(clip, clipDir, boot, space);
+            }
+            else
+            {
+                yield return RecordClip(clip, clipDir, space);
+            }
+
+            Debug.Log("[Clip] Done.");
+            Quit(0);
+        }
+
+        /// <summary>Step the on-foot player out of the spawn hull onto real, dry, solid ground near the ship
+        /// (terrain-aware, like <see cref="ScreenshotDirector"/>), reporting whether a safe pose was reached.</summary>
+        private IEnumerator PlaceOnSurface(GameBootstrap boot, Action<bool> done)
+        {
+            var pc = FindAnyObjectByType<PlayerController>();
+            if (pc == null)
+            {
+                done(false);
+                yield break;
+            }
+
+            var p = boot.PlayerPosition;
+            var anchor = new Vector3(p.x, p.y, p.z);
+            bool placed = false;
+            float t = 0f;
+            while (t < CaptureReadyTimeout)
+            {
+                if (!placed)
+                {
+                    placed = pc.PlaceForCaptureNear(anchor, pitch: 4f);
+                }
+
+                bool alive = !boot.AwaitingRespawnConfirm && boot.Health > 0f;
+                if (placed && pc.IsCaptureGrounded && !pc.IsHeadUnderwater() && alive)
+                {
+                    yield return new WaitForSecondsRealtime(ChunkSettle);
+                    done(true);
+                    yield break;
+                }
+
+                t += Time.unscaledDeltaTime;
+                yield return null;
+            }
+
+            done(false);
+        }
+
+        /// <summary>The capture loop: fix the frame clock, then write exactly one frame + one slice of audio per
+        /// iteration. Per frame it applies the diegetic motion (ship cruise / character walk — all client-side,
+        /// so deterministic under captureFramerate) and the recording-camera move, before the frame is rendered.</summary>
+        private IEnumerator RecordClip(ClipSpec clip, string clipDir, SpaceView space)
+        {
+            string framesDir = Path.Combine(clipDir, "frames");
+            Directory.CreateDirectory(framesDir);
+
+            var pc = FindAnyObjectByType<PlayerController>();
+            Camera viewCam = pc != null ? pc.Camera : Camera.main;
+            Camera hudFreeSource = (clip.hud || viewCam == null) ? null : viewCam;
+            if (hudFreeSource == null && !clip.hud)
+            {
+                Debug.LogWarning("[Clip] No view camera found — falling back to full-frame (HUD) capture.");
+            }
+
+            int fps = clip.fps > 0 ? clip.fps : 30;
+            int totalFrames = Mathf.Max(1, Mathf.RoundToInt(clip.lengthSeconds * fps));
+            string wavPath = Path.Combine(clipDir, "audio.wav");
+            string cam = (clip.camera ?? "static").ToLowerInvariant();
+
+            // Cockpit menu navigation: step through the requested tabs over the clip so the menu reads as
+            // interactive (the OS cursor isn't captured, but the panel changes ARE visible).
+            bool cycleTabs = clip.openMenu && clip.menuTabs != null && clip.menuTabs.Length > 0;
+            GameMenu menu = cycleTabs ? FindAnyObjectByType<GameMenu>() : null;
+            int lastSeg = -1;
+
+            using (var writer = new ClipFrameWriter(framesDir, ClipWidth, ClipHeight, hudFreeSource))
+            {
+                Time.captureFramerate = fps;
+                writer.StartAudio();
+
+                for (int f = 0; f < totalFrames; f++)
+                {
+                    float u = totalFrames > 1 ? f / (float)(totalFrames - 1) : 0f;
+
+                    if (menu != null)
+                    {
+                        int seg = Mathf.Clamp(Mathf.FloorToInt(u * clip.menuTabs.Length), 0, clip.menuTabs.Length - 1);
+                        if (seg != lastSeg)
+                        {
+                            menu.SwitchFromUi(clip.menuTabs[seg]);
+                            lastSeg = seg;
+                        }
+                    }
+
+                    ApplyDiegeticMotion(clip, cam, space, pc, u);
+
+                    Vector3 cpos = default;
+                    Quaternion crot = Quaternion.identity;
+                    bool overridePose = hudFreeSource != null
+                        && ComputeCameraPose(cam, clip, viewCam, u, out cpos, out crot);
+
+                    yield return new WaitForEndOfFrame();
+                    writer.CaptureFrame(overridePose, cpos, crot);
+                }
+
+                Time.captureFramerate = 0;
+                space?.SetFlightThrottle(-1f); // release the forced controls
+                pc?.ClearWalkInput();
+
+                string wrote = writer.FinishAudio(wavPath);
+                Debug.Log($"[Clip] {clip.name}: wrote {writer.FrameCount} frames to {framesDir}; audio={(wrote ?? "(none)")}");
+            }
+        }
+
+        /// <summary>Records the "land" scene as a small captured state machine: cruise toward the body, open the
+        /// landing-pad chooser (the "pick a spot" beat), hold on the map, then commit a touchdown and film the
+        /// descent until the ship leaves space. Always full-frame (the pad map + HUD are part of the shot), so the
+        /// nebula/stars come through too. Phase lengths are framed in frames so they stay deterministic under
+        /// captureFramerate.</summary>
+        private IEnumerator RecordLandingClip(ClipSpec clip, string clipDir, GameBootstrap boot, SpaceView space)
+        {
+            string framesDir = Path.Combine(clipDir, "frames");
+            Directory.CreateDirectory(framesDir);
+
+            int fps = clip.fps > 0 ? clip.fps : 30;
+            int reachCap = Mathf.RoundToInt(16f * fps);   // max time to cruise toward the planet
+            int padWaitCap = Mathf.RoundToInt(6f * fps);  // max wait for the pad map to render
+            int descentCap = Mathf.RoundToInt(6f * fps);  // max descent (fly-down) film time
+            int surfaceTail = Mathf.RoundToInt(6f * fps); // arrival on the surface after leaving space
+            string wavPath = Path.Combine(clipDir, "audio.wav");
+
+            // Always HUD/full-frame: the landing-pad map + descent HUD are screen-space and must be in the shot.
+            using (var writer = new ClipFrameWriter(framesDir, ClipWidth, ClipHeight, null))
+            {
+                Time.captureFramerate = fps;
+                writer.StartAudio();
+
+                // 1) Gentle approach: steer at the nearest PLANET but throttle DOWN before landing range so the
+                //    planet grows in view and the ship STAYS in space (a full-speed dive auto-leaves space — the
+                //    bug that killed the descent). Stop once we're ~1.6× the landing range away.
+                for (int i = 0; i < reachCap; i++)
+                {
+                    float ratio = space.CaptureSteerToNearestBody(0.6f);
+                    yield return new WaitForEndOfFrame();
+                    writer.CaptureFrame();
+                    if (ratio >= 0f && ratio <= 1.6f)
+                    {
+                        break;
+                    }
+                }
+
+                space.SetFlightThrottle(0f);
+
+                // 2) Open the planet/pad map and wait for it to render.
+                bool opened = space.CaptureOpenLandMap();
+                for (int i = 0; i < padWaitCap && !space.CaptureLandMapShowing; i++)
+                {
+                    yield return new WaitForEndOfFrame();
+                    writer.CaptureFrame();
+                }
+
+                Debug.Log($"[Clip] land: opened={opened} mapShowing={space.CaptureLandMapShowing}");
+
+                // 3) A short beat on the map, then a synthetic cursor glides onto a free pad and "clicks" it.
+                for (int i = 0; i < Mathf.RoundToInt(0.7f * fps); i++)
+                {
+                    yield return new WaitForEndOfFrame();
+                    writer.CaptureFrame();
+                }
+
+                if (space.CaptureBeginPadClick())
+                {
+                    int moveF = Mathf.RoundToInt(1.3f * fps);
+                    for (int i = 0; i < moveF; i++)
+                    {
+                        space.CaptureCursorProgress(moveF > 1 ? i / (float)(moveF - 1) : 1f);
+                        yield return new WaitForEndOfFrame();
+                        writer.CaptureFrame();
+                    }
+
+                    for (int i = 0; i < Mathf.RoundToInt(0.4f * fps); i++) // press beat
+                    {
+                        yield return new WaitForEndOfFrame();
+                        writer.CaptureFrame();
+                    }
+
+                    space.CaptureCommitPadClick();
+                }
+                else
+                {
+                    space.CaptureLandOnPad(0);
+                }
+
+                // 4) Film straight through the touchdown: the leave-space transition, the loading, and the arrival
+                //    ON the planet surface. boot.InSpace flips almost instantly (the fly-down isn't gated by it),
+                //    so we capture a FIXED window rather than polling — that's what reads as "the landing".
+                int postLand = descentCap + surfaceTail;
+                for (int i = 0; i < postLand; i++)
+                {
+                    yield return new WaitForEndOfFrame();
+                    writer.CaptureFrame();
+                }
+
+                Debug.Log($"[Clip] land: post-land {postLand} frames captured, inSpace={boot.InSpace}");
+
+                Time.captureFramerate = 0;
+                space.SetFlightThrottle(-1f);
+                string wrote = writer.FinishAudio(wavPath);
+                Debug.Log($"[Clip] {clip.name}: wrote {writer.FrameCount} frames to {framesDir}; audio={(wrote ?? "(none)")}");
+            }
+        }
+
+        /// <summary>Apply the clip's in-world motion for frame fraction <paramref name="u"/> (0..1): ship heading /
+        /// pitch / throttle in space, or walk + look on the surface. All of this is client-side.</summary>
+        private static void ApplyDiegeticMotion(ClipSpec clip, string cam, SpaceView space, PlayerController pc, float u)
+        {
+            if (space != null)
+            {
+                if (cam == "yaw_sweep")
+                {
+                    space.SetFlightYaw(Mathf.Lerp(clip.yawStart, clip.yawEnd, u));
+                }
+
+                if (Mathf.Abs(clip.shipPitch) > 0.001f)
+                {
+                    space.SetFlightPitch(clip.shipPitch);
+                }
+
+                if (clip.shipThrottle > 0f)
+                {
+                    space.SetFlightThrottle(clip.shipThrottle);
+                }
+            }
+
+            if (pc != null && string.Equals(clip.scene, "surface", StringComparison.OrdinalIgnoreCase))
+            {
+                if (Mathf.Abs(clip.walkForward) > 0.001f || Mathf.Abs(clip.walkStrafe) > 0.001f)
+                {
+                    pc.SetWalkInput(clip.walkStrafe, clip.walkForward);
+                }
+
+                if (Mathf.Abs(clip.lookYawStart - clip.lookYawEnd) > 0.001f || Mathf.Abs(clip.lookPitch) > 0.001f)
+                {
+                    pc.SetLookAngles(Mathf.Lerp(clip.lookYawStart, clip.lookYawEnd, u), clip.lookPitch);
+                }
+            }
+        }
+
+        /// <summary>Compute the recording camera's pose for a cinematic move (orbit / dolly / pan) relative to the
+        /// live view camera at frame fraction <paramref name="u"/>. Returns false for static / yaw_sweep (the clone
+        /// just mirrors the live view).</summary>
+        private static bool ComputeCameraPose(string cam, ClipSpec clip, Camera viewCam, float u,
+            out Vector3 pos, out Quaternion rot)
+        {
+            pos = default;
+            rot = default;
+            if (viewCam == null)
+            {
+                return false;
+            }
+
+            Transform vt = viewCam.transform;
+            switch (cam)
+            {
+                case "orbit":
+                {
+                    Vector3 focus = vt.position + vt.forward * clip.orbitRadius;
+                    float ang = Mathf.Lerp(clip.yawStart, clip.yawEnd, u) * Mathf.Deg2Rad;
+                    Vector3 offset = new Vector3(Mathf.Sin(ang), 0f, Mathf.Cos(ang)) * clip.orbitRadius
+                                     + Vector3.up * clip.orbitHeight;
+                    pos = focus + offset;
+                    rot = Quaternion.LookRotation((focus - pos).normalized, Vector3.up);
+                    return true;
+                }
+
+                case "dolly":
+                {
+                    pos = vt.position + vt.forward * (clip.dollyDistance * u);
+                    rot = vt.rotation;
+                    return true;
+                }
+
+                case "pan":
+                {
+                    pos = vt.position;
+                    rot = vt.rotation * Quaternion.Euler(
+                        Mathf.Lerp(clip.pitchStart, clip.pitchEnd, u),
+                        Mathf.Lerp(clip.yawStart, clip.yawEnd, u),
+                        0f);
+                    return true;
+                }
+
+                default:
+                    return false; // static / yaw_sweep
+            }
+        }
+
+        /// <summary>World options for a capture world: the full Peaceful preset (PlanetEnemies + UFOs + SpaceNpcs
+        /// off AND SpaceCombat=false — so nothing shoots the ship in space either), planet-pinned for surface
+        /// clips. This is why a clip is never interrupted or fast-forwarded by hostiles.</summary>
+        private static WorldCreationOptions CaptureWorldOptions(ClipSpec clip)
+        {
+            var opts = WorldCreationOptions.Peaceful();
+            if (clip != null && string.Equals(clip.scene, "surface", StringComparison.OrdinalIgnoreCase)
+                && !string.IsNullOrEmpty(clip.planet))
+            {
+                opts.StartPlanetType = clip.planet;
+            }
+
+            return opts;
+        }
+
+        /// <summary>Records the boot chain itself: from the first frame through the studio splash → title splash →
+        /// main menu, then "clicks" New Game (starts a world) and films the loading screen until the world is
+        /// ready. Always full-frame (it is all screen-space UI). The splash chain advances on scaled time
+        /// (Time.deltaTime), so captureFramerate keeps it at natural pace.</summary>
+        private IEnumerator RecordIntroClip(ClipSpec clip, string clipDir, AppShell shell)
+        {
+            string framesDir = Path.Combine(clipDir, "frames");
+            Directory.CreateDirectory(framesDir);
+
+            int fps = clip.fps > 0 ? clip.fps : 30;
+            int menuWaitCap = Mathf.RoundToInt(15f * fps); // max wait for the splash chain to reach the menu
+            int menuHold = Mathf.RoundToInt(2.5f * fps);   // dwell on the menu before "clicking" New Game
+            int loadCap = Mathf.RoundToInt(12f * fps);     // max wait for the world to load
+            int tail = Mathf.RoundToInt(1.5f * fps);       // a moment of the loaded world
+            string wavPath = Path.Combine(clipDir, "audio.wav");
+
+            using (var writer = new ClipFrameWriter(framesDir, ClipWidth, ClipHeight, null))
+            {
+                Time.captureFramerate = fps;
+                writer.StartAudio();
+
+                // 1) Studio + splash chain → main menu.
+                for (int i = 0; i < menuWaitCap && shell.Phase != ShellPhase.MainMenu; i++)
+                {
+                    yield return new WaitForEndOfFrame();
+                    writer.CaptureFrame();
+                }
+
+                // 2) Dwell on the menu.
+                for (int i = 0; i < menuHold; i++)
+                {
+                    yield return new WaitForEndOfFrame();
+                    writer.CaptureFrame();
+                }
+
+                // 3) "Click" New Game — start a fresh (peaceful) world.
+                LocalServerLauncher.DeleteWorld(WorldName + "_intro");
+                shell.StartSingleplayerWorld(WorldName + "_intro", _seed,
+                    creativeUnlockAll: true, creativeAllShips: true, creativeKit: true,
+                    worldOptions: CaptureWorldOptions(clip));
+
+                // 4) Film the loading screen until the world is ready (then a short tail of the world).
+                for (int i = 0; i < loadCap; i++)
+                {
+                    yield return new WaitForEndOfFrame();
+                    writer.CaptureFrame();
+                    var boot = shell.CurrentBoot;
+                    if (shell.Phase == ShellPhase.InGame && boot != null && boot.WorldReady)
+                    {
+                        break;
+                    }
+                }
+
+                for (int i = 0; i < tail; i++)
+                {
+                    yield return new WaitForEndOfFrame();
+                    writer.CaptureFrame();
+                }
+
+                Time.captureFramerate = 0;
+                string wrote = writer.FinishAudio(wavPath);
+                Debug.Log($"[Clip] {clip.name}: wrote {writer.FrameCount} frames to {framesDir}; audio={(wrote ?? "(none)")}");
+            }
+        }
+
+        /// <summary>Output root: explicit -clipOut, else <c>&lt;repo&gt;/marketing/clips</c> in the editor, else
+        /// <c>persistentDataPath/clips</c> in a player build (the ps1 passes -clipOut).</summary>
+        private string ResolveOutDir()
+        {
+            if (!string.IsNullOrEmpty(_outDir))
+            {
+                return _outDir;
+            }
+
+#if UNITY_EDITOR
+            string repo = Path.GetFullPath(Path.Combine(Application.dataPath, "..", "..")); // dataPath = <repo>/client/Assets
+            return Path.Combine(repo, "marketing", "clips");
+#else
+            return Path.Combine(Application.persistentDataPath, "clips");
+#endif
+        }
+
+        private static IEnumerator WaitForPhase(AppShell shell, ShellPhase phase, float timeout)
+        {
+            float t = 0f;
+            while (shell.Phase != phase && t < timeout)
+            {
+                t += Time.unscaledDeltaTime;
+                yield return null;
+            }
+        }
+
+        private static IEnumerator WaitUntil(Func<bool> cond, float timeout)
+        {
+            float t = 0f;
+            while (!cond() && t < timeout)
+            {
+                t += Time.unscaledDeltaTime;
+                yield return null;
+            }
+        }
+
+        private void Quit(int code)
+        {
+            Time.captureFramerate = 0;
+#if UNITY_EDITOR
+            if (_headless)
+            {
+                UnityEditor.EditorApplication.Exit(code);
+            }
+            else
+            {
+                UnityEditor.EditorApplication.isPlaying = false;
+            }
+#else
+            Application.Quit(code);
+#endif
+        }
+    }
+}

--- a/client/Assets/BlocksBeyondTheStars/Scripts/ClipDirector.cs.meta
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/ClipDirector.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d290f287a7660244094189acb859f021

--- a/client/Assets/BlocksBeyondTheStars/Scripts/ClipFrameWriter.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/ClipFrameWriter.cs
@@ -1,0 +1,307 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Unity.Collections;
+using UnityEngine;
+
+namespace BlocksBeyondTheStars.Client
+{
+    /// <summary>
+    /// The reusable capture core behind <see cref="ClipDirector"/>: writes one PNG per rendered frame plus a
+    /// single WAV of the game audio, frame-synced. It does NOT drive the scene or own the timing — the caller
+    /// fixes <see cref="Time.captureFramerate"/> and calls <see cref="CaptureFrame"/> once per rendered frame
+    /// (after <c>WaitForEndOfFrame</c>), then <see cref="FinishAudio"/> at the end. An external FFmpeg step
+    /// (capture-clips.ps1) muxes <c>frame_%05d.png</c> + <c>audio.wav</c> into an MP4.
+    ///
+    /// Two video modes, chosen per clip:
+    /// <list type="bullet">
+    ///   <item><b>HUD-free</b> (<paramref name="hudFreeSource"/> set) — renders a throwaway clone of the view
+    ///   camera into a render texture, exactly like <see cref="CameraTool"/>: no visor composite, no HUD canvas.</item>
+    ///   <item><b>With HUD</b> (source null) — the full composited frame via
+    ///   <see cref="ScreenCapture.CaptureScreenshotAsTexture()"/>, like <see cref="ScreenshotDirector"/>.</item>
+    /// </list>
+    ///
+    /// Audio is captured with <see cref="AudioRenderer"/>: while <see cref="Time.captureFramerate"/> is set,
+    /// Unity advances the audio DSP by exactly one capture-frame per rendered frame, so reading one frame of
+    /// samples per <see cref="CaptureFrame"/> stays in sync even when the offline render runs slower than
+    /// real time. This needs a real audio device — it produces silence under <c>-batchmode -nographics</c>.
+    /// </summary>
+    public sealed class ClipFrameWriter : IDisposable
+    {
+        private readonly int _width;
+        private readonly int _height;
+        private readonly string _framesDir;
+
+        // HUD-free path (null => capture the full composited frame incl. HUD via ScreenCapture).
+        private readonly Camera _hudFreeSource;
+        private RenderTexture _rt;
+        private GameObject _camGo;
+        private Camera _cam;
+        private Texture2D _readback;
+
+        // Audio
+        private readonly int _channels;
+        private readonly int _sampleRate;
+        private readonly List<float> _samples = new List<float>(1 << 20);
+        private bool _audioStarted;
+
+        private int _frameIndex;
+
+        public int FrameCount => _frameIndex;
+
+        public ClipFrameWriter(string framesDir, int width, int height, Camera hudFreeSource)
+        {
+            _framesDir = framesDir;
+            _width = Mathf.Max(2, width);
+            _height = Mathf.Max(2, height);
+            _hudFreeSource = hudFreeSource;
+            Directory.CreateDirectory(_framesDir);
+
+            // Clear any frames left from an earlier run so a shorter clip can't inherit stale trailing frames
+            // (which would corrupt the FFmpeg sequence mux).
+            foreach (var old in Directory.GetFiles(_framesDir, "frame_*.png"))
+            {
+                try { File.Delete(old); }
+                catch { /* best effort */ }
+            }
+
+            _channels = ChannelCount(AudioSettings.speakerMode);
+            _sampleRate = AudioSettings.outputSampleRate;
+
+            if (_hudFreeSource != null)
+            {
+                _rt = new RenderTexture(_width, _height, 24, RenderTextureFormat.ARGB32) { name = "ClipRT" };
+                _rt.Create();
+
+                _camGo = new GameObject("ClipCamera");
+                _cam = _camGo.AddComponent<Camera>();
+                _cam.enabled = false;             // we drive it manually with Render() each frame
+                _cam.targetTexture = _rt;
+            }
+        }
+
+        /// <summary>Begin capturing the game audio. Call once, before the first <see cref="CaptureFrame"/>.</summary>
+        public void StartAudio()
+        {
+            AudioRenderer.Start();
+            _audioStarted = true;
+        }
+
+        /// <summary>Write one video frame (PNG) and pull one frame of audio. Call once per rendered frame,
+        /// after <c>yield return new WaitForEndOfFrame()</c> so the pipeline has finished the frame.</summary>
+        public void CaptureFrame() => CaptureFrame(false, default, default);
+
+        /// <summary>As <see cref="CaptureFrame()"/>, but for the HUD-free path the clone camera is placed at an
+        /// explicit pose (a cinematic camera move) instead of mirroring the live view camera. Ignored in HUD mode.</summary>
+        public void CaptureFrame(bool overridePose, Vector3 pos, Quaternion rot)
+        {
+            CaptureVideoFrame(overridePose, pos, rot);
+            CaptureAudioFrame();
+        }
+
+        private void CaptureVideoFrame(bool overridePose, Vector3 overridePos, Quaternion overrideRot)
+        {
+            string path = Path.Combine(_framesDir, $"frame_{_frameIndex + 1:D5}.png");
+            try
+            {
+                byte[] png;
+                if (_hudFreeSource != null)
+                {
+                    // Re-sync the clone to the live view camera, render it into the RT, read it back. A cinematic
+                    // camera move (overridePose) keeps the source's lens settings but places the clone elsewhere.
+                    _cam.CopyFrom(_hudFreeSource); // FOV, clip planes, HUD-excluded culling mask
+                    _cam.enabled = false;
+                    _cam.targetTexture = _rt;
+                    if (overridePose)
+                    {
+                        _cam.transform.SetPositionAndRotation(overridePos, overrideRot);
+                    }
+                    else
+                    {
+                        _cam.transform.SetPositionAndRotation(
+                            _hudFreeSource.transform.position, _hudFreeSource.transform.rotation);
+                    }
+
+                    _cam.Render();
+
+                    var prevActive = RenderTexture.active;
+                    try
+                    {
+                        RenderTexture.active = _rt;
+                        if (_readback == null)
+                        {
+                            _readback = new Texture2D(_width, _height, TextureFormat.RGB24, mipChain: false);
+                        }
+
+                        _readback.ReadPixels(new Rect(0, 0, _width, _height), 0, 0);
+                        _readback.Apply(false);
+                        png = _readback.EncodeToPNG();
+                    }
+                    finally
+                    {
+                        RenderTexture.active = prevActive;
+                    }
+                }
+                else
+                {
+                    Texture2D tex = null;
+                    try
+                    {
+                        tex = ScreenCapture.CaptureScreenshotAsTexture(); // full frame incl. overlay HUD
+                        png = tex.EncodeToPNG();
+                    }
+                    finally
+                    {
+                        if (tex != null)
+                        {
+                            UnityEngine.Object.Destroy(tex);
+                        }
+                    }
+                }
+
+                File.WriteAllBytes(path, png);
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning($"[Clip] frame {_frameIndex + 1} failed: {e.Message}");
+            }
+
+            _frameIndex++;
+        }
+
+        private void CaptureAudioFrame()
+        {
+            if (!_audioStarted)
+            {
+                return;
+            }
+
+            int perChannel = AudioRenderer.GetSampleCountForCaptureFrame();
+            int total = perChannel * _channels;
+            if (total <= 0)
+            {
+                return;
+            }
+
+            var buffer = new NativeArray<float>(total, Allocator.Temp);
+            try
+            {
+                AudioRenderer.Render(buffer);
+                for (int i = 0; i < total; i++)
+                {
+                    _samples.Add(buffer[i]);
+                }
+            }
+            finally
+            {
+                buffer.Dispose();
+            }
+        }
+
+        /// <summary>Stop audio capture and write the accumulated samples as a 16-bit PCM WAV. Call once when
+        /// the clip is done. Returns the WAV path (or null if no audio was captured).</summary>
+        public string FinishAudio(string wavPath)
+        {
+            if (_audioStarted)
+            {
+                AudioRenderer.Stop();
+                _audioStarted = false;
+            }
+
+            if (_samples.Count == 0)
+            {
+                return null;
+            }
+
+            try
+            {
+                WriteWav16(wavPath, _samples, _channels, _sampleRate);
+                return wavPath;
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning($"[Clip] WAV write failed: {e.Message}");
+                return null;
+            }
+        }
+
+        private static void WriteWav16(string path, List<float> samples, int channels, int sampleRate)
+        {
+            int dataBytes = samples.Count * 2; // 16-bit
+            int byteRate = sampleRate * channels * 2;
+            using var fs = new FileStream(path, FileMode.Create, FileAccess.Write);
+            using var w = new BinaryWriter(fs);
+
+            // RIFF header
+            w.Write(new[] { 'R', 'I', 'F', 'F' });
+            w.Write(36 + dataBytes);
+            w.Write(new[] { 'W', 'A', 'V', 'E' });
+            // fmt chunk
+            w.Write(new[] { 'f', 'm', 't', ' ' });
+            w.Write(16);                       // PCM fmt chunk size
+            w.Write((short)1);                 // PCM
+            w.Write((short)channels);
+            w.Write(sampleRate);
+            w.Write(byteRate);
+            w.Write((short)(channels * 2));    // block align
+            w.Write((short)16);                // bits per sample
+            // data chunk
+            w.Write(new[] { 'd', 'a', 't', 'a' });
+            w.Write(dataBytes);
+            for (int i = 0; i < samples.Count; i++)
+            {
+                short s = (short)(Mathf.Clamp(samples[i], -1f, 1f) * short.MaxValue);
+                w.Write(s);
+            }
+        }
+
+        private static int ChannelCount(AudioSpeakerMode mode)
+        {
+            switch (mode)
+            {
+                case AudioSpeakerMode.Mono: return 1;
+                case AudioSpeakerMode.Stereo: return 2;
+                case AudioSpeakerMode.Quad: return 4;
+                case AudioSpeakerMode.Surround: return 5;
+                case AudioSpeakerMode.Mode5point1: return 6;
+                case AudioSpeakerMode.Mode7point1: return 8;
+                case AudioSpeakerMode.Prologic: return 2;
+                default: return 2;
+            }
+        }
+
+        public void Dispose()
+        {
+            if (_audioStarted)
+            {
+                AudioRenderer.Stop();
+                _audioStarted = false;
+            }
+
+            if (_cam != null)
+            {
+                _cam.targetTexture = null;
+            }
+
+            if (_readback != null)
+            {
+                UnityEngine.Object.Destroy(_readback);
+                _readback = null;
+            }
+
+            if (_camGo != null)
+            {
+                UnityEngine.Object.Destroy(_camGo);
+                _camGo = null;
+                _cam = null;
+            }
+
+            if (_rt != null)
+            {
+                _rt.Release();
+                UnityEngine.Object.Destroy(_rt);
+                _rt = null;
+            }
+        }
+    }
+}

--- a/client/Assets/BlocksBeyondTheStars/Scripts/ClipFrameWriter.cs.meta
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/ClipFrameWriter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7050b6021374ba145936f9f1ba06f3af

--- a/client/Assets/BlocksBeyondTheStars/Scripts/ClipManifest.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/ClipManifest.cs
@@ -1,0 +1,105 @@
+using System;
+using System.IO;
+using UnityEngine;
+
+namespace BlocksBeyondTheStars.Client
+{
+    /// <summary>
+    /// One entry in the clip manifest — a single short clip to record. Plain serializable fields so Unity's
+    /// <see cref="JsonUtility"/> can load it; the field initializers are the defaults applied when a key is
+    /// absent from the JSON. See <see cref="ClipManifest"/> for the file shape and <see cref="ClipDirector"/>
+    /// for how each field drives capture.
+    /// </summary>
+    [Serializable]
+    public sealed class ClipSpec
+    {
+        public string name = "clip";          // output sub-folder + mp4 name; also selected by -clipName
+        public string scene = "space";        // space | surface | cockpit
+        public string planet = "";            // optional: pin the world to this planet type (surface scenes)
+        public float lengthSeconds = 8f;
+        public int fps = 30;
+        public bool hud;                       // true = full frame incl. HUD; false = clean HUD-free view
+        public bool openMenu;                  // cockpit: open the Tab menu (needs hud=true to be visible)
+        public int[] menuTabs;                 // cockpit: tab indices to step through while open (0=Inv,1=Craft,2=Tech,3=Ship,4=Map,5=Missions,6=Character,7=Alliances,8=Story,9=Companions,10=Photos)
+
+        // Recording-camera move (HUD-free clips only): how the capture camera itself moves.
+        //   static    — follow the live view camera (no move)
+        //   yaw_sweep — DIEGETIC: sweep the SHIP heading (space); camera stays on the view
+        //   orbit     — orbit the capture camera around the live view, sweeping yawStart..yawEnd degrees
+        //   dolly     — push the capture camera along the view direction by dollyDistance metres
+        //   pan       — rotate the capture camera in place, sweeping yaw (yawStart..End) + pitch (pitchStart..End)
+        public string camera = "static";
+        public float yawStart;                 // yaw_sweep ship heading / orbit angle / pan yaw — first frame
+        public float yawEnd;                   // ... last frame
+        public float pitchStart;               // pan camera pitch — first frame
+        public float pitchEnd;                 // ... last frame
+        public float orbitRadius = 12f;        // orbit: distance from the focus point
+        public float orbitHeight = 3f;         // orbit: camera height above the focus
+        public float dollyDistance = 6f;       // dolly: metres moved along the view dir over the clip (+ = push in)
+
+        // Diegetic motion (the world actually moves; all client-side, deterministic under captureFramerate).
+        public float shipThrottle;             // space: 0..1 forward cruise (0 = drift)
+        public float shipPitch;                // space: ship climb(+)/dive(-) heading, degrees
+        public float walkForward;              // surface: -1..1 walk (forward = +1)
+        public float walkStrafe;               // surface: -1..1 strafe
+        public float lookYawStart;             // surface: body/look yaw sweep while walking — first frame
+        public float lookYawEnd;               // ... last frame
+        public float lookPitch;                // surface: look pitch
+    }
+
+    /// <summary>
+    /// A list of clips to record, loaded from a JSON file passed via <c>-clipManifest &lt;path&gt;</c>. Shape:
+    /// <code>{ "clips": [ { "name": "space_pan", "scene": "space", "camera": "yaw_sweep", ... }, ... ] }</code>
+    /// One player run records ONE clip (selected with <c>-clipName</c>) and quits — capture-clips.ps1 reads the
+    /// same file and loops the player over every clip, which keeps each run a single, proven world start
+    /// (multi-world-per-process is intentionally avoided).
+    /// </summary>
+    [Serializable]
+    public sealed class ClipManifest
+    {
+        public ClipSpec[] clips = Array.Empty<ClipSpec>();
+
+        public static ClipManifest Load(string path)
+        {
+            try
+            {
+                if (string.IsNullOrEmpty(path) || !File.Exists(path))
+                {
+                    return null;
+                }
+
+                var m = JsonUtility.FromJson<ClipManifest>(File.ReadAllText(path));
+                if (m == null || m.clips == null || m.clips.Length == 0)
+                {
+                    Debug.LogWarning($"[Clip] manifest '{path}' has no clips.");
+                    return null;
+                }
+
+                return m;
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning($"[Clip] failed to load manifest '{path}': {e.Message}");
+                return null;
+            }
+        }
+
+        public ClipSpec Find(string clipName)
+        {
+            if (clips == null)
+            {
+                return null;
+            }
+
+            foreach (var c in clips)
+            {
+                if (c != null && string.Equals(c.name, clipName, StringComparison.OrdinalIgnoreCase))
+                {
+                    return c;
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/client/Assets/BlocksBeyondTheStars/Scripts/ClipManifest.cs.meta
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/ClipManifest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3256f7a3fc107134eaed36558c044131

--- a/client/Assets/BlocksBeyondTheStars/Scripts/PlayerController.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/PlayerController.cs
@@ -1063,6 +1063,32 @@ namespace BlocksBeyondTheStars.Client
             }
         }
 
+        /// <summary>Cinematic-capture hooks (<see cref="ClipDirector"/>): drive the on-foot player's walk + look
+        /// without keyboard input so a recorded clip shows the character actually moving. <see cref="_captureWalk"/>
+        /// gates this — when false the normal <c>Input.GetAxis</c> path is untouched in regular play.</summary>
+        private bool _captureWalk;
+        private float _captureH, _captureV;
+        public void SetWalkInput(float horizontal, float vertical)
+        {
+            _captureH = horizontal;
+            _captureV = vertical;
+            _captureWalk = true;
+        }
+
+        public void ClearWalkInput() => _captureWalk = false;
+
+        /// <summary>Set the body yaw + look pitch directly (same as the rotation half of <see cref="SetCapturePose"/>),
+        /// for a cinematic look-around while walking.</summary>
+        public void SetLookAngles(float yaw, float pitch)
+        {
+            transform.eulerAngles = new Vector3(0f, yaw, 0f);
+            _pitch = Mathf.Clamp(pitch, -89f, 89f);
+            if (Camera != null)
+            {
+                Camera.transform.localEulerAngles = new Vector3(_pitch, 0f, 0f);
+            }
+        }
+
         /// <summary>Capture hook (<see cref="ScreenshotDirector"/>): place the on-foot player on REAL terrain near
         /// an anchor (the landed ship) and face back toward it, for a per-planet surface shot. Unlike the blind
         /// <see cref="SetCapturePose"/>, this is terrain-aware. It probes a ring of spots around the ship (radii
@@ -1384,8 +1410,8 @@ namespace BlocksBeyondTheStars.Client
 
         private void Move()
         {
-            float h = Input.GetAxis("Horizontal");
-            float v = Input.GetAxis("Vertical");
+            float h = _captureWalk ? _captureH : Input.GetAxis("Horizontal");
+            float v = _captureWalk ? _captureV : Input.GetAxis("Vertical");
             Vector3 move = (transform.right * h + transform.forward * v) * _effMoveSpeed;
 
             float prevVy = _verticalVelocity; // captured before the grounded reset (for landing shake)

--- a/client/Assets/BlocksBeyondTheStars/Scripts/SpaceView.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/SpaceView.cs
@@ -25,6 +25,128 @@ namespace BlocksBeyondTheStars.Client
         /// input, which is absent during an unattended capture run.</summary>
         public void SetFlightYaw(float yawDeg) => _yaw = yawDeg;
 
+        /// <summary>Cinematic-capture hooks (<see cref="ClipDirector"/>): force forward thrust + pitch without
+        /// keyboard input so a recorded clip shows the ship actually cruising. <see cref="_captureThrottle"/> is
+        /// &lt; 0 when disabled, so the normal input-driven flight path is untouched in regular play.</summary>
+        private float _captureThrottle = -1f;
+        public void SetFlightThrottle(float throttle) => _captureThrottle = throttle < 0f ? -1f : Mathf.Clamp01(throttle);
+        public void SetFlightPitch(float pitchDeg) => _pitch = Mathf.Clamp(pitchDeg, -80f, 80f);
+        private float CaptureForward() => _captureThrottle >= 0f ? _captureThrottle : Input.GetAxis("Vertical");
+
+        // --- Cinematic landing hooks (ClipDirector): a hands-off version of the player's fly-in → pick-pad → land. ---
+        public bool CaptureLandMapShowing => _landMapGo != null;
+        public void CaptureLandOnPad(int padIndex) => LandOnPad(padIndex);
+
+        /// <summary>Steer + cruise toward the nearest landable body (planets/moons; stations skipped). Returns the
+        /// distance to it as a MULTIPLE of its landing range (1 = at landing range, larger = farther), or -1 if
+        /// there's none. The caller throttles down before it reaches ~1 so the ship doesn't dive into the surface
+        /// (a full-speed dive auto-leaves space, which is why the descent never played before).</summary>
+        public float CaptureSteerToNearestBody(float throttle)
+        {
+            if (_ship == null || _landables == null)
+            {
+                return -1f;
+            }
+
+            Vector3 pos = _ship.transform.localPosition;
+            Vector3 target = Vector3.zero;
+            float bestSq = float.MaxValue;
+            float landRange = 1f;
+            foreach (var b in _landables)
+            {
+                float sq = (b.Pos - pos).sqrMagnitude;
+                if (sq < bestSq)
+                {
+                    bestSq = sq;
+                    target = b.Pos;
+                    landRange = b.Radius + KeepOutMargin + LandBand;
+                }
+            }
+
+            if (bestSq == float.MaxValue)
+            {
+                return -1f;
+            }
+
+            Vector3 to = (target - pos).normalized;
+            float wantYaw = Mathf.Atan2(to.x, to.z) * Mathf.Rad2Deg;
+            float wantPitch = -Mathf.Asin(Mathf.Clamp(to.y, -1f, 1f)) * Mathf.Rad2Deg;
+            _yaw = Mathf.MoveTowardsAngle(_yaw, wantYaw, 60f * Time.deltaTime);
+            _pitch = Mathf.MoveTowards(_pitch, Mathf.Clamp(wantPitch, -80f, 80f), 45f * Time.deltaTime);
+            _captureThrottle = Mathf.Clamp01(throttle);
+            return Mathf.Sqrt(bestSq) / Mathf.Max(1f, landRange);
+        }
+
+        /// <summary>Open the planet/pad map for the body the server already has pads for (it auto-sends them for
+        /// the current body). Returns false if no pads are known yet. ShowLandMap renders next frame because the
+        /// chooser's body id now matches the server's.</summary>
+        public bool CaptureOpenLandMap()
+        {
+            if (Game == null || Game.LandingPads == null || Game.LandingPads.Length == 0)
+            {
+                return false;
+            }
+
+            OpenPadChooser(Game.LandingPadsBody ?? string.Empty);
+            return true;
+        }
+
+        // Synthetic pad-click cursor — the OS cursor isn't in a ScreenCapture, so we draw + animate our own onto
+        // the pad map and "press" a free pad. Populated by ShowLandMap (free-pad centres in the panel's space).
+        private readonly System.Collections.Generic.List<(Vector2 center, int index)> _captureFreePads
+            = new System.Collections.Generic.List<(Vector2, int)>();
+        private RectTransform _captureCursor;
+        private Vector2 _cursorStart, _cursorTarget;
+        private int _capturePadIndex = -1;
+
+        /// <summary>Spawn the cursor and aim it at the first free pad. Returns false if the map/free pad isn't ready.</summary>
+        public bool CaptureBeginPadClick()
+        {
+            if (_landMapGo == null || _captureFreePads.Count == 0)
+            {
+                return false;
+            }
+
+            var first = _captureFreePads[0];
+            _capturePadIndex = first.index;
+            _cursorTarget = first.center;
+            _cursorStart = new Vector2(first.center.x, 60f); // glide down from the top of the panel
+
+            var go = new GameObject("CaptureCursor", typeof(RectTransform));
+            go.transform.SetParent(_landMapGo.transform, false);
+            var img = go.AddComponent<UnityEngine.UI.Image>();
+            img.color = new Color(1f, 1f, 1f, 0.95f);
+            img.raycastTarget = false;
+            _captureCursor = go.GetComponent<RectTransform>();
+            CaptureCursorProgress(0f);
+            return true;
+        }
+
+        /// <summary>Move the cursor from its start toward the pad (t 0..1), shrinking a touch as it "presses".</summary>
+        public void CaptureCursorProgress(float t)
+        {
+            if (_captureCursor == null)
+            {
+                return;
+            }
+
+            Vector2 p = Vector2.Lerp(_cursorStart, _cursorTarget, Mathf.Clamp01(t));
+            float s = Mathf.Lerp(26f, 18f, Mathf.Clamp01(t));
+            UiKit.Place(_captureCursor.gameObject, p.x - s * 0.5f, p.y - s * 0.5f, s, s);
+        }
+
+        /// <summary>Commit the click: land on the chosen pad (HideLandMap tears down the cursor with the panel).</summary>
+        public void CaptureCommitPadClick()
+        {
+            if (_capturePadIndex >= 0)
+            {
+                LandOnPad(_capturePadIndex);
+            }
+
+            _capturePadIndex = -1;
+            _captureCursor = null;
+        }
+
         private static readonly Vector3 SceneOrigin = new Vector3(0f, 6000f, 0f);
         private const float SeqDuration = 1.6f;
         private const float LandDuration = 2.2f;  // landing flies the ship away toward the planet — a touch longer so the shrink reads
@@ -316,13 +438,13 @@ namespace BlocksBeyondTheStars.Client
             if (_engine != null)
             {
                 _engine.volume = Mathf.MoveTowards(_engine.volume, (_phase == Phase.Cruise && !_eva) ? 0.25f : 0.08f, Time.deltaTime * 0.5f);
-                _engine.pitch = 1f + 0.2f * Mathf.Clamp01(Mathf.Abs(Input.GetAxis("Vertical")));
+                _engine.pitch = 1f + 0.2f * Mathf.Clamp01(Mathf.Abs(CaptureForward()));
             }
 
             // Engine flame: a real ParticleSystem thruster (BuildThruster) whose emission + jet speed track the
             // throttle. The small Unlit nozzle core (_exhaust) just glows at the vent; the old stretching flame +
             // cube exhaust bits are retired in favour of the particle jet.
-            float throttle = _phase == Phase.Cruise ? Mathf.Clamp01(Input.GetAxis("Vertical")) : 0f;
+            float throttle = _phase == Phase.Cruise ? Mathf.Clamp01(CaptureForward()) : 0f;
             if (_exhaust != null)
             {
                 _exhaust.localScale = new Vector3(0.5f, 0.5f, 0.55f + throttle * 0.5f); // steady nozzle glow core
@@ -932,7 +1054,7 @@ namespace BlocksBeyondTheStars.Client
             {
                 _yaw += Input.GetAxis("Mouse X") * LookSpeed * _shipTurnMul;
                 _pitch = Mathf.Clamp(_pitch - Input.GetAxis("Mouse Y") * LookSpeed * _shipTurnMul, -80f, 80f);
-                fwd = Input.GetAxis("Vertical");
+                fwd = CaptureForward();
                 strafe = Input.GetAxis("Horizontal");
             }
 
@@ -1138,6 +1260,7 @@ namespace BlocksBeyondTheStars.Client
 
             HideLandMap();
             _landMapBody = _choosePadBody;
+            _captureFreePads.Clear(); // re-collected below for the synthetic capture cursor
             EnsureUi();
 
             var loc = Game.Localizer;
@@ -1211,6 +1334,7 @@ namespace BlocksBeyondTheStars.Client
                 if (free)
                 {
                     UiKit.AddButton(panel.transform, mx, my, marker, marker, label, () => LandOnPad(padIndex));
+                    _captureFreePads.Add((new Vector2(mx + marker * 0.5f, my + marker * 0.5f), padIndex));
                 }
                 else
                 {

--- a/marketing/clips/clips.json
+++ b/marketing/clips/clips.json
@@ -1,0 +1,62 @@
+{
+  "clips": [
+    {
+      "name": "intro",
+      "scene": "intro",
+      "lengthSeconds": 20,
+      "fps": 30,
+      "hud": true
+    },
+    {
+      "name": "space_cruise",
+      "scene": "space",
+      "lengthSeconds": 8,
+      "fps": 30,
+      "hud": true,
+      "camera": "yaw_sweep",
+      "shipThrottle": 0.8,
+      "yawStart": -10,
+      "yawEnd": 10
+    },
+    {
+      "name": "space_turn",
+      "scene": "space",
+      "lengthSeconds": 8,
+      "fps": 30,
+      "hud": true,
+      "camera": "yaw_sweep",
+      "shipThrottle": 0.6,
+      "yawStart": -45,
+      "yawEnd": 45
+    },
+    {
+      "name": "approach_land",
+      "scene": "land",
+      "lengthSeconds": 12,
+      "fps": 30,
+      "hud": true
+    },
+    {
+      "name": "cockpit_hud",
+      "scene": "cockpit",
+      "lengthSeconds": 6,
+      "fps": 30,
+      "hud": true,
+      "openMenu": true,
+      "menuTabs": [1, 2, 4]
+    },
+    {
+      "name": "surface_walk",
+      "scene": "surface",
+      "planet": "jungle",
+      "lengthSeconds": 7,
+      "fps": 30,
+      "hud": false,
+      "camera": "static",
+      "walkForward": 1,
+      "lookYawStart": -25,
+      "lookYawEnd": 25,
+      "lookPitch": 2
+    }
+  ]
+}

--- a/scripts/capture-clips.ps1
+++ b/scripts/capture-clips.ps1
@@ -1,0 +1,122 @@
+<#
+.SYNOPSIS
+  Captures short in-game video clips (with audio) from the built game player, then muxes them to MP4.
+
+.DESCRIPTION
+  Reads a JSON clip manifest (marketing/clips/clips.json by default) and, for each clip, runs the built
+  Windows player with -captureClip + -clipName. The in-game ClipDirector self-installs, drives the client
+  into that clip's scene and renders a deterministic offline clip: one PNG per frame (1920x1080) plus a
+  frame-synced audio.wav, then quits. One world start per run (the proven path). Afterwards this script
+  muxes each clip's PNG sequence + WAV into an H.264 MP4 with FFmpeg; the lossless PNG sequence + WAV are
+  kept alongside the MP4 as an editing intermediate.
+
+  Each clip picks its own scene (space / surface / cockpit), HUD on/off, length, fps and camera move in the
+  manifest. The HUD language is fixed at world start, so a full DE+EN set is two passes (-Lang both).
+
+  Capture must run HEADED (a real audio device) — there is no -batchmode here, or the audio is silent.
+
+  Requires a current player build (scripts/build-client.ps1) — the build bundles the local server, which
+  singleplayer needs. Pass -Build to (re)build first. Requires FFmpeg on PATH (or -FfmpegPath).
+
+  Output: <repo>/marketing/clips/<lang>/<clip>.mp4 (+ <clip>/frames/*.png + <clip>/audio.wav)
+
+.EXAMPLE
+  ./scripts/capture-clips.ps1                       # all clips, German + English
+  ./scripts/capture-clips.ps1 -Lang en             # English only
+  ./scripts/capture-clips.ps1 -Build               # build the client first, then capture
+  ./scripts/capture-clips.ps1 -Clips space_pan     # only the named clip(s)
+#>
+param(
+    [ValidateSet("both", "de", "en")]
+    [string] $Lang = "both",
+    [string] $Exe,
+    [string] $OutRoot,
+    [string] $Manifest,
+    [string[]] $Clips,            # optional: only these clip names (default: all in the manifest)
+    [long]   $Seed = 424242,
+    [switch] $Build,
+    [string] $FfmpegPath = "ffmpeg"
+)
+
+$ErrorActionPreference = "Stop"
+$repo = Split-Path -Parent $PSScriptRoot
+if (-not $Exe)      { $Exe = Join-Path $repo "client/Build/Windows/BlocksBeyondTheStars.exe" }
+if (-not $OutRoot)  { $OutRoot = Join-Path $repo "marketing/clips" }
+if (-not $Manifest) { $Manifest = Join-Path $repo "marketing/clips/clips.json" }
+
+if ($Build) {
+    Write-Host "Building the client first..." -ForegroundColor Cyan
+    & (Join-Path $PSScriptRoot "build-client.ps1")
+    if ($LASTEXITCODE -ne 0) { throw "build-client.ps1 failed (exit $LASTEXITCODE)." }
+}
+
+if (-not (Test-Path $Exe))      { throw "Player build not found at '$Exe'. Run scripts/build-client.ps1 first (or pass -Build)." }
+if (-not (Test-Path $Manifest)) { throw "Clip manifest not found at '$Manifest'." }
+
+# Parse the manifest so we know which clips to capture (and each clip's fps for the mux).
+$spec = Get-Content $Manifest -Raw | ConvertFrom-Json
+$clipList = $spec.clips
+if ($Clips) { $clipList = $clipList | Where-Object { $Clips -contains $_.name } }
+if (-not $clipList) { throw "No matching clips in '$Manifest'." }
+
+# FFmpeg is required for the mux step; capture still runs without it, but warn loudly.
+$haveFfmpeg = $null -ne (Get-Command $FfmpegPath -ErrorAction SilentlyContinue)
+if (-not $haveFfmpeg) {
+    Write-Warning "FFmpeg not found ('$FfmpegPath'). PNG frames + WAV will be written, but no MP4 is muxed. Install FFmpeg or pass -FfmpegPath."
+}
+
+$langs = if ($Lang -eq "both") { @("de", "en") } else { @($Lang) }
+
+foreach ($l in $langs) {
+    $out = Join-Path $OutRoot $l
+    New-Item -ItemType Directory -Force -Path $out | Out-Null
+
+    foreach ($clip in $clipList) {
+        $name = $clip.name
+        $fps = if ($clip.fps) { [int]$clip.fps } else { 30 }
+
+        Write-Host "Capturing clip '$name' ('$l') → $out" -ForegroundColor Cyan
+        $args = @(
+            "-captureClip",
+            "-clipManifest", $Manifest,
+            "-clipName", $name,
+            "-clipOut", $out,
+            "-lang", $l,
+            "-seed", $Seed,
+            "-screen-width", "1920",
+            "-screen-height", "1080",
+            "-screen-fullscreen", "0"
+        )
+
+        $proc = Start-Process -FilePath $Exe -ArgumentList $args -PassThru -Wait
+        if ($proc.ExitCode -ne 0) {
+            Write-Warning "Capture run '$name' ('$l') exited with code $($proc.ExitCode) — check the player log."
+        }
+
+        $clipDir = Join-Path $out $name
+        $framesGlob = Join-Path $clipDir "frames/frame_%05d.png"
+        $wav = Join-Path $clipDir "audio.wav"
+        $mp4 = Join-Path $out "$name.mp4"
+
+        $frameCount = @(Get-ChildItem -Path (Join-Path $clipDir "frames") -Filter *.png -ErrorAction SilentlyContinue).Count
+        Write-Host "  → $frameCount frame(s) captured" -ForegroundColor Green
+
+        if ($haveFfmpeg -and $frameCount -gt 0) {
+            Write-Host "  Muxing → $mp4" -ForegroundColor Cyan
+            $ffArgs = @("-y", "-framerate", $fps, "-i", $framesGlob)
+            if (Test-Path $wav) { $ffArgs += @("-i", $wav) }
+            $ffArgs += @("-c:v", "libx264", "-pix_fmt", "yuv420p", "-crf", "16")
+            if (Test-Path $wav) { $ffArgs += @("-c:a", "aac", "-b:a", "192k", "-shortest") }
+            $ffArgs += $mp4
+
+            & $FfmpegPath @ffArgs
+            if ($LASTEXITCODE -ne 0) {
+                Write-Warning "FFmpeg mux failed (exit $LASTEXITCODE) for '$name' ('$l')."
+            } else {
+                Write-Host "  → wrote $mp4" -ForegroundColor Green
+            }
+        }
+    }
+}
+
+Write-Host "Done. Clips under $OutRoot" -ForegroundColor Green


### PR DESCRIPTION
Records short marketing clips from the built player, driven by a JSON manifest — the moving-picture sibling of the screenshot pipeline.

## What it adds
- **ClipDirector** self-installs on `-captureClip`; one clip per run selected via `-clipManifest`/`-clipName`. Scenes: `space` / `surface` / `cockpit` / `land` / `intro`.
- **ClipFrameWriter** writes a deterministic PNG sequence (HUD-free camera clone or full-frame `ScreenCapture`) + a frame-synced WAV via `AudioRenderer` under `Time.captureFramerate`.
- **Motion hooks** (all input-gated → no effect in normal play): `SpaceView` throttle/pitch/steer-to-body + landing-pad chooser + synthetic pad-click cursor; `PlayerController` walk/look.
- Capture worlds are created **fresh + peaceful** (`DeleteWorld` + `Peaceful` preset) so clips aren't interrupted by hostiles.
- **scripts/capture-clips.ps1** loops the player per clip/language and muxes each to MP4 with FFmpeg; `marketing/clips/clips.json` is the example set.

## Verification
- Local Unity player build: **Succeeded, 0 warnings** from the new/changed files.
- Runtime-verified clips (EN): intro, space cruise/turn, cockpit (menu tab cycling), surface walk — all with synced real audio.

## Known limitation
- `approach_land`: approach + planet/pad map + synthetic pad-click work, but the planet ends up too far away and the descent isn't visually finished yet (tracked for follow-up).

Generated frames/wav/mp4 stay local (under the gitignored `marketing/`); only source is committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)