### PR TITLE
fix(combat): stop enemy attack FX from following a player into the ship

### DIFF
--- a/client/Assets/BlocksBeyondTheStars/Scripts/CreatureView.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/CreatureView.cs
@@ -149,7 +149,9 @@ namespace BlocksBeyondTheStars.Client
                         audio.At(entry.Bank + "_alert", entry.Root.transform.position, entry.Pitch, 0.9f, entry.Echo);
                     }
 
-                    if (c.Hostile && Time.time >= entry.NextAttack
+                    // No bite-lunge once the player has fled into their ship: the server stops targeting a
+                    // boarded player (no proximity damage), so the render side must not keep mauling the hull.
+                    if (c.Hostile && !Game.Aboard && Time.time >= entry.NextAttack
                         && (entry.Root.transform.position - Game.PlayerPosition).sqrMagnitude < 9f)
                     {
                         entry.NextAttack = Time.time + Random.Range(1.5f, 3.5f);

--- a/client/Assets/BlocksBeyondTheStars/Scripts/WorldEntities.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/WorldEntities.cs
@@ -76,8 +76,12 @@ namespace BlocksBeyondTheStars.Client
                 vel.y = 0f;
                 Vector3 toPlayer = Game.PlayerPosition - scenePos;
                 toPlayer.y = 0f;
+                // A player who has fled into their ship is off-limits: the server already drops them as a
+                // target (no hunt, no proximity damage), so mirror that here — the machine stops stalking and
+                // holds its fire instead of staring at / shooting the hull.
+                bool playerAboard = Game.Aboard;
                 bool nearPlayer = toPlayer.sqrMagnitude < 64f;
-                Vector3 face = e.Hostile && nearPlayer ? toPlayer : vel;
+                Vector3 face = e.Hostile && nearPlayer && !playerAboard ? toPlayer : vel;
                 if (face.sqrMagnitude > 0.01f)
                 {
                     en.Root.transform.rotation = Quaternion.Slerp(
@@ -105,8 +109,9 @@ namespace BlocksBeyondTheStars.Client
                     }
 
                     // Hostile attack (throttled). Hovering drones snipe with a red laser from afar; ground
-                    // robots only claw in melee range.
-                    if (e.Hostile && Time.time >= en.NextAttack)
+                    // robots only claw in melee range. Suppressed entirely once the player is aboard the ship —
+                    // they've broken off pursuit, so no laser bolts or claw swipes follow them inside.
+                    if (e.Hostile && !playerAboard && Time.time >= en.NextAttack)
                     {
                         if (en.IsDrone)
                         {

--- a/tests/BlocksBeyondTheStars.Tests/EnemyMovementTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/EnemyMovementTests.cs
@@ -119,6 +119,42 @@ public sealed class EnemyMovementTests : IDisposable
     }
 
     [Fact]
+    public void PlanetEnemies_IgnoreAPlayerWhoFledAboardTheShip()
+    {
+        // Regression: fleeing into the ship must break off the hunt entirely — the machine neither chases
+        // nor harms a boarded player (the client mirrors this by holding its laser/claw FX). Boarded players
+        // are filtered out of the enemy target list, so even point-blank they take no damage.
+        var server = Started("aboardsafe", out var repo);
+        using (repo)
+        {
+            var pilot = server.AddLocalPlayer("Refugee");
+            pilot.State.AboardShip = false; // spawn on foot so an enemy actually spawns and turns hostile
+
+            for (int i = 0; i < 40 && server.PlanetEnemies.Count == 0; i++)
+            {
+                server.Tick(0.5);
+            }
+
+            Assert.NotEmpty(server.PlanetEnemies);
+            var enemy = server.PlanetEnemies[0];
+
+            // Park the enemy on top of the player, then board: well inside both hunt and proximity range.
+            pilot.State.Position = enemy.Position;
+            pilot.State.AboardShip = true;
+            pilot.State.Health = 100f;
+
+            var start = enemy.Position;
+            for (int i = 0; i < 15; i++)
+            {
+                server.Tick(0.2); // 3 s sitting on top of a boarded player
+            }
+
+            Assert.Equal(100f, pilot.State.Health); // no proximity damage while aboard
+            Assert.True(enemy.Position.Equals(start), "a boarded player is no target — the machine must not chase them");
+        }
+    }
+
+    [Fact]
     public void SpaceHostiles_PatrolInsteadOfHangingStill()
     {
         var server = Started("patrol", out var repo);


### PR DESCRIPTION
## Problem
On a planet, when a laser drone (or any hostile) attacks you and you flee into your ship, you **still see the attacks**: drones keep firing red laser bolts, ground robots keep clawing, and wild creatures keep biting at the hull — even though you're safely aboard. Fleeing into the ship should make every attacker break off.

## Root cause
The actual combat logic was **already correct** server-side: boarded players (`AboardShip`) are filtered out of the enemy/creature target lists ([`GameServerEnemies.cs:52`](../blob/main/src/BlocksBeyondTheStars.GameServer/GameServerEnemies.cs#L52), [`GameServerCreatures.cs:161`](../blob/main/src/BlocksBeyondTheStars.GameServer/GameServerCreatures.cs#L161)), so a boarded player is neither hunted nor damaged.

The bug was **render-only**: the client attack FX fired on *hostility + range* alone and never checked the aboard state, so the cosmetic lasers/claws/bites kept playing.

## Fix (client-only, mirrors the existing "server owns damage, client mirrors FX" pattern)
- **`WorldEntities.cs`** — gated the stalk-facing and the entire attack block on `!Game.Aboard`: drones hold their laser, ground robots hold their claw, and both stop staring at the hull once you board.
- **`CreatureView.cs`** — gated the bite-lunge FX on `!Game.Aboard`.
- `Game.Aboard` is synced from the server's `PlayerState.AboardShip` (set by `UpdateAboard` when you step inside the ship hull).

## Tests
- New server regression test `PlanetEnemies_IgnoreAPlayerWhoFledAboardTheShip`: a boarded, point-blank player takes **no damage** and is **not chased**.
- **698/698** .NET tests green.
- Local Unity Windows player build verified (client DLL compiles, exe produced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)