### PR TITLE
fix(ship): keep wild creatures and planet enemies out of the parked ship

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -17,6 +17,19 @@ world-gen; SQLite persistence.
 
 ---
 
+### ★ Keep wildlife (and planet enemies) out of the parked ship (2026-06-22) — ✅ server-only done (700 green, 0 warns; NO Unity build needed)
+A wild creature could end up **inside** the landed ship. The ship is an object with AABB checks (no voxel collision),
+and movement can't enter (it freezes at the hull) — so the cause was **placement**: `PlaceLandedShip` never evicted a
+creature the ship parked on/over (or that a ship redesign grew over), leaving it sealed in the cabin.
+- New `TryPushOutsideShip(p, out outside)` helper (`GameServerShipStructure.cs`) — same bounds as `EntityBlockedByShip`,
+  pushes a point just past the nearest horizontal hull face (keeps height).
+- **P1** `EvictWildlifeFromShips()` runs at the end of `PlaceLandedShip` (companions are left alone — they may follow
+  their owner aboard). **P2** `MoveCreatures` ejects any wild creature whose current position is inside, every tick.
+- **P3** creature spawn-reject now tests `EntityBlockedByShip` (the movement barrier) instead of the tighter interior box,
+  closing the shell where a spawn was allowed but immediately frozen against the hull.
+- **P5** planet enemies (`MovePlanetEnemy`) get the same eject-if-inside + block-the-move-into-the-hull guard.
+- **P4** 2 new tests in `CreatureTests.cs` (park-over-creature sweep + per-tick eject). Suite **700 passing**.
+
 ### ★ Tiered radio reach + live voice chat (2026-06-21) — ✅ server+tests done (8 new, suite green); voice SHIPPED ON by default; NEEDS Unity build
 - **Tiered radio reach** (text **and** voice): `comm_radio` = same world, new `system_radio` = same star system, new
   `galaxy_radio` = whole game. New items/recipes/blueprints (`data/items.json`/`recipes.json`/`blueprints.json`, de+en

--- a/src/BlocksBeyondTheStars.GameServer/GameServerCreatures.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerCreatures.cs
@@ -377,8 +377,10 @@ public sealed partial class GameServer
                 }
 
                 var pos = new Vector3f(px + 0.5f, y, pz + 0.5f);
-                if (!HabitatSuitable(sp, pos) || ShipInteriorContains(pos))
+                if (!HabitatSuitable(sp, pos) || EntityBlockedByShip(pos))
                 {
+                    // Reject the SAME volume the movement barrier guards (not just the tight interior box), so a
+                    // creature never spawns in the thin shell where it would immediately be frozen against the hull.
                     continue; // never spawn inside (or clipping into) a landed ship
                 }
 
@@ -491,6 +493,14 @@ public sealed partial class GameServer
                 continue;
             }
 
+            // Safety net: a wild creature that somehow ended up inside a parked ship (ship placed/grown over it,
+            // an old save, a numeric edge) is pushed back out of the hull this tick instead of being stuck inside.
+            if (TryPushOutsideShip(creature.Position, out var ejected))
+            {
+                creature.Position = ejected;
+                continue;
+            }
+
             if (creature.FrozenTimer > 0)
             {
                 creature.FrozenTimer = System.Math.Max(0, creature.FrozenTimer - dt);
@@ -590,6 +600,32 @@ public sealed partial class GameServer
             creature.Position = EntityBlockedByShip(next) ? creature.Position : next;
         }
     }
+
+    /// <summary>Pushes any WILD creature standing inside a parked ship's hull back outside (companions are left
+    /// alone — they may legitimately follow their owner aboard). Called when a ship is (re-)placed so a creature
+    /// the ship parks on/over isn't sealed into the cabin; <see cref="MoveCreatures"/> is the continuous net.</summary>
+    private void EvictWildlifeFromShips()
+    {
+        foreach (var creature in _creatures)
+        {
+            if (!creature.IsCompanion && TryPushOutsideShip(creature.Position, out var outside))
+            {
+                creature.Position = outside;
+            }
+        }
+    }
+
+    /// <summary>Spawns a wild creature of the first roster species at an exact position, bypassing the spawn
+    /// habitat/ship checks. Test-only — lets a test plant a creature inside a parked ship to prove it is
+    /// evicted. Returns the new creature's id.</summary>
+    public string SpawnCreatureAtForTest(Vector3f at)
+    {
+        SpawnCreature(_speciesRoster[0], at);
+        return _creatures[^1].Id;
+    }
+
+    /// <summary>Runs the placement-time eviction sweep directly (no tick) so a test can isolate it.</summary>
+    public void EvictWildlifeFromShipsForTest() => EvictWildlifeFromShips();
 
     /// <summary>2D (x,z) distance check matching <see cref="CreatureBehaviour"/>'s aggro test.</summary>
     private static bool WithinAggro(Vector3f from, Vector3f to)

--- a/src/BlocksBeyondTheStars.GameServer/GameServerEnemies.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerEnemies.cs
@@ -233,6 +233,14 @@ public sealed partial class GameServer
     /// the move and re-rolls the heading. Returns true when the enemy actually moved.</summary>
     private bool MovePlanetEnemy(CombatEntity enemy, List<PlayerSession> targets, HashSet<string> warded, double dt)
     {
+        // Safety net: a machine that ended up inside a parked ship (ship placed/grown over it) is pushed back
+        // out of the hull rather than left stalking from inside the cabin.
+        if (TryPushOutsideShip(enemy.Position, out var ejected))
+        {
+            enemy.Position = ejected;
+            return false;
+        }
+
         // Nearest detectable player — cloaked, god-mode and companion-warded players read as undetectable, so
         // the machine never paths toward them.
         PlayerSession? nearest = null;
@@ -305,7 +313,14 @@ public sealed partial class GameServer
 
         int hover = drone ? ScanDroneHover : 0;          // scan-drones float above the ground
         float bob = drone ? DroneBob * res.VertWave : 0f; // ...and hover-bob; robots stay grounded
-        enemy.Position = new Vector3f(nx, groundY + hover + bob, nz);
+        var candidate = new Vector3f(nx, groundY + hover + bob, nz);
+        if (EntityBlockedByShip(candidate))
+        {
+            enemy.Loco.ModeTimer = 0f; // ship hull in the way — re-roll the heading next tick instead of entering
+            return false;
+        }
+
+        enemy.Position = candidate;
         return res.Moving;
     }
 

--- a/src/BlocksBeyondTheStars.GameServer/GameServerShipStructure.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerShipStructure.cs
@@ -85,6 +85,8 @@ public sealed partial class GameServer
         rec.Placed = true;
         _log.Info($"Ship parked at ({rec.Origin.X}, {rec.Origin.Y}, {rec.Origin.Z}) — {s.Cells.Count} cells, {rec.Stations.Count} stations.");
 
+        EvictWildlifeFromShips(); // a creature the ship just parked on/over is pushed back out, not sealed in
+
         BroadcastToWorld(LandedShipMessage(playerId, rec, removed: false));
         RegisterDoors(); // pick up the ship's doors (+ keep settlement/other-ship doors in sync)
     }
@@ -428,6 +430,68 @@ public sealed partial class GameServer
             }
         }
 
+        return false;
+    }
+
+    /// <summary>
+    /// If the position sits inside (or against) a parked ship's hull bounds — the same volume
+    /// <see cref="EntityBlockedByShip"/> guards — returns a point just beyond the NEAREST horizontal hull face
+    /// (keeping the original height). Lets an entity that got enclosed — e.g. the ship was parked or grown
+    /// over a wandering creature — be pushed back out of the cabin instead of staying stuck inside. Returns
+    /// false (and leaves <paramref name="outside"/> = <paramref name="p"/>) when the position is clear of
+    /// every parked ship.
+    /// </summary>
+    private bool TryPushOutsideShip(Vector3f p, out Vector3f outside)
+    {
+        const float m = 0.5f;
+        const float clear = 0.05f; // step a hair past the margin so the result is unambiguously outside
+        foreach (var rec in _worlds.Active.LandedShips.Values)
+        {
+            if (!rec.Placed)
+            {
+                continue;
+            }
+
+            var s = rec.Structure;
+            double dx = WorldConstants.WrapDeltaX(p.X - rec.Origin.X, _world.Circumference);
+            double dz = p.Z - rec.Origin.Z;
+            if (dx < -m || dx > s.Width + m
+                || p.Y < rec.Origin.Y - 1 - m || p.Y > rec.Origin.Y + s.Height + m
+                || dz < -m || dz > s.Length + m)
+            {
+                continue; // not inside this ship
+            }
+
+            // Exit via the closest of the four horizontal faces (distance to step to clear each one).
+            double toMinX = dx + m + clear;              // step toward -X
+            double toMaxX = (s.Width + m + clear) - dx;  // step toward +X
+            double toMinZ = dz + m + clear;              // step toward -Z
+            double toMaxZ = (s.Length + m + clear) - dz; // step toward +Z
+            double best = System.Math.Min(System.Math.Min(toMinX, toMaxX), System.Math.Min(toMinZ, toMaxZ));
+
+            float ox = p.X, oz = p.Z;
+            if (best == toMinX)
+            {
+                ox = (float)(p.X - toMinX);
+            }
+            else if (best == toMaxX)
+            {
+                ox = (float)(p.X + toMaxX);
+            }
+            else if (best == toMinZ)
+            {
+                oz = (float)(p.Z - toMinZ);
+            }
+            else
+            {
+                oz = (float)(p.Z + toMaxZ);
+            }
+
+            outside = new Vector3f(ox, p.Y, oz);
+            return true;
+        }
+
+        outside = p;
         return false;
     }
 

--- a/tests/BlocksBeyondTheStars.Tests/CreatureTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/CreatureTests.cs
@@ -259,6 +259,85 @@ public sealed class CreatureTests : IDisposable
         }
     }
 
+    // ---------------- Keeping wildlife out of the parked ship ----------------
+
+    private SvGameServer StartedWithShip(out SqliteWorldRepository repo)
+    {
+        repo = new SqliteWorldRepository(new SaveGamePaths(_root, "creatureship"));
+        var st = new LoopbackServerTransport(new LoopbackLink());
+        var config = new ServerConfig
+        {
+            WorldName = "creatureship",
+            Seed = 4242,
+            StartPlanet = "jungle",  // "many" fauna → a non-empty species roster
+            AutoSaveIntervalMinutes = 9999,
+            PlaceStarterShip = true, // park the player's ship so there is a hull to test against
+        };
+        var server = new SvGameServer(config, _content, st, repo);
+        server.Start();
+        return server;
+    }
+
+    /// <summary>A world point a couple of blocks up from the centre-bottom of Host's parked ship — i.e. inside
+    /// the cabin — plus its floored cell, for the <c>ShipInteriorContainsCellForTest</c> assertions.</summary>
+    private static (Vector3f Point, int Cx, int Cy, int Cz) ShipInteriorSpot(SvGameServer server)
+    {
+        var a = server.ShipAnchorOf("Host");
+        var p = new Vector3f(a.X + 0.5f, a.Y + 2f, a.Z + 0.5f);
+        return (p, (int)Math.Floor(p.X), (int)Math.Floor(p.Y), (int)Math.Floor(p.Z));
+    }
+
+    private static bool CreatureCellInsideShip(SvGameServer server, string id)
+    {
+        var c = server.Creatures.First(x => x.Id == id);
+        return server.ShipInteriorContainsCellForTest(
+            (int)Math.Floor(c.Position.X), (int)Math.Floor(c.Position.Y), (int)Math.Floor(c.Position.Z));
+    }
+
+    [Fact]
+    public void ParkingTheShipOverACreature_PushesItOutOfTheHull()
+    {
+        var server = StartedWithShip(out var repo);
+        using (repo)
+        {
+            server.AddLocalPlayer("Host"); // parks the ship on its pad
+
+            var (spot, cx, cy, cz) = ShipInteriorSpot(server);
+            string id = server.SpawnCreatureAtForTest(spot);
+            Assert.True(server.ShipInteriorContainsCellForTest(cx, cy, cz), "the creature was planted inside the hull");
+
+            server.EvictWildlifeFromShipsForTest(); // the sweep PlaceLandedShip runs right after parking
+
+            Assert.False(CreatureCellInsideShip(server, id),
+                "a creature the ship parked over must be pushed outside, not sealed in the cabin");
+        }
+    }
+
+    [Fact]
+    public void ACreatureInsideTheShip_IsEjected_OnTheNextTick()
+    {
+        var server = StartedWithShip(out var repo);
+        using (repo)
+        {
+            var p = server.AddLocalPlayer("Host"); // parks the ship
+            var anchor = server.ShipAnchorOf("Host");
+
+            // Stand just outside the hull (and not aboard) so the player stays a live creature target and the
+            // planted creature is kept in range rather than pruned for being far from everyone.
+            p.State.AboardShip = false;
+            p.State.Position = new Vector3f(anchor.X + 12f, anchor.Y + 1f, anchor.Z);
+
+            var (spot, cx, cy, cz) = ShipInteriorSpot(server);
+            string id = server.SpawnCreatureAtForTest(spot);
+            Assert.True(server.ShipInteriorContainsCellForTest(cx, cy, cz));
+
+            server.TickForTest(0.2);
+
+            Assert.False(CreatureCellInsideShip(server, id),
+                "MoveCreatures must eject a creature that ended up inside the ship");
+        }
+    }
+
     // ---------------- Eating (food heals, poison harms) ----------------
 
     [Fact]


### PR DESCRIPTION
## What

A wild creature could end up sealed **inside** the landed ship. The ship is an object guarded by AABB checks (no voxel collision), and movement can't get a creature in (it freezes at the hull) — so the real cause was **placement**: `PlaceLandedShip` never evicted a creature the ship parked on/over (or that a ship redesign grew over), leaving it stuck in the cabin.

## Changes (server-only)

- **New `TryPushOutsideShip(p, out outside)`** helper (`GameServerShipStructure.cs`) — same bounds as `EntityBlockedByShip`, pushes a point just past the nearest horizontal hull face, keeping its height.
- **P1 — evict on placement:** `EvictWildlifeFromShips()` runs at the end of `PlaceLandedShip`. Companions are left alone (they may legitimately follow their owner aboard).
- **P2 — per-tick safety net:** `MoveCreatures` ejects any wild creature whose *current* position is inside the hull, instead of only freezing its next step.
- **P3 — harden spawn:** creature spawn-reject now tests `EntityBlockedByShip` (the movement barrier) rather than the tighter interior box, closing the thin shell where a spawn was allowed but immediately frozen against the hull.
- **P5 — planet enemies:** `MovePlanetEnemy` gets the same eject-if-inside guard plus a block on stepping into the hull (robots/drones previously had no ship barrier at all).
- **P4 — tests:** 2 new regression tests in `CreatureTests.cs` (park-over-creature sweep + per-tick eject).

## Verification

- No NetCodec or client change → **no Unity build needed**.
- Clean solution build: **0 warnings, 0 errors**.
- Full suite: **700 passing** (was 698, +2 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)