### PR TITLE
feat(client): WS6 slice — PBR-ish GGX specular + roughness-aware reflection on voxels

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -51,7 +51,20 @@ Per-item detail lives in the dated work log below.
 
 ---
 
-### ★ Graphics WS4: per-biome cinematic mood LUTs (2026-06-24) — ✅ code done + local Unity build green, NOT committed
+### ★ Graphics WS6 (slice): PBR-ish specular + reflection on voxels (2026-06-24) — ✅ code done + local Unity build green (shader clean), NOT committed
+Scoped slice of the deferred WS6 track. WS6 as a whole was re-assessed: real point lights (rejected before, custom-lit
+shader bypasses the light loop) and GPU instancing (N/A — chunk meshes are unique geometry) are dropped; greedy meshing
+is a separate perf track. The one safe, visual, shader-only slice = upgrade the voxel BRDF.
+- [BlockAtlas.shader](client/Assets/BlocksBeyondTheStars/Shaders/BlockAtlas.shader): replaced the Blinn-Phong sun
+  highlight with Unity's **stable GGX** specular (no NaN at low roughness), tinted by a metallic **F0** (0.04 dielectric →
+  albedo for metals); driven by the existing per-block gloss/metal vertex attributes. Environment reflection is now
+  **roughness-aware** (metals reflect head-on in their own colour, dielectrics at grazing via Fresnel). Applied to both
+  the URP and Built-in passes, including the placed-coloured-light glint. Matte blocks unchanged; metal/crystal/ice/water
+  gain sharper, brighter highlights + believable reflections. Diffuse deliberately left untouched (no darkening regressions).
+- Caught + fixed a shader-compile error mid-build (the lamp glint still referenced the removed `specPow`/`specCol`).
+- Deferred WS6 sub-tracks: greedy meshing (perf), per-texel metallic/smoothness maps. WS5 (Built-in fallback) to revisit.
+
+### ★ Graphics WS4: per-biome cinematic mood LUTs (2026-06-24) — ✅ done &amp; merged (PR#51, 5349f27; CI + local Unity build green)
 Follow-up to the quick-win block (WS1–3). Adds a procedural **per-biome colour-grade LUT** that the per-channel
 `ColorAdjustments` grade can't express — a teal-orange shadow→highlight tonal split + per-mood contrast/saturation.
 - [UrpScenePost.cs](client/Assets/BlocksBeyondTheStars/Scripts/UrpScenePost.cs): a `ColorLookup` volume override fed a

--- a/client/Assets/BlocksBeyondTheStars/Shaders/BlockAtlas.shader
+++ b/client/Assets/BlocksBeyondTheStars/Shaders/BlockAtlas.shader
@@ -168,26 +168,36 @@ Shader "BlocksBeyondTheStars/BlockAtlas"
                 float3 col = albedo * (light * (amb + 0.5 * ndl * sky * shadow) + 0.05) * faceAo;
                 col += albedo * (_Sc_Indoor * 0.5 * (1.0 - sky)) * faceAo;
 
-                float gloss = i.mat.r;
-                float metal = i.mat.g;
-                float3 H = normalize(L + V);
-                float specPow = lerp(8.0, 200.0, gloss);
-                float spec = pow(saturate(dot(N, H)), specPow) * gloss * ndl * sky * shadow;
-                float3 specCol = lerp(float3(1, 1, 1), albedo, metal);
-                col += light * specCol * spec * 1.2;
+                float gloss = i.mat.r;            // perceptual smoothness (0 = matte .. 1 = mirror)
+                float metal = i.mat.g;            // metallic (0 = dielectric .. 1 = metal)
+                float rough = clamp(1.0 - gloss, 0.045, 1.0);
 
+                // Specular: Unity's stable GGX form (no NaN at low roughness), tinted by the metallic F0
+                // (0.04 dielectric → albedo for metals). Tight, bright glints on smooth/metal faces feed the bloom.
+                float3 H = normalize(L + V);
+                float nh = saturate(dot(N, H));
+                float lh = saturate(dot(L, H));
+                float r2 = rough * rough;
+                float dterm = nh * nh * (r2 - 1.0) + 1.00001;
+                float specTerm = r2 / ((dterm * dterm) * max(0.1, lh * lh) * (rough * 4.0 + 2.0));
+                float3 F0 = lerp(float3(0.04, 0.04, 0.04), albedo, metal);
+                col += light * F0 * (specTerm * ndl * sky * shadow);
+
+                // Environment reflection of the sky colour, roughness-aware: metals reflect strongly (tinted by
+                // F0) even head-on, dielectrics mostly at grazing angles (Fresnel). Additive, faded by skylight.
                 float3 envCol = (_Sc_Sky.a < 0.5) ? light : _Sc_Sky.rgb;
-                float3 reflTint = lerp(envCol, envCol * albedo, metal);
-                float fres = pow(1.0 - saturate(dot(N, V)), 4.0);
-                float reflK = saturate(gloss * (0.25 + 0.6 * metal)) * fres * sky;
-                col = lerp(col, reflTint, reflK);
+                float nv = saturate(dot(N, V));
+                float fres = pow(1.0 - nv, 5.0);
+                float gr = 1.0 - rough;
+                float3 Fr = F0 + (max(float3(gr, gr, gr), F0) - F0) * fres;
+                col += envCol * Fr * (saturate(gloss) * sky * 0.5);
 
                 col += albedo * i.mat.a * 3.0; // HDR overdrive: push emitters past white so ACES + bloom give a real glow
 
                 // Placed coloured lights (flood-filled per-vertex, TEXCOORD3): illuminate this surface in
                 // their colour, regardless of sun/skylight, so lamps light caves + night builds. The baked
                 // dominant direction (TEXCOORD4) lets us shade them like the sun — N·L diffuse shaping + a
-                // Blinn-Phong glint + normal-map relief — so lamps sculpt the surface instead of flat-washing
+                // GGX glint + normal-map relief — so lamps sculpt the surface instead of flat-washing
                 // it. A fill floor keeps faces the light wrapped around lit; bright enough to feed the bloom.
                 float blLen = length(i.blDir);
                 if (blLen > 0.01)
@@ -195,8 +205,12 @@ Shader "BlocksBeyondTheStars/BlockAtlas"
                     float3 blL = i.blDir / blLen;
                     float blNdl = saturate(dot(N, blL));
                     col += albedo * i.bl * (0.5 + 0.5 * blNdl) * 2.0;
-                    float blSpec = pow(saturate(dot(N, normalize(blL + V))), specPow) * gloss * blNdl;
-                    col += i.bl * specCol * blSpec * 1.2;
+                    float3 blH = normalize(blL + V);
+                    float blNh = saturate(dot(N, blH));
+                    float blLh = saturate(dot(blL, blH));
+                    float blDterm = blNh * blNh * (r2 - 1.0) + 1.00001;
+                    float blSpec = r2 / ((blDterm * blDterm) * max(0.1, blLh * blLh) * (rough * 4.0 + 2.0));
+                    col += i.bl * F0 * (blSpec * blNdl);
                 }
                 else
                 {
@@ -420,24 +434,29 @@ Shader "BlocksBeyondTheStars/BlockAtlas"
                 // (so the cabin is lit but the sunlit outdoors seen through windows is untouched).
                 col += albedo * (_Sc_Indoor * 0.5 * (1.0 - sky)) * faceAo;
 
-                float gloss = i.mat.r;
-                float metal = i.mat.g;
+                float gloss = i.mat.r;            // perceptual smoothness
+                float metal = i.mat.g;            // metallic
+                float rough = clamp(1.0 - gloss, 0.045, 1.0);
 
-                // Specular sun highlight (Blinn-Phong). Tighter + brighter as gloss rises; metals
-                // tint the highlight with the albedo. Gated by ndl + skylight (no sun glint in caves).
+                // Specular sun highlight: Unity's stable GGX form, tinted by the metallic F0 (0.04 dielectric →
+                // albedo for metals). Tight, bright glints on smooth/metal faces; gated by ndl + skylight.
                 float3 H = normalize(L + V);
-                float specPow = lerp(8.0, 200.0, gloss);
-                float spec = pow(saturate(dot(N, H)), specPow) * gloss * ndl * sky;
-                fixed3 specCol = lerp(fixed3(1, 1, 1), albedo, metal);
-                col += light * specCol * spec * 1.2;
+                float nh = saturate(dot(N, H));
+                float lh = saturate(dot(L, H));
+                float r2 = rough * rough;
+                float dterm = nh * nh * (r2 - 1.0) + 1.00001;
+                float specTerm = r2 / ((dterm * dterm) * max(0.1, lh * lh) * (rough * 4.0 + 2.0));
+                fixed3 F0 = lerp(fixed3(0.04, 0.04, 0.04), albedo, metal);
+                col += light * F0 * (specTerm * ndl * sky);
 
-                // Grazing-angle environment reflection (sky colour); metals tint it. No sky to reflect
-                // underground, so it fades with skylight too.
+                // Roughness-aware environment reflection of the sky colour: metals reflect strongly (tinted by
+                // F0) even head-on, dielectrics mostly at grazing angles (Fresnel). Additive, faded by skylight.
                 fixed3 envCol = (_Sc_Sky.a < 0.5) ? light : _Sc_Sky.rgb;
-                fixed3 reflTint = lerp(envCol, envCol * albedo, metal);
-                float fres = pow(1.0 - saturate(dot(N, V)), 4.0);
-                float reflK = saturate(gloss * (0.25 + 0.6 * metal)) * fres * sky;
-                col = lerp(col, reflTint, reflK);
+                float nv = saturate(dot(N, V));
+                float fres = pow(1.0 - nv, 5.0);
+                float gr = 1.0 - rough;
+                fixed3 Fr = F0 + (max(float3(gr, gr, gr), F0) - F0) * fres;
+                col += envCol * Fr * (saturate(gloss) * sky * 0.5);
 
                 // Emissive blocks glow independently of sun + fog (lights/lava/crystals/ores), so they
                 // shine at night and the bloom pass picks them up. Alpha carries the emission strength.
@@ -445,7 +464,7 @@ Shader "BlocksBeyondTheStars/BlockAtlas"
 
                 // Placed coloured lights (flood-filled per-vertex, TEXCOORD3): illuminate this surface in
                 // their colour, regardless of sun/skylight, so lamps light caves + night builds. The baked
-                // dominant direction (TEXCOORD4) shades them like the sun — N·L diffuse + a Blinn-Phong glint
+                // dominant direction (TEXCOORD4) shades them like the sun — N·L diffuse + a GGX glint
                 // + normal-map relief — so lamps sculpt the surface; a fill floor keeps wrapped-around faces lit.
                 float blLen = length(i.blDir);
                 if (blLen > 0.01)
@@ -453,8 +472,12 @@ Shader "BlocksBeyondTheStars/BlockAtlas"
                     float3 blL = i.blDir / blLen;
                     float blNdl = saturate(dot(N, blL));
                     col += albedo * i.bl * (0.5 + 0.5 * blNdl) * 2.0;
-                    float blSpec = pow(saturate(dot(N, normalize(blL + V))), specPow) * gloss * blNdl;
-                    col += i.bl * specCol * blSpec * 1.2;
+                    float3 blH = normalize(blL + V);
+                    float blNh = saturate(dot(N, blH));
+                    float blLh = saturate(dot(blL, blH));
+                    float blDterm = blNh * blNh * (r2 - 1.0) + 1.00001;
+                    float blSpec = r2 / ((blDterm * blDterm) * max(0.1, blLh * blLh) * (rough * 4.0 + 2.0));
+                    col += i.bl * F0 * (blSpec * blNdl);
                 }
                 else
                 {


### PR DESCRIPTION
## What & why
A scoped, **shader-only** slice of the deferred WS6 track. Upgrades the voxel BRDF using the per-block `gloss`/`metal` attributes already baked into the chunk mesh — no mesher or content changes.

## How
[`BlockAtlas.shader`](client/Assets/BlocksBeyondTheStars/Shaders/BlockAtlas.shader), both the URP **and** Built-in passes:
- **Specular**: replaced the Blinn-Phong sun highlight with Unity's **stable GGX** form (no NaN at low roughness), tinted by a metallic **F0** (0.04 dielectric → albedo for metals).
- **Environment reflection**: now **roughness-aware** — metals reflect head-on in their own colour, dielectrics mostly at grazing angles (Fresnel).
- The **placed-coloured-light glint** uses the same GGX/F0 model.
- Matte blocks are unchanged; metal / crystal / ice / water gain sharper, brighter highlights and believable reflections. Diffuse left untouched (no darkening regressions).

## WS6 re-scope
- ❌ Real point lights — dropped (rejected before; the custom-lit shader deliberately bypasses the URP light loop for perf).
- ❌ GPU instancing — N/A (chunk meshes are unique geometry, not instances).
- ⏭ Greedy meshing — separate perf track. Per-texel metallic/smoothness maps — deferred.

## Verification
Local Unity Windows build **green**; `BlockAtlas` shader compiles clean (a mid-build compile error — the lamp glint still referenced the removed `specPow`/`specCol` — was caught and fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)