### PR TITLE
feat(client): global Brightness control (post-exposure)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -51,7 +51,16 @@ Per-item detail lives in the dated work log below.
 
 ---
 
-### ★ Graphics WS6 (slice): PBR-ish specular + reflection on voxels (2026-06-24) — ✅ code done + local Unity build green (shader clean), NOT committed
+### ★ Graphics: global Brightness control (2026-06-24) — ✅ code done + local Unity build green, NOT committed
+Follow-up to the look quick-wins: enabling the full in-game post stack (ACES tonemap + vignette + SSAO + cool LUTs)
+made worlds read darker than the old un-graded image; a tester saw a (correctly) blue daytime planet as too dark.
+- Added a **global Brightness setting** (default **1.15** = a touch above neutral, so every world is a bit brighter out
+  of the box) driving the colour grade's `postExposure` in [UrpScenePost.cs](client/Assets/BlocksBeyondTheStars/Scripts/UrpScenePost.cs)
+  (`ExposureFor`, `SetBrightness`). Wired from [WorldRig.cs](client/Assets/BlocksBeyondTheStars/Scripts/WorldRig.cs);
+  live slider in [UiSettings.cs](client/Assets/BlocksBeyondTheStars/Scripts/UiSettings.cs) (`ui.settings.brightness`, de/en, 70–150%).
+- Global + per-display tunable; diffuse/ambient + LUTs untouched (cleanest "overall brighter" lever).
+
+### ★ Graphics WS6 (slice): PBR-ish specular + reflection on voxels (2026-06-24) — ✅ done &amp; merged (PR#52, 4dfd123; CI + local Unity build green, shader clean)
 Scoped slice of the deferred WS6 track. WS6 as a whole was re-assessed: real point lights (rejected before, custom-lit
 shader bypasses the light loop) and GPU instancing (N/A — chunk meshes are unique geometry) are dropped; greedy meshing
 is a separate perf track. The one safe, visual, shader-only slice = upgrade the voxel BRDF.

--- a/client/Assets/BlocksBeyondTheStars/Scripts/ClientSettings.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/ClientSettings.cs
@@ -78,6 +78,10 @@ namespace BlocksBeyondTheStars.Client
         /// edges MSAA can't (voxel highlights, normal-map relief). A post-pass, so it needs camera post-processing
         /// on; gated to Medium+ (Potato/Low skip it for the frame-time budget). Applied in <see cref="ApplyCameraLook"/>.</summary>
         public bool Smaa = true;
+        /// <summary>Global scene brightness, applied as a post-exposure lift on the colour grade so it affects every
+        /// world uniformly (and is tunable per display). 1.0 = neutral; the default sits a touch above neutral so the
+        /// ACES-tonemapped scene isn't too dark. Driven into <see cref="UrpScenePost"/>.</summary>
+        public float Brightness = 1.15f;
         /// <summary>Screen-space lens flare on the sun + bright emitters (cheap, very sci-fi).</summary>
         public bool LensFlare = true;
         /// <summary>Subtle camera motion blur while flying the ship / driving the speeder (High+ only).</summary>

--- a/client/Assets/BlocksBeyondTheStars/Scripts/UiSettings.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/UiSettings.cs
@@ -70,6 +70,10 @@ namespace BlocksBeyondTheStars.Client
                 () => { S.ViewDistanceChunks = Mathf.Clamp(S.ViewDistanceChunks - 1, 1, 8); Rebuild(); },
                 () => { S.ViewDistanceChunks = Mathf.Clamp(S.ViewDistanceChunks + 1, 1, 8); Rebuild(); },
                 S.ViewDistanceChunks.ToString());
+            Stepper(ref y, L("ui.settings.brightness"), (S.Brightness - 0.7f) / 0.8f, 0.7f, 1.5f,
+                () => { S.Brightness = Mathf.Clamp(S.Brightness - 0.05f, 0.7f, 1.5f); UrpScenePost.Instance?.SetBrightness(S.Brightness); Rebuild(); },
+                () => { S.Brightness = Mathf.Clamp(S.Brightness + 0.05f, 0.7f, 1.5f); UrpScenePost.Instance?.SetBrightness(S.Brightness); Rebuild(); },
+                Mathf.RoundToInt(S.Brightness * 100f) + "%");
             // Frame pacing. VSync off (+ optional fps cap) is the recommended fix when the game runs sluggish
             // on the Linux/Proton client, where VSync can lock to a hard 30 fps.
             Toggle(ref y, L("ui.settings.vsync"), S.VSync, () => { S.VSync = !S.VSync; Rebuild(); });

--- a/client/Assets/BlocksBeyondTheStars/Scripts/UrpScenePost.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/UrpScenePost.cs
@@ -37,6 +37,10 @@ namespace BlocksBeyondTheStars.Client
         public bool LensFlareEnabled = true;
         public bool MotionBlurEnabled = true;
 
+        /// <summary>Global scene brightness (1.0 = neutral). Drives the colour grade's post-exposure so every world
+        /// brightens/darkens uniformly. Wired from WorldRig; the settings slider pushes it live via <see cref="SetBrightness"/>.</summary>
+        public float Brightness = 1.15f;
+
         private ColorAdjustments _grade;
         private ColorLookup _lut;
         private DepthOfField _menuBlur;
@@ -100,7 +104,7 @@ namespace BlocksBeyondTheStars.Client
             _grain.intensity.Override(0f);
 
             _grade = profile.Add<ColorAdjustments>(true);
-            _grade.postExposure.Override(0.08f);
+            _grade.postExposure.Override(ExposureFor(Brightness));
             _grade.contrast.Override(6f);
             _grade.saturation.Override(6f);
             _grade.colorFilter.Override(Color.white);
@@ -267,6 +271,20 @@ namespace BlocksBeyondTheStars.Client
             _grade.colorFilter.Override(Color.Lerp(Color.white, blendedTint, 0.7f));
             _grade.saturation.Override(Mathf.Clamp((saturation - 1f) * 100f + 6f, -100f, 100f));
             _grade.contrast.Override(Mathf.Clamp((contrast - 1f) * 100f + 6f, -100f, 100f));
+        }
+
+        /// <summary>Maps the 1.0-neutral brightness setting to a post-exposure stop offset. 1.0 keeps the tuned
+        /// neutral (+0.08 EV); above/below lifts/drops the whole graded frame uniformly.</summary>
+        private static float ExposureFor(float brightness) => 0.08f + (brightness - 1f) * 1.2f;
+
+        /// <summary>Live brightness update from the settings slider — re-exposes the colour grade for every world.</summary>
+        public void SetBrightness(float brightness)
+        {
+            Brightness = brightness;
+            if (_grade != null)
+            {
+                _grade.postExposure.Override(ExposureFor(brightness));
+            }
         }
 
         /// <summary>Selects the cinematic mood LUT for the current biome (WS4): a teal-orange tonal split + contrast/

--- a/client/Assets/BlocksBeyondTheStars/Scripts/WorldRig.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/WorldRig.cs
@@ -334,6 +334,7 @@ namespace BlocksBeyondTheStars.Client
             urpPost.Preset = shell.Settings.Preset;                 // gates lens flare (Medium+) / motion blur (High+)
             urpPost.LensFlareEnabled = shell.Settings.LensFlare;
             urpPost.MotionBlurEnabled = shell.Settings.MotionBlur;
+            urpPost.Brightness = shell.Settings.Brightness; // global scene brightness (post-exposure)
 
             // Terrain-scanner overlay (Feature 40): through-wall ore glow markers after a scan pulse.
             var oreScan = root.AddComponent<OreScanView>();

--- a/data/locales/de.json
+++ b/data/locales/de.json
@@ -844,6 +844,7 @@
   "ui.settings.vsync": "VSync",
   "ui.settings.fps_cap": "Bildraten-Begrenzung",
   "ui.settings.fps_cap.unlimited": "Unbegrenzt",
+  "ui.settings.brightness": "Helligkeit",
   "ui.settings.smaa": "Kantenglättung (SMAA)",
   "ui.settings.lens_flare": "Lens-Flare",
   "ui.settings.motion_blur": "Bewegungsunschärfe (Flug)",

--- a/data/locales/en.json
+++ b/data/locales/en.json
@@ -839,6 +839,7 @@
   "ui.settings.vsync": "VSync",
   "ui.settings.fps_cap": "Frame-rate limit",
   "ui.settings.fps_cap.unlimited": "Unlimited",
+  "ui.settings.brightness": "Brightness",
   "ui.settings.smaa": "Smooth edges (SMAA)",
   "ui.settings.lens_flare": "Lens flare",
   "ui.settings.motion_blur": "Motion blur (flight)",


### PR DESCRIPTION
## What & why
Enabling the full in-game post stack (ACES tonemap + vignette + SSAO + cool biome LUTs, PRs #50/#51/#52) made worlds read **darker** than the old un-graded image — a tester saw a (correctly) blue daytime planet as too dark. This adds a **global, per-display brightness lever** so every world lifts uniformly.

## How
- New **Brightness** setting (default **1.15** = a touch above neutral, so all worlds are a bit brighter out of the box) driving the colour grade's `postExposure` in [`UrpScenePost`](client/Assets/BlocksBeyondTheStars/Scripts/UrpScenePost.cs) (`ExposureFor` / `SetBrightness`).
- Wired from [`WorldRig`](client/Assets/BlocksBeyondTheStars/Scripts/WorldRig.cs); **live slider** in [`UiSettings`](client/Assets/BlocksBeyondTheStars/Scripts/UiSettings.cs) (`ui.settings.brightness`, de/en, 70–150%).
- Diffuse/ambient lighting + the LUTs are untouched — only the final exposure is lifted (the cleanest "overall brighter" lever).

## Verification
Local Unity Windows build **green**, no compiler errors; locale parity (en/de) preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)