### PR TITLE
fix(client): soft water reflections + visible sky bodies

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -51,7 +51,19 @@ Per-item detail lives in the dated work log below.
 
 ---
 
-### ★ Graphics WS5: remove the dead Built-in-RP post stack (2026-06-24) — ✅ code done + local Unity build green, NOT committed
+### ★ Graphics bugfixes: soft water reflections + visible sky bodies (2026-06-24) — ✅ code done + local Unity build green, NOT committed
+Two tester-reported render bugs:
+- **Water reflections too hard** — [BlockAtlasTransparent.shader](client/Assets/BlocksBeyondTheStars/Shaders/BlockAtlasTransparent.shader)
+  water SSR was a pixel-sharp mirror. Stronger wave-normal jitter on the reflection ray, a 5-tap blur of the reflected
+  scene colour, base Fresnel 0.35→0.16 (calm water reflects less head-on), blend 0.7→0.55 → soft, watery reflection.
+- **Sky bodies always black** — at day they were dimmed hard (×0.45) and showed only a 0.04 earthshine floor, so against
+  the bright ACES-tonemapped sky they crushed to black; the limb-darkening term was also inverted (dark centre).
+  [SkyBodyPhase.shader](client/Assets/BlocksBeyondTheStars/Shaders/SkyBodyPhase.shader): fixed limb darkening (world-space
+  view dir, bright centre), added a soft wrap floor over the crisp terminator, `_Earthshine` 0.04→0.12;
+  [SkyBodiesView.cs](client/Assets/BlocksBeyondTheStars/Scripts/SkyBodiesView.cs) day-time brightness floor 0.45→0.7.
+  (If the phase still reads off after testing, the next step is verifying the `_PhaseSunDir` sign vs the terrain sun.)
+
+### ★ Graphics WS5: remove the dead Built-in-RP post stack (2026-06-24) — ✅ done &amp; merged (PR#54, eb0d2b3; CI + local Unity build green)
 The project always runs URP (every quality level assigns it), so the Built-in-RP post path never executed. Re-scoped
 WS5 from the analysis (it is NOT all dead — `VisorGlass` is used by `VisorMenuGlass`, `VisorComposite` is the Built-in
 visor path) down to the genuinely-orphaned **post stack**, and removed it:

--- a/client/Assets/BlocksBeyondTheStars/Scripts/SkyBodiesView.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/SkyBodiesView.cs
@@ -179,7 +179,9 @@ namespace BlocksBeyondTheStars.Client
                 // the horizon. (The lit/unlit split across the disc is the phase, handled in the shader.)
                 b.Mat.SetVector(PhaseSunDirId, sunDir);
                 float horizon = Mathf.Clamp01((dir.y + 0.04f) / 0.12f);
-                b.Mat.color = ShaderColor.Srgb(b.Tint * Mathf.Lerp(1.15f, 0.45f, day) * horizon);
+                // Overall dim: bodies dominate the night sky and fade toward day — but keep a higher day-time floor
+                // so they don't wash to black against the bright ACES-tonemapped daytime sky (they're a feature).
+                b.Mat.color = ShaderColor.Srgb(b.Tint * Mathf.Lerp(1.25f, 0.7f, day) * horizon);
             }
         }
 

--- a/client/Assets/BlocksBeyondTheStars/Shaders/BlockAtlasTransparent.shader
+++ b/client/Assets/BlocksBeyondTheStars/Shaders/BlockAtlasTransparent.shader
@@ -215,9 +215,13 @@ Shader "BlocksBeyondTheStars/BlockAtlasTransparent"
                     // is SSR localised to WATER — no full-screen pass, so no darkening risk, and it only reflects
                     // the surface that should (the sea), never matte walls.
                     float3 Vw = normalize(i.wp - _WorldSpaceCameraPos);
-                    float3 rn = normalize(N + float3(wob.x, 0.0, wob.y) * 0.06);
+                    // Stronger wave perturbation on the reflection ray breaks the mirror into a soft, watery
+                    // reflection instead of a hard pixel-perfect one.
+                    float3 rn = normalize(N + float3(wob.x, 0.0, wob.y) * 0.12);
                     float3 Rw = reflect(Vw, rn);
-                    float fres = lerp(0.35, 1.0, pow(1.0 - saturate(dot(-Vw, rn)), 4.0)); // base sheen + full mirror at grazing angles
+                    // Lower base sheen so head-on water reflects little (full mirror only at grazing angles) and
+                    // the depth/bed colour shows through more — the old 0.35 made calm water read like glass.
+                    float fres = lerp(0.16, 1.0, pow(1.0 - saturate(dot(-Vw, rn)), 4.0));
                     float3 reflCol = _Sc_Sky.rgb; // most of a water reflection is the sky
                     float3 sp = i.wp;
                     float stepLen = 0.5;
@@ -234,13 +238,20 @@ Shader "BlocksBeyondTheStars/BlockAtlasTransparent"
                         float rayEye = -TransformWorldToView(sp).z;
                         if (rayEye > hitEye + 0.1 && rayEye < hitEye + 4.0)
                         {
-                            reflCol = SampleSceneColor(ruv);
+                            // Soft 5-tap blur of the reflected scene colour so the mirror is gently diffused
+                            // (water is never a perfect mirror) — kills the "too hard" sharp reflection.
+                            float2 br = 0.0035;
+                            reflCol = (SampleSceneColor(ruv)
+                                     + SampleSceneColor(ruv + float2(br.x, 0.0))
+                                     + SampleSceneColor(ruv - float2(br.x, 0.0))
+                                     + SampleSceneColor(ruv + float2(0.0, br.y))
+                                     + SampleSceneColor(ruv - float2(0.0, br.y))) * 0.2;
                             break;
                         }
                     }
                     float sunSpec = pow(saturate(dot(Rw, normalize(_Sc_SunDir.xyz))), 220.0) * 4.0;
                     reflCol += light * sunSpec;
-                    col = lerp(col, reflCol, saturate(fres) * 0.7);
+                    col = lerp(col, reflCol, saturate(fres) * 0.55);
 
                     alpha = 1.0; // bed + reflection composited here → opaque output, no hardware double-blend
                     } // _Sc_ScreenFx (depth/opaque available)

--- a/client/Assets/BlocksBeyondTheStars/Shaders/SkyBodyPhase.shader
+++ b/client/Assets/BlocksBeyondTheStars/Shaders/SkyBodyPhase.shader
@@ -13,7 +13,7 @@ Shader "BlocksBeyondTheStars/SkyBodyPhase"
         _MainTex ("Texture", 2D) = "white" {}
         // xyz = world-space direction TO the sun (set per-material each frame). w unused.
         _PhaseSunDir ("Sun Direction", Vector) = (0, 0, 1, 0)
-        _Earthshine ("Night-side floor", Range(0, 0.4)) = 0.04
+        _Earthshine ("Night-side floor", Range(0, 0.4)) = 0.12
         _TermSoft ("Terminator softness", Range(0.001, 0.4)) = 0.07
         _LimbDark ("Limb darkening", Range(0, 1)) = 0.35
     }
@@ -42,7 +42,7 @@ Shader "BlocksBeyondTheStars/SkyBodyPhase"
             float _LimbDark;
 
             struct Attributes { float4 positionOS : POSITION; float3 normal : NORMAL; float2 uv : TEXCOORD0; };
-            struct Varyings { float4 positionCS : SV_POSITION; float3 wn : TEXCOORD0; float2 uv : TEXCOORD1; float3 vn : TEXCOORD2; };
+            struct Varyings { float4 positionCS : SV_POSITION; float3 wn : TEXCOORD0; float2 uv : TEXCOORD1; float3 wp : TEXCOORD2; };
 
             Varyings vert(Attributes v)
             {
@@ -50,7 +50,7 @@ Shader "BlocksBeyondTheStars/SkyBodyPhase"
                 float3 wp = TransformObjectToWorld(v.positionOS.xyz);
                 o.positionCS = TransformWorldToHClip(wp);
                 o.wn = TransformObjectToWorldNormal(v.normal);
-                o.vn = TransformWorldToViewDir(o.wn); // view-space normal for limb darkening
+                o.wp = wp; // world position → world-space view dir for limb darkening
                 o.uv = TRANSFORM_TEX(v.uv, _MainTex);
                 return o;
             }
@@ -60,13 +60,18 @@ Shader "BlocksBeyondTheStars/SkyBodyPhase"
                 float3 N = normalize(i.wn);
                 float3 L = normalize(_PhaseSunDir.xyz);
                 float ndl = dot(N, L);
-                // Soft day/night boundary → a smooth terminator (the lit fraction of the visible disc IS the phase).
+                // Crisp terminator (the lit fraction of the visible disc IS the phase) over a soft wrap floor so
+                // the night side / day-time bodies read as a faint disc instead of a pure-black silhouette.
                 float lit = smoothstep(-_TermSoft, _TermSoft, ndl);
+                float wrap = saturate(ndl * 0.5 + 0.5);
+                float shade = max(lit, wrap * wrap * 0.35);
                 float3 tex = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, i.uv).rgb;
-                float3 col = _Color.rgb * tex * (_Earthshine + (1.0 - _Earthshine) * lit);
-                // Limb darkening: dim the disc edge (normal facing away from the viewer) for a rounder, less flat read.
-                float facing = saturate(normalize(i.vn).z * -1.0 + 1.0); // ~1 at centre, ~0 at the rim
-                col *= lerp(1.0 - _LimbDark, 1.0, saturate(facing));
+                float3 col = _Color.rgb * tex * (_Earthshine + (1.0 - _Earthshine) * shade);
+                // Limb darkening via the world-space view direction: bright at the disc centre (normal toward the
+                // camera), dimmer at the rim — a rounder read. (The old view-space-z form was inverted.)
+                float3 Vw = normalize(_WorldSpaceCameraPos - i.wp);
+                float facing = saturate(dot(N, Vw)); // ~1 at centre, ~0 at the rim
+                col *= lerp(1.0 - _LimbDark, 1.0, facing);
                 return half4(col, 1);
             }
             ENDHLSL
@@ -96,14 +101,14 @@ Shader "BlocksBeyondTheStars/SkyBodyPhase"
             float _LimbDark;
 
             struct appdata { float4 vertex : POSITION; float3 normal : NORMAL; float2 uv : TEXCOORD0; };
-            struct v2f { float4 pos : SV_POSITION; float3 wn : TEXCOORD0; float2 uv : TEXCOORD1; float3 vn : TEXCOORD2; };
+            struct v2f { float4 pos : SV_POSITION; float3 wn : TEXCOORD0; float2 uv : TEXCOORD1; float3 wp : TEXCOORD2; };
 
             v2f vert(appdata v)
             {
                 v2f o;
                 o.pos = UnityObjectToClipPos(v.vertex);
                 o.wn = UnityObjectToWorldNormal(v.normal);
-                o.vn = mul((float3x3)UNITY_MATRIX_V, o.wn);
+                o.wp = mul(unity_ObjectToWorld, v.vertex).xyz; // world pos for world-space view dir limb darkening
                 o.uv = TRANSFORM_TEX(v.uv, _MainTex);
                 return o;
             }
@@ -114,10 +119,13 @@ Shader "BlocksBeyondTheStars/SkyBodyPhase"
                 float3 L = normalize(_PhaseSunDir.xyz);
                 float ndl = dot(N, L);
                 float lit = smoothstep(-_TermSoft, _TermSoft, ndl);
+                float wrap = saturate(ndl * 0.5 + 0.5);
+                float shade = max(lit, wrap * wrap * 0.35);
                 fixed3 tex = tex2D(_MainTex, i.uv).rgb;
-                fixed3 col = _Color.rgb * tex * (_Earthshine + (1.0 - _Earthshine) * lit);
-                float facing = saturate(normalize(i.vn).z * -1.0 + 1.0);
-                col *= lerp(1.0 - _LimbDark, 1.0, saturate(facing));
+                fixed3 col = _Color.rgb * tex * (_Earthshine + (1.0 - _Earthshine) * shade);
+                float3 Vw = normalize(_WorldSpaceCameraPos - i.wp);
+                float facing = saturate(dot(N, Vw)); // ~1 at centre, ~0 at the rim
+                col *= lerp(1.0 - _LimbDark, 1.0, facing);
                 return fixed4(col, 1);
             }
             ENDCG


### PR DESCRIPTION
Two tester-reported render bugs.

## Water reflections too hard
The water SSR in [`BlockAtlasTransparent.shader`](client/Assets/BlocksBeyondTheStars/Shaders/BlockAtlasTransparent.shader) sampled a **pixel-perfect mirror**. Softened it:
- Stronger wave-normal jitter on the reflection ray (0.06 → 0.12) breaks up the mirror.
- 5-tap blur of the reflected scene colour — gently diffused, "watery".
- Base Fresnel 0.35 → 0.16 — calm water reflects little head-on (full mirror only at grazing angles), so depth/bed shows through.
- Reflection blend 0.7 → 0.55.

## Sky bodies always black
At day the bodies were dimmed hard (×0.45) and showed only a 0.04 earthshine floor, so against the bright ACES-tonemapped daytime sky they crushed to black; the limb-darkening term was also **inverted** (dark centre).
- [`SkyBodyPhase.shader`](client/Assets/BlocksBeyondTheStars/Shaders/SkyBodyPhase.shader): fixed limb darkening (world-space view dir → bright centre, dim rim), added a soft wrap floor over the crisp terminator so the night side / day-time bodies read as a faint disc instead of a black silhouette, `_Earthshine` 0.04 → 0.12.
- [`SkyBodiesView.cs`](client/Assets/BlocksBeyondTheStars/Scripts/SkyBodiesView.cs): day-time brightness floor 0.45 → 0.7 (bodies are a feature; keep them visible).
- If the phase still reads off after testing, the follow-up is verifying `_PhaseSunDir`'s sign/space vs the terrain sun.

## Verification
Local Unity Windows build **green**, both shaders compile clean (checked explicitly — shader errors don't fail the player build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)