### PR TITLE
fix(client): clear water — you can see into / through it again

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -51,7 +51,13 @@ Per-item detail lives in the dated work log below.
 
 ---
 
-### ★ Graphics bugfixes: soft water reflections + visible sky bodies (2026-06-24) — ✅ code done + local Unity build green, NOT committed
+### ★ Water clarity tuning (2026-06-24) — ✅ tester-approved + local Unity build green, NOT committed
+Follow-up to the water-reflection fix: the tester still couldn't see into the water. Root cause (analysed):
+deep water was opaque by ~6 m + a high base tile alpha (0.62), so the bed never read through. Tuned to clear water:
+- [BlockTextureAtlas.cs](client/Assets/BlocksBeyondTheStars/Scripts/BlockTextureAtlas.cs): water tile base alpha 0.62 → **0.28** (the bed reads through with only a light blue wash).
+- [BlockAtlasTransparent.shader](client/Assets/BlocksBeyondTheStars/Shaders/BlockAtlasTransparent.shader): depth opacity ramp 6 m → **16 m**, deep-water opacity add 0.4 → 0.16, depth darkening ×0.85 → ×0.45 (lighter, gentler deep tint); reflection strength down (base Fresnel 0.16 → 0.08, grazing cap 1.0 → 0.7, blend 0.55 → 0.45). The green "dapple" the tester saw is the underwater bed showing through — confirmed (water tile is pure blue).
+
+### ★ Graphics bugfixes: soft water reflections + visible sky bodies (2026-06-24) — ✅ done &amp; merged (PR#55, 75657a7; CI + local Unity build green)
 Two tester-reported render bugs:
 - **Water reflections too hard** — [BlockAtlasTransparent.shader](client/Assets/BlocksBeyondTheStars/Shaders/BlockAtlasTransparent.shader)
   water SSR was a pixel-sharp mirror. Stronger wave-normal jitter on the reflection ray, a 5-tap blur of the reflected

--- a/client/Assets/BlocksBeyondTheStars/Scripts/BlockTextureAtlas.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/BlockTextureAtlas.cs
@@ -257,7 +257,7 @@ namespace BlocksBeyondTheStars.Client
             // transparent block shader keys off this tile alpha to render water clear-blue (vs frosted glass).
             if (key == "water")
             {
-                FadeTileAlpha(ox, oy, 0.62f);
+                FadeTileAlpha(ox, oy, 0.28f); // clear water → the bed reads through, only a light blue wash (depth tint adds blue with depth)
             }
         }
 

--- a/client/Assets/BlocksBeyondTheStars/Shaders/BlockAtlasTransparent.shader
+++ b/client/Assets/BlocksBeyondTheStars/Shaders/BlockAtlasTransparent.shader
@@ -188,9 +188,9 @@ Shader "BlocksBeyondTheStars/BlockAtlasTransparent"
                     float sceneEye = LinearEyeDepth(SampleSceneDepth(screenUV), _ZBufferParams);
                     float fragEye = -TransformWorldToView(i.wp).z;
                     float column = max(0.0, sceneEye - fragEye); // metres of water column at this pixel
-                    float depth01 = saturate(column / 6.0);
-                    col = lerp(col, col * 0.45 + light * float3(0.015, 0.07, 0.13), depth01 * 0.85);
-                    alpha = lerp(alpha, saturate(alpha + 0.4), depth01); // deep water turns opaque, hides the bed
+                    float depth01 = saturate(column / 16.0); // see far deeper before it reads "deep" (was 6 m)
+                    col = lerp(col, col * 0.6 + light * float3(0.03, 0.10, 0.16), depth01 * 0.45); // gentler, lighter deep tint
+                    alpha = lerp(alpha, saturate(alpha + 0.16), depth01); // deep water stays much more see-through
                     float edge = 1.0 - saturate(column / 0.55);          // ~1 right at the waterline / around objects
                     if (edge > 0.01)
                     {
@@ -219,9 +219,9 @@ Shader "BlocksBeyondTheStars/BlockAtlasTransparent"
                     // reflection instead of a hard pixel-perfect one.
                     float3 rn = normalize(N + float3(wob.x, 0.0, wob.y) * 0.12);
                     float3 Rw = reflect(Vw, rn);
-                    // Lower base sheen so head-on water reflects little (full mirror only at grazing angles) and
-                    // the depth/bed colour shows through more — the old 0.35 made calm water read like glass.
-                    float fres = lerp(0.16, 1.0, pow(1.0 - saturate(dot(-Vw, rn)), 4.0));
+                    // Keep the reflection a sheen, not a mirror, so you can see INTO the water: low base sheen and
+                    // a capped grazing maximum (0.7, not full mirror) let the depth/bed colour read through.
+                    float fres = lerp(0.08, 0.7, pow(1.0 - saturate(dot(-Vw, rn)), 4.0));
                     float3 reflCol = _Sc_Sky.rgb; // most of a water reflection is the sky
                     float3 sp = i.wp;
                     float stepLen = 0.5;
@@ -251,7 +251,7 @@ Shader "BlocksBeyondTheStars/BlockAtlasTransparent"
                     }
                     float sunSpec = pow(saturate(dot(Rw, normalize(_Sc_SunDir.xyz))), 220.0) * 4.0;
                     reflCol += light * sunSpec;
-                    col = lerp(col, reflCol, saturate(fres) * 0.55);
+                    col = lerp(col, reflCol, saturate(fres) * 0.45);
 
                     alpha = 1.0; // bed + reflection composited here → opaque output, no hardware double-blend
                     } // _Sc_ScreenFx (depth/opaque available)


### PR DESCRIPTION
Follow-up to the water-reflection softening (#55): the tester still couldn't see into the water.

## Root cause
Deep water went opaque by ~6 m and the base water tile alpha was **0.62**, so the bed never read through — the surface looked like a flat blue/green sheet. (The green "dapple" the tester saw is the underwater bed showing through — confirmed, the water tile is pure blue.)

## Tuning
- [`BlockTextureAtlas.cs`](client/Assets/BlocksBeyondTheStars/Scripts/BlockTextureAtlas.cs): water tile base alpha **0.62 → 0.28** (bed reads through, light blue wash; the depth tint still adds blue with depth).
- [`BlockAtlasTransparent.shader`](client/Assets/BlocksBeyondTheStars/Shaders/BlockAtlasTransparent.shader): depth opacity ramp **6 m → 16 m**, deep-water opacity add 0.4 → 0.16, depth darkening ×0.85 → ×0.45. Reflection strength also down (base Fresnel 0.16 → 0.08, grazing cap 1.0 → 0.7, blend 0.55 → 0.45).

Tester-approved. Local Unity build green, shader compiles clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)