### PR TITLE
refactor: remove the vestigial "block placer" item

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -51,7 +51,17 @@ Per-item detail lives in the dated work log below.
 
 ---
 
-### ★ Water clarity tuning (2026-06-24) — ✅ tester-approved + local Unity build green, NOT committed
+### ★ Remove vestigial "block placer" item (2026-06-25) — ✅ code done + 717 tests green, NOT committed
+Tester asked why the Block Placer exists when blocks are placed directly (select a block item → right-click). It's
+dead: `ToolKind.BlockPlacer` is never branched on anywhere, and the item has no `placesBlock`, so holding it does
+nothing — a leftover from an earlier "hold one placer tool" design. Removed it everywhere:
+- Starter inventory ([GameServer.cs](src/BlocksBeyondTheStars.GameServer/GameServer.cs)) — dropped the grant and
+  closed the gap (drill / scanner / lamp / machete / pistol now fill slots 0-4); item def ([items.json](data/items.json));
+  de/en locale keys; the granted-set entry in CraftingConsistencyTests; the icon-gen script entry.
+- Kept the generic `ToolKind.BlockPlacer` enum + ContentEditor option (harmless content-authoring facility).
+- Old saves keep an "unknown" block_placer in inventory (null-checked, harmless); new worlds start clean.
+
+### ★ Water clarity tuning (2026-06-24) — ✅ done &amp; merged (PR#56, cac8bb9; CI + local Unity build green)
 Follow-up to the water-reflection fix: the tester still couldn't see into the water. Root cause (analysed):
 deep water was opaque by ~6 m + a high base tile alpha (0.62), so the bed never read through. Tuned to clear water:
 - [BlockTextureAtlas.cs](client/Assets/BlocksBeyondTheStars/Scripts/BlockTextureAtlas.cs): water tile base alpha 0.62 → **0.28** (the bed reads through with only a light blue wash).

--- a/data/items.json
+++ b/data/items.json
@@ -66,7 +66,6 @@
 
   { "key": "basic_drill",     "nameKey": "item.basic_drill.name",     "category": "tool", "maxStack": 1, "descriptionKey": "item.basic_drill.desc", "tool": { "kind": "drill", "tier": 1, "miningPower": 1.0, "energyPerUse": 0.0 } },
   { "key": "titanium_drill",  "nameKey": "item.titanium_drill.name",  "category": "tool", "maxStack": 1, "descriptionKey": "item.titanium_drill.desc", "tool": { "kind": "drill", "tier": 2, "miningPower": 2.0, "energyPerUse": 0.5 } },
-  { "key": "block_placer",    "nameKey": "item.block_placer.name",    "category": "tool", "maxStack": 1, "descriptionKey": "item.block_placer.desc", "tool": { "kind": "blockPlacer", "tier": 1, "energyPerUse": 0.0 } },
   { "key": "hand_scanner",    "nameKey": "item.hand_scanner.name",    "category": "tool", "maxStack": 1, "descriptionKey": "item.hand_scanner.desc", "tool": { "kind": "scanner", "tier": 1, "energyPerUse": 0.2 } },
   { "key": "field_medkit",    "nameKey": "item.field_medkit.name",    "category": "tool", "maxStack": 1, "descriptionKey": "item.field_medkit.desc", "tool": { "kind": "gadget", "tier": 2, "energyPerUse": 18.0 } },
   { "key": "stasis_projector","nameKey": "item.stasis_projector.name","category": "tool", "maxStack": 1, "descriptionKey": "item.stasis_projector.desc", "tool": { "kind": "gadget", "tier": 2, "energyPerUse": 4.0 } },

--- a/data/locales/de.json
+++ b/data/locales/de.json
@@ -238,8 +238,6 @@
   "item.basic_drill.desc": "Ein einfacher Bohrer für weiche und häufige Blöcke.",
   "item.titanium_drill.name": "Titanbohrer",
   "item.titanium_drill.desc": "Baut härtere Erze wie Titan ab.",
-  "item.block_placer.name": "Blockplatzierer",
-  "item.block_placer.desc": "Setzt Blöcke aus deinem Inventar.",
   "item.hand_scanner.name": "Handscanner",
   "item.hand_scanner.desc": "Erkennt nahe Rohstoffe.",
   "item.field_medkit.name": "Feld-Medkit",

--- a/data/locales/en.json
+++ b/data/locales/en.json
@@ -234,8 +234,6 @@
   "item.basic_drill.desc": "A simple drill for soft and common blocks.",
   "item.titanium_drill.name": "Titanium Drill",
   "item.titanium_drill.desc": "Mines harder ores such as titanium.",
-  "item.block_placer.name": "Block Placer",
-  "item.block_placer.desc": "Places blocks from your inventory.",
   "item.hand_scanner.name": "Hand Scanner",
   "item.hand_scanner.desc": "Detects nearby resources.",
   "item.field_medkit.name": "Field Medkit",

--- a/src/BlocksBeyondTheStars.GameServer/GameServer.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServer.cs
@@ -1702,14 +1702,14 @@ public sealed partial class GameServer
                 : (_config.AdminPlayers.Contains(name) ? PlayerRole.Admin : PlayerRole.Player),
         };
 
-        // Starter kit: a basic drill, a block placer and a hand scanner in the first hotbar slots,
-        // plus a suit lamp so the player can light up caves / the ship at night (toggle with L).
+        // Starter kit: a basic drill and a hand scanner in the first hotbar slots, plus a suit lamp so the
+        // player can light up caves / the ship at night (toggle with L). Blocks are placed directly — select
+        // a block item and right-click — so there is no separate "block placer" tool.
         state.Inventory.SetSlot(0, new ItemStack("basic_drill", 1));
-        state.Inventory.SetSlot(1, new ItemStack("block_placer", 1));
-        state.Inventory.SetSlot(2, new ItemStack("hand_scanner", 1));
-        state.Inventory.SetSlot(3, new ItemStack("suit_lamp", 1));
-        state.Inventory.SetSlot(4, new ItemStack("machete", 1));       // a simple starter melee weapon
-        state.Inventory.SetSlot(5, new ItemStack("scrap_pistol", 1));   // ...and a weak ranged sidearm so a fresh
+        state.Inventory.SetSlot(1, new ItemStack("hand_scanner", 1));
+        state.Inventory.SetSlot(2, new ItemStack("suit_lamp", 1));
+        state.Inventory.SetSlot(3, new ItemStack("machete", 1));       // a simple starter melee weapon
+        state.Inventory.SetSlot(4, new ItemStack("scrap_pistol", 1));   // ...and a weak ranged sidearm so a fresh
                                                                         // player can fight back from a distance, not
                                                                         // only by walking into a hostile's bite range
 

--- a/tests/BlocksBeyondTheStars.Tests/CraftingConsistencyTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/CraftingConsistencyTests.cs
@@ -163,7 +163,7 @@ public sealed class CraftingConsistencyTests
         // Items handed out by code rather than a recipe/drop (so legitimately not in Obtainable()):
         var granted = new HashSet<string>
         {
-            "basic_drill", "block_placer", "hand_scanner", "scrap_pistol", // starter hotbar kit
+            "basic_drill", "hand_scanner", "scrap_pistol", // starter hotbar kit
             "ai_memory_fragment",                          // VEGA data-terminal structure loot
             "toxic_berries",                               // runtime poison variant of a toxic flora's berries
         };

--- a/tools/ai-assets/gen_item_icons.py
+++ b/tools/ai-assets/gen_item_icons.py
@@ -86,7 +86,6 @@ ITEMS = [
     ("mining_beam", "a high-tech handheld mining laser beam emitter"),
     ("basic_drill", "a handheld mining power drill"),
     ("titanium_drill", "a heavy-duty titanium mining drill"),
-    ("block_placer", "a construction tool projecting a glowing cube"),
     ("hand_scanner", "a small handheld scanner device"),
     # Weapons
     ("machete", "a steel machete blade with a grip handle"),


### PR DESCRIPTION
## Why
A tester asked why the **Block Placer** exists when blocks are placed directly — select a block item and right-click. It's **dead code**: `ToolKind.BlockPlacer` is never branched on anywhere in client or server logic, and the item carries no `placesBlock`, so holding it and right-clicking does nothing. A leftover from an earlier "hold one placer tool" design that was replaced by direct per-block placement (`PlayerController` checks the held item's `PlacesBlock`).

## Removed
- **Starter inventory** ([`GameServer`](src/BlocksBeyondTheStars.GameServer/GameServer.cs)): dropped the grant and closed the gap so drill / scanner / lamp / machete / pistol fill hotbar slots 0–4.
- Item definition ([`items.json`](data/items.json)) + de/en locale keys + the granted-set entry in `CraftingConsistencyTests` + the icon-generation script entry.

## Kept
- The generic `ToolKind.BlockPlacer` enum value + the ContentEditor tool-kind option (a harmless content-authoring facility).

## Notes
Old saves keep an "unknown" `block_placer` in inventory — content lookups are null-checked, so it's harmless; new worlds start clean.

## Verification
`dotnet test` green — **717 tests**, incl. locale parity (en/de) + crafting consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)