### PR TITLE
ci: skip build/test/lint/CodeQL on doc- and image-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,13 @@
 # the PR, even though the local build keeps TreatWarningsAsErrors=false (Directory.Build.props) for a
 # friction-free dev loop. The tree currently builds clean (0 warnings), so this only guards regressions.
 #
-# REQUIRED-CHECK SAFE docs-only skip: rather than skipping the whole workflow with paths-ignore (which
-# would leave a *required* check stuck on "Expected — Waiting for status" for a docs-only PR), the
-# workflow always runs and a `changes` job decides whether the heavy `build-test` job runs. On a
-# docs-only PR `build-test` is skipped via its `if:`, and GitHub counts a skipped required job as a pass —
-# so the `Build + test (.NET, headless)` check still reports green and never blocks a docs PR. Any
-# code/content file in the diff makes it run for real. `data/**` and `web/**` count as code (they feed
-# tests, e.g. the en/de locale-parity test), so they are NOT in the doc-only exclusions below.
+# REQUIRED-CHECK SAFE doc/screenshot-only skip: rather than skipping the whole workflow with paths-ignore
+# (which would leave a *required* check stuck on "Expected — Waiting for status" for a docs-only PR), the
+# workflow always runs and a `changes` job decides whether the heavy `build-test`/`format` jobs run. On a
+# doc- or image-only PR they are skipped via their `if:`, and GitHub counts a skipped required job as a
+# pass — so the `Build + test (.NET, headless)` check still reports green and never blocks the PR. Any
+# code/content file in the diff makes them run for real. The doc/image skip list lives in the shared
+# reusable workflow .github/workflows/detect-doc-only.yml (also used by lint.yml and codeql.yml).
 
 name: CI
 
@@ -38,37 +38,11 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Decides whether the PR diff contains anything other than documentation. Only meaningful for PRs;
-  # direct pushes to main always build (see build-test's `if:`), so the detection step is PR-only.
+  # Decides whether the PR diff contains anything other than documentation or images. Always runs (no
+  # job-level `if:`) so that on a push to main it succeeds and the downstream `needs: changes` is met;
+  # the detection itself is PR-only (see the reusable workflow). `nondocs` is consumed by build-test/format.
   changes:
-    name: Detect code changes
-    runs-on: ubuntu-latest
-    outputs:
-      nondocs: ${{ steps.detect.outputs.nondocs }}
-    steps:
-      # Lists the PR's changed files via the API (no checkout needed) and sets nondocs=true if ANY file is
-      # not documentation. Doc-only PRs (Markdown, docs/**, licences, issue/PR templates) leave it false, so
-      # build-test/format skip and — a skipped required job counting as a pass — never block a docs PR.
-      # data/** and web/** are treated as code (they feed tests, e.g. the en/de locale-parity test).
-      # (Done with an explicit case match rather than dorny/paths-filter, whose `some` glob semantics made a
-      # `**/*` + `!doc` list always true.)
-      - name: Detect non-doc changes
-        id: detect
-        if: github.event_name == 'pull_request'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          files="$(gh api --paginate "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" --jq '.[].filename')"
-          nondocs=false
-          while IFS= read -r f; do
-            [ -z "$f" ] && continue
-            case "$f" in
-              *.md|docs/*|LICENSE*|NOTICES*|THIRD-PARTY*|.github/ISSUE_TEMPLATE/*|.github/pull_request_template.md) ;;
-              *) nondocs=true; break ;;
-            esac
-          done <<< "$files"
-          echo "nondocs=$nondocs" >> "$GITHUB_OUTPUT"
-          echo "Changed files:"; printf '%s\n' "$files"; echo "nondocs=$nondocs"
+    uses: ./.github/workflows/detect-doc-only.yml
 
   build-test:
     name: Build + test (.NET, headless)

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,6 +4,14 @@
 # security_events scope, while the workflow's built-in GITHUB_TOKEN already has `security-events: write` — no
 # extra credentials. Findings land in the repo's Security → Code scanning tab (and enable Copilot Autofix).
 #
+# Doc/screenshot-only PRs skip the whole analysis via the shared detect-doc-only reusable workflow. Unlike
+# ci.yml/lint.yml — whose required checks are job names, where a skipped job counts as a pass — the required
+# "CodeQL" check is posted by the code-scanning service after SARIF upload, NOT by this job. So skipping the
+# job would leave a *required* "CodeQL" check stuck on "Expected — Waiting for status". For that reason
+# "CodeQL" has been REMOVED from main's required status checks; it still runs on every push to main and on
+# the weekly schedule, so the default branch stays fully scanned. (Re-add it as required only if this gate
+# is reverted.)
+#
 # C# is analysed in MANUAL build mode: it compiles BlocksBeyondTheStars.CI.slnf (every .NET project except the
 # Windows-only Launcher) so CodeQL gets full type/call resolution. Manual mode extracts only what the compiler
 # compiles, so the Unity client C# under client/Assets/ — which needs the Unity editor and isn't in any .csproj
@@ -29,8 +37,17 @@ permissions:
   contents: read
 
 jobs:
+  # Shared doc/image detection (see .github/workflows/detect-doc-only.yml). Always runs so pushes/schedule
+  # succeed; `nondocs` gates analyze so a doc- or image-only PR skips scanning entirely.
+  changes:
+    uses: ./.github/workflows/detect-doc-only.yml
+
   analyze:
     name: CodeQL (${{ matrix.language }})
+    needs: changes
+    # Run on every push to main and on the weekly schedule; for a PR, only when a non-doc/non-image file
+    # changed. Doc/screenshot-only PRs skip — safe because "CodeQL" is no longer a required check (see header).
+    if: github.event_name != 'pull_request' || needs.changes.outputs.nondocs == 'true'
     runs-on: ubuntu-latest
     permissions:
       security-events: write

--- a/.github/workflows/detect-doc-only.yml
+++ b/.github/workflows/detect-doc-only.yml
@@ -1,0 +1,59 @@
+# Reusable doc/asset-only change detector, shared by ci.yml, lint.yml and codeql.yml.
+#
+# Output `nondocs` is "true" when the PR diff contains ANY file that is not documentation or an
+# image (marketing screenshot, texture, icon, …). Callers gate their heavy jobs on it, so a PR that
+# only touches Markdown/docs/licences or image files skips build, tests, format, lint and CodeQL.
+# Because each of those is a job-name required check, a *skipped* required job still counts as a pass,
+# so doc/screenshot-only PRs stay green and are never blocked. (CodeQL is handled separately: its
+# required check is posted by the code-scanning service, not the job, so it is gated here AND removed
+# from main's required checks — see codeql.yml.)
+#
+# Only meaningful for pull_request events. On push/schedule the detection step is skipped and
+# `nondocs` stays empty; callers run unconditionally via `github.event_name != 'pull_request'`.
+#
+# IMPORTANT: this is the SINGLE SOURCE OF TRUTH for the doc/image skip list. To change what counts as
+# doc-only, edit the `case` below here — do not re-add per-workflow copies. `data/**` and `web/**` are
+# deliberately NOT skipped: they feed the headless tests (e.g. the en/de locale-parity test).
+name: Detect doc-only changes
+
+on:
+  workflow_call:
+    outputs:
+      nondocs:
+        description: "true if the PR diff contains any non-doc, non-image file"
+        value: ${{ jobs.detect.outputs.nondocs }}
+
+permissions:
+  contents: read
+
+jobs:
+  detect:
+    name: Detect code changes
+    runs-on: ubuntu-latest
+    outputs:
+      nondocs: ${{ steps.detect.outputs.nondocs }}
+    steps:
+      # Lists the PR's changed files via the API (no checkout needed) and sets nondocs=true if ANY file
+      # is neither documentation nor an image. (Explicit case match rather than dorny/paths-filter, whose
+      # `some` glob semantics made a `**/*` + `!doc` list always true.)
+      - name: Detect non-doc changes
+        id: detect
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          files="$(gh api --paginate "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" --jq '.[].filename')"
+          nondocs=false
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            case "$f" in
+              # Documentation
+              *.md|docs/*|LICENSE*|NOTICES*|THIRD-PARTY*|.github/ISSUE_TEMPLATE/*|.github/pull_request_template.md) ;;
+              # Images (screenshots, textures, icons) — none affect the .NET tests, ruff, web-js,
+              # actionlint or CodeQL analysis, so an image-only change is safe to skip everywhere.
+              *.png|*.jpg|*.jpeg|*.gif|*.webp|*.bmp|*.svg|*.ico) ;;
+              *) nondocs=true; break ;;
+            esac
+          done <<< "$files"
+          echo "nondocs=$nondocs" >> "$GITHUB_OUTPUT"
+          echo "Changed files:"; printf '%s\n' "$files"; echo "nondocs=$nondocs"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,9 @@
 # Lightweight per-language syntax/lint checks for the non-.NET parts of the repo. The C# side is covered by
 # ci.yml (build with -warnaserror + dotnet format) and codeql.yml; this fills the gaps: Python, web JS, and
-# the workflow YAML itself. Each job is independent and fast (seconds), so they all run on every PR/push.
+# the workflow YAML itself. Each job is independent and fast (seconds).
+#
+# Doc/screenshot-only PRs skip all three jobs via the shared detect-doc-only reusable workflow (same
+# required-check-safe pattern as ci.yml: a skipped required job counts as a pass). Pushes to main always run.
 
 name: Lint
 
@@ -13,10 +16,17 @@ permissions:
   contents: read
 
 jobs:
+  # Shared doc/image detection (see .github/workflows/detect-doc-only.yml). Always runs so pushes succeed;
+  # `nondocs` gates the lint jobs below so a doc- or image-only PR skips them.
+  changes:
+    uses: ./.github/workflows/detect-doc-only.yml
+
   # Python AI backend — ruff is both the linter and the syntax checker. Config (if any) is read from
   # ai-backend/pyproject.toml; today it runs ruff's default rule set, which the tree already passes.
   ruff:
     name: ruff (Python ai-backend)
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.nondocs == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -30,6 +40,8 @@ jobs:
   # an ESLint config or browser-global allowlist. (Inline <script> in the minigame HTML is not covered.)
   web-js:
     name: web JS syntax (node --check)
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.nondocs == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -52,6 +64,8 @@ jobs:
   # and does not flag shell style in the existing run: scripts. Pinned for reproducibility.
   actionlint:
     name: actionlint (workflows)
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.nondocs == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
## What

Doc- and image-only PRs (Markdown, `docs/**`, licences, **and** screenshots/textures/icons) now skip the heavy CI jobs instead of running a full build/test/lint/CodeQL pass.

## Why

The detection only existed in `ci.yml` (inlined), so `lint.yml` and `codeql.yml` ran unconditionally on every PR — a screenshot-only PR (e.g. #63 regenerating marketing screenshots) still paid for ruff, web-js, actionlint and a CodeQL analysis. This centralises the logic and broadens it to images.

## How

- **New reusable workflow** `.github/workflows/detect-doc-only.yml` — the single source of truth for the doc/image skip list. Outputs `nondocs` (true if the PR diff contains any non-doc, non-image file).
- **`ci.yml`** — replaces the ~48-line inlined detector with a one-line `uses:` call.
- **`lint.yml`** — gates `ruff`, `web-js`, `actionlint` on `nondocs`.
- **`codeql.yml`** — gates `analyze` on `nondocs`.

Required-check-safe by design: a *skipped* required job counts as a pass, so doc/image-only PRs stay green and are never blocked. `data/**` and `web/**` are deliberately **not** skipped — they feed the headless en/de locale-parity test.

## CodeQL note (no action needed)

CodeQL's required check is posted by the code-scanning service after SARIF upload, not by the job — so a skipped job would otherwise hang a required "CodeQL" check on *"Expected — Waiting for status"*. Verified that **`CodeQL` is already absent from `main`'s required status checks** (required today: Build+test, Format, ruff, web JS, actionlint), so this gate is safe as-is. CodeQL still runs on every push to `main` and on the weekly schedule, so the default branch stays fully scanned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)