### PR TITLE
chore: gitignore devlog drafts + drop dead UWB reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,6 @@ client/Assets/BlocksBeyondTheStars/Scripts/BugReportBuildSecrets.Generated.cs.me
 # Build/capture run logs (client)
 client/build-run.log
 client/capture-run.log
+
+# Local devlog drafts (posted manually to itch.io; not part of the repo)
+client/devlog-*.md

--- a/client/Assets/BlocksBeyondTheStars/BlocksBeyondTheStars.Client.asmdef
+++ b/client/Assets/BlocksBeyondTheStars/BlocksBeyondTheStars.Client.asmdef
@@ -3,8 +3,7 @@
   "rootNamespace": "BlocksBeyondTheStars.Client",
   "references": [
     "Unity.RenderPipelines.Universal.Runtime",
-    "Unity.RenderPipelines.Core.Runtime",
-    "VoltstroStudios.UnityWebBrowser"
+    "Unity.RenderPipelines.Core.Runtime"
   ],
   "includePlatforms": [],
   "excludePlatforms": [],

--- a/docs/developer/WEBCLIENT_FEASIBILITY.md
+++ b/docs/developer/WEBCLIENT_FEASIBILITY.md
@@ -1,6 +1,7 @@
 # Web client (Unity WebGL) — feasibility decision
 
-Status: feasibility decided — not built · 2026-06-19
+Status: feasibility decided — not built · 2026-06-19 (re-verified 2026-06-26: the Wiki/Arcade blocker
+is gone after the "Stream D" native-UI refactor — see Constraints/Blockers below)
 
 ## Decision
 
@@ -53,13 +54,19 @@ list.
 - A Unity WebGL build profile (Lite quality) + asset bundling.
 - MessagePack `ContractlessResolver` does not survive IL2CPP AOT — the wire serialization would need an
   AOT-safe path for the WebGL build.
-- The in-game UWB wiki/arcade browser content is lost under WebGL.
+- ~~The in-game UWB wiki/arcade browser content is lost under WebGL.~~ **Resolved (2026-06-26):** the
+  "Stream D" refactor replaced the embedded browser. The Wiki is now native uGUI (`WikiUI.cs`) and the
+  Arcade runs an engine-free C# `MinigameHost` (`Client.Core/Minigames`) rendering Canvas2D→Texture2D→
+  RawImage (`MinigameHostUI.cs`). No UWB/CEF plugin remains and `BBS_UWB` is undefined, so both screens
+  are already WebGL-compatible — this is no longer a blocker (and it also unblocked the Linux build).
 - ~177 MB of `Resources` would have to be downloaded/streamed — shrink + bundle first.
 - Serving the built WebGL files from `/play` + version negotiation so the served client matches the
   server.
 
 ## Bottom line
 
-Treat the browser client as a ~4–6 week Lite-only sub-project taken on after the native client is
-solid. Nothing on the server needs to change to start it; the work is entirely the Unity WebGL build
-and the constraints/blockers above.
+Treat the browser client as a **~3–5 week** Lite-only sub-project taken on after the native client is
+solid (down from 4–6 now that the Wiki/Arcade no longer need re-integration). Nothing on the server
+needs to change to start it; the work is entirely the Unity WebGL build and the constraints/blockers
+above. The two remaining hard risks are MessagePack-Contractless under IL2CPP/AOT and the absence of
+in-browser singleplayer (Lite is multiplayer-only) — validate both as spikes before investing.


### PR DESCRIPTION
## What

Housekeeping after the **Stream D** native-UI refactor (which replaced the embedded UWB/CEF browser with native uGUI — `WikiUI` for the Codex, a pure C# `MinigameHost` for the Arcade) and a refresh of the web-client feasibility notes.

- **asmdef:** removed the dead `VoltstroStudios.UnityWebBrowser` reference. The plugin/DLL no longer ships and `BBS_UWB` is undefined, so the reference only produced a Unity console warning. No code uses the namespace (verified — only a comment in `VoiceChat.cs` mentions `BBS_UWB`).
- **docs/developer/WEBCLIENT_FEASIBILITY.md:** the Wiki/Arcade "lost under WebGL" blocker is now resolved — both screens are native and WebGL-compatible (this also unblocked the Linux build). Estimate revised from ~4–6 to **~3–5 weeks**; the two remaining hard risks (MessagePack-Contractless under IL2CPP/AOT, no in-browser singleplayer) are called out.
- **.gitignore:** ignore `client/devlog-*.md` (local devlog drafts, posted manually to itch.io — not repo content).

## Risk

Minimal — docs + `.gitignore` + removal of an already-dead asmdef reference (can only fix compilation warnings, not break them). No runtime code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)