### PR TITLE
feat(scanning): scan trees as a named per-world species

### DIFF
--- a/docs/user/USER_MANUAL.md
+++ b/docs/user/USER_MANUAL.md
@@ -284,6 +284,9 @@ the hauler slow and heavy. Hull + shield are shown on the HUD; shields recharge,
 - With a scanner selected, **left-click** a creature or block to scan it. Scans award **knowledge points**
   used to unlock blueprints; the readout shows subject/info/threat/knowledge (first-time scans highlight
   the "new discovery" bonus).
+- **Plants and trees scan as named species.** A scanned plant (flora) or tree reads as this world's coined
+  species name with an **edible/toxic** classification, not just a block. A tree's trunk and its leaves are
+  the same species, so scanning either one counts as a single discovery.
 - **Terrain scanner** (`terrain_scanner`, workshop recipe + blueprint): a **right-click** gadget that
   pulses once (10 suit energy, 10 s cooldown) and reveals ores, crystal and data caches within 20 blocks
   as through-wall glow markers for 8 s, tinted by ore type. An `ai_core_mk2` extends the radius.

--- a/src/BlocksBeyondTheStars.GameServer/GameServerFlora.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerFlora.cs
@@ -26,6 +26,11 @@ public sealed partial class GameServer
     private readonly HashSet<ushort> _floraIds = new();
     private readonly Dictionary<ushort, HashSet<ushort>> _floraHostIds = new();
     private readonly Dictionary<ushort, BlocksBeyondTheStars.Shared.Definitions.FloraSpecies> _floraSpeciesByBlock = new();
+
+    // This world's single tree species + the block ids (trunk + leaves) it covers, so a scan of either
+    // reads as the same coined, edible/toxic tree (built in InitFlora; see TreeSpeciesForBlock).
+    private BlocksBeyondTheStars.Shared.Definitions.TreeSpecies? _treeSpecies;
+    private readonly HashSet<ushort> _treeBlockIds = new();
     private Dictionary<Vector3i, (ushort FloraId, double Timer)> _floraRegrow => _worlds.Active.FloraRegrow;
 
     private void InitFlora()
@@ -57,7 +62,29 @@ public sealed partial class GameServer
                 }
             }
         }
+
+        // Per-world tree species: the trunk (wood_log) and crown (tree_leaves) share this world's one coined
+        // name + edible/toxic trait (deterministic from seed + planet), surfaced when the player scans a tree.
+        _treeSpecies = null;
+        _treeBlockIds.Clear();
+        if (planet != null && BlocksBeyondTheStars.WorldGeneration.TreeGenerator.Generate(planet, _meta.Seed) is { } tree)
+        {
+            _treeSpecies = tree;
+            foreach (var key in new[] { "wood_log", "tree_leaves" })
+            {
+                if (_content.GetBlock(key) is { } b && b.NumericId.Value != 0)
+                {
+                    _treeBlockIds.Add(b.NumericId.Value);
+                }
+            }
+        }
     }
+
+    /// <summary>This world's tree species for a block key (name + toxic trait) if the block is a tree block
+    /// (trunk or leaves), else null. Trunk and leaves both map to the same species — one tree, one identity.
+    /// Used by the scanner to name + classify a scanned tree.</summary>
+    public BlocksBeyondTheStars.Shared.Definitions.TreeSpecies? TreeSpeciesForBlock(string blockKey)
+        => _treeSpecies != null && _content.GetBlock(blockKey) is { } b && _treeBlockIds.Contains(b.NumericId.Value) ? _treeSpecies : null;
 
     /// <summary>This world's generated flora species for a block key (name + toxic trait), or null if the
     /// block isn't flora here. Used by the scanner to name + classify a scanned plant.</summary>

--- a/src/BlocksBeyondTheStars.GameServer/GameServerScanning.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerScanning.cs
@@ -34,6 +34,9 @@ public sealed partial class GameServer
         string threat = "—";
         int value;
         string display = subjectKey;
+        // First-scan ledger key. Defaults to the species/block key; trees override it to a shared key so the
+        // trunk and the leaves count as one discovery.
+        string ledgerKey = $"{subjectType}:{subjectKey}";
 
         if (subjectType == "creature" && _speciesById.TryGetValue(subjectKey, out var sp))
         {
@@ -45,8 +48,17 @@ public sealed partial class GameServer
         else if (subjectType == "block" && _content.GetBlock(subjectKey) is { } block)
         {
             var drops = string.Join(", ", block.Drops.Select(d => $"{d.Item}×{d.Count}"));
-            // Flora reads as a named species with an edible/toxic classification; other blocks report yield.
-            if (FloraSpeciesForBlock(subjectKey) is { } flora)
+            // Trees and flora read as a named species with an edible/toxic classification; other blocks
+            // report yield. Trunk + leaves share the world's one tree species AND a single ledger key, so
+            // scanning either part counts as one discovery.
+            if (TreeSpeciesForBlock(subjectKey) is { } tree)
+            {
+                info = drops.Length > 0 ? $"Yields: {drops}" : "Foliage of the tree.";
+                threat = tree.Toxic ? "Toxic" : "Edible";
+                display = string.IsNullOrEmpty(tree.Name) ? subjectKey : tree.Name;
+                ledgerKey = $"tree:{tree.Id}";
+            }
+            else if (FloraSpeciesForBlock(subjectKey) is { } flora)
             {
                 info = drops.Length > 0 ? $"Yields: {drops}" : "Harvestable flora.";
                 threat = flora.Toxic ? "Toxic" : "Edible";
@@ -64,8 +76,8 @@ public sealed partial class GameServer
             return new ScanResult { Subject = subjectKey, Info = "Unknown subject.", Threat = "—" };
         }
 
-        // Ledger key stays the species/block key (stable first-scan tracking); the readout shows `display`.
-        return Award(session, $"{subjectType}:{subjectKey}", display, info, threat, value);
+        // Ledger key tracks the first scan (per species/block, or shared per tree); the readout shows `display`.
+        return Award(session, ledgerKey, display, info, threat, value);
     }
 
     /// <summary>Ship scan of a space asteroid — reveals whether it holds resources (server knows the loot).</summary>

--- a/src/BlocksBeyondTheStars.Shared/Definitions/TreeSpecies.cs
+++ b/src/BlocksBeyondTheStars.Shared/Definitions/TreeSpecies.cs
@@ -1,0 +1,24 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+namespace BlocksBeyondTheStars.Shared.Definitions;
+
+/// <summary>
+/// A world's generated tree species: a coined name + a toxic/edible trait layered onto the fixed tree
+/// blocks (<c>wood_log</c> trunk + <c>tree_leaves</c> crown). The world grows one tree identity — the trunk
+/// and the leaves read as the same species, so scanning either counts as one discovery. Derived
+/// deterministically from the world seed + planet (see <c>TreeGenerator</c>), so a given world always names
+/// and classifies its trees the same way without storing anything. The counterpart to <see cref="FloraSpecies"/>
+/// for the (non-catalogued) tree blocks.
+/// </summary>
+public sealed class TreeSpecies
+{
+    /// <summary>Per-world species id ("tr0").</summary>
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>Coined, pronounceable tree name (e.g. "Skarnwood"), shown to the player on scan.</summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>Whether the tree is toxic (vs. edible/benign) — reported on scan, mirrors flora classification.</summary>
+    public bool Toxic { get; set; }
+}

--- a/src/BlocksBeyondTheStars.WorldGeneration/NameGenerator.cs
+++ b/src/BlocksBeyondTheStars.WorldGeneration/NameGenerator.cs
@@ -41,12 +41,21 @@ public static class NameGenerator
     public static string Creature(Random rng)
         => Word(rng, 2, 3) + " " + Word(rng, 1, 2).ToLowerInvariant();
 
+    private static readonly string[] TreeSuffixes =
+    {
+        "wood", "bark", "oak", "pine", "timber", "trunk", "grove", "ash", "elm", "fir",
+    };
+
     /// <summary>A coined flora name, e.g. "Skarn weed" or "Threll" — a stem, usually with a botanical suffix.</summary>
     public static string Flora(Random rng)
     {
         string stem = Word(rng, 2, 3);
         return rng.NextDouble() < 0.75 ? stem + FloraSuffixes[rng.Next(FloraSuffixes.Length)] : stem;
     }
+
+    /// <summary>A coined tree name, e.g. "Skarnwood" or "Threlloak" — a stem with an arboreal suffix.</summary>
+    public static string Tree(Random rng)
+        => Word(rng, 2, 3) + TreeSuffixes[rng.Next(TreeSuffixes.Length)];
 
     /// <summary>A coined personal name for an NPC, e.g. "Kra Thraxon" — a short given name + a longer surname,
     /// both capitalised (so it reads as a person, not a lowercase-epithet creature). Thousands of combinations.</summary>

--- a/src/BlocksBeyondTheStars.WorldGeneration/TreeGenerator.cs
+++ b/src/BlocksBeyondTheStars.WorldGeneration/TreeGenerator.cs
@@ -1,0 +1,36 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using BlocksBeyondTheStars.Shared.Definitions;
+
+namespace BlocksBeyondTheStars.WorldGeneration;
+
+/// <summary>
+/// Deterministically derives a planet's tree identity (<see cref="TreeSpecies"/>) from the world seed +
+/// planet — the arboreal counterpart to <see cref="FloraGenerator"/>. Unlike flora there is a single tree
+/// block pair (<c>wood_log</c> + <c>tree_leaves</c>) shared by every tree shape, so a world coins exactly
+/// one tree species (the trunk and the leaves read as the same plant). Same seed + planet → the same
+/// species, so nothing needs storing. Surfaced when the player scans a trunk or leaf block.
+/// </summary>
+public static class TreeGenerator
+{
+    /// <summary>This world's tree species, or null on worlds that grow no trees (airless / barren).</summary>
+    public static TreeSpecies? Generate(PlanetType planet, long worldSeed)
+    {
+        // Airless + barren worlds grow no flora, and trees gate on flora (see WorldGenerator.StampTrees),
+        // so they have no tree identity either.
+        if (planet.IsAirless || planet.FloraDensity <= 0)
+        {
+            return null;
+        }
+
+        long planetSeed = worldSeed ^ WorldGenerator.StableHash(planet.Key) ^ 0x77EEA1100B;
+        var rng = new System.Random(unchecked((int)(planetSeed ^ (planetSeed >> 32))));
+        return new TreeSpecies
+        {
+            Id = "tr0",
+            Name = NameGenerator.Tree(rng),
+            Toxic = rng.NextDouble() < 0.3, // most trees are benign; a notable minority is toxic (matches flora)
+        };
+    }
+}

--- a/tests/BlocksBeyondTheStars.Tests/ScanningTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/ScanningTests.cs
@@ -88,6 +88,30 @@ public sealed class ScanningTests : IDisposable
     }
 
     [Fact]
+    public void ScanTree_ReportsNamedSpecies_AndTrunkLeavesShareOneDiscovery()
+    {
+        var server = Started("jungle", out var repo); // a treed world
+        using (repo)
+        {
+            var p = server.AddLocalPlayer("Scout");
+
+            // The trunk scans as this world's coined, edible/toxic tree species — not the raw block key.
+            var trunk = server.ScanSubject("Scout", "block", "wood_log");
+            Assert.True(trunk.FirstTime);
+            Assert.True(trunk.KnowledgeGained >= 1);
+            Assert.NotEqual("wood_log", trunk.Subject);
+            Assert.Contains(trunk.Threat, new[] { "Edible", "Toxic" });
+
+            // The leaves are the SAME tree → already discovered, so no further knowledge.
+            var leaves = server.ScanSubject("Scout", "block", "tree_leaves");
+            Assert.False(leaves.FirstTime);
+            Assert.Equal(0, leaves.KnowledgeGained);
+            Assert.Equal(trunk.Subject, leaves.Subject);          // same coined name
+            Assert.Equal(trunk.KnowledgeGained, p.State.KnowledgePoints); // unchanged
+        }
+    }
+
+    [Fact]
     public void ScanAsteroid_RevealsResources_AndGrantsKnowledge()
     {
         var server = Started("rocky", out var repo, r => r.FreeSpaceFlight = true);


### PR DESCRIPTION
## What

Scanning a tree trunk (`wood_log`) or leaves (`tree_leaves`) previously returned a generic block readout ("Yields: wood_log×1") with no species name — unlike flora, which scans as a coined, edible/toxic species. Trees now read the same way.

## Changes

- **New `TreeSpecies`** (Shared/Definitions) + **`TreeGenerator`** roster (WorldGeneration): one coined tree species per world, deterministic from world seed + planet, nothing stored. The arboreal counterpart to `FloraSpecies`/`FloraGenerator`.
- **`NameGenerator.Tree`** coins arboreal names (e.g. "Skarnwood").
- **Server** builds the tree species in `InitFlora` (`_treeSpecies`/`_treeBlockIds`) and exposes `TreeSpeciesForBlock`.
- **Scanner** (`GameServerScanning`) names + classifies a scanned tree (edible/toxic). Trunk and leaves share one species **and** one first-scan ledger key, so scanning either part counts as a single discovery worth 1 knowledge point.
- Tests + user manual updated.

## Notes / decisions

- Trees are intentionally **not** added to `FloraCatalog` (which drives worldgen placement, regrow, replant-host validation and billboard rendering) — a parallel tree roster keeps those systems untouched.
- There is only one tree block pair in the game, so a world has exactly one tree species; trunk + leaves deliberately share it.

## Verification

- 738/738 server tests green (incl. new `ScanTree_…`), 0 warnings.
- No `client/Assets` changes → no Unity build required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)