### PR TITLE
docs(adr): mark ADR 0009 (embedded browser) as superseded

### DIFF
--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -85,6 +85,6 @@ ones are marked, not deleted.
 - [0006 — Torus world topology](adr/0006-torus-world-topology.md)
 - [0007 — Multi-world resident instancing](adr/0007-multi-world-resident-instancing.md)
 - [0008 — Optional, offline-safe LLM backend](adr/0008-optional-offline-safe-llm-backend.md)
-- [0009 — Embedded browser for the in-game Wiki + Arcade](adr/0009-embedded-browser-wiki-arcade.md)
+- [0009 — Embedded browser for the in-game Wiki + Arcade](adr/0009-embedded-browser-wiki-arcade.md) — *superseded (now native UI)*
 - [0010 — Velopack distribution + self-host portal](adr/0010-velopack-distribution-and-self-host-portal.md)
 - [0011 — CodeQL code scanning strategy](adr/0011-codeql-security-scanning-strategy.md)

--- a/docs/developer/adr/0009-embedded-browser-wiki-arcade.md
+++ b/docs/developer/adr/0009-embedded-browser-wiki-arcade.md
@@ -1,8 +1,17 @@
 # ADR 0009 — In-game Wiki and Arcade via an embedded browser
 
-- **Status:** Accepted
+- **Status:** Superseded (2026-06-26) — the embedded browser was replaced by native Unity UI.
 - **Date:** 2026-06-19
 - **Context source:** `MINIGAMES_AND_WIKI.md`
+
+> **Superseded (2026-06-26).** The "Stream D" refactor removed the embedded browser
+> (UnityWebBrowser/CEF) entirely. The Codex/Wiki is now a native uGUI screen (`WikiUI.cs`) and the
+> Arcade runs a pure, engine-free C# host (`Client.Core/Minigames/MinigameHost`) that renders a
+> `Canvas2D` to a texture (`MinigameHostUI.cs`). No UWB/CEF packages, no `BBS_UWB` define and no
+> `LocalContentServer` are shipped anymore; `web/` is retained only as the authoring source the C#
+> games were ported from. Because the native UI carries no browser-engine dependency, it also builds
+> cross-platform (Linux) and removes the WebGL blocker noted in *Consequences* below. This record is
+> kept for historical context; the decision it describes is no longer in effect.
 
 ## Context
 


### PR DESCRIPTION
Final cleanup of the Stream-D leftovers (after #69 / #72 / #73).

ADR 0009 documented rendering the in-game Wiki + Arcade through an embedded browser (UnityWebBrowser/CEF). That approach was replaced by native Unity UI — `WikiUI` for the Codex and a pure C# `MinigameHost` for the Arcade — so the decision is no longer in effect.

- Set the ADR status to **Superseded (2026-06-26)** with a note explaining the native-UI replacement (the record itself is kept as history).
- Flagged it as *superseded* in the ADR index (`docs/developer/README.md`).

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)