### PR TITLE
Longer planet view distance + smoother on-foot performance

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -72,8 +72,11 @@ view distance fixed: at VD8 ~1700 active MeshColliders were shoved through the P
 RepositionChunks — now colliders are disabled beyond `ChunkColliderDistanceBlocks` (96 m, baked mesh kept for instant
 re-enable) and chunk components are cached (no per-move GetComponent); reposition also re-triggers on vertical movement so a
 straight-down fall re-enables ground colliders in time. New tests: `ChunkStreamingTests` (budget + far-sweep + client VD),
-client e2e `ClientViewDistance_ExtendsTheStreamedTerrain_OverTheWire`. STILL OPEN: chunk LOD (A5) for VD8 to be fully smooth
-+ fill faster; client far-chunk unload; haze fine-tune. Plan: `plans/PLANET_VIEW_DISTANCE_AND_SMOOTHNESS_PLAN.md`.
+client e2e `ClientViewDistance_ExtendsTheStreamedTerrain_OverTheWire`. **LOD step 1 (distance-based vertical detail):** far
+columns (Chebyshev > 3) stream only the band around their actual surface instead of the full -3..+2 span, roughly halving the
+chunk count at VD8 (~1734→~770) for faster fill + a lighter client — near columns keep the full span for caves/digging
+(`FarColumns_StreamOnlyTheSurfaceBand...`). STILL OPEN: visual far-mesh/greedy LOD (render kept chunks cheaper / see beyond
+VD8); client far-chunk unload; haze fine-tune. Plan: `plans/PLANET_VIEW_DISTANCE_AND_SMOOTHNESS_PLAN.md`.
 
 ### ★ Fix titanium/carbide progression deadlock (2026-06-26) — ✅ data+tests green, NOT committed to main, content/data only (no Unity build)
 Confirmed a pre-existing **hard survival deadlock**: the only Tier-2 drill (`titanium_drill`) required `carbide`, but carbide

--- a/TODO.md
+++ b/TODO.md
@@ -6,7 +6,7 @@ plans live under [docs/](docs/) (committed); this file is the high-level status.
 keep it current when controls/features change. Last consolidated 2026-06-04.
 
 **Build:** `scripts/build-client.ps1` (Windows) or `scripts/build-client.sh` (Linux) — publishes shared libs + bundled server + Unity player.
-**Test:** `dotnet test` — currently **795 passing** (2026-06-26). Locale parity (en/de) is enforced by a test.
+**Test:** `dotnet test` — currently **741 server + 86 client passing** (2026-06-27). Locale parity (en/de) is enforced by a test.
 **Conventions:** English docs/comments; in-game text bilingual DE+EN; commit to `main` with the
 Claude `Co-Authored-By` trailer; OpenAI texture + ElevenLabs sound generation is blanket-approved
 (no per-batch gate).
@@ -59,6 +59,21 @@ Per-item detail lives in the dated work log below.
   single-source-of-truth working end-to-end (validated: published the initial Windows zip).
 
 ---
+
+### ★ Planet view distance + on-foot smoothness (2026-06-27) — ✅ server 741 + client 86 tests green, local Unity build green, on branch `feat/planet-view-distance` (NOT merged)
+Planet surface felt close-horizoned and slow. **A1** default render distance 2→4 (~32→64 m; per-planet/weather haze still
+scales off it). **A2** the hard-coded per-tick chunk-stream budget is now `ServerConfig.ChunkStreamPerTick` (default 16,
+host-tunable) so the wider view fills faster — the true off-thread worker-pool gen was judged too risky to land blind (the
+cratered-moon flag is ambient on the shared generator; SQLite threading). **A4** wired the previously-dead
+`ServerWorld.UnloadFarChunks` into a throttled tick sweep so the server chunk cache stops growing unbounded on exploration.
+**C** per-player view distance: the in-game slider now travels in `JoinRequest.ViewDistanceChunks` (clamped 1–8) and drives
+server streaming, so it extends actual terrain on dedicated servers too, not just local fog. **A3** on-foot input-lag at high
+view distance fixed: at VD8 ~1700 active MeshColliders were shoved through the PhysX broadphase every block-moved by
+RepositionChunks — now colliders are disabled beyond `ChunkColliderDistanceBlocks` (96 m, baked mesh kept for instant
+re-enable) and chunk components are cached (no per-move GetComponent); reposition also re-triggers on vertical movement so a
+straight-down fall re-enables ground colliders in time. New tests: `ChunkStreamingTests` (budget + far-sweep + client VD),
+client e2e `ClientViewDistance_ExtendsTheStreamedTerrain_OverTheWire`. STILL OPEN: chunk LOD (A5) for VD8 to be fully smooth
++ fill faster; client far-chunk unload; haze fine-tune. Plan: `plans/PLANET_VIEW_DISTANCE_AND_SMOOTHNESS_PLAN.md`.
 
 ### ★ Fix titanium/carbide progression deadlock (2026-06-26) — ✅ data+tests green, NOT committed to main, content/data only (no Unity build)
 Confirmed a pre-existing **hard survival deadlock**: the only Tier-2 drill (`titanium_drill`) required `carbide`, but carbide

--- a/TODO.md
+++ b/TODO.md
@@ -75,8 +75,11 @@ straight-down fall re-enables ground colliders in time. New tests: `ChunkStreami
 client e2e `ClientViewDistance_ExtendsTheStreamedTerrain_OverTheWire`. **LOD step 1 (distance-based vertical detail):** far
 columns (Chebyshev > 3) stream only the band around their actual surface instead of the full -3..+2 span, roughly halving the
 chunk count at VD8 (~1734→~770) for faster fill + a lighter client — near columns keep the full span for caves/digging
-(`FarColumns_StreamOnlyTheSurfaceBand...`). STILL OPEN: visual far-mesh/greedy LOD (render kept chunks cheaper / see beyond
-VD8); client far-chunk unload; haze fine-tune. Plan: `plans/PLANET_VIEW_DISTANCE_AND_SMOOTHNESS_PLAN.md`.
+(`FarColumns_StreamOnlyTheSurfaceBand...`). **Client far-chunk unload:** the client used to never unload (its chunk set + the
+per-block reposition loop grew unbounded over long travel); now chunks past `ChunkUnloadDistanceBlocks` (384, beyond the 256
+renderer cull) are destroyed, and the server's far-chunk sweep also drops the evicted coords from every player's sent-set so
+they re-stream fresh on return — no new protocol. STILL OPEN: visual far-mesh/greedy LOD (render kept chunks cheaper / see
+beyond VD8); haze fine-tune. Plan: `plans/PLANET_VIEW_DISTANCE_AND_SMOOTHNESS_PLAN.md`.
 
 ### ★ Fix titanium/carbide progression deadlock (2026-06-26) — ✅ data+tests green, NOT committed to main, content/data only (no Unity build)
 Confirmed a pre-existing **hard survival deadlock**: the only Tier-2 drill (`titanium_drill`) required `carbide`, but carbide

--- a/TODO.md
+++ b/TODO.md
@@ -78,8 +78,11 @@ chunk count at VD8 (~1734→~770) for faster fill + a lighter client — near co
 (`FarColumns_StreamOnlyTheSurfaceBand...`). **Client far-chunk unload:** the client used to never unload (its chunk set + the
 per-block reposition loop grew unbounded over long travel); now chunks past `ChunkUnloadDistanceBlocks` (384, beyond the 256
 renderer cull) are destroyed, and the server's far-chunk sweep also drops the evicted coords from every player's sent-set so
-they re-stream fresh on return — no new protocol. STILL OPEN: visual far-mesh/greedy LOD (render kept chunks cheaper / see
-beyond VD8); haze fine-tune. Plan: `plans/PLANET_VIEW_DISTANCE_AND_SMOOTHNESS_PLAN.md`.
+they re-stream fresh on return — no new protocol. **Haze fine-tune:** the fog start fraction + max haze are now tied to the
+world's atmosphere density (clear/thin worlds stay crisp across near+mid and only veil the far edge; soupy worlds + fog/sand
+weather stay near & dense), so a clear world shows the farther terrain the larger view distance streams. STILL OPEN: visual
+far-mesh/greedy LOD (render kept chunks cheaper / see beyond VD8) — high risk, in-editor iteration only. Plan:
+`plans/PLANET_VIEW_DISTANCE_AND_SMOOTHNESS_PLAN.md`.
 
 ### ★ Fix titanium/carbide progression deadlock (2026-06-26) — ✅ data+tests green, NOT committed to main, content/data only (no Unity build)
 Confirmed a pre-existing **hard survival deadlock**: the only Tier-2 drill (`titanium_drill`) required `carbide`, but carbide

--- a/client/Assets/BlocksBeyondTheStars/Scripts/ClientSettings.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/ClientSettings.cs
@@ -67,7 +67,12 @@ namespace BlocksBeyondTheStars.Client
         public int WindowedWidth = 1600;
         public int WindowedHeight = 900;
 
-        public int ViewDistanceChunks = 2;
+        // Default render distance in 16-block chunks (slider range 1–8 in the settings menu). Raised from the old
+        // default of 2 (≈32 m — a near, foggy horizon) to 4 (≈64 m) so the world reads farther out of the box; the
+        // per-planet/weather haze still scales off this (Sky.ApplyFog), so denser-atmosphere worlds stay hazier.
+        // Singleplayer forwards this to the bundled server as the streaming radius (AppShell → --view-distance),
+        // and the server now reclaims out-of-range chunks (far-chunk sweep), so the larger radius stays bounded.
+        public int ViewDistanceChunks = 4;
         public float UiScale = 1f;
 
         // Frame pacing. Exposed as its own switch instead of being baked into the quality preset: with VSync

--- a/client/Assets/BlocksBeyondTheStars/Scripts/GameBootstrap.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/GameBootstrap.cs
@@ -789,6 +789,13 @@ namespace BlocksBeyondTheStars.Client
         // (the sharedMesh stays assigned, no re-bake). Generous enough to cover footing, jumps, and digging.
         public float ChunkColliderDistanceBlocks = 96f;
 
+        // Performance: the client otherwise NEVER unloads a chunk, so a long exploration grows _chunkObjects (and
+        // the per-block-move RepositionChunks loop over it) without bound. Chunks farther than this are destroyed —
+        // set well beyond the renderer-cull distance so a chunk that could still be visible is never dropped; the
+        // server's far-chunk sweep forgets the same chunks, so they re-stream fresh if the player walks back.
+        public float ChunkUnloadDistanceBlocks = 384f;
+        private readonly List<ChunkCoord> _unloadScratch = new List<ChunkCoord>();
+
         // Performance (P2): assigning MeshCollider.sharedMesh cooks the collision mesh synchronously on the
         // main thread — the single heaviest per-chunk op. Instead we run Physics.BakeMesh on a worker thread
         // and assign the (now-cached) cook back on the main thread in DrainBakedColliders. _colliderGen +
@@ -1236,6 +1243,8 @@ namespace BlocksBeyondTheStars.Client
             var pp = PlayerPosition;
             float cullSq = ChunkDrawDistanceBlocks * ChunkDrawDistanceBlocks;
             float colliderSq = ChunkColliderDistanceBlocks * ChunkColliderDistanceBlocks;
+            float unloadSq = ChunkUnloadDistanceBlocks * ChunkUnloadDistanceBlocks;
+            _unloadScratch.Clear();
             foreach (var kv in _chunkObjects)
             {
                 var view = kv.Value;
@@ -1248,6 +1257,15 @@ namespace BlocksBeyondTheStars.Client
                 view.Go.transform.position = new Vector3(SceneX(origin.X), origin.Y, SceneZ(origin.Z));
 
                 float distSq = ChunkDistSqToPlayer(kv.Key, pp);
+
+                // Far-chunk unload: a chunk the player has travelled well past (beyond even the renderer cull) is
+                // destroyed so the resident set stays bounded. Collected here, removed after the loop (can't mutate
+                // the dictionary mid-iteration). The server forgets it too, so it re-streams if the player returns.
+                if (distSq > unloadSq)
+                {
+                    _unloadScratch.Add(kv.Key);
+                    continue;
+                }
 
                 // Distance culling: disable the renderer of chunks well beyond the draw distance so the
                 // accumulated far chunks stop costing draw calls; re-enabled when the player moves back into
@@ -1268,6 +1286,24 @@ namespace BlocksBeyondTheStars.Client
                     view.Collider.enabled = collide;
                     view.ColliderEnabled = collide;
                 }
+            }
+
+            // Process the far-chunk unloads collected above (after iterating, so the dictionary isn't mutated
+            // mid-loop). Drop every bit of per-chunk bookkeeping so nothing dangles, and the world data + its
+            // light sources, then destroy the GameObject. A re-stream rebuilds it from scratch.
+            for (int i = 0; i < _unloadScratch.Count; i++)
+            {
+                var coord = _unloadScratch[i];
+                if (_chunkObjects.TryGetValue(coord, out var view) && view?.Go != null)
+                {
+                    Destroy(view.Go);
+                }
+
+                _chunkObjects.Remove(coord);
+                _dirty.Remove(coord);
+                _colliderGen.Remove(coord);
+                _meshGen.Remove(coord);
+                World.RemoveChunk(coord);
             }
         }
 

--- a/client/Assets/BlocksBeyondTheStars/Scripts/GameBootstrap.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/GameBootstrap.cs
@@ -29,6 +29,10 @@ namespace BlocksBeyondTheStars.Client
         /// <summary>Per-install name-verification secret (see <see cref="ClientSettings.PlayerToken"/>).</summary>
         public string Token = "";
 
+        /// <summary>The player's chosen render distance in chunks, forwarded to the server in the JoinRequest so a
+        /// remote/dedicated host streams terrain at this radius (not just the local fog). 0 = let the server decide.</summary>
+        public int ViewDistanceChunks = 0;
+
         /// <summary>While this client hosts the server in-game: the "ip:port" friends join over the LAN
         /// (announced in chat + as a toast). Empty when joining a remote server or in singleplayer.</summary>
         public string HostInfo = "";
@@ -746,7 +750,23 @@ namespace BlocksBeyondTheStars.Client
             return string.Empty;
         }
 
-        private readonly Dictionary<ChunkCoord, GameObject> _chunkObjects = new Dictionary<ChunkCoord, GameObject>();
+        /// <summary>A loaded chunk's GameObject plus its cached components, so the per-block-move reposition pass
+        /// (RepositionChunks) never calls GetComponent on every loaded chunk — at a large view distance that loop
+        /// runs over ~1700 chunks each time the player crosses a block, and GetComponent there was a real cost.
+        /// <see cref="ColliderEnabled"/>/<see cref="RendererEnabled"/> cache the current toggle state so we only
+        /// flip a component when it actually changes (toggling a MeshCollider adds/removes it from the PhysX
+        /// broadphase — doing that needlessly per move is exactly the hitch we're avoiding).</summary>
+        private sealed class ChunkView
+        {
+            public GameObject Go = null!;
+            public MeshFilter Filter = null!;
+            public MeshRenderer Renderer = null!;
+            public MeshCollider Collider = null!;
+            public bool ColliderEnabled = true;
+            public bool RendererEnabled = true;
+        }
+
+        private readonly Dictionary<ChunkCoord, ChunkView> _chunkObjects = new Dictionary<ChunkCoord, ChunkView>();
         private readonly HashSet<ChunkCoord> _dirty = new HashSet<ChunkCoord>();
 
         // Performance (P1): cap how many chunk meshes are (re)built per frame so a burst of chunks arriving
@@ -760,6 +780,14 @@ namespace BlocksBeyondTheStars.Client
         // draw calls. Generous default so normally-visible chunks are never culled; lower it to trade view
         // distance for fewer draw calls. Re-evaluated in RepositionChunks (throttled to once per block moved).
         public float ChunkDrawDistanceBlocks = 256f;
+
+        // Performance: collision is only needed where the player can actually walk/dig, so chunks farther than
+        // this (blocks, seam-aware 3D distance) keep their baked collision mesh but have the MeshCollider DISABLED.
+        // A disabled collider is out of the PhysX broadphase, so RepositionChunks moving its transform every
+        // block-moved is cheap — at a high view distance, leaving ~1700 colliders active and shoving them through
+        // the static broadphase each move was the main on-foot input-lag/stutter source. Re-enabling is instant
+        // (the sharedMesh stays assigned, no re-bake). Generous enough to cover footing, jumps, and digging.
+        public float ChunkColliderDistanceBlocks = 96f;
 
         // Performance (P2): assigning MeshCollider.sharedMesh cooks the collision mesh synchronously on the
         // main thread — the single heaviest per-chunk op. Instead we run Physics.BakeMesh on a worker thread
@@ -1121,7 +1149,7 @@ namespace BlocksBeyondTheStars.Client
                 if (Network.Connected)
                 {
                     Network.Join(PlayerName, string.IsNullOrEmpty(Password) ? null : Password, German ? "de" : "en",
-                        string.IsNullOrEmpty(Token) ? null : Token);
+                        string.IsNullOrEmpty(Token) ? null : Token, ViewDistanceChunks);
                     Network.SendAppearance(SkinRgb, TorsoRgb, ArmRgb, LegRgb, HullRgb);
                     if (!string.IsNullOrEmpty(FacePixels))
                     {
@@ -1181,18 +1209,23 @@ namespace BlocksBeyondTheStars.Client
             // Round worlds: keep every loaded chunk drawn at the copy nearest the player as it laps the world
             // in EITHER direction. Near chunks resolve to their canonical position (a no-op write); only
             // chunks across a seam shift by ±Circumference (X) / ±LatitudePeriod (Z). Throttled to once per
-            // block of movement on either axis.
+            // block of movement on any axis. Y is included because the renderer-cull and near-only-collider
+            // toggling in RepositionChunks are 3D distance-based: a straight-down jetpack descent must re-enable
+            // the ground colliders below before the player reaches them, or they'd fall through.
             int chunkAnchorX = Mathf.FloorToInt(PlayerPosition.x);
+            int chunkAnchorY = Mathf.FloorToInt(PlayerPosition.y);
             int chunkAnchorZ = Mathf.FloorToInt(PlayerPosition.z);
-            if (chunkAnchorX != _lastReposX || chunkAnchorZ != _lastReposZ)
+            if (chunkAnchorX != _lastReposX || chunkAnchorY != _lastReposY || chunkAnchorZ != _lastReposZ)
             {
                 _lastReposX = chunkAnchorX;
+                _lastReposY = chunkAnchorY;
                 _lastReposZ = chunkAnchorZ;
                 RepositionChunks();
             }
         }
 
         private int _lastReposX = int.MinValue;
+        private int _lastReposY = int.MinValue;
         private int _lastReposZ = int.MinValue;
 
         /// <summary>Re-places every loaded chunk GameObject at the seam-aware scene position for the player's
@@ -1202,28 +1235,38 @@ namespace BlocksBeyondTheStars.Client
         {
             var pp = PlayerPosition;
             float cullSq = ChunkDrawDistanceBlocks * ChunkDrawDistanceBlocks;
+            float colliderSq = ChunkColliderDistanceBlocks * ChunkColliderDistanceBlocks;
             foreach (var kv in _chunkObjects)
             {
-                if (kv.Value == null)
+                var view = kv.Value;
+                if (view == null || view.Go == null)
                 {
                     continue;
                 }
 
                 var origin = WorldConstants.ChunkOrigin(kv.Key);
-                kv.Value.transform.position = new Vector3(SceneX(origin.X), origin.Y, SceneZ(origin.Z));
+                view.Go.transform.position = new Vector3(SceneX(origin.X), origin.Y, SceneZ(origin.Z));
 
-                // Distance culling (A4): disable the renderer of chunks well beyond the draw distance so the
-                // accumulated far chunks (never unloaded) stop costing draw calls; re-enabled when the player
-                // moves back into range. Colliders are left intact (cheap when untouched, and far physics still
-                // resolves). Frustum culling Unity does for free once the per-chunk bounds are correct (A1).
-                var mr = kv.Value.GetComponent<MeshRenderer>();
-                if (mr != null)
+                float distSq = ChunkDistSqToPlayer(kv.Key, pp);
+
+                // Distance culling: disable the renderer of chunks well beyond the draw distance so the
+                // accumulated far chunks stop costing draw calls; re-enabled when the player moves back into
+                // range. Frustum culling Unity does for free once the per-chunk bounds are correct.
+                bool visible = distSq <= cullSq;
+                if (view.RendererEnabled != visible && view.Renderer != null)
                 {
-                    bool visible = ChunkDistSqToPlayer(kv.Key, pp) <= cullSq;
-                    if (mr.enabled != visible)
-                    {
-                        mr.enabled = visible;
-                    }
+                    view.Renderer.enabled = visible;
+                    view.RendererEnabled = visible;
+                }
+
+                // Near-only colliders: only chunks within reach keep an ACTIVE collider; far ones are disabled so
+                // moving their transform each block costs nothing in PhysX (the broadphase ignores them). The
+                // baked sharedMesh stays assigned, so coming back into range re-enables collision instantly.
+                bool collide = distSq <= colliderSq;
+                if (view.ColliderEnabled != collide && view.Collider != null)
+                {
+                    view.Collider.enabled = collide;
+                    view.ColliderEnabled = collide;
                 }
             }
         }
@@ -1289,16 +1332,16 @@ namespace BlocksBeyondTheStars.Client
             LandedShips.Clear();
             LandedShipsChanged?.Invoke();
 
-            foreach (var go in _chunkObjects.Values)
+            foreach (var view in _chunkObjects.Values)
             {
-                if (go != null)
+                if (view?.Go != null)
                 {
                     // SetActive(false) takes effect immediately; Destroy is deferred to frame end. Without
                     // this the settle-freeze raycast (PlayerController) could still hit a stale collider from
                     // the *old* world this frame, "find ground", release early, and drop the player into the
                     // void before the new world's floor chunk has streamed in (the station-boarding fall).
-                    go.SetActive(false);
-                    Destroy(go);
+                    view.Go.SetActive(false);
+                    Destroy(view.Go);
                 }
             }
 
@@ -1603,28 +1646,29 @@ namespace BlocksBeyondTheStars.Client
         {
             // Reuse this chunk's existing render mesh on a rebuild (A3) — avoids a per-remesh Mesh allocation and
             // the leak of the previous one (A2 raises the rebuild rate, which would otherwise grow that leak).
-            bool exists = _chunkObjects.TryGetValue(coord, out var go) && go != null;
-            var reuse = exists ? go.GetComponent<MeshFilter>().sharedMesh : null;
+            bool exists = _chunkObjects.TryGetValue(coord, out var view) && view?.Go != null;
+            var reuse = exists ? view!.Filter.sharedMesh : null;
             var (mesh, collider) = data.ToMeshes(reuse);
 
             if (!exists)
             {
-                go = new GameObject($"Chunk {coord.X},{coord.Y},{coord.Z}");
+                var go = new GameObject($"Chunk {coord.X},{coord.Y},{coord.Z}");
                 go.transform.SetParent(transform);
                 var origin = WorldConstants.ChunkOrigin(coord);
                 go.transform.position = new Vector3(SceneX(origin.X), origin.Y, SceneZ(origin.Z)); // seam-aware on both ground axes (torus)
-                go.AddComponent<MeshFilter>();
+                var filter = go.AddComponent<MeshFilter>();
                 var mr = go.AddComponent<MeshRenderer>();
                 // Submesh 0 → opaque atlas, submesh 1 → see-through atlas (glass/fields). Fall back to a
                 // single material if the transparent shader is missing (the spare submesh just won't draw).
                 mr.sharedMaterials = ChunkMaterialTransparent != null
                     ? new[] { ChunkMaterial, ChunkMaterialTransparent }
                     : new[] { ChunkMaterial };
-                go.AddComponent<MeshCollider>();
-                _chunkObjects[coord] = go;
+                var mc = go.AddComponent<MeshCollider>();
+                view = new ChunkView { Go = go, Filter = filter, Renderer = mr, Collider = mc };
+                _chunkObjects[coord] = view;
             }
 
-            go.GetComponent<MeshFilter>().sharedMesh = mesh;
+            view!.Filter.sharedMesh = mesh;
 
             // The collider uses the solid-only mesh (fluids excluded) so the player can swim into water/lava.
             // Baking the collision mesh is the heaviest per-chunk step, so do it off the main thread (P2): bump
@@ -1632,7 +1676,7 @@ namespace BlocksBeyondTheStars.Client
             // in DrainBakedColliders.
             int bakeGen = (_colliderGen.TryGetValue(coord, out var g) ? g : 0) + 1;
             _colliderGen[coord] = bakeGen;
-            var mcol = go.GetComponent<MeshCollider>();
+            var mcol = view!.Collider;
             if (collider == null)
             {
                 if (mcol != null)
@@ -1672,9 +1716,9 @@ namespace BlocksBeyondTheStars.Client
                 bool assigned = false;
                 if (baked.Epoch == WorldEpoch
                     && _colliderGen.TryGetValue(baked.Coord, out var gen) && gen == baked.Gen
-                    && _chunkObjects.TryGetValue(baked.Coord, out var go) && go != null)
+                    && _chunkObjects.TryGetValue(baked.Coord, out var view) && view?.Go != null)
                 {
-                    var mc = go.GetComponent<MeshCollider>();
+                    var mc = view.Collider;
                     if (mc != null)
                     {
                         mc.sharedMesh = baked.Collider; // cook cached by BakeMesh → cheap assign, no main-thread stall

--- a/client/Assets/BlocksBeyondTheStars/Scripts/Sky.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/Sky.cs
@@ -394,14 +394,22 @@ namespace BlocksBeyondTheStars.Client
                 far = Mathf.Lerp(far, far * 0.7f, dawn);
             }
 
-            RenderSettings.fogStartDistance = far * 0.55f;
+            // Where the haze begins, as a fraction of the far edge: thin/clear-air worlds stay CRISP across the
+            // near + mid distance and only veil the far edge (high start), while soupy worlds haze from much
+            // closer in (low start). This keeps the per-planet/per-atmosphere character while letting a clear
+            // world actually show the farther terrain the (now larger) view distance streams. Weather that already
+            // crushed `far` keeps its near, dense look — a small `far` lands the haze close even at a high factor.
+            float startFactor = Mathf.Lerp(0.72f, 0.5f, Mathf.Clamp01(airDensity));
+            float fogStart = far * startFactor;
+            RenderSettings.fogStartDistance = fogStart;
             RenderSettings.fogEndDistance = far;
 
             // The actual visible haze: an explicit distance blend the block shader applies (Unity's MixFog is dead
-            // on the unlit voxels). Strong toward the sky at the far edge so it masks chunk pop-in; faded out
-            // indoors via _indoor so the cabin never hazes.
-            float maxHaze = (FogEnabled ? 0.7f : 0f) * (1f - _indoor); // 0 indoors or when the player disabled fog
-            Shader.SetGlobalVector(FogId, new Vector4(far * 0.55f, far, maxHaze, FogEnabled ? 1f : 0f));
+            // on the unlit voxels). Strong toward the sky at the far edge so it masks chunk pop-in; a touch thinner
+            // on clear worlds so distant terrain reads through; faded out indoors via _indoor so the cabin never hazes.
+            float hazeStrength = Mathf.Lerp(0.6f, 0.75f, Mathf.Clamp01(airDensity));
+            float maxHaze = (FogEnabled ? hazeStrength : 0f) * (1f - _indoor); // 0 indoors or when the player disabled fog
+            Shader.SetGlobalVector(FogId, new Vector4(fogStart, far, maxHaze, FogEnabled ? 1f : 0f));
         }
 
         /// <summary>Places the glowing sun billboard in the sky in the sun direction, tinted by the

--- a/client/Assets/BlocksBeyondTheStars/Scripts/WorldRig.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/WorldRig.cs
@@ -34,6 +34,7 @@ namespace BlocksBeyondTheStars.Client
             boot.Token = shell.Settings.PlayerToken ?? "";
             boot.HostInfo = shell.HostInfo ?? "";
             boot.German = shell.Settings.Language == "de";
+            boot.ViewDistanceChunks = shell.Settings.ViewDistanceChunks; // forward the slider so remote hosts stream this radius
             boot.ChunkMaterial = material;
             boot.SkinRgb = Rgb(shell.Settings.SkinColor);
             boot.TorsoRgb = Rgb(shell.Settings.TorsoColor);

--- a/src/BlocksBeyondTheStars.Client.Core/ClientWorld.cs
+++ b/src/BlocksBeyondTheStars.Client.Core/ClientWorld.cs
@@ -78,6 +78,35 @@ namespace BlocksBeyondTheStars.Client
             _lightSources.Clear();
         }
 
+        /// <summary>Drops a single chunk the client has travelled well out of view of, so the client-side chunk
+        /// cache (and its light-source index) stays bounded over a long exploration instead of growing for the
+        /// whole distance travelled. The server's far-chunk sweep forgets the same chunk, so it re-streams fresh
+        /// if the player returns. Returns whether a chunk was actually removed.</summary>
+        public bool RemoveChunk(ChunkCoord coord)
+        {
+            coord = WorldConstants.CanonicalChunk(coord, _circumference);
+            if (!_chunks.Remove(coord))
+            {
+                return false;
+            }
+
+            // Clear this chunk's glow-block light sources too (only if any exist — usually none, so skip the
+            // 16³ scan entirely on the common path).
+            if (_lightSources.Count > 0)
+            {
+                var origin = WorldConstants.ChunkOrigin(coord);
+                int nsz = WorldConstants.ChunkSize;
+                for (int x = 0; x < nsz; x++)
+                    for (int y = 0; y < nsz; y++)
+                        for (int z = 0; z < nsz; z++)
+                        {
+                            _lightSources.Remove(new Vector3i(origin.X + x, origin.Y + y, origin.Z + z));
+                        }
+            }
+
+            return true;
+        }
+
         public bool TryGetChunk(ChunkCoord coord, out ChunkData chunk)
             => _chunks.TryGetValue(WorldConstants.CanonicalChunk(coord, _circumference), out chunk);
 

--- a/src/BlocksBeyondTheStars.Client.Core/NetworkClient.cs
+++ b/src/BlocksBeyondTheStars.Client.Core/NetworkClient.cs
@@ -138,8 +138,8 @@ namespace BlocksBeyondTheStars.Client
 
         public void Connect(string host, int port) => _transport.Connect(host, port);
 
-        public void Join(string playerName, string? password = null, string locale = "en", string? token = null)
-            => Send(new JoinRequest { PlayerName = playerName, Password = password, Locale = locale, Token = token });
+        public void Join(string playerName, string? password = null, string locale = "en", string? token = null, int viewDistanceChunks = 0)
+            => Send(new JoinRequest { PlayerName = playerName, Password = password, Locale = locale, Token = token, ViewDistanceChunks = viewDistanceChunks });
 
         /// <summary>Asks the server for the greeting line of the nearby NPC of this role ("vendor"/"quartermaster")
         /// when opening its interaction (item 15). The server gates on proximity and replies with an NpcGreeting.</summary>

--- a/src/BlocksBeyondTheStars.GameServer/GameServer.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServer.cs
@@ -119,6 +119,10 @@ public sealed partial class GameServer
     private ServerWorld _world => _worlds.Active.World;
 
     private double _sinceAutoSave;
+    // Far-chunk unload throttle: sweeping every loaded chunk against every player each tick would be wasteful,
+    // so the server only evicts out-of-range cached chunks on this cadence (seconds). Bounds server memory on
+    // long exploration — without it _loaded grows unbounded as a player crosses the world (the cache never shrank).
+    private double _sinceChunkSweep;
     // Fractional playtime carry: whole seconds are flushed into _meta.CumulativePlaytimeSeconds, the
     // sub-second remainder lives here between ticks. Only advanced while a player is joined.
     private double _playtimeCarry;
@@ -745,6 +749,15 @@ public sealed partial class GameServer
             ticking.Add(_worlds.Active.LocationId);
         }
 
+        // Decide once per tick whether this is a chunk-sweep tick (throttled), then run the eviction per active
+        // world inside the loop so each world's anchors are its own players. See SweepFarChunks.
+        _sinceChunkSweep += deltaSeconds;
+        bool sweepDue = _sinceChunkSweep >= ChunkSweepIntervalSeconds;
+        if (sweepDue)
+        {
+            _sinceChunkSweep = 0;
+        }
+
         foreach (var locId in ticking)
         {
             if (!SetActiveWorld(locId))
@@ -766,6 +779,10 @@ public sealed partial class GameServer
             TickVoidRescue(deltaSeconds);
             TickShipAi(deltaSeconds); // VEGA advisor hints + memory-fragment redemption
             StreamChunks();
+            if (sweepDue)
+            {
+                SweepFarChunks();
+            }
         }
 
         SampleHistories(deltaSeconds);
@@ -1226,10 +1243,20 @@ public sealed partial class GameServer
         SendNpcs(session);
     }
 
+    /// <summary>Upper bound on a client-requested render distance (matches the in-game slider's max), so a
+    /// spoofed JoinRequest can't make the server stream/generate an enormous column (memory/CPU DoS).</summary>
+    private const int MaxClientViewDistanceChunks = 8;
+
+    /// <summary>This player's streaming radius in chunks: their requested view distance (clamped to the slider
+    /// range) when they sent one, otherwise the host's configured default.</summary>
+    private int EffectiveViewRadius(PlayerSession session)
+        => session.ViewDistance > 0
+            ? System.Math.Clamp(session.ViewDistance, 1, MaxClientViewDistanceChunks)
+            : System.Math.Max(1, _config.ViewDistanceChunks);
+
     private void StreamChunks()
     {
-        int radius = System.Math.Max(1, _config.ViewDistanceChunks);
-        const int perTickBudget = 12;
+        int perTickBudget = System.Math.Max(1, _config.ChunkStreamPerTick);
 
         // Chunk band the build height maps to — the streamed column is clamped into it so a spoofed player
         // position can't make the server generate/cache chunks at arbitrary heights (memory DoS). See MinBuildY.
@@ -1238,6 +1265,7 @@ public sealed partial class GameServer
 
         foreach (var session in JoinedInActiveWorld())
         {
+            int radius = EffectiveViewRadius(session); // per-player: honour the client's View Distance slider
             var center = WorldConstants.WorldToChunk(session.State.Position.ToBlock());
             center = new ChunkCoord(center.X, System.Math.Clamp(center.Y, minChunkY, maxChunkY), center.Z);
 
@@ -1292,6 +1320,39 @@ public sealed partial class GameServer
                 sent++;
             }
         }
+    }
+
+    /// <summary>How often (seconds) the server evicts cached chunks that drifted out of every player's keep-range.
+    /// Coarse on purpose: chunk caching is cheap and re-loading is on-demand, so a slow sweep is plenty to keep
+    /// memory bounded without scanning the whole cache every tick.</summary>
+    private const double ChunkSweepIntervalSeconds = 10.0;
+
+    /// <summary>Evicts cached chunks in the active world that fall outside the keep-range of every joined player,
+    /// bounding server memory on long exploration (the cache otherwise only ever grew). The keep radius sits a
+    /// few chunks beyond the streaming radius so a chunk the player can currently see is never dropped; chunks
+    /// regenerate on demand (with persisted edits re-applied) if the player returns, and the client keeps its own
+    /// copy regardless (it never unloads), so eviction is invisible. Honours <see cref="ServerConfig.MaxLoadedChunksPerPlayer"/>
+    /// in spirit by keeping the resident set proportional to the view, not the distance travelled.</summary>
+    private void SweepFarChunks()
+    {
+        var anchors = new List<ChunkCoord>();
+        int maxViewRadius = 1;
+        foreach (var session in JoinedInActiveWorld())
+        {
+            anchors.Add(WorldConstants.WorldToChunk(session.State.Position.ToBlock()));
+            maxViewRadius = System.Math.Max(maxViewRadius, EffectiveViewRadius(session));
+        }
+
+        if (anchors.Count == 0)
+        {
+            return; // nobody here — leave the cache as-is (an idle world isn't growing it)
+        }
+
+        // Keep a margin beyond the widest player's horizontal streaming radius so the diagonal/vertical fringe of
+        // the streamed column (dy -3..+2) is never evicted while still in view. A single shared keep radius (the
+        // max across players) is safe: it can only keep MORE than any one player needs, never less.
+        int keepRadius = maxViewRadius + 4;
+        _world.UnloadFarChunks(anchors, keepRadius);
     }
 
     /// <summary>Fills a chunk message's sparse colour-modifier + shape arrays from the chunk's dyed/glowing/
@@ -1624,7 +1685,7 @@ public sealed partial class GameServer
         var (joinBody, joinBodyType) = RestoreJoinBody(state);
         LoadWorld(joinBodyType, joinBody);
 
-        var session = new PlayerSession(connectionId, state) { Joined = true, CurrentLocationId = joinBody, Locale = NormalizeLocale(join.Locale) };
+        var session = new PlayerSession(connectionId, state) { Joined = true, CurrentLocationId = joinBody, Locale = NormalizeLocale(join.Locale), ViewDistance = join.ViewDistanceChunks };
         _sessions[connectionId] = session;
         SetupPlayerShip(session); // give the player their own ship, stamped into their world
         EnsureSafeSpawn(session); // self-heal a position persisted mid-fall (don't load them into the void)

--- a/src/BlocksBeyondTheStars.GameServer/GameServer.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServer.cs
@@ -1247,6 +1247,17 @@ public sealed partial class GameServer
     /// spoofed JoinRequest can't make the server stream/generate an enormous column (memory/CPU DoS).</summary>
     private const int MaxClientViewDistanceChunks = 8;
 
+    /// <summary>Horizontal radius (chunks, Chebyshev) within which the FULL vertical span streams — so caves,
+    /// overhangs and digging straight down near the player are always covered. Beyond it, only the surface band
+    /// (below) streams. Small view distances (≤ this) are therefore unaffected by the vertical LOD.</summary>
+    private const int NearFullColumnRadius = 3;
+
+    /// <summary>For far columns, how many chunks below / above the column's surface chunk still stream — the
+    /// visible shell of distant terrain (cliffs just under the surface, trees/features just above). Kept small;
+    /// fog hides the far edge, so a tall distant cliff cropping a chunk low is acceptable for the perf win.</summary>
+    private const int FarSurfaceBandBelow = 1;
+    private const int FarSurfaceBandAbove = 1;
+
     /// <summary>This player's streaming radius in chunks: their requested view distance (clamped to the slider
     /// range) when they sent one, otherwise the host's configured default.</summary>
     private int EffectiveViewRadius(PlayerSession session)
@@ -1273,16 +1284,46 @@ public sealed partial class GameServer
             // own chunk (its floor) then loads before everything else, so a freshly spawned/teleported player
             // gets solid ground under them immediately instead of falling through while a fixed bottom-up
             // order slowly works up toward the surface (which, on a fresh world's slow first-gen + a large
-            // view distance, could outlast the client's settle-freeze and drop them below the terrain). A
-            // taller vertical span (esp. below) is still covered so digging down never outruns the terrain.
+            // view distance, could outlast the client's settle-freeze and drop them below the terrain).
+            //
+            // Distance-based vertical LOD: near the player (Chebyshev ≤ NearFullColumnRadius) the FULL vertical
+            // span streams so digging down / walking into caves never outruns the terrain. Beyond that, only the
+            // band around THAT column's actual surface streams — the deep underground + high air far away are
+            // never seen, so skipping them roughly halves the chunk count at a large view distance (faster fill,
+            // lighter client). Surface-relative (not player-relative) so a distant valley or peak well off the
+            // player's own altitude still streams its visible shell.
+            var planet = _world.Planet;
             var pending = new List<(ChunkCoord Coord, int DistSq)>();
-            for (int dy = -3; dy <= 2; dy++)
-                for (int dx = -radius; dx <= radius; dx++)
-                    for (int dz = -radius; dz <= radius; dz++)
+            for (int dx = -radius; dx <= radius; dx++)
+                for (int dz = -radius; dz <= radius; dz++)
+                {
+                    int loDy, hiDy;
+                    if (System.Math.Max(System.Math.Abs(dx), System.Math.Abs(dz)) <= NearFullColumnRadius)
                     {
+                        loDy = -3;
+                        hiDy = 2; // full near column (unchanged behaviour)
+                    }
+                    else
+                    {
+                        int worldX = (center.X + dx) * WorldConstants.ChunkSize + WorldConstants.ChunkSize / 2;
+                        int worldZ = (center.Z + dz) * WorldConstants.ChunkSize + WorldConstants.ChunkSize / 2;
+                        int surfCy = WorldConstants.WorldToChunk(
+                            new Vector3i(worldX, _generator.SurfaceHeight(planet, worldX, worldZ), worldZ)).Y;
+                        loDy = surfCy - FarSurfaceBandBelow - center.Y;
+                        hiDy = surfCy + FarSurfaceBandAbove - center.Y;
+                    }
+
+                    for (int dy = loDy; dy <= hiDy; dy++)
+                    {
+                        int cy = center.Y + dy;
+                        if (cy < minChunkY || cy > maxChunkY)
+                        {
+                            continue; // never stream/generate outside the build-height band
+                        }
+
                         // Canonicalize longitude so chunks just west of the seam (center.X+dx < 0) stream as the
                         // wrapped chunk from the far side — the player can see across X = 0 ≡ X = Circumference.
-                        var coord = WorldConstants.CanonicalChunk(new ChunkCoord(center.X + dx, center.Y + dy, center.Z + dz), _world.Circumference);
+                        var coord = WorldConstants.CanonicalChunk(new ChunkCoord(center.X + dx, cy, center.Z + dz), _world.Circumference);
                         if (session.SentChunks.Contains(coord))
                         {
                             continue;
@@ -1290,6 +1331,7 @@ public sealed partial class GameServer
 
                         pending.Add((coord, dx * dx + dy * dy + dz * dz));
                     }
+                }
 
             pending.Sort((a, b) => a.DistSq.CompareTo(b.DistSq));
 

--- a/src/BlocksBeyondTheStars.GameServer/GameServer.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServer.cs
@@ -1394,7 +1394,21 @@ public sealed partial class GameServer
         // the streamed column (dy -3..+2) is never evicted while still in view. A single shared keep radius (the
         // max across players) is safe: it can only keep MORE than any one player needs, never less.
         int keepRadius = maxViewRadius + 4;
-        _world.UnloadFarChunks(anchors, keepRadius);
+        var removed = _world.UnloadFarChunks(anchors, keepRadius);
+
+        // Also drop the evicted coords from every player's sent-set. A swept chunk is far from EVERY anchor (that
+        // is the sweep's condition), so this is safe for all sessions — and it lets the client unload the same far
+        // chunks (bounding its own memory) and still get them re-streamed fresh if it walks back into range.
+        if (removed.Count > 0)
+        {
+            foreach (var session in JoinedInActiveWorld())
+            {
+                foreach (var coord in removed)
+                {
+                    session.SentChunks.Remove(coord);
+                }
+            }
+        }
     }
 
     /// <summary>Fills a chunk message's sparse colour-modifier + shape arrays from the chunk's dyed/glowing/

--- a/src/BlocksBeyondTheStars.GameServer/PlayerSession.cs
+++ b/src/BlocksBeyondTheStars.GameServer/PlayerSession.cs
@@ -41,6 +41,12 @@ public sealed class PlayerSession
     /// <summary>Chunks already streamed to this client, to avoid resending.</summary>
     public HashSet<ChunkCoord> SentChunks { get; } = new();
 
+    /// <summary>The client's requested render distance in chunks (from its JoinRequest), or 0 if it didn't say.
+    /// When set, it drives this player's streaming radius (clamped server-side) instead of the host's config —
+    /// so the in-game View Distance slider extends the actually-streamed terrain on dedicated servers too, not
+    /// only the local fog. 0 = fall back to <see cref="ServerConfig.ViewDistanceChunks"/>.</summary>
+    public int ViewDistance { get; set; }
+
     /// <summary>Short rolling history of the player's recent state (for /bump diagnostics).</summary>
     public List<BumpSample> History { get; } = new();
     public double SinceHistorySample;

--- a/src/BlocksBeyondTheStars.GameServer/ServerWorld.cs
+++ b/src/BlocksBeyondTheStars.GameServer/ServerWorld.cs
@@ -168,12 +168,14 @@ public sealed class ServerWorld
         }
     }
 
-    /// <summary>Unloads cached chunks that are not within <paramref name="keep"/> of any anchor.</summary>
-    public int UnloadFarChunks(IReadOnlyCollection<ChunkCoord> anchors, int keepRadius)
+    /// <summary>Unloads cached chunks that are not within <paramref name="keepRadius"/> of any anchor and returns
+    /// the coords that were dropped — the caller also clears them from each player's sent-set so they re-stream
+    /// (fresh) if the player returns.</summary>
+    public IReadOnlyList<ChunkCoord> UnloadFarChunks(IReadOnlyCollection<ChunkCoord> anchors, int keepRadius)
     {
         if (anchors.Count == 0)
         {
-            return 0;
+            return System.Array.Empty<ChunkCoord>();
         }
 
         int keepSq = keepRadius * keepRadius;
@@ -201,6 +203,6 @@ public sealed class ServerWorld
             _loaded.Remove(coord);
         }
 
-        return toRemove.Count;
+        return toRemove;
     }
 }

--- a/src/BlocksBeyondTheStars.GameServer/ServerWorld.cs
+++ b/src/BlocksBeyondTheStars.GameServer/ServerWorld.cs
@@ -56,6 +56,10 @@ public sealed class ServerWorld
 
     public int LoadedChunkCount => _loaded.Count;
 
+    /// <summary>Whether a chunk is currently resident in the cache (canonicalized like the cache keys). For
+    /// tests/diagnostics — e.g. asserting far-chunk eviction by <see cref="UnloadFarChunks"/>.</summary>
+    public bool IsChunkLoaded(ChunkCoord coord) => _loaded.ContainsKey(WorldConstants.CanonicalChunk(coord, Circumference));
+
     public ChunkData GetOrLoadChunk(ChunkCoord coord)
     {
         // Longitude wraps: a chunk a whole lap away is the same chunk. Canonicalize X so the cache and

--- a/src/BlocksBeyondTheStars.Networking/Messages.cs
+++ b/src/BlocksBeyondTheStars.Networking/Messages.cs
@@ -25,6 +25,11 @@ public sealed class JoinRequest
     /// <summary>The player's chosen UI language ("en"/"de"). The server remembers it so dynamic, server-authored
     /// text (item 15: LLM NPC greetings) is generated in the player's language. Defaults to English.</summary>
     public string Locale { get; set; } = "en";
+
+    /// <summary>The client's chosen render distance in chunks (the in-game View Distance slider). The server
+    /// streams this player's terrain at this radius (clamped server-side) instead of the host config, so a wider
+    /// slider extends the visible terrain on dedicated servers too. 0 (default) = let the server decide.</summary>
+    public int ViewDistanceChunks { get; set; }
 }
 
 public sealed class MoveIntent

--- a/src/BlocksBeyondTheStars.Shared/Configuration/ServerConfig.cs
+++ b/src/BlocksBeyondTheStars.Shared/Configuration/ServerConfig.cs
@@ -43,6 +43,13 @@ public sealed class ServerConfig
     public int ViewDistanceChunks { get; set; } = 4;
     public int MaxLoadedChunksPerPlayer { get; set; } = 256;
 
+    /// <summary>How many chunks the server streams to each player per tick. Raised from the historical hard-coded
+    /// 12 to keep the (larger, default-4) view filling promptly — a wider view distance has quadratically more
+    /// chunks to send, so a too-small budget makes terrain "thaw in" slowly at the horizon. Each freshly streamed
+    /// chunk that isn't cached is generated synchronously in the tick, so this also bounds first-visit gen cost:
+    /// a host seeing tick overruns on weak hardware can lower it; a strong host can raise it for snappier fill.</summary>
+    public int ChunkStreamPerTick { get; set; } = 16;
+
     public string Difficulty { get; set; } = "normal";
     public bool AllowGuests { get; set; } = true;
 

--- a/tests/BlocksBeyondTheStars.Client.Tests/ClientServerHarness.cs
+++ b/tests/BlocksBeyondTheStars.Client.Tests/ClientServerHarness.cs
@@ -88,11 +88,12 @@ public sealed class ClientServerHarness : IDisposable
         };
     }
 
-    /// <summary>Connects + joins, then pumps until the server accepts the join (or a tick budget runs out).</summary>
-    public void Join(string playerName = "Tester", int maxTicks = 20)
+    /// <summary>Connects + joins, then pumps until the server accepts the join (or a tick budget runs out).
+    /// <paramref name="viewDistanceChunks"/> mirrors the in-game slider (0 = let the host decide).</summary>
+    public void Join(string playerName = "Tester", int maxTicks = 20, int viewDistanceChunks = 0)
     {
         Client.Connect("loopback", 0);
-        Client.Join(playerName);
+        Client.Join(playerName, viewDistanceChunks: viewDistanceChunks);
         PumpUntil(() => JoinAccepted != null || JoinRejected != null, maxTicks);
     }
 

--- a/tests/BlocksBeyondTheStars.Client.Tests/JoinAndStreamingTests.cs
+++ b/tests/BlocksBeyondTheStars.Client.Tests/JoinAndStreamingTests.cs
@@ -65,4 +65,31 @@ public sealed class JoinAndStreamingTests
 
         Assert.True(checkedAny, "Expected the player's own chunk to be among those streamed to the client.");
     }
+
+    [Fact]
+    public void ClientViewDistance_ExtendsTheStreamedTerrain_OverTheWire()
+    {
+        // Host default is radius 1 (ClientServerHarness); the client asks for radius 3 via the JoinRequest.
+        using var h = new ClientServerHarness(LoadContent());
+        h.Join("FarSighted", maxTicks: 20, viewDistanceChunks: 3);
+        Assert.NotNull(h.JoinAccepted);
+
+        // Let the (now wider) view stream in fully.
+        h.PumpUntil(() => false, maxTicks: 80);
+
+        var center = Shared.World.WorldConstants.WorldToChunk(h.Server.Sessions[1].State.Position.ToBlock());
+
+        // A column 2 east is inside the client's radius-3 view but outside the host's radius-1 default — it only
+        // reaches the client because the slider value travelled in the JoinRequest and drove server streaming.
+        bool gotWithinClientView = false;
+        bool gotBeyondClientView = false;
+        foreach (var key in h.Chunks.Keys)
+        {
+            if (key.Item1 == center.X + 2) gotWithinClientView = true;
+            if (key.Item1 == center.X + 5) gotBeyondClientView = true; // beyond radius 3 — must never stream
+        }
+
+        Assert.True(gotWithinClientView, "client's radius-3 view should stream terrain past the host's radius-1 default");
+        Assert.False(gotBeyondClientView, "nothing beyond the client's requested radius should stream");
+    }
 }

--- a/tests/BlocksBeyondTheStars.Tests/ChunkStreamingTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/ChunkStreamingTests.cs
@@ -1,0 +1,152 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using System;
+using System.IO;
+using BlocksBeyondTheStars.Networking.Transport;
+using BlocksBeyondTheStars.Persistence;
+using BlocksBeyondTheStars.Shared.Configuration;
+using BlocksBeyondTheStars.Shared.Content;
+using BlocksBeyondTheStars.Shared.Geometry;
+using BlocksBeyondTheStars.Shared.World;
+using Xunit;
+using SvGameServer = BlocksBeyondTheStars.GameServer.GameServer;
+
+namespace BlocksBeyondTheStars.Tests;
+
+/// <summary>Covers the chunk-streaming budget (A2) and the far-chunk eviction sweep (A4): the per-tick stream
+/// budget is honoured (so a wider view fills proportionally faster), and chunks that drift outside every
+/// player's keep-range are dropped from the cache while the player's own region stays resident.</summary>
+public sealed class ChunkStreamingTests : IDisposable
+{
+    private readonly string _root;
+    private readonly GameContent _content;
+
+    public ChunkStreamingTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "bbts_sweep_" + Guid.NewGuid().ToString("N"));
+        _content = ContentLoader.LoadFromDirectory(TestPaths.DataDir());
+    }
+
+    private int ChunksLoadedAfterOneTick(string name, int budget)
+    {
+        var repo = new SqliteWorldRepository(new SaveGamePaths(_root, name));
+        var st = new LoopbackServerTransport(new LoopbackLink());
+        var config = new ServerConfig
+        {
+            WorldName = name,
+            Seed = 1,
+            AutoSaveIntervalMinutes = 9999,
+            PlaceStarterShip = false,
+            ViewDistanceChunks = 4,
+            ChunkStreamPerTick = budget,
+        };
+        var server = new SvGameServer(config, _content, st, repo);
+        server.Start();
+        server.AddLocalPlayer("Streamer");
+        int before = server.World.LoadedChunkCount;
+        server.TickForTest(0.1); // exactly one streaming pass
+        int delta = server.World.LoadedChunkCount - before;
+        repo.Dispose();
+        return delta;
+    }
+
+    [Fact]
+    public void StreamBudget_ControlsHowFastTheViewFills()
+    {
+        // A bigger per-tick budget sends (and so caches) more new chunks in a single streaming pass — that is the
+        // knob that keeps the wider default view from thawing in slowly at the horizon.
+        int small = ChunksLoadedAfterOneTick("budget_small", 4);
+        int large = ChunksLoadedAfterOneTick("budget_large", 20);
+
+        Assert.True(small <= 4, $"one tick must not stream more than the budget (got {small} for budget 4)");
+        Assert.True(large > small, $"a larger budget should fill faster (large={large}, small={small})");
+    }
+
+    [Fact]
+    public void Sweep_EvictsFarChunks_ButKeepsThePlayersOwnRegion()
+    {
+        using var repo = new SqliteWorldRepository(new SaveGamePaths(_root, "sweep"));
+        var st = new LoopbackServerTransport(new LoopbackLink());
+        var config = new ServerConfig
+        {
+            WorldName = "sweep",
+            Seed = 1,
+            AutoSaveIntervalMinutes = 9999,
+            PlaceStarterShip = false,
+            ViewDistanceChunks = 2,
+        };
+        var server = new SvGameServer(config, _content, st, repo);
+        server.Start();
+
+        // Use the player's natural safe spawn (set by the join-time spawn guard) so the runtime void-rescue never
+        // relocates them mid-test — that would move the anchor and invalidate the assertions.
+        var p = server.AddLocalPlayer("Wanderer");
+        var nearChunk = WorldConstants.WorldToChunk(p.State.Position.ToBlock());
+
+        // Stream the player's own region in (12 chunks/tick).
+        for (int i = 0; i < 20; i++)
+        {
+            server.TickForTest(0.1);
+        }
+
+        Assert.True(server.World.IsChunkLoaded(nearChunk), "the player's own chunk should be resident");
+
+        // Force a chunk far away into the cache (e.g. a query from another subsystem) — it sits well outside the
+        // player's keep-range and is exactly what the sweep is meant to reclaim. Offset from the actual anchor so
+        // it's far regardless of where the player spawned.
+        var farChunk = new ChunkCoord(nearChunk.X, nearChunk.Y, nearChunk.Z + 400); // ~6400 blocks away in Z
+        server.World.GetOrLoadChunk(farChunk);
+        Assert.True(server.World.IsChunkLoaded(farChunk), "the far chunk should be cached right after loading it");
+
+        // Tick past the sweep interval (player stays put, so the near region is the anchor).
+        for (int i = 0; i < 15; i++)
+        {
+            server.TickForTest(1.0);
+        }
+
+        Assert.False(server.World.IsChunkLoaded(farChunk), "the far chunk should have been swept out of the cache");
+        Assert.True(server.World.IsChunkLoaded(nearChunk), "the player's own region must stay resident through the sweep");
+    }
+
+    [Fact]
+    public void ClientViewDistance_ExtendsStreamingRadius_BeyondHostDefault()
+    {
+        using var repo = new SqliteWorldRepository(new SaveGamePaths(_root, "vd"));
+        var st = new LoopbackServerTransport(new LoopbackLink());
+        var config = new ServerConfig
+        {
+            WorldName = "vd",
+            Seed = 1,
+            AutoSaveIntervalMinutes = 9999,
+            PlaceStarterShip = false,
+            ViewDistanceChunks = 1, // small host default — the client asks for more
+            ChunkStreamPerTick = 16,
+        };
+        var server = new SvGameServer(config, _content, st, repo);
+        server.Start();
+
+        var p = server.AddLocalPlayer("FarSighted");
+        p.ViewDistance = 3; // the client's slider, larger than the host's radius-1 default
+        var center = WorldConstants.WorldToChunk(p.State.Position.ToBlock());
+
+        for (int i = 0; i < 30; i++)
+        {
+            server.TickForTest(0.1); // fill the view; short dt so the 10 s sweep never trips
+        }
+
+        // A chunk 2 east is inside the client's radius-3 view but outside the host's radius-1 default — it is
+        // resident only because the client's requested view distance drove the streaming radius.
+        var withinClientView = new ChunkCoord(center.X + 2, center.Y, center.Z);
+        // A chunk 5 east is beyond even the client's radius — it must never have been streamed.
+        var beyondClientView = new ChunkCoord(center.X + 5, center.Y, center.Z);
+
+        Assert.True(server.World.IsChunkLoaded(withinClientView), "client's wider view distance should stream terrain past the host default");
+        Assert.False(server.World.IsChunkLoaded(beyondClientView), "nothing beyond the client's requested radius should stream");
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { /* best effort */ }
+    }
+}

--- a/tests/BlocksBeyondTheStars.Tests/ChunkStreamingTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/ChunkStreamingTests.cs
@@ -93,10 +93,13 @@ public sealed class ChunkStreamingTests : IDisposable
         Assert.True(server.World.IsChunkLoaded(nearChunk), "the player's own chunk should be resident");
 
         // Force a chunk far away into the cache (e.g. a query from another subsystem) — it sits well outside the
-        // player's keep-range and is exactly what the sweep is meant to reclaim. Offset from the actual anchor so
-        // it's far regardless of where the player spawned.
-        var farChunk = new ChunkCoord(nearChunk.X, nearChunk.Y, nearChunk.Z + 400); // ~6400 blocks away in Z
+        // player's keep-range and is exactly what the sweep is meant to reclaim. Canonicalize it the way the
+        // streamer/cache do (the world is a torus on BOTH axes), so the coord matches the key the sweep evicts —
+        // SentChunks only ever holds canonical coords in production.
+        var farChunk = WorldConstants.CanonicalChunk(
+            new ChunkCoord(nearChunk.X, nearChunk.Y, nearChunk.Z + 40), server.World.Circumference);
         server.World.GetOrLoadChunk(farChunk);
+        p.SentChunks.Add(farChunk); // pretend it was streamed to the player, so we can assert it gets forgotten
         Assert.True(server.World.IsChunkLoaded(farChunk), "the far chunk should be cached right after loading it");
 
         // Tick past the sweep interval (player stays put, so the near region is the anchor).
@@ -106,6 +109,7 @@ public sealed class ChunkStreamingTests : IDisposable
         }
 
         Assert.False(server.World.IsChunkLoaded(farChunk), "the far chunk should have been swept out of the cache");
+        Assert.DoesNotContain(farChunk, p.SentChunks); // forgotten too → it re-streams fresh if the player returns
         Assert.True(server.World.IsChunkLoaded(nearChunk), "the player's own region must stay resident through the sweep");
     }
 

--- a/tests/BlocksBeyondTheStars.Tests/ChunkStreamingTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/ChunkStreamingTests.cs
@@ -145,6 +145,50 @@ public sealed class ChunkStreamingTests : IDisposable
         Assert.False(server.World.IsChunkLoaded(beyondClientView), "nothing beyond the client's requested radius should stream");
     }
 
+    [Fact]
+    public void FarColumns_StreamOnlyTheSurfaceBand_WhileNearColumnsStreamTheFullVerticalSpan()
+    {
+        using var repo = new SqliteWorldRepository(new SaveGamePaths(_root, "lod"));
+        var st = new LoopbackServerTransport(new LoopbackLink());
+        var config = new ServerConfig
+        {
+            WorldName = "lod",
+            Seed = 1,
+            AutoSaveIntervalMinutes = 9999,
+            PlaceStarterShip = false,
+            ViewDistanceChunks = 5,   // radius 5 > the near-full-column radius (3), so there are "far" columns
+            ChunkStreamPerTick = 64,  // drain the whole view quickly
+        };
+        var server = new SvGameServer(config, _content, st, repo);
+        server.Start();
+
+        var p = server.AddLocalPlayer("Surveyor");
+        var center = WorldConstants.WorldToChunk(p.State.Position.ToBlock());
+
+        for (int i = 0; i < 30; i++)
+        {
+            server.TickForTest(0.1); // short dt so the 10 s far-chunk sweep never trips
+        }
+
+        // The player's own column (dx=0) keeps the full 6-layer vertical span (-3..+2) for caves/digging.
+        int nearLayers = 0;
+        for (int cy = center.Y - 3; cy <= center.Y + 2; cy++)
+        {
+            if (server.World.IsChunkLoaded(new ChunkCoord(center.X, cy, center.Z))) nearLayers++;
+        }
+
+        // A far column (dx=5, Chebyshev 5 > 3) streams only the band around its surface — count over a wide
+        // vertical window so we catch the band wherever the terrain there sits.
+        int farLayers = 0;
+        for (int cy = center.Y - 8; cy <= center.Y + 8; cy++)
+        {
+            if (server.World.IsChunkLoaded(new ChunkCoord(center.X + 5, cy, center.Z))) farLayers++;
+        }
+
+        Assert.Equal(6, nearLayers); // near column: full vertical span
+        Assert.InRange(farLayers, 1, 3); // far column: just the surface band (below+surface+above)
+    }
+
     public void Dispose()
     {
         try { Directory.Delete(_root, recursive: true); } catch { /* best effort */ }


### PR DESCRIPTION
Addresses the planet-surface feedback: view distance too short, terrain thawing in late at the horizon, and on-foot input lag — while keeping the per-planet/per-weather haze character.

## Changes (4 commits)
- **Longer view distance + plumbing** (`600d0aa8`): default render distance 2→4; the in-game slider now travels in `JoinRequest.ViewDistanceChunks` (clamped 1–8) and drives server streaming, so it extends real terrain on dedicated servers too (not just local fog). Per-tick chunk-stream budget is now `ServerConfig.ChunkStreamPerTick` (default 16, host-tunable). Server far-chunk sweep wired up (the dead `UnloadFarChunks`) to bound the chunk cache. On-foot input-lag fix: near-only colliders (far chunks' `MeshCollider` disabled → out of the PhysX broadphase, baked mesh kept for instant re-enable) + cached chunk components (no per-move `GetComponent`) + reposition re-triggers on vertical movement.
- **Distance-based vertical LOD** (`8908e7c3`): far columns stream only the band around their actual surface instead of the full -3..+2 span — roughly halves the chunk count at VD8 (~1734→~770) for faster fill + a lighter client; near columns keep the full span for caves/digging.
- **Client far-chunk unload** (`8177b192`): the client no longer accumulates chunks without bound — chunks past 384 m (beyond the renderer cull) are destroyed; the server's sweep also forgets the evicted coords from each player's sent-set so they re-stream fresh on return (no new protocol).
- **Per-atmosphere haze tuning** (`72db494c`): fog start fraction + max haze are tied to atmosphere density — clear/thin worlds stay crisp across near+mid and only veil the far edge; soupy worlds + fog/sandstorm weather stay near & dense.

## Tests
- Server **742** + client **86** green.
- New `ChunkStreamingTests` (per-tick budget, far-chunk sweep + SentChunks forget, client view distance over the wire, vertical-LOD surface band) and a client e2e `ClientViewDistance_ExtendsTheStreamedTerrain_OverTheWire`.
- Local Unity Windows build green (bundled singleplayer server republished).

## Deliberately out of scope
- Visual far-mesh/greedy mesher LOD (render kept chunks cheaper / see beyond VD8) — high risk, needs in-editor iteration. Documented in `plans/PLANET_VIEW_DISTANCE_AND_SMOOTHNESS_PLAN.md`.
- Worker-pool chunk generation — deferred (cratered-moon flag is ambient on the shared generator + SQLite threading); the budget knob covers the need.

🤖 Generated with [Claude Code](https://claude.com/claude-code)