### PR TITLE
feat(flora): make the spawn/regrow source recognizable

### DIFF
--- a/client/Assets/BlocksBeyondTheStars/Scripts/FloraGrowthFx.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/FloraGrowthFx.cs
@@ -1,0 +1,166 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using System.Collections.Generic;
+using BlocksBeyondTheStars.Networking.Messages;
+using UnityEngine;
+
+namespace BlocksBeyondTheStars.Client
+{
+    /// <summary>
+    /// Makes a flora SPAWN/REGROW source recognizable. When a harvested plant is scheduled to regrow the
+    /// server sends <see cref="FloraRegrowStarted"/>; this spawns a small green sprout at that cell and grows
+    /// it in over the regrow delay, so the otherwise-bare cell visibly reads as "something is growing here"
+    /// rather than the plant popping back from nothing. When the real plant returns (a <see cref="BlockChanged"/>
+    /// at the cell) or the timer elapses, the sprout is removed. Purely cosmetic + render-only — the server
+    /// stays authoritative over the actual block; a missed message just means no sprout, never a gameplay change.
+    ///
+    /// Code-built on the always-included Unlit shader (no assets, no new shader), mirroring <see cref="MiningFx"/>.
+    /// This also subsumes the original "tint the host block" idea, which is impossible: the host's top face is
+    /// culled under the plant, so it never reaches the mesh — a cell marker is the only workable cue (and it
+    /// also covers the bare regrow window, which a host tint never could).
+    /// </summary>
+    public sealed class FloraGrowthFx : MonoBehaviour
+    {
+        public GameBootstrap Game;
+
+        // The minimum / full sprout size (local units) and the start fraction so it is visible the instant it
+        // appears rather than growing up from an invisible speck.
+        private const float Width = 0.42f;
+        private const float Height = 0.62f;
+        private const float StartFraction = 0.12f;
+
+        private readonly Dictionary<Vector3Int, Sprout> _sprouts = new();
+        private bool _subscribed;
+
+        private void Update()
+        {
+            if (!_subscribed && Game?.Network != null)
+            {
+                Game.Network.FloraRegrowStartedReceived += OnRegrowStarted;
+                Game.Network.BlockChanged += OnBlockChanged;
+                _subscribed = true;
+            }
+        }
+
+        private void OnDestroy()
+        {
+            if (_subscribed && Game?.Network != null)
+            {
+                Game.Network.FloraRegrowStartedReceived -= OnRegrowStarted;
+                Game.Network.BlockChanged -= OnBlockChanged;
+            }
+        }
+
+        private void OnRegrowStarted(FloraRegrowStarted m)
+        {
+            var cell = new Vector3Int(m.X, m.Y, m.Z);
+            if (_sprouts.TryGetValue(cell, out var existing) && existing != null)
+            {
+                existing.Restart(Mathf.Max(0.1f, m.Seconds));
+                return;
+            }
+
+            var sprout = Sprout.Spawn(cell, Mathf.Max(0.1f, m.Seconds), Width, Height, StartFraction);
+            sprout.OnFinished = () => _sprouts.Remove(cell);
+            _sprouts[cell] = sprout;
+        }
+
+        /// <summary>The real plant (or any block) arrived on a tracked cell — the sprout has served its purpose,
+        /// drop it so it doesn't overlap the freshly meshed flora.</summary>
+        private void OnBlockChanged(BlockChanged m)
+        {
+            var cell = new Vector3Int(m.X, m.Y, m.Z);
+            if (m.Block != 0 && _sprouts.TryGetValue(cell, out var sprout))
+            {
+                _sprouts.Remove(cell);
+                if (sprout != null)
+                {
+                    Destroy(sprout.gameObject);
+                }
+            }
+        }
+
+        private static Material _mat;
+
+        private static Material SproutMaterial()
+        {
+            if (_mat != null)
+            {
+                return _mat;
+            }
+
+            var shader = Shader.Find("Unlit/Color") ?? Shader.Find("BlocksBeyondTheStars/VertexColorOpaque");
+            _mat = new Material(shader) { color = ShaderColor.Srgb(new Color(0.36f, 0.62f, 0.26f)) };
+            return _mat;
+        }
+
+        /// <summary>One growing sprout: two crossed quads on a base-pivoted root that scales up from a seedling
+        /// to full height over the regrow delay, then self-removes (the real plant takes over).</summary>
+        private sealed class Sprout : MonoBehaviour
+        {
+            public System.Action OnFinished;
+
+            private float _seconds;
+            private float _t;
+            private float _width;
+            private float _height;
+            private float _startFraction;
+
+            public static Sprout Spawn(Vector3Int cell, float seconds, float width, float height, float startFraction)
+            {
+                // The cell is the air cell above the host, so the sprout's base sits on the ground at cell.Y.
+                var root = new GameObject("FloraSprout");
+                root.transform.position = new Vector3(cell.x + 0.5f, cell.y, cell.z + 0.5f);
+
+                var mat = SproutMaterial();
+                for (int i = 0; i < 2; i++)
+                {
+                    var quad = GameObject.CreatePrimitive(PrimitiveType.Quad);
+                    var col = quad.GetComponent<Collider>();
+                    if (col != null)
+                    {
+                        Destroy(col);
+                    }
+
+                    quad.transform.SetParent(root.transform, false);
+                    quad.transform.localPosition = new Vector3(0f, 0.5f, 0f); // base at the root origin (the ground)
+                    quad.transform.localRotation = Quaternion.Euler(0f, i * 90f, 0f);
+                    quad.GetComponent<Renderer>().sharedMaterial = mat;
+                    quad.GetComponent<Renderer>().shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.Off;
+                }
+
+                var sprout = root.AddComponent<Sprout>();
+                sprout._width = width;
+                sprout._height = height;
+                sprout._startFraction = startFraction;
+                sprout.Restart(seconds);
+                return sprout;
+            }
+
+            public void Restart(float seconds)
+            {
+                _seconds = seconds;
+                _t = 0f;
+                Apply();
+            }
+
+            private void Update()
+            {
+                _t += Time.deltaTime;
+                Apply();
+                if (_t >= _seconds)
+                {
+                    OnFinished?.Invoke();
+                    Destroy(gameObject);
+                }
+            }
+
+            private void Apply()
+            {
+                float grow = Mathf.Lerp(_startFraction, 1f, _seconds > 0f ? Mathf.Clamp01(_t / _seconds) : 1f);
+                transform.localScale = new Vector3(_width, _height * grow, _width);
+            }
+        }
+    }
+}

--- a/client/Assets/BlocksBeyondTheStars/Scripts/FloraGrowthFx.cs.meta
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/FloraGrowthFx.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d7f68a91e53ff3e469c3625dc88906cf

--- a/client/Assets/BlocksBeyondTheStars/Scripts/WorldRig.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/WorldRig.cs
@@ -364,6 +364,10 @@ namespace BlocksBeyondTheStars.Client
             miningFx.Camera = cam;
             miningFx.Reach = pc.Reach;
 
+            // Flora spawn/regrow cue: a growing sprout marks a harvested cell while its plant regrows.
+            var floraGrowthFx = root.AddComponent<FloraGrowthFx>();
+            floraGrowthFx.Game = boot;
+
             // Tool/weapon VFX (beam + muzzle flash + impact sparks, drill sparks).
             var weaponFx = root.AddComponent<WeaponFx>();
             pc.Weapons = weaponFx;

--- a/src/BlocksBeyondTheStars.Client.Core/NetworkClient.cs
+++ b/src/BlocksBeyondTheStars.Client.Core/NetworkClient.cs
@@ -82,6 +82,10 @@ namespace BlocksBeyondTheStars.Client
         public event Action<DoorList>? DoorsReceived;
         public event Action<MiningProgress>? MiningProgressReceived;
 
+        // A harvested plant has begun regrowing on its cell: lets the client show the spawn source as a sprout
+        // that grows in until the plant returns (cosmetic — the plant pops back via BlockChanged regardless).
+        public event Action<FloraRegrowStarted>? FloraRegrowStartedReceived;
+
         // Data-cube minigames: cubes to render on the current world + the player's downloaded-games collection.
         public event Action<DataCubeList>? DataCubesReceived;
         public event Action<GameUnlocks>? GameUnlocksReceived;
@@ -505,6 +509,7 @@ namespace BlocksBeyondTheStars.Client
                 case DataCubeList m: DataCubesReceived?.Invoke(m); break;
                 case GameUnlocks m: GameUnlocksReceived?.Invoke(m); break;
                 case MiningProgress m: MiningProgressReceived?.Invoke(m); break;
+                case FloraRegrowStarted m: FloraRegrowStartedReceived?.Invoke(m); break;
                 case ScanResult m: ScanResultReceived?.Invoke(m); break;
                 case WreckRepairStatus m: WreckRepairStatusChanged?.Invoke(m); break;
                 case ShipRepairStatus m: ShipRepairStatusChanged?.Invoke(m); break;

--- a/src/BlocksBeyondTheStars.GameServer/GameServer.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServer.cs
@@ -348,6 +348,7 @@ public sealed partial class GameServer
             InitFluids();
             InitFire();
             InitFlora();
+            LoadFloraRegrow(); // restore persisted harvest regrowths so a restart doesn't strand bare cells
             InitCreatures();
             LoadContainers();
 

--- a/src/BlocksBeyondTheStars.GameServer/GameServerFlora.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerFlora.cs
@@ -202,7 +202,11 @@ public sealed partial class GameServer
         // grows in over the delay (the plant pops back on its own via BlockChanged regardless of this).
         BroadcastToWorld(new FloraRegrowStarted
         {
-            X = pos.X, Y = pos.Y, Z = pos.Z, Block = floraId, Seconds = (float)FloraRegrowSeconds,
+            X = pos.X,
+            Y = pos.Y,
+            Z = pos.Z,
+            Block = floraId,
+            Seconds = (float)FloraRegrowSeconds,
         });
     }
 

--- a/src/BlocksBeyondTheStars.GameServer/GameServerFlora.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerFlora.cs
@@ -168,9 +168,43 @@ public sealed partial class GameServer
         return def != null && IsFlora(def.NumericId.Value) && IsValidFloraHost(def.NumericId.Value, new Vector3i(x, y, z));
     }
 
-    /// <summary>Schedules a harvested plant to regrow on its cell (if the host stays intact).</summary>
+    /// <summary>Restores this world's persisted flora regrowths into the queue (so a harvest-then-restart
+    /// brings the plant back instead of leaving it gone for good). Non-void worlds only — stations grow none.</summary>
+    private void LoadFloraRegrow()
+    {
+        if (_world.Planet.Void)
+        {
+            return;
+        }
+
+        foreach (var fr in _repo.ListFloraRegrow(_world.LocationId))
+        {
+            // Drop stale rows whose block is no longer flora in this content set (defensive — keeps the queue clean).
+            if (IsFlora(fr.Block))
+            {
+                _floraRegrow[fr.WorldPosition] = (fr.Block, fr.Timer);
+            }
+            else
+            {
+                _repo.DeleteFloraRegrow(_world.LocationId, fr.WorldPosition);
+            }
+        }
+    }
+
+    /// <summary>Schedules a harvested plant to regrow on its cell (if the host stays intact). Persisted so the
+    /// regrow survives a restart — without it the harvest's air edit would keep the cell bare for good.</summary>
     private void ScheduleFloraRegrow(Vector3i pos, ushort floraId)
-        => _floraRegrow[pos] = (floraId, FloraRegrowSeconds);
+    {
+        _floraRegrow[pos] = (floraId, FloraRegrowSeconds);
+        _repo.SaveFloraRegrow(_world.LocationId, pos, floraId, FloraRegrowSeconds);
+
+        // Cosmetic cue: tell clients the spawn source has started regrowing so they can render a sprout that
+        // grows in over the delay (the plant pops back on its own via BlockChanged regardless of this).
+        BroadcastToWorld(new FloraRegrowStarted
+        {
+            X = pos.X, Y = pos.Y, Z = pos.Z, Block = floraId, Seconds = (float)FloraRegrowSeconds,
+        });
+    }
 
     private void TickFlora(double dt)
     {
@@ -208,6 +242,7 @@ public sealed partial class GameServer
             foreach (var pos in done)
             {
                 _floraRegrow.Remove(pos);
+                _repo.DeleteFloraRegrow(_world.LocationId, pos); // consumed (regrew or host lost) — clear the persisted row
             }
         }
     }

--- a/src/BlocksBeyondTheStars.Networking/Messages.cs
+++ b/src/BlocksBeyondTheStars.Networking/Messages.cs
@@ -582,6 +582,24 @@ public sealed class BlockChanged
     public int Shape { get; set; }
 }
 
+/// <summary>A harvested surface plant has begun regrowing on its (now bare) cell: the server broadcasts this
+/// once, the moment the regrow is scheduled, so the client can show the spawn source as a small sprout that
+/// grows in over <see cref="Seconds"/> until the real plant returns (a normal BlockChanged). <see cref="Block"/>
+/// is the flora block id coming back, so the marker can wear its tile. Purely cosmetic — gameplay is unchanged
+/// whether or not a client renders it; a client may ignore it and just see the plant pop back at the end.</summary>
+public sealed class FloraRegrowStarted
+{
+    public int X { get; set; }
+    public int Y { get; set; }
+    public int Z { get; set; }
+
+    /// <summary>The flora block id that will return on this cell when the regrow completes.</summary>
+    public ushort Block { get; set; }
+
+    /// <summary>Seconds until the plant returns (the regrow delay), so the client can pace the grow-in.</summary>
+    public float Seconds { get; set; }
+}
+
 /// <summary>Mining progress on a block (a harder block needs several drill hits): Fraction 0..1 of the
 /// way to breaking. The client shows a crack overlay; the block stays until it breaks (BlockChanged).</summary>
 public sealed class MiningProgress

--- a/src/BlocksBeyondTheStars.Networking/NetCodec.cs
+++ b/src/BlocksBeyondTheStars.Networking/NetCodec.cs
@@ -276,6 +276,10 @@ public static class NetCodec
 
         // Cargo hold: move items between the personal inventory and the ship's cargo hold (per-item or bulk).
         Register(170, typeof(MoveCargoItemIntent));      // Client -> Server
+
+        // Flora regrow cue: a harvested plant has started regrowing — the client shows the spawn source as a
+        // sprout that grows in until the plant returns (purely cosmetic; the plant pops back regardless).
+        Register(171, typeof(FloraRegrowStarted));       // Server -> Client
     }
 
     private static void Register(byte tag, Type type)

--- a/src/BlocksBeyondTheStars.Persistence/IWorldRepository.cs
+++ b/src/BlocksBeyondTheStars.Persistence/IWorldRepository.cs
@@ -133,6 +133,24 @@ public readonly struct BlockEdit
     }
 }
 
+/// <summary>A scheduled surface-flora regrowth: a harvested plant that returns on its cell after a delay,
+/// as long as its host block stays intact. Persisted so the regrow survives a server restart — otherwise a
+/// harvest-then-restart removes the plant for good (the harvest leaves a persisted air edit that overrides
+/// the procedural baseline, and the in-memory regrow timer that would bring it back is lost).</summary>
+public readonly struct StoredFloraRegrow
+{
+    public readonly Vector3i WorldPosition;
+    public readonly ushort Block;
+    public readonly double Timer;
+
+    public StoredFloraRegrow(Vector3i worldPosition, ushort block, double timer)
+    {
+        WorldPosition = worldPosition;
+        Block = block;
+        Timer = timer;
+    }
+}
+
 /// <summary>
 /// Abstraction over savegame persistence. The default implementation is SQLite-backed
 /// (portable); a PostgreSQL implementation can be added later
@@ -156,6 +174,15 @@ public interface IWorldRepository : IDisposable
 
     /// <summary>Loads all stored block edits that fall inside the given chunk.</summary>
     IReadOnlyList<BlockEdit> LoadChunkEdits(string planet, ChunkCoord chunk);
+
+    /// <summary>Stores (inserts or replaces) a scheduled flora regrowth, keyed by its world cell.</summary>
+    void SaveFloraRegrow(string planet, Vector3i worldPosition, ushort block, double timer);
+
+    /// <summary>Lists all scheduled flora regrowths on a planet (restored into the regrow queue on world load).</summary>
+    IReadOnlyList<StoredFloraRegrow> ListFloraRegrow(string planet);
+
+    /// <summary>Removes a scheduled flora regrowth (the plant returned, or its host was lost).</summary>
+    void DeleteFloraRegrow(string planet, Vector3i worldPosition);
 
     PlayerState? LoadPlayer(string playerId);
     void SavePlayer(PlayerState player);

--- a/src/BlocksBeyondTheStars.Persistence/SqliteWorldRepository.cs
+++ b/src/BlocksBeyondTheStars.Persistence/SqliteWorldRepository.cs
@@ -89,7 +89,10 @@ public sealed class SqliteWorldRepository : IWorldRepository
                 px REAL NOT NULL, py REAL NOT NULL, pz REAL NOT NULL, boardable INTEGER NOT NULL, blocks TEXT NOT NULL);
             CREATE TABLE IF NOT EXISTS structure_edit (
                 structure TEXT NOT NULL, x INTEGER NOT NULL, y INTEGER NOT NULL, z INTEGER NOT NULL,
-                block INTEGER NOT NULL, PRIMARY KEY (structure, x, y, z));");
+                block INTEGER NOT NULL, PRIMARY KEY (structure, x, y, z));
+            CREATE TABLE IF NOT EXISTS flora_regrow (
+                planet TEXT NOT NULL, x INTEGER NOT NULL, y INTEGER NOT NULL, z INTEGER NOT NULL,
+                block INTEGER NOT NULL, timer REAL NOT NULL, PRIMARY KEY (planet, x, y, z));");
         // (Landing pads are deterministic + live-occupancy now — no per-player landing_zone table; item 38.)
 
         // Migrate older saves to carry per-voxel colour modifiers (dyed blocks / coloured lights). The
@@ -421,6 +424,61 @@ public sealed class SqliteWorldRepository : IWorldRepository
             cmd.Parameters.AddWithValue("$x", x);
             cmd.Parameters.AddWithValue("$y", y);
             cmd.Parameters.AddWithValue("$z", z);
+            cmd.ExecuteNonQuery();
+        }
+    }
+
+    // --- Flora regrowth (harvested plants returning on their cell) ---
+
+    public void SaveFloraRegrow(string planet, Vector3i worldPosition, ushort block, double timer)
+    {
+        lock (_gate)
+        {
+            using var cmd = Connection.CreateCommand();
+            cmd.CommandText = "INSERT INTO flora_regrow (planet, x, y, z, block, timer) " +
+                              "VALUES ($p, $x, $y, $z, $b, $t) " +
+                              "ON CONFLICT(planet, x, y, z) DO UPDATE SET block=excluded.block, timer=excluded.timer;";
+            cmd.Parameters.AddWithValue("$p", planet);
+            cmd.Parameters.AddWithValue("$x", worldPosition.X);
+            cmd.Parameters.AddWithValue("$y", worldPosition.Y);
+            cmd.Parameters.AddWithValue("$z", worldPosition.Z);
+            cmd.Parameters.AddWithValue("$b", block);
+            cmd.Parameters.AddWithValue("$t", timer);
+            cmd.ExecuteNonQuery();
+        }
+    }
+
+    public IReadOnlyList<StoredFloraRegrow> ListFloraRegrow(string planet)
+    {
+        var result = new List<StoredFloraRegrow>();
+        lock (_gate)
+        {
+            using var cmd = Connection.CreateCommand();
+            cmd.CommandText = "SELECT x, y, z, block, timer FROM flora_regrow WHERE planet = $p;";
+            cmd.Parameters.AddWithValue("$p", planet);
+            using var reader = cmd.ExecuteReader();
+            while (reader.Read())
+            {
+                result.Add(new StoredFloraRegrow(
+                    new Vector3i(reader.GetInt32(0), reader.GetInt32(1), reader.GetInt32(2)),
+                    (ushort)reader.GetInt32(3),
+                    reader.GetDouble(4)));
+            }
+        }
+
+        return result;
+    }
+
+    public void DeleteFloraRegrow(string planet, Vector3i worldPosition)
+    {
+        lock (_gate)
+        {
+            using var cmd = Connection.CreateCommand();
+            cmd.CommandText = "DELETE FROM flora_regrow WHERE planet = $p AND x = $x AND y = $y AND z = $z;";
+            cmd.Parameters.AddWithValue("$p", planet);
+            cmd.Parameters.AddWithValue("$x", worldPosition.X);
+            cmd.Parameters.AddWithValue("$y", worldPosition.Y);
+            cmd.Parameters.AddWithValue("$z", worldPosition.Z);
             cmd.ExecuteNonQuery();
         }
     }

--- a/src/BlocksBeyondTheStars.Shared/Content/GameContent.cs
+++ b/src/BlocksBeyondTheStars.Shared/Content/GameContent.cs
@@ -214,6 +214,7 @@ public sealed class GameContent
         AssignBlockIds();
         MarkTintableDefaults();
         MarkShapeableDefaults();
+        MarkFloraHostDefaults();
 
         // Palette lookup: index by numeric id (air at 0).
         ushort max = 0;
@@ -280,6 +281,26 @@ public sealed class GameContent
             if (_blocks.TryGetValue(key, out var block))
             {
                 block.Shapeable = true;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Marks every block that any <see cref="FloraCatalog"/> species can root on as a <see
+    /// cref="BlockDefinition.FloraHost"/>. Derived from the catalog's host lists (the single source of truth)
+    /// so worldgen, server harvest-regrow and the client's "fertile ground" cue all share one flag instead of
+    /// re-deriving the host set. Applied here so client and server compute the identical set.
+    /// </summary>
+    private void MarkFloraHostDefaults()
+    {
+        foreach (var species in BlocksBeyondTheStars.Shared.Definitions.FloraCatalog.All)
+        {
+            foreach (var hostKey in species.Hosts)
+            {
+                if (_blocks.TryGetValue(hostKey, out var block))
+                {
+                    block.FloraHost = true;
+                }
             }
         }
     }

--- a/src/BlocksBeyondTheStars.Shared/Definitions/BlockDefinition.cs
+++ b/src/BlocksBeyondTheStars.Shared/Definitions/BlockDefinition.cs
@@ -67,6 +67,15 @@ public sealed class BlockDefinition
     /// </summary>
     public bool Shapeable { get; set; }
 
+    /// <summary>
+    /// Whether surface flora may root on top of this block — i.e. it is a host surface for at least one
+    /// species in <see cref="FloraCatalog"/> (grass, dirt, mud, sand, stone, crystal, water, …). Derived
+    /// from the catalog by the content registry (not in JSON) so client and server agree, and so worldgen,
+    /// harvest-regrow and the client's "fertile ground" cue all read the same flag instead of re-deriving
+    /// the host set. A plain terrain block; says nothing about which species (that stays in the catalog).
+    /// </summary>
+    public bool FloraHost { get; set; }
+
     // --- Assigned by the registry, not present in JSON ---
 
     /// <summary>Dense numeric id assigned at load time; what chunks actually store.</summary>

--- a/tests/BlocksBeyondTheStars.Tests/FloraTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/FloraTests.cs
@@ -303,6 +303,62 @@ public sealed class FloraTests : IDisposable
         }
     }
 
+    [Fact]
+    public void FloraHostFlag_MarksGroundSurfaces_NotPlantsOrMachines()
+    {
+        // Every surface a catalog species roots on is flagged a host...
+        Assert.True(_content.GetBlock("grass")!.FloraHost);
+        Assert.True(_content.GetBlock("mud")!.FloraHost);
+        Assert.True(_content.GetBlock("sand")!.FloraHost);
+        Assert.True(_content.GetBlock("water")!.FloraHost); // lily pads root on the water surface
+
+        // ...while plants themselves and pure building materials are not hosts.
+        Assert.False(_content.GetBlock("flora_plant")!.FloraHost);
+        Assert.False(_content.GetBlock("iron_wall")!.FloraHost);
+    }
+
+    [Fact]
+    public void FloraHostFlag_CoversTheWholeCatalogHostUnion()
+    {
+        foreach (var key in FloraCatalog.All.SelectMany(s => s.Hosts).Distinct())
+        {
+            var block = _content.GetBlock(key);
+            if (block != null)
+            {
+                Assert.True(block.FloraHost, $"'{key}' is a catalog host and must carry the FloraHost flag.");
+            }
+        }
+    }
+
+    [Fact]
+    public void HarvestedFlora_RegrowSurvivesRestart()
+    {
+        var mud = _content.GetBlock("mud")!.NumericId;
+        var floraPlant = _content.GetBlock("flora_plant")!.NumericId;
+        var host = new Vector3i(102, 99, 100);
+        var cell = new Vector3i(102, 100, 100);
+
+        // First session: plant, harvest, and shut down BEFORE the regrow timer elapses.
+        var server1 = Started(out var repo1);
+        var session1 = server1.AddLocalPlayer("Botanist");
+        session1.State.Position = new Vector3f(100f, 100f, 100f);
+        server1.World.SetBlock(host, mud);
+        server1.World.SetBlock(cell, floraPlant);
+        server1.MineBlock(session1.State.PlayerId, cell.X, cell.Y, cell.Z);
+        server1.Tick(1.0); // far short of FloraRegrowSeconds — still air
+        Assert.True(server1.World.GetBlock(cell).IsAir);
+        repo1.Dispose(); // simulate a server restart on the same save
+
+        // Second session on the same save folder: the persisted regrow must bring the plant back.
+        var server2 = Started(out var repo2);
+        using (repo2)
+        {
+            server2.AddLocalPlayer("Botanist");
+            server2.Tick(31.0); // > FloraRegrowSeconds → regrow step
+            Assert.Equal(floraPlant.Value, server2.World.GetBlock(cell).Value);
+        }
+    }
+
     public void Dispose()
     {
         try

--- a/tests/BlocksBeyondTheStars.Tests/NetworkingTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/NetworkingTests.cs
@@ -35,6 +35,19 @@ public class NetworkingTests
     }
 
     [Fact]
+    public void Codec_RoundTrips_FloraRegrowStarted()
+    {
+        var msg = new FloraRegrowStarted { X = 102, Y = 100, Z = -5, Block = 77, Seconds = 30f };
+        var typed = Assert.IsType<FloraRegrowStarted>(NetCodec.Decode(NetCodec.Encode(msg)));
+
+        Assert.Equal(102, typed.X);
+        Assert.Equal(100, typed.Y);
+        Assert.Equal(-5, typed.Z);
+        Assert.Equal(77, typed.Block);
+        Assert.Equal(30f, typed.Seconds);
+    }
+
+    [Fact]
     public void Codec_ReturnsNull_ForUnknownTag()
     {
         Assert.Null(NetCodec.Decode(new byte[] { 200, 1, 2, 3 }));


### PR DESCRIPTION
## Was & Warum

Macht die **Spawn-/Nachwachs-Quelle von Flora erkennbar**. Eine geerntete Pflanze wuchs bisher lautlos aus dem Nichts nach, und ein Server-Neustart ließ die Zelle für immer kahl. Drei Bausteine (aus der vorherigen A/B/C-Analyse):

### C — Datenmodell + Persistenz
- `BlockDefinition.FloraHost`, abgeleitet aus der `FloraCatalog`-Host-Union via `GameContent.MarkFloraHostDefaults` (spiegelt das Tintable/Shapeable-Muster) → Client & Server teilen ein „fruchtbarer Boden"-Flag statt es doppelt herzuleiten.
- Geplante Regrowths werden persistiert (neue `flora_regrow`-Tabelle + `IWorldRepository` Save/List/Delete). **Behebt einen echten Bug:** der Luft-Edit der Ernte überschrieb die Baseline dauerhaft → Pflanze nach Neustart für immer weg. Jetzt wird beim Welt-Load wiederhergestellt.

### B — sichtbarer Nachwachs-Hinweis
- Neue Nachricht `FloraRegrowStarted` (NetCodec-Tag 171), gebroadcastet beim Einplanen des Regrows; Client `FloraGrowthFx` lässt einen kleinen Sämling auf der kahlen Zelle über die Nachwachs-Dauer hochwachsen und entfernt ihn, wenn die echte Pflanze zurückkommt. Rein kosmetisch + render-only; der Server bleibt autoritativ.

### A → in B integriert
Der ursprüngliche „Host-Block tönen"-Ansatz ist technisch unmöglich — die Oberseite des Hosts wird **unter der Pflanze geculled** und erreicht das Mesh nie. Der Zell-Sämling ersetzt ihn (und deckt zusätzlich das leere Nachwachs-Fenster ab, was eine Host-Tönung nie konnte).

## Tests / Verifikation
- Neue Tests: `FloraHost`-Flag + „Regrow überlebt Neustart" (FloraTests), Codec-Round-Trip (NetworkingTests).
- **Server 746/746 + Client-Core 86/86 grün**, 0 Build-Warnungen, **Unity-Player-Build grün**.

## Offen
- ⚠️ **In-Game-Sichtprüfung des Sämling-Looks** steht noch aus (Höhe/Breite/Farbe/Form sind Konstanten oben in `FloraGrowthFx.cs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
