### PR TITLE
feat(editors): allow much larger ships, stations and cities

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -6,7 +6,7 @@ plans live under [docs/](docs/) (committed); this file is the high-level status.
 keep it current when controls/features change. Last consolidated 2026-06-04.
 
 **Build:** `scripts/build-client.ps1` (Windows) or `scripts/build-client.sh` (Linux) — publishes shared libs + bundled server + Unity player.
-**Test:** `dotnet test` — currently **741 server + 86 client passing** (2026-06-27). Locale parity (en/de) is enforced by a test.
+**Test:** `dotnet test` — currently **747 server + 86 client passing** (2026-06-27). Locale parity (en/de) is enforced by a test.
 **Conventions:** English docs/comments; in-game text bilingual DE+EN; commit to `main` with the
 Claude `Co-Authored-By` trailer; OpenAI texture + ElevenLabs sound generation is blanket-approved
 (no per-batch gate).
@@ -59,6 +59,23 @@ Per-item detail lives in the dated work log below.
   single-source-of-truth working end-to-end (validated: published the initial Windows zip).
 
 ---
+
+### ★ Bigger ships / stations / cities in the editors (2026-06-27) — ✅ server 747 tests green, local Unity build green, on branch `feat/planet-view-distance` (NOT committed)
+Editor build volumes raised: **ship 24×16×24 → 48×32×48**, **structure (station + settlement) 32×16×32 → 128×128×128**
+(`ShipEditor`/`StructureEditor.MaxW/MaxH/MaxL`). The old one-GameObject-per-cell rendering collapsed at that scale, so
+both editors now render placed cells through a new chunked combined-mesh renderer
+[`EditorVoxelChunkView.cs`](client/Assets/BlocksBeyondTheStars/Scripts/EditorVoxelChunkView.cs) — 16³ chunks, exposed-face
+culling, directional shading baked into vertex colours (one `VertexColorOpaque` material), a `MeshCollider` per chunk;
+place/remove now resolve the target cell from `hit.point ± normal·0.5` instead of a per-cell transform. The data model,
+merge tools and netcode already carried arbitrary dimensions (no cap). Settlement **placement** was the real
+large-build blocker and was scaled to the footprint: flatness tolerance `clamp(maxDim/8, 8..24)`, denser wet/flatness
+sampling grid (~every 16 blocks), big footprints excluded from floating-island seating (≤40), 64→160 placement attempts,
+and the terrain carve bounded to the actual relief height (a 128-tall tower no longer carves a ~2M-block air column).
+Settlements also get a **stepped support plinth** (flat floor at `gy`, each column filled solid down to the natural
+surface — deep downhill, shallow uphill, depth-capped) so a big build on a slope meets the ground all round instead of
+floating over a dip — a real multi-level foundation. Space stations live in void worlds → no placement gate. New test
+`LargeTemplate_HonorsFullDimensions_NoSizeCap`. Docs:
+[SHIP_TYPE_EDITOR.md](docs/developer/SHIP_TYPE_EDITOR.md) + [STATION_SETTLEMENT_EDITOR.md](docs/developer/STATION_SETTLEMENT_EDITOR.md).
 
 ### ★ Planet view distance + on-foot smoothness (2026-06-27) — ✅ server 741 + client 86 tests green, local Unity build green, on branch `feat/planet-view-distance` (NOT merged)
 Planet surface felt close-horizoned and slow. **A1** default render distance 2→4 (~32→64 m; per-planet/weather haze still

--- a/client/Assets/BlocksBeyondTheStars/Scripts/EditorVoxelChunkView.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/EditorVoxelChunkView.cs
@@ -1,0 +1,341 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using System.Collections.Generic;
+using BlocksBeyondTheStars.Shared.Geometry;
+using BlocksBeyondTheStars.Shared.World;
+using UnityEngine;
+
+namespace BlocksBeyondTheStars.Client
+{
+    /// <summary>
+    /// Chunked combined-mesh voxel renderer shared by the in-game ship + structure editors. Replaces the old
+    /// one-GameObject-per-cell approach (a cube + collider per placed cell), which collapsed past a few
+    /// thousand cells — so the editors can now hold large builds (ships up to 48³, structures up to 128³).
+    ///
+    /// Cells live in fixed <see cref="ChunkSize"/>³ chunks; each chunk is ONE combined mesh + one
+    /// <see cref="MeshCollider"/>, rebuilt only when one of its cells (or a neighbour-chunk border cell)
+    /// changes. Exposed cube faces are culled against solid neighbours, so a hollow station shell stays cheap.
+    /// Per-face directional shading is baked into vertex colours, so a single <c>VertexColorOpaque</c> material
+    /// reads in 3D with no per-cell materials. Edits mark chunks dirty; <see cref="Flush"/> (called once a
+    /// frame) rebuilds them in a batch, so loading a big design is a handful of mesh builds, not thousands.
+    /// </summary>
+    internal sealed class EditorVoxelChunkView
+    {
+        /// <summary>One authored cell's render data. The editor resolves the base colour (dye/glow/palette)
+        /// and passes it in; the view only renders + culls.</summary>
+        internal struct Cell
+        {
+            public Color Color;   // resolved base colour
+            public bool Glow;     // brighten toward full (stand-in for the in-game emissive look)
+            public int Shape;     // packed shape+orientation (0 = plain cube)
+            public bool Marker;   // interaction marker — drawn as a small inset cube, never occludes
+        }
+
+        private const int ChunkSize = 16;
+
+        private sealed class Slot
+        {
+            public GameObject Go;
+            public MeshFilter Filter;
+            public MeshCollider Collider;
+            public readonly Dictionary<Vector3i, Cell> Cells = new();
+        }
+
+        private readonly Transform _parent;
+        private readonly Material _material;
+        private readonly Dictionary<Vector3i, Cell> _all = new();    // every cell — occupancy + render data
+        private readonly Dictionary<Vector3i, Slot> _slots = new();  // chunk coord -> slot
+        private readonly HashSet<Vector3i> _dirty = new();
+
+        public EditorVoxelChunkView(Transform parent)
+        {
+            _parent = parent;
+            var shader = Shader.Find("BlocksBeyondTheStars/VertexColorOpaque") ?? Shader.Find("Unlit/Color");
+            _material = new Material(shader);
+
+            // The vertex-colour shader tints by the global day/night light; pin it to neutral white so the
+            // editor renders consistently regardless of any tint left over from a prior in-game session.
+            Shader.SetGlobalVector("_Sc_Light", new Vector4(1f, 1f, 1f, 1f));
+        }
+
+        public int Count => _all.Count;
+
+        public bool Contains(Vector3i cell) => _all.ContainsKey(cell);
+
+        /// <summary>Adds or replaces a cell and marks its chunk (and any bordering neighbour chunk) dirty.</summary>
+        public void Set(Vector3i cell, Cell data)
+        {
+            _all[cell] = data;
+            var cc = ChunkOf(cell);
+            if (!_slots.TryGetValue(cc, out var slot))
+            {
+                slot = CreateSlot(cc);
+                _slots[cc] = slot;
+            }
+
+            slot.Cells[cell] = data;
+            MarkDirty(cell, cc);
+        }
+
+        /// <summary>Removes a cell (if present) and marks the affected chunks dirty.</summary>
+        public void Remove(Vector3i cell)
+        {
+            if (!_all.Remove(cell))
+            {
+                return;
+            }
+
+            var cc = ChunkOf(cell);
+            if (_slots.TryGetValue(cc, out var slot))
+            {
+                slot.Cells.Remove(cell);
+            }
+
+            MarkDirty(cell, cc);
+        }
+
+        /// <summary>Drops every cell + chunk (used when loading a design or resetting the room).</summary>
+        public void Clear()
+        {
+            foreach (var slot in _slots.Values)
+            {
+                if (slot.Filter != null && slot.Filter.sharedMesh != null)
+                {
+                    Object.Destroy(slot.Filter.sharedMesh);
+                }
+
+                if (slot.Go != null)
+                {
+                    Object.Destroy(slot.Go);
+                }
+            }
+
+            _slots.Clear();
+            _all.Clear();
+            _dirty.Clear();
+        }
+
+        public void Dispose()
+        {
+            Clear();
+            if (_material != null)
+            {
+                Object.Destroy(_material);
+            }
+        }
+
+        /// <summary>Rebuilds every chunk touched since the last call. Returns immediately when nothing changed,
+        /// so it is cheap to call every frame.</summary>
+        public void Flush()
+        {
+            if (_dirty.Count == 0)
+            {
+                return;
+            }
+
+            foreach (var cc in _dirty)
+            {
+                if (_slots.TryGetValue(cc, out var slot))
+                {
+                    RebuildSlot(slot);
+                }
+            }
+
+            _dirty.Clear();
+        }
+
+        // --- chunk bookkeeping --------------------------------------------------------------------------
+
+        private static int FloorDiv(int a, int b) => (a >= 0 ? a : a - (b - 1)) / b;
+
+        private static Vector3i ChunkOf(Vector3i c)
+            => new Vector3i(FloorDiv(c.X, ChunkSize), FloorDiv(c.Y, ChunkSize), FloorDiv(c.Z, ChunkSize));
+
+        private void MarkDirty(Vector3i cell, Vector3i cc)
+        {
+            _dirty.Add(cc);
+
+            // A cube face is culled against the neighbour cell, which may sit in an adjacent chunk — rebuild
+            // those too so a wall flush against a chunk border updates on both sides.
+            AddNeighbourChunk(cell, 1, 0, 0);
+            AddNeighbourChunk(cell, -1, 0, 0);
+            AddNeighbourChunk(cell, 0, 1, 0);
+            AddNeighbourChunk(cell, 0, -1, 0);
+            AddNeighbourChunk(cell, 0, 0, 1);
+            AddNeighbourChunk(cell, 0, 0, -1);
+        }
+
+        private void AddNeighbourChunk(Vector3i cell, int dx, int dy, int dz)
+        {
+            var nc = ChunkOf(new Vector3i(cell.X + dx, cell.Y + dy, cell.Z + dz));
+            if (_slots.ContainsKey(nc))
+            {
+                _dirty.Add(nc);
+            }
+        }
+
+        private Slot CreateSlot(Vector3i cc)
+        {
+            var go = new GameObject($"Chunk {cc.X},{cc.Y},{cc.Z}", typeof(MeshFilter), typeof(MeshRenderer), typeof(MeshCollider));
+            go.transform.SetParent(_parent, false); // mesh is authored in world cell coords (identity transform)
+            go.GetComponent<MeshRenderer>().sharedMaterial = _material;
+            return new Slot
+            {
+                Go = go,
+                Filter = go.GetComponent<MeshFilter>(),
+                Collider = go.GetComponent<MeshCollider>(),
+            };
+        }
+
+        // --- meshing ------------------------------------------------------------------------------------
+
+        // Scratch buffers reused across rebuilds (one chunk is built at a time on the main thread).
+        private static readonly List<Vector3> _verts = new();
+        private static readonly List<Color> _colors = new();
+        private static readonly List<int> _tris = new();
+
+        /// <summary>True if the cell at <paramref name="p"/> is a solid cube that should hide the face turned
+        /// toward it. Shaped + marker cells never occlude (they don't fill the cell).</summary>
+        private bool Occludes(Vector3i p)
+            => _all.TryGetValue(p, out var c) && c.Shape == 0 && !c.Marker;
+
+        private void RebuildSlot(Slot slot)
+        {
+            _verts.Clear();
+            _colors.Clear();
+            _tris.Clear();
+
+            foreach (var kv in slot.Cells)
+            {
+                var cell = kv.Key;
+                var data = kv.Value;
+                var origin = new Vector3(cell.X, cell.Y, cell.Z);
+
+                if (data.Marker)
+                {
+                    // Markers read as small floating cubes so they stand apart from solid blocks.
+                    for (int f = 0; f < 6; f++)
+                    {
+                        AddFace(origin, f, 0.25f, 0.75f, data.Color, data.Glow);
+                    }
+                }
+                else if (data.Shape != 0)
+                {
+                    AddShape(origin, data);
+                }
+                else
+                {
+                    // Plain cube: emit only the faces exposed to a non-occluding neighbour.
+                    if (!Occludes(new Vector3i(cell.X, cell.Y + 1, cell.Z))) AddFace(origin, 0, 0f, 1f, data.Color, data.Glow);
+                    if (!Occludes(new Vector3i(cell.X, cell.Y - 1, cell.Z))) AddFace(origin, 1, 0f, 1f, data.Color, data.Glow);
+                    if (!Occludes(new Vector3i(cell.X + 1, cell.Y, cell.Z))) AddFace(origin, 2, 0f, 1f, data.Color, data.Glow);
+                    if (!Occludes(new Vector3i(cell.X - 1, cell.Y, cell.Z))) AddFace(origin, 3, 0f, 1f, data.Color, data.Glow);
+                    if (!Occludes(new Vector3i(cell.X, cell.Y, cell.Z + 1))) AddFace(origin, 4, 0f, 1f, data.Color, data.Glow);
+                    if (!Occludes(new Vector3i(cell.X, cell.Y, cell.Z - 1))) AddFace(origin, 5, 0f, 1f, data.Color, data.Glow);
+                }
+            }
+
+            var mesh = slot.Filter.sharedMesh;
+            if (mesh == null)
+            {
+                mesh = new Mesh { name = "EditorChunk", indexFormat = UnityEngine.Rendering.IndexFormat.UInt32 };
+                slot.Filter.sharedMesh = mesh;
+            }
+            else
+            {
+                mesh.Clear();
+            }
+
+            if (_verts.Count > 0)
+            {
+                mesh.SetVertices(_verts);
+                mesh.SetColors(_colors);
+                mesh.SetTriangles(_tris, 0);
+                mesh.RecalculateBounds();
+            }
+
+            // A MeshCollider with a null/empty mesh raycasts nothing — exactly right for an emptied chunk.
+            slot.Collider.sharedMesh = null;
+            slot.Collider.sharedMesh = _verts.Count > 0 ? mesh : null;
+        }
+
+        private void AddShape(Vector3 origin, Cell data)
+        {
+            var faces = BlockShapeGeometry.Build(ShapeCode.ShapeOf(data.Shape), ShapeCode.OrientationOf(data.Shape));
+            if (faces == null)
+            {
+                return;
+            }
+
+            foreach (var face in faces)
+            {
+                Vector3 a = origin + face.A, b = origin + face.B, c = origin + face.C;
+                Vector3 edge1 = b - a;
+                Vector3 edge2 = (face.IsQuad ? origin + face.D : c) - a;
+                Vector3 nrm = Vector3.Cross(edge1, edge2).normalized;
+                float shade = Mathf.Clamp(0.76f + 0.24f * nrm.y, 0.5f, 1f);
+                Color col = Tint(data.Color, shade, data.Glow);
+
+                int b0 = _verts.Count;
+                _verts.Add(a); _verts.Add(b); _verts.Add(c);
+                _colors.Add(col); _colors.Add(col); _colors.Add(col);
+                _tris.Add(b0); _tris.Add(b0 + 1); _tris.Add(b0 + 2);
+                if (face.IsQuad)
+                {
+                    _verts.Add(origin + face.D);
+                    _colors.Add(col);
+                    _tris.Add(b0); _tris.Add(b0 + 2); _tris.Add(b0 + 3);
+                }
+            }
+        }
+
+        /// <summary>Appends one box face (winding + corner order match <c>ChunkMesher.FaceQuad</c> so the
+        /// outward side is the front face), shaded by face direction and baked into the vertex colour.</summary>
+        private void AddFace(Vector3 p, int face, float lo, float hi, Color color, bool glow)
+        {
+            Vector3[] q = FaceQuad(p, face, lo, hi);
+            Color col = Tint(color, FaceShade(face), glow);
+
+            int b0 = _verts.Count;
+            _verts.Add(q[0]); _verts.Add(q[1]); _verts.Add(q[2]); _verts.Add(q[3]);
+            _colors.Add(col); _colors.Add(col); _colors.Add(col); _colors.Add(col);
+            _tris.Add(b0); _tris.Add(b0 + 1); _tris.Add(b0 + 2);
+            _tris.Add(b0); _tris.Add(b0 + 2); _tris.Add(b0 + 3);
+        }
+
+        /// <summary>Base colour × face shade; glowing cells keep a bright floor so they read as emissive.</summary>
+        private static Color Tint(Color c, float shade, bool glow)
+        {
+            float s = glow ? Mathf.Max(shade, 0.85f) : shade;
+            return new Color(c.r * s, c.g * s, c.b * s, 1f);
+        }
+
+        /// <summary>Relative brightness per face (top brightest, bottom darkest), mirroring the in-game
+        /// <c>ChunkMesher.FaceShade</c> so editor cubes read the same way they will in the world.</summary>
+        private static float FaceShade(int face) => face switch
+        {
+            0 => 1.00f, // +Y top
+            1 => 0.50f, // -Y bottom
+            2 => 0.82f, // +X
+            3 => 0.72f, // -X
+            4 => 0.66f, // +Z
+            _ => 0.76f, // -Z
+        };
+
+        /// <summary>The four corners of a box face on <c>[lo,hi]³</c> offset by <paramref name="p"/>. Corner
+        /// order + winding match <c>ChunkMesher.FaceQuad</c> (front face = outward).</summary>
+        private static Vector3[] FaceQuad(Vector3 p, int face, float lo, float hi)
+        {
+            switch (face)
+            {
+                case 0: return new[] { p + new Vector3(lo, hi, lo), p + new Vector3(lo, hi, hi), p + new Vector3(hi, hi, hi), p + new Vector3(hi, hi, lo) }; // +Y
+                case 1: return new[] { p + new Vector3(lo, lo, hi), p + new Vector3(lo, lo, lo), p + new Vector3(hi, lo, lo), p + new Vector3(hi, lo, hi) }; // -Y
+                case 2: return new[] { p + new Vector3(hi, lo, lo), p + new Vector3(hi, hi, lo), p + new Vector3(hi, hi, hi), p + new Vector3(hi, lo, hi) }; // +X
+                case 3: return new[] { p + new Vector3(lo, lo, hi), p + new Vector3(lo, hi, hi), p + new Vector3(lo, hi, lo), p + new Vector3(lo, lo, lo) }; // -X
+                case 4: return new[] { p + new Vector3(hi, lo, hi), p + new Vector3(hi, hi, hi), p + new Vector3(lo, hi, hi), p + new Vector3(lo, lo, hi) }; // +Z
+                default: return new[] { p + new Vector3(lo, lo, lo), p + new Vector3(lo, hi, lo), p + new Vector3(hi, hi, lo), p + new Vector3(hi, lo, lo) }; // -Z
+            }
+        }
+    }
+}

--- a/client/Assets/BlocksBeyondTheStars/Scripts/EditorVoxelChunkView.cs.meta
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/EditorVoxelChunkView.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 614224de25acae744b300102be590738

--- a/client/Assets/BlocksBeyondTheStars/Scripts/ShipEditor.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/ShipEditor.cs
@@ -23,7 +23,8 @@ namespace BlocksBeyondTheStars.Client
     {
         public AppShell Shell;
 
-        private const int MaxW = 24, MaxH = 16, MaxL = 24;
+        private const int MaxW = 48, MaxH = 32, MaxL = 48;
+        private const float RaycastDist = 1200f;
 
         private Camera _cam;
         private GameObject _floor;
@@ -33,9 +34,8 @@ namespace BlocksBeyondTheStars.Client
         /// colour 0xRRGGBB, packed shape+orientation). Elements/stations carry no modifiers.</summary>
         private struct CellData { public string Id; public string Kind; public int Tint, Glow, Shape; }
 
-        private readonly Dictionary<Vector3i, CellData> _design = new();   // cell -> authored cell
-        private readonly Dictionary<Vector3i, GameObject> _cells = new();
-        private readonly Dictionary<string, Material> _mats = new();
+        private readonly Dictionary<Vector3i, CellData> _design = new();   // cell -> authored cell (export source)
+        private EditorVoxelChunkView _view;                                // chunked combined-mesh renderer
 
         private struct Pal { public string Id, Label, Kind; public Color Color; }
         private Pal[] _palette;
@@ -77,13 +77,14 @@ namespace BlocksBeyondTheStars.Client
             _cam = camGo.AddComponent<Camera>();
             _cam.clearFlags = CameraClearFlags.SolidColor;
             _cam.backgroundColor = new Color(0.02f, 0.03f, 0.06f);
-            _cam.farClipPlane = 400f;
+            _cam.farClipPlane = 800f;
             camGo.AddComponent<AudioListener>();
-            _cam.transform.position = new Vector3(MaxW / 2f, 6f, -10f);
+            _cam.transform.position = new Vector3(MaxW / 2f, 10f, -18f);
             _yaw = 0f;
             _pitch = 15f;
             _cam.transform.rotation = Quaternion.Euler(_pitch, _yaw, 0f);
 
+            _view = new EditorVoxelChunkView(transform);
             BuildRoom();
             BuildUi();
         }
@@ -207,7 +208,7 @@ namespace BlocksBeyondTheStars.Client
                 _cam.transform.rotation = Quaternion.Euler(_pitch, _yaw, 0f);
             }
 
-            float speed = (Input.GetKey(KeyCode.LeftShift) ? 18f : 9f) * Time.deltaTime;
+            float speed = (Input.GetKey(KeyCode.LeftShift) ? 30f : 14f) * Time.deltaTime;
             var move = Vector3.zero;
             if (Input.GetKey(KeyCode.W)) move += _cam.transform.forward;
             if (Input.GetKey(KeyCode.S)) move -= _cam.transform.forward;
@@ -242,14 +243,18 @@ namespace BlocksBeyondTheStars.Client
             {
                 _brushOrient = (_brushOrient + 1) & 3;
             }
+
+            _view.Flush(); // upload any chunk meshes touched by this frame's edits
         }
 
-        /// <summary>Resolves the cell a placement would land in (floor hit or hit-block neighbour).</summary>
+        /// <summary>Resolves the cell a placement would land in: the floor column, or the empty cell just
+        /// outside the hit face (the chunk mesh is authored in world coords, so the hit point + normal locate
+        /// the cell directly — no per-cell GameObject to read a transform from).</summary>
         private bool TryGetTargetCell(out Vector3i cell)
         {
             cell = default;
             var ray = _cam.ScreenPointToRay(Input.mousePosition);
-            if (!Physics.Raycast(ray, out var hit, 200f))
+            if (!Physics.Raycast(ray, out var hit, RaycastDist))
             {
                 return false;
             }
@@ -260,11 +265,26 @@ namespace BlocksBeyondTheStars.Client
             }
             else
             {
-                var t = hit.collider.transform.position;
-                var hc = new Vector3i(Mathf.FloorToInt(t.x), Mathf.FloorToInt(t.y), Mathf.FloorToInt(t.z));
-                cell = new Vector3i(hc.X + Mathf.RoundToInt(hit.normal.x), hc.Y + Mathf.RoundToInt(hit.normal.y), hc.Z + Mathf.RoundToInt(hit.normal.z));
+                Vector3 outside = hit.point + hit.normal * 0.5f; // step out of the hit cell into its empty neighbour
+                cell = new Vector3i(Mathf.FloorToInt(outside.x), Mathf.FloorToInt(outside.y), Mathf.FloorToInt(outside.z));
             }
 
+            return true;
+        }
+
+        /// <summary>Resolves the actual occupied cell under the cursor (for removal); false if the ray misses
+        /// every block or hits only the floor.</summary>
+        private bool TryGetHitCell(out Vector3i cell)
+        {
+            cell = default;
+            var ray = _cam.ScreenPointToRay(Input.mousePosition);
+            if (!Physics.Raycast(ray, out var hit, RaycastDist) || hit.collider.gameObject == _floor)
+            {
+                return false;
+            }
+
+            Vector3 inside = hit.point - hit.normal * 0.5f; // step into the hit cell
+            cell = new Vector3i(Mathf.FloorToInt(inside.x), Mathf.FloorToInt(inside.y), Mathf.FloorToInt(inside.z));
             return true;
         }
 
@@ -321,17 +341,10 @@ namespace BlocksBeyondTheStars.Client
 
         private void TryRemove()
         {
-            var ray = _cam.ScreenPointToRay(Input.mousePosition);
-            if (Physics.Raycast(ray, out var hit, 200f) && hit.collider.gameObject != _floor)
+            if (TryGetHitCell(out var cell) && _design.ContainsKey(cell))
             {
-                var t = hit.collider.transform.position;
-                var cell = new Vector3i(Mathf.FloorToInt(t.x), Mathf.FloorToInt(t.y), Mathf.FloorToInt(t.z));
-                if (_cells.TryGetValue(cell, out var go))
-                {
-                    Destroy(go);
-                    _cells.Remove(cell);
-                    _design.Remove(cell);
-                }
+                _design.Remove(cell);
+                _view.Remove(cell);
             }
         }
 
@@ -351,56 +364,23 @@ namespace BlocksBeyondTheStars.Client
 
         private void PlaceCellData(Vector3i cell, Pal pal, CellData data)
         {
-            GameObject go;
-            Mesh shapeMesh = data.Shape != 0
-                ? EditorVoxelPreview.ShapeMesh(ShapeCode.ShapeOf(data.Shape), ShapeCode.OrientationOf(data.Shape))
-                : null;
-            if (shapeMesh != null)
-            {
-                go = new GameObject($"Cell {pal.Id}", typeof(MeshFilter), typeof(MeshRenderer));
-                go.GetComponent<MeshFilter>().sharedMesh = shapeMesh;
-                var bc = go.AddComponent<BoxCollider>();
-                bc.center = Vector3.one * 0.5f;
-                bc.size = Vector3.one;
-                go.transform.SetParent(transform, false);
-                go.transform.position = new Vector3(cell.X, cell.Y, cell.Z);
-            }
-            else
-            {
-                go = GameObject.CreatePrimitive(PrimitiveType.Cube);
-                go.name = $"Cell {pal.Id}";
-                go.transform.SetParent(transform, false);
-                go.transform.position = new Vector3(cell.X + 0.5f, cell.Y + 0.5f, cell.Z + 0.5f);
-                go.transform.localScale = Vector3.one * 0.98f;
-            }
-
-            go.GetComponent<Renderer>().sharedMaterial = MatFor(pal, data);
-            _cells[cell] = go;
-            _design[cell] = data;
-        }
-
-        private bool InBounds(Vector3i c) => c.X >= 0 && c.X < MaxW && c.Y >= 0 && c.Y < MaxH && c.Z >= 0 && c.Z < MaxL;
-
-        private Material MatFor(Pal pal, CellData data)
-        {
+            // Dye wins for the base colour; a pure glow cell shows its glow colour; else the palette swatch
+            // (mirrors the in-game look). The chunked view bakes the directional shading + face culling.
             Color baseCol = data.Tint != 0
                 ? EditorVoxelPreview.RgbToColor(data.Tint)
                 : (data.Glow != 0 ? EditorVoxelPreview.RgbToColor(data.Glow) : pal.Color);
-            string key = $"{pal.Id}|{data.Tint}|{data.Glow}";
-            if (!_mats.TryGetValue(key, out var m))
+
+            _design[cell] = data;
+            _view.Set(cell, new EditorVoxelChunkView.Cell
             {
-                m = Lit(baseCol, null);
-                if (data.Glow != 0)
-                {
-                    m.EnableKeyword("_EMISSION");
-                    m.SetColor("_EmissionColor", ShaderColor.Srgb(EditorVoxelPreview.RgbToColor(data.Glow)));
-                }
-
-                _mats[key] = m;
-            }
-
-            return m;
+                Color = baseCol,
+                Glow = data.Glow != 0,
+                Shape = data.Shape,
+                Marker = false, // the ship editor has no markers (elements + stations are solid anchors)
+            });
         }
+
+        private bool InBounds(Vector3i c) => c.X >= 0 && c.X < MaxW && c.Y >= 0 && c.Y < MaxH && c.Z >= 0 && c.Z < MaxL;
 
         // ----------------------------- UI (modern uGUI) -----------------------------
 
@@ -427,6 +407,7 @@ namespace BlocksBeyondTheStars.Client
 
         private void OnDestroy()
         {
+            _view?.Dispose();
             if (_canvas != null)
             {
                 Destroy(_canvas.gameObject);
@@ -841,12 +822,7 @@ namespace BlocksBeyondTheStars.Client
             {
                 var layout = JsonUtility.FromJson<ExportLayoutJson>(File.ReadAllText(layoutPath));
 
-                foreach (var go in _cells.Values)
-                {
-                    Destroy(go);
-                }
-
-                _cells.Clear();
+                _view.Clear();
                 _design.Clear();
 
                 if (layout?.cells != null)
@@ -869,6 +845,8 @@ namespace BlocksBeyondTheStars.Client
                         PlaceCellData(cell, pal, data);
                     }
                 }
+
+                _view.Flush(); // build all loaded chunks in one batch
 
                 string shipPath = Path.Combine(dir, "ship.json");
                 if (File.Exists(shipPath) && JsonUtility.FromJson<ExportShipJson>(File.ReadAllText(shipPath)) is { } ship)

--- a/client/Assets/BlocksBeyondTheStars/Scripts/StructureEditor.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/StructureEditor.cs
@@ -27,7 +27,8 @@ namespace BlocksBeyondTheStars.Client
         public AppShell Shell;
         public Mode EditorMode = Mode.Station;
 
-        private const int MaxW = 32, MaxH = 16, MaxL = 32;
+        private const int MaxW = 128, MaxH = 128, MaxL = 128;
+        private const float RaycastDist = 2400f;
 
         private Camera _cam;
         private GameObject _floor;
@@ -37,9 +38,8 @@ namespace BlocksBeyondTheStars.Client
         /// (dye/glow colour 0xRRGGBB, packed shape+orientation). Markers carry no modifiers.</summary>
         private struct CellData { public string Id; public string Kind; public int Tint, Glow, Shape; }
 
-        private readonly Dictionary<Vector3i, CellData> _design = new();
-        private readonly Dictionary<Vector3i, GameObject> _cells = new();
-        private readonly Dictionary<string, Material> _mats = new();
+        private readonly Dictionary<Vector3i, CellData> _design = new();   // cell -> authored cell (export source)
+        private EditorVoxelChunkView _view;                                // chunked combined-mesh renderer
 
         private struct Pal { public string Id, Label, Kind; public Color Color; }
         private Pal[] _palette;
@@ -76,12 +76,13 @@ namespace BlocksBeyondTheStars.Client
             _cam = camGo.AddComponent<Camera>();
             _cam.clearFlags = CameraClearFlags.SolidColor;
             _cam.backgroundColor = new Color(0.02f, 0.03f, 0.06f);
-            _cam.farClipPlane = 500f;
+            _cam.farClipPlane = 1600f;
             camGo.AddComponent<AudioListener>();
-            _cam.transform.position = new Vector3(MaxW / 2f, 8f, -12f);
+            _cam.transform.position = new Vector3(MaxW / 2f, 18f, -36f);
             _pitch = 18f;
             _cam.transform.rotation = Quaternion.Euler(_pitch, _yaw, 0f);
 
+            _view = new EditorVoxelChunkView(transform);
             BuildRoom();
             BuildUi();
         }
@@ -204,7 +205,7 @@ namespace BlocksBeyondTheStars.Client
                 _cam.transform.rotation = Quaternion.Euler(_pitch, _yaw, 0f);
             }
 
-            float speed = (Input.GetKey(KeyCode.LeftShift) ? 22f : 11f) * Time.deltaTime;
+            float speed = (Input.GetKey(KeyCode.LeftShift) ? 55f : 22f) * Time.deltaTime;
             var move = Vector3.zero;
             if (Input.GetKey(KeyCode.W)) move += _cam.transform.forward;
             if (Input.GetKey(KeyCode.S)) move -= _cam.transform.forward;
@@ -232,29 +233,13 @@ namespace BlocksBeyondTheStars.Client
                 _brushOrient = (_brushOrient + 1) & 3;
                 if (_orientLabel != null) _orientLabel.text = (_brushOrient * 90) + "°";
             }
+
+            _view.Flush(); // upload any chunk meshes touched by this frame's edits
         }
 
         private void TryPlace()
         {
-            var ray = _cam.ScreenPointToRay(Input.mousePosition);
-            if (!Physics.Raycast(ray, out var hit, 300f))
-            {
-                return;
-            }
-
-            Vector3i cell;
-            if (hit.collider.gameObject == _floor)
-            {
-                cell = new Vector3i(Mathf.FloorToInt(hit.point.x), 0, Mathf.FloorToInt(hit.point.z));
-            }
-            else
-            {
-                var t = hit.collider.transform.position;
-                var hc = new Vector3i(Mathf.FloorToInt(t.x), Mathf.FloorToInt(t.y), Mathf.FloorToInt(t.z));
-                cell = new Vector3i(hc.X + Mathf.RoundToInt(hit.normal.x), hc.Y + Mathf.RoundToInt(hit.normal.y), hc.Z + Mathf.RoundToInt(hit.normal.z));
-            }
-
-            if (InBounds(cell) && !_design.ContainsKey(cell))
+            if (TryGetTargetCell(out var cell) && InBounds(cell) && !_design.ContainsKey(cell))
             {
                 PlaceCell(cell, _palette[_selected]);
             }
@@ -262,18 +247,51 @@ namespace BlocksBeyondTheStars.Client
 
         private void TryRemove()
         {
-            var ray = _cam.ScreenPointToRay(Input.mousePosition);
-            if (Physics.Raycast(ray, out var hit, 300f) && hit.collider.gameObject != _floor)
+            if (TryGetHitCell(out var cell) && _design.ContainsKey(cell))
             {
-                var t = hit.collider.transform.position;
-                var cell = new Vector3i(Mathf.FloorToInt(t.x), Mathf.FloorToInt(t.y), Mathf.FloorToInt(t.z));
-                if (_cells.TryGetValue(cell, out var go))
-                {
-                    Destroy(go);
-                    _cells.Remove(cell);
-                    _design.Remove(cell);
-                }
+                _design.Remove(cell);
+                _view.Remove(cell);
             }
+        }
+
+        /// <summary>Resolves the empty cell just outside the hit face (or the floor column) for placement. The
+        /// chunk mesh is authored in world coords, so the hit point + normal locate the cell directly.</summary>
+        private bool TryGetTargetCell(out Vector3i cell)
+        {
+            cell = default;
+            var ray = _cam.ScreenPointToRay(Input.mousePosition);
+            if (!Physics.Raycast(ray, out var hit, RaycastDist))
+            {
+                return false;
+            }
+
+            if (hit.collider.gameObject == _floor)
+            {
+                cell = new Vector3i(Mathf.FloorToInt(hit.point.x), 0, Mathf.FloorToInt(hit.point.z));
+            }
+            else
+            {
+                Vector3 outside = hit.point + hit.normal * 0.5f;
+                cell = new Vector3i(Mathf.FloorToInt(outside.x), Mathf.FloorToInt(outside.y), Mathf.FloorToInt(outside.z));
+            }
+
+            return true;
+        }
+
+        /// <summary>Resolves the actual occupied cell under the cursor (for removal); false on a miss or a
+        /// floor-only hit.</summary>
+        private bool TryGetHitCell(out Vector3i cell)
+        {
+            cell = default;
+            var ray = _cam.ScreenPointToRay(Input.mousePosition);
+            if (!Physics.Raycast(ray, out var hit, RaycastDist) || hit.collider.gameObject == _floor)
+            {
+                return false;
+            }
+
+            Vector3 inside = hit.point - hit.normal * 0.5f;
+            cell = new Vector3i(Mathf.FloorToInt(inside.x), Mathf.FloorToInt(inside.y), Mathf.FloorToInt(inside.z));
+            return true;
         }
 
         private void PlaceCell(Vector3i cell, Pal pal)
@@ -292,59 +310,23 @@ namespace BlocksBeyondTheStars.Client
 
         private void PlaceCellData(Vector3i cell, Pal pal, CellData data)
         {
-            GameObject go;
-            Mesh shapeMesh = data.Shape != 0
-                ? EditorVoxelPreview.ShapeMesh(ShapeCode.ShapeOf(data.Shape), ShapeCode.OrientationOf(data.Shape))
-                : null;
-            if (shapeMesh != null)
-            {
-                // Shaped cells render the real in-game geometry (unit cell 0..1), with a unit box collider
-                // so place/remove raycasts still hit them.
-                go = new GameObject($"Cell {pal.Id}", typeof(MeshFilter), typeof(MeshRenderer));
-                go.GetComponent<MeshFilter>().sharedMesh = shapeMesh;
-                var bc = go.AddComponent<BoxCollider>();
-                bc.center = Vector3.one * 0.5f;
-                bc.size = Vector3.one;
-                go.transform.SetParent(transform, false);
-                go.transform.position = new Vector3(cell.X, cell.Y, cell.Z);
-            }
-            else
-            {
-                go = GameObject.CreatePrimitive(PrimitiveType.Cube);
-                go.name = $"Cell {pal.Id}";
-                go.transform.SetParent(transform, false);
-                go.transform.position = new Vector3(cell.X + 0.5f, cell.Y + 0.5f, cell.Z + 0.5f);
-                go.transform.localScale = Vector3.one * (pal.Kind == "marker" ? 0.6f : 0.98f);
-            }
-
-            go.GetComponent<Renderer>().sharedMaterial = MatFor(pal, data);
-            _cells[cell] = go;
-            _design[cell] = data;
-        }
-
-        private bool InBounds(Vector3i c) => c.X >= 0 && c.X < MaxW && c.Y >= 0 && c.Y < MaxH && c.Z >= 0 && c.Z < MaxL;
-
-        private Material MatFor(Pal pal, CellData data)
-        {
             // Dye wins for the base colour; a pure glow cell shows its glow colour; else the palette swatch.
+            // The chunked view bakes directional shading + face culling; markers render as small inset cubes.
             Color baseCol = data.Tint != 0
                 ? EditorVoxelPreview.RgbToColor(data.Tint)
                 : (data.Glow != 0 ? EditorVoxelPreview.RgbToColor(data.Glow) : pal.Color);
-            string key = $"{pal.Id}|{data.Tint}|{data.Glow}";
-            if (!_mats.TryGetValue(key, out var m))
+
+            _design[cell] = data;
+            _view.Set(cell, new EditorVoxelChunkView.Cell
             {
-                m = Lit(baseCol, null);
-                if (data.Glow != 0)
-                {
-                    m.EnableKeyword("_EMISSION");
-                    m.SetColor("_EmissionColor", ShaderColor.Srgb(EditorVoxelPreview.RgbToColor(data.Glow)));
-                }
-
-                _mats[key] = m;
-            }
-
-            return m;
+                Color = baseCol,
+                Glow = data.Glow != 0,
+                Shape = data.Shape,
+                Marker = pal.Kind == "marker",
+            });
         }
+
+        private bool InBounds(Vector3i c) => c.X >= 0 && c.X < MaxW && c.Y >= 0 && c.Y < MaxH && c.Z >= 0 && c.Z < MaxL;
 
         // ----------------------------- export -----------------------------
 
@@ -482,12 +464,7 @@ namespace BlocksBeyondTheStars.Client
             {
                 var layout = JsonUtility.FromJson<LayoutJson>(File.ReadAllText(layoutPath));
 
-                foreach (var go in _cells.Values)
-                {
-                    Destroy(go);
-                }
-
-                _cells.Clear();
+                _view.Clear();
                 _design.Clear();
 
                 if (layout?.cells != null)
@@ -510,6 +487,8 @@ namespace BlocksBeyondTheStars.Client
                         PlaceCellData(cell, pal, data);
                     }
                 }
+
+                _view.Flush(); // build all loaded chunks in one batch
 
                 string metaPath = Path.Combine(dir, "structure.json");
                 if (File.Exists(metaPath) && JsonUtility.FromJson<MetaJson>(File.ReadAllText(metaPath)) is { } meta)
@@ -595,6 +574,7 @@ namespace BlocksBeyondTheStars.Client
 
         private void OnDestroy()
         {
+            _view?.Dispose();
             if (_canvas != null)
             {
                 Destroy(_canvas.gameObject);

--- a/docs/developer/SHIP_TYPE_EDITOR.md
+++ b/docs/developer/SHIP_TYPE_EDITOR.md
@@ -83,7 +83,7 @@ share one source of truth.
 
 - **Launch:** AppShell gets a new phase `ShipEditor` (main menu button → enter; Esc → back to menu).
 - **Build room:** a small flat platform in an empty starfield (reuse `MenuBackground`/`Sky` ambiance);
-  a bounded build volume (e.g. up to 24×16×24) with a faint grid + origin marker.
+  a bounded build volume (**48×32×48**, `ShipEditor.MaxW/MaxH/MaxL`) with a faint grid + origin marker.
 - **Movement:** reuse a trimmed `PlayerController` (walk + jump, or a free-fly toggle) with no vitals/
   combat — just look + move + place/remove. Block selection box + place/remove like in-game (MiningFx /
   the place path), but client-only (no server).
@@ -149,5 +149,6 @@ merge for ships + items + recipes.)
 3. **Where to save / how to integrate:** export to a user folder + `merge_ship.py` into `data/` (the
    recommended path), or write straight into `data/` from the editor (simpler for a solo dev, but mixes
    tool output with source). Recommend **export + merge script**.
-4. **Build-volume bounds + block budget:** a sensible max size (e.g. 24×16×24) to keep stamping/cost
-   reasonable — confirm or set.
+4. **Build-volume bounds + block budget:** ships are bounded to **48×32×48** (`ShipEditor.MaxW/MaxH/MaxL`);
+   structures (station/settlement editor) to **128×128×128**. The editor renders the build as a chunked
+   combined mesh (`EditorVoxelChunkView`) so large volumes stay performant.

--- a/docs/developer/STATION_SETTLEMENT_EDITOR.md
+++ b/docs/developer/STATION_SETTLEMENT_EDITOR.md
@@ -6,6 +6,18 @@ build to verify). Requested: build a **space-station editor** and a **town/villa
 editor), then make world generation pick from **lists of hand-designed station/village/town types** *in
 addition to* procedural generation.
 
+> **Update (2026-06-27) — large builds.** The structure editor's build volume is now **128×128×128**
+> (`StructureEditor.MaxW/MaxH/MaxL`; the ship editor is 48×32×48). To keep large builds editable the editors
+> render the placed cells as a chunked combined mesh with face culling (`EditorVoxelChunkView`) instead of one
+> GameObject per cell. The settlement **placement** allocator scales with the footprint: the flatness
+> tolerance grows with build size, the wet/flatness gates sample a denser grid, large footprints are excluded
+> from floating-island seating, and the terrain carve is bounded to the actual relief height (so a 128-tall
+> tower no longer carves a 2M-block column). Settlements also get a **stepped support plinth**: the flat floor
+> stays level at `gy`, but each column is filled solid down to the natural surface (deep downhill, shallow
+> uphill, depth-capped), so a big build on a slope meets the ground all the way round instead of a flat slab
+> floating over a dip — a real multi-level foundation. Space stations live in void worlds, so they have no
+> placement gate. There is no size cap in the data model or merge tools — the editor bound is the only limit.
+
 What shipped differs from the design below in two notable ways:
 - **One editor, two modes — not two editors.** Both the station and the settlement editor are the single
   `client/.../StructureEditor.cs` (`Mode.Station` / `Mode.Settlement`); the menu exposes both entries

--- a/src/BlocksBeyondTheStars.GameServer/GameServerSettlements.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerSettlements.cs
@@ -289,22 +289,56 @@ public sealed partial class GameServer
         var origin = p.Origin;
         var foundationId = _content.GetBlock(surface)?.NumericId ?? BlockId.Air;
 
+        // Carve only as high as terrain actually rises above the foundation. Placement guarantees a low height
+        // spread, so the surface never climbs more than a handful of blocks over gy — clearing the structure's
+        // FULL height (up to 128 for a hand-authored tower) would be millions of pointless air writes. Sample
+        // the footprint coarsely to find that intrusion height. (On a sky island the ground is far below, so
+        // maxSurf - gy goes negative and the carve collapses to the minimum.)
+        var planet = _world.Planet;
+        int maxSurf = gy;
+        for (int x = 0; x < s.Width; x += 8)
+            for (int z = 0; z < s.Length; z += 8)
+            {
+                maxSurf = System.Math.Max(maxSurf, _generator.SurfaceHeight(planet, origin.X + x, origin.Z + z));
+            }
+
+        int clearH = System.Math.Clamp(maxSurf - gy + 3, 2, s.Height);
+
         // 1) Clear any terrain occupying the build volume above the foundation, so a hill never buries the
         //    buildings (the structure's own air cells are otherwise left as whatever was there).
         for (int x = 0; x < s.Width; x++)
             for (int z = 0; z < s.Length; z++)
-                for (int y = 1; y < s.Height; y++)
+                for (int y = 1; y < clearH; y++)
                 {
                     _world.SetBlock(new Vector3i(origin.X + x, gy + y, origin.Z + z), BlockId.Air);
                 }
 
-        // 2) Flatten a foundation slab at ground level across the footprint (so it sits flush).
+        // 2) Foundation row + support skirt. The buildings are authored on one flat plane, so the floor at gy
+        //    must stay level — but on a slope a single flat slab would hang in mid-air on the downhill side. So
+        //    each column also gets a stepped plinth: solid fill from gy down to the natural surface, deep on the
+        //    downhill side, shallow uphill. The result is a real multi-level foundation that meets the ground
+        //    all the way round instead of a flat platform floating over a dip. (Skipped on sky islands, whose
+        //    deck is meant to float over the void.) Depth is capped so a missed crevasse can't fill a chasm.
         if (!foundationId.IsAir)
         {
+            const int maxSkirt = 48;
             for (int x = 0; x < s.Width; x++)
                 for (int z = 0; z < s.Length; z++)
                 {
-                    _world.SetBlock(new Vector3i(origin.X + x, gy, origin.Z + z), foundationId);
+                    int wx = origin.X + x, wz = origin.Z + z;
+                    _world.SetBlock(new Vector3i(wx, gy, wz), foundationId); // flat floor row
+
+                    if (p.OnIsland)
+                    {
+                        continue;
+                    }
+
+                    int colSurf = _generator.SurfaceHeight(planet, wx, wz);
+                    int floorY = System.Math.Max(colSurf + 1, gy - maxSkirt);
+                    for (int y = gy - 1; y >= floorY; y--) // fill the gap down to the natural ground
+                    {
+                        _world.SetBlock(new Vector3i(wx, y, wz), foundationId);
+                    }
                 }
         }
 
@@ -347,7 +381,16 @@ public sealed partial class GameServer
         int pad0Z = _landingPads.Count > 0 ? _landingPads[0].CenterZ : 0;
         int maxDist = System.Math.Max(80, (int)(circ * 0.4));
 
-        for (int attempt = 0; attempt < 64; attempt++)
+        // A bigger build seats on a bigger, carved + foundationed footprint, so it tolerates more terrain
+        // relief than a small hut; and a large footprint can't fully cover a (small) floating island, so big
+        // builds always go on the ground. Both gates scale with the footprint so hand-authored 128² structures
+        // can actually find a home, while small settlements keep their tight, must-be-flat seating.
+        int maxSpread = System.Math.Clamp(System.Math.Max(w, l) / 8, 8, 24);
+        bool canIsland = wantIsland && System.Math.Max(w, l) <= 40;
+
+        // Larger footprints are harder to fit, so give the search more candidate spots before giving up.
+        int attempts = System.Math.Max(w, l) > 48 ? 160 : 64;
+        for (int attempt = 0; attempt < attempts; attempt++)
         {
             double ang = rng.NextDouble() * System.Math.PI * 2.0;
             int dist = 40 + rng.Next(0, maxDist);
@@ -361,7 +404,7 @@ public sealed partial class GameServer
 
             int ox = cx - w / 2, oz = cz - l / 2;
 
-            if (wantIsland)
+            if (canIsland)
             {
                 if (TryIslandFootprint(planet, ox, oz, w, l, out int itop))
                 {
@@ -374,7 +417,7 @@ public sealed partial class GameServer
                 continue; // wanted a sky island here but the footprint isn't fully on one
             }
 
-            if (FootprintWet(planet, ox, oz, w, l) || FootprintSpread(planet, ox, oz, w, l) > 8)
+            if (FootprintWet(planet, ox, oz, w, l) || FootprintSpread(planet, ox, oz, w, l) > maxSpread)
             {
                 continue; // in water/lava, or on terrain too uneven to seat the build
             }
@@ -389,14 +432,22 @@ public sealed partial class GameServer
         return false;
     }
 
-    /// <summary>The nine footprint sample columns (corners, edge mid-points, centre) in world coords.</summary>
+    /// <summary>Footprint sample columns (world coords) used by the wet + flatness gates. A small footprint
+    /// samples a fixed 3×3 (corners, edge mid-points, centre); a large one samples a denser grid (≈ every 16
+    /// blocks) so a lake or a steep slope buried in the middle of a 128² footprint can't slip past the gates.</summary>
     private static IEnumerable<(int X, int Z)> FootprintSamples(int ox, int oz, int w, int l)
     {
-        int x0 = ox, x1 = ox + w / 2, x2 = ox + w - 1;
-        int z0 = oz, z1 = oz + l / 2, z2 = oz + l - 1;
-        yield return (x0, z0); yield return (x1, z0); yield return (x2, z0);
-        yield return (x0, z1); yield return (x1, z1); yield return (x2, z1);
-        yield return (x0, z2); yield return (x1, z2); yield return (x2, z2);
+        int nx = System.Math.Clamp(w / 16 + 1, 2, 9);
+        int nz = System.Math.Clamp(l / 16 + 1, 2, 9);
+        for (int ix = 0; ix <= nx; ix++)
+        {
+            int x = ox + (int)((long)(w - 1) * ix / nx);
+            for (int iz = 0; iz <= nz; iz++)
+            {
+                int z = oz + (int)((long)(l - 1) * iz / nz);
+                yield return (x, z);
+            }
+        }
     }
 
     private bool FootprintWet(PlanetType planet, int ox, int oz, int w, int l)

--- a/tests/BlocksBeyondTheStars.Tests/StructureTemplateTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/StructureTemplateTests.cs
@@ -135,6 +135,52 @@ public sealed class StructureTemplateTests
         Assert.Equal(0x06, s.GetShape(2, 1, 2));
     }
 
+    [Fact]
+    public void LargeTemplate_HonorsFullDimensions_NoSizeCap()
+    {
+        // The in-game structure editor now authors builds up to 128³; the generators must carry those full
+        // dimensions through untruncated (block + marker at the far corner round-trip), so a big hand-built
+        // station/city isn't silently clamped to a smaller envelope.
+        var c = Content();
+        ushort hull = c.GetBlock("iron_wall")!.NumericId.Value;
+        ushort stone = c.GetBlock("stone")!.NumericId.Value;
+
+        const int n = 128;
+        var stationT = new StructureTemplate
+        {
+            Key = "huge_station", Name = "Huge", Tier = "huge", Kind = "station",
+            Width = n, Height = n, Length = n,
+            Cells = new List<TemplateCell>
+            {
+                new() { X = 0, Y = 0, Z = 0, Kind = "block", Id = "iron_wall" },
+                new() { X = n - 1, Y = n - 1, Z = n - 1, Kind = "block", Id = "iron_wall" },
+                new() { X = n - 1, Y = 0, Z = n - 1, Kind = "marker", Id = "vendor" },
+            },
+        };
+
+        var station = StationGenerator.FromTemplate(stationT, c);
+        Assert.Equal(n, station.Width);
+        Assert.Equal(n, station.Height);
+        Assert.Equal(n, station.Length);
+        Assert.Equal(hull, station.Get(n - 1, n - 1, n - 1)); // far corner survives — no truncation
+
+        var settlementT = new StructureTemplate
+        {
+            Key = "huge_city", Name = "City", Tier = "city", Kind = "settlement",
+            Width = n, Height = n, Length = n,
+            Cells = new List<TemplateCell>
+            {
+                new() { X = n - 1, Y = n - 1, Z = n - 1, Kind = "block", Id = "stone" },
+            },
+        };
+
+        var city = SettlementGenerator.FromTemplate(settlementT, c);
+        Assert.Equal(n, city.Width);
+        Assert.Equal(n, city.Height);
+        Assert.Equal(n, city.Length);
+        Assert.Equal(stone, city.Get(n - 1, n - 1, n - 1));
+    }
+
     // --- Tier-matched / pack-filtered / weighted selection (P1) ---
 
     private static StructureTemplate Tpl(string key, string tier, string pack = "default", int weight = 1)

--- a/tests/BlocksBeyondTheStars.Tests/StructureTemplateTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/StructureTemplateTests.cs
@@ -148,8 +148,13 @@ public sealed class StructureTemplateTests
         const int n = 128;
         var stationT = new StructureTemplate
         {
-            Key = "huge_station", Name = "Huge", Tier = "huge", Kind = "station",
-            Width = n, Height = n, Length = n,
+            Key = "huge_station",
+            Name = "Huge",
+            Tier = "huge",
+            Kind = "station",
+            Width = n,
+            Height = n,
+            Length = n,
             Cells = new List<TemplateCell>
             {
                 new() { X = 0, Y = 0, Z = 0, Kind = "block", Id = "iron_wall" },
@@ -166,8 +171,13 @@ public sealed class StructureTemplateTests
 
         var settlementT = new StructureTemplate
         {
-            Key = "huge_city", Name = "City", Tier = "city", Kind = "settlement",
-            Width = n, Height = n, Length = n,
+            Key = "huge_city",
+            Name = "City",
+            Tier = "city",
+            Kind = "settlement",
+            Width = n,
+            Height = n,
+            Length = n,
             Cells = new List<TemplateCell>
             {
                 new() { X = n - 1, Y = n - 1, Z = n - 1, Kind = "block", Id = "stone" },


### PR DESCRIPTION
## What

Raises the in-game editor build volumes so players can author genuinely large craft and settlements:

- **Ship editor:** 24×16×24 → **48×32×48**
- **Structure editor (station + settlement):** 32×16×32 → **128×128×128**

## Why this needed more than bumping constants

The data model, merge tools and netcode already carried arbitrary dimensions — but two things broke at this scale, and both are fixed here:

### 1. Editor rendering (chunked combined mesh)
The old editors rendered **one GameObject + collider per placed cell**, which collapses past a few thousand cells. New [`EditorVoxelChunkView`](client/Assets/BlocksBeyondTheStars/Scripts/EditorVoxelChunkView.cs) renders the build as 16³ chunks, one combined mesh + `MeshCollider` each, with exposed-face culling and directional shading baked into vertex colours (a single `VertexColorOpaque` material — no new shader, so no Always-Included gotcha). Edits mark chunks dirty and a once-a-frame `Flush()` rebuilds them. Place/remove now resolve the target cell from `hit.point ± normal·0.5` instead of a per-cell transform. Both editors share it.

### 2. Settlement placement + seating
The allocator and stamping assumed small footprints:
- Flatness tolerance scales with the build: `clamp(maxDim/8, 8..24)`.
- Wet/flatness gates sample a **denser grid** (~every 16 blocks) instead of a fixed 3×3.
- Large footprints are excluded from **floating-island** seating; 64 → 160 placement attempts.
- The terrain **carve is bounded to the actual relief height** (a 128-tall tower no longer carves a ~2M-block air column).
- New **stepped support plinth**: the floor stays flat at `gy`, each column is filled solid down to the natural surface (deep downhill, shallow uphill, depth-capped, skipped on sky islands) so a big build on a slope meets the ground all round instead of floating over a dip — a real multi-level foundation.

Space stations live in void worlds, so they have no placement gate.

## Tests / verification
- New `LargeTemplate_HonorsFullDimensions_NoSizeCap` guards the no-cap 128³ pass-through through both generators.
- **747 server tests green**; GameServer builds 0 warnings / 0 errors.
- **Local Unity client build green** (`build: Succeeded`, no compiler errors).

Docs: [SHIP_TYPE_EDITOR.md](docs/developer/SHIP_TYPE_EDITOR.md), [STATION_SETTLEMENT_EDITOR.md](docs/developer/STATION_SETTLEMENT_EDITOR.md), TODO work log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)