### PR TITLE
docs: factories/ruins player docs + README source URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Design your ship block by block, fly real system-scale routes, dock at space sta
 *   **System-Scale Flight:** Fly between unique procedurally generated planets and jump between star systems.
 *   **Complete Freedom:** Every block can be mined, reshaped, and rebuilt.
 *   **Deep Crafting:** Mine, smelt, unlock blueprints, and craft everything from hover speeders to space stations.
+*   **Explore & Claim:** Discover rare factories with their own production terminals, salvage fallen ruins and treasure chests — and claim a factory as your own base with a rare access code.
 *   **In-Game Editors:** Design your own ships, stations, and cities block by block.
 *   **Rich Multiplayer:** Form alliances, share bases, and communicate via global radio.
 *   **The VEGA Protocol:** An optional story campaign narrated by your ship's AI companion.
@@ -292,7 +293,9 @@ planet, seam-free), 18 planet types including exotic ones (skylands, fungal, cor
 salt flats, …) with their own flora and fauna, swimming/diving, creature taming, a craftable hover
 speeder, mining → crafting → blueprints →
 ship building, real system-scale space flight (with jumps between systems) with stations,
-settlements and NPCs, peaceful NPC trader traffic, the
+settlements and NPCs, peaceful NPC trader traffic, rare **factories** with roster-limited
+production terminals, fallen **ruins** and **treasure chests**, **access-code claiming** that
+turns a factory into your own editable base, the
 **"VEGA Protocol" story campaign** (a swappable, story-agnostic engine with lore fragments, three
 Guardian machine types and a two-route finale), multiplayer with per-player ships, **player
 alliances**, shared bases and trading, planet **bases + teleporter pads**, material dyeing and
@@ -312,6 +315,9 @@ Blocks Beyond the Stars is **free and open-source software**, licensed under the
 **[GNU Affero General Public License v3.0 or later](LICENSE)** (AGPL-3.0-or-later).
 You may run, study, share and modify it; if you run a modified version for others over a
 network, the AGPL requires you to offer them its source code.
+
+**Source code:** [github.com/marceld23/BlocksBeyondTheStars](https://github.com/marceld23/BlocksBeyondTheStars)
+— the canonical repository for the corresponding source, wherever you obtained this build.
 
 Third-party libraries and bundled assets keep their own (permissive) licenses — see
 [NOTICES.md](NOTICES.md).

--- a/docs/user/USER_MANUAL.md
+++ b/docs/user/USER_MANUAL.md
@@ -8,7 +8,7 @@ chat/admin commands. This is a living document.
 > truth for player-facing operation. (Written in English per project doc policy; in-game text itself is
 > bilingual DE/EN.)
 
-Last updated: 2026-06-19.
+Last updated: 2026-06-27.
 
 ---
 
@@ -274,6 +274,33 @@ the hauler slow and heavy. Hull + shield are shown on the HUD; shields recharge,
 - A crashed wreck shows a **wreck panel** (right HUD) with a hull-repair progress bar. Aim at a breach
   (missing hull cell) and press **R** while holding the **matching block** — the panel lists which blocks
   are still needed. When fully repaired, **Claim ship** adds it to your fleet.
+
+### Factories
+- **Factories** are rare industrial halls found on some breathable worlds — metal walls and windows with
+  one or more **machine bays** whose presses, rotors and conveyors run continuously, plus a **factory
+  terminal** by the door. No two are alike (size, machine count and layout are world-specific).
+- Stand near the **factory terminal** to craft from it (Tab → Crafting → **Factory** category). Factory
+  recipes turn **cheaper, less-rare raw materials into the same output as the workshop, but in bulk** —
+  more input per step, fewer refining stages. The catch: each factory only makes the **1–4 items on its
+  own roster**, so a recipe the menu lists may say *"Use a factory terminal that makes this"* — you'll need
+  a different factory. Factory crafts **cannot be disassembled** back into their inputs.
+- **Operating a terminal is public** — you don't need to own a factory to craft there. But a spawned
+  factory is **read-only** (you can't mine or rebuild it) until you **claim** it: stand at the terminal
+  with an **SPS access code** (see below) and press **E**. Claiming spends one code, makes the factory
+  **your base** (you and your **allies** can rebuild it freely), and persists across reloads. One code
+  claims one factory.
+
+### Ruins & treasure chests
+- **Ruins** are the collapsed remains of fallen settlements — mostly surviving ground walls, one
+  half-standing tower, and rubble overgrown by flora. Unlike bases and stations they are **not protected**:
+  every block is **freely mineable**, and what you clear stays cleared. VEGA may hint at *"structural
+  echoes nearby — ruins or wreckage"*; bring a scanner, there's often something worth digging out.
+- **Treasure chests** are standalone lootable caches scattered away from settlements. Each is looted
+  **once** and holds richer salvage than ordinary drops — and they are the main world source of a rare
+  **SPS access code**.
+- **SPS access codes** (`access_code`) are the rare item used to claim a factory as your base. You get them
+  two ways, both uncommon: as loot from a **treasure chest**, or by **buying** one from a trader's **Market**
+  (a steep barter recipe). Keep one if you find it — it's your key to turning a factory into a home.
 
 ### Trade
 - **Player ↔ player:** press **T** near a player to open a modal trade. Each side stages an offer (+/−) and

--- a/web/wiki/articles.json
+++ b/web/wiki/articles.json
@@ -32,6 +32,22 @@
     }
   },
   {
+    "id": "factories",
+    "title": { "en": "Factories & Production Terminals", "de": "Fabriken & Produktionsterminals" },
+    "body": {
+      "en": "<p>Some breathable worlds hide a rare <b>factory</b> — an industrial hall whose presses, rotors and conveyors run nonstop, with a <b>factory terminal</b> by the door. No two are built alike.</p><p>Stand near the terminal and craft from the <i>Factory</i> category. Factory recipes turn <b>cheaper, less-rare materials into the same goods as the <span class=\"link\" data-link=\"cat:recipes\">workshop</span>, but in bulk</b> — more input, fewer steps. The catch: each factory only makes the few items on its own roster, so some recipes ask you to find a different factory, and factory crafts can't be taken apart again.</p><p>Crafting at a factory is free for anyone. But a factory is read-only until you <b>claim</b> it: stand at the terminal with an <b>SPS access code</b> and press <b>E</b>. That spends the code and makes the factory your base — you and your allies can rebuild it, and the claim sticks across reloads.</p>",
+      "de": "<p>Auf manchen atembaren Welten verbirgt sich eine seltene <b>Fabrik</b> — eine Industriehalle, deren Pressen, Rotoren und Förderbänder pausenlos laufen, mit einem <b>Fabrikterminal</b> an der Tür. Keine gleicht der anderen.</p><p>Stell dich ans Terminal und fertige in der Kategorie <i>Fabrik</i>. Fabrikrezepte machen aus <b>günstigeren, weniger seltenen Materialien dieselben Güter wie die <span class=\"link\" data-link=\"cat:recipes\">Werkstatt</span>, aber in großer Menge</b> — mehr Einsatz, weniger Schritte. Der Haken: Jede Fabrik stellt nur die wenigen Dinge auf ihrer eigenen Liste her, manche Rezepte verweisen dich also auf eine andere Fabrik, und Fabrik-Fertigungen lassen sich nicht wieder zerlegen.</p><p>Das Fertigen an einer Fabrik ist für alle frei. Doch eine Fabrik ist schreibgeschützt, bis du sie <b>beanspruchst</b>: Stell dich mit einem <b>SPS-Code</b> ans Terminal und drücke <b>E</b>. Das verbraucht den Code und macht die Fabrik zu deiner Basis — du und deine Verbündeten könnt sie umbauen, und der Anspruch bleibt über Neuladen erhalten.</p>"
+    }
+  },
+  {
+    "id": "ruins-and-treasure",
+    "title": { "en": "Ruins & Treasure", "de": "Ruinen & Schätze" },
+    "body": {
+      "en": "<p><b>Ruins</b> are the collapsed remains of fallen settlements — broken walls, a lone half-standing tower, and rubble reclaimed by flora. Unlike bases and stations they are <b>not protected</b>: every block is yours to mine, and what you clear stays cleared. VEGA may warn of <i>structural echoes nearby</i> — bring a <span class=\"link\" data-link=\"cat:tech\">scanner</span> and dig around.</p><p><b>Treasure chests</b> are lootable caches hidden away from towns. Each is looted only once and holds richer salvage than ordinary finds — and they are the main world source of a rare <b>SPS access code</b>, the item that lets you claim a <span class=\"link\" data-link=\"guide:factories\">factory</span> as your own base. You can also buy a code from a trader's Market, but it's steep. Keep any code you find.</p>",
+      "de": "<p><b>Ruinen</b> sind die eingestürzten Überreste verfallener Siedlungen — zerbrochene Mauern, ein einzelner halb stehender Turm und von Pflanzen überwuchertes Geröll. Anders als Basen und Stationen sind sie <b>nicht geschützt</b>: Jeden Block darfst du abbauen, und was du abräumst, bleibt weg. VEGA warnt manchmal vor <i>strukturellen Echos in der Nähe</i> — nimm einen <span class=\"link\" data-link=\"cat:tech\">Scanner</span> mit und grab nach.</p><p><b>Schatztruhen</b> sind plünderbare Verstecke abseits der Orte. Jede lässt sich nur einmal leeren und enthält wertvolleres Bergegut als gewöhnliche Funde — und sie sind die wichtigste Weltquelle für einen seltenen <b>SPS-Code</b>, den Gegenstand, mit dem du eine <span class=\"link\" data-link=\"guide:factories\">Fabrik</span> als eigene Basis beanspruchst. Einen Code gibt es auch im Markt eines Händlers zu kaufen, aber teuer. Heb jeden Code auf, den du findest.</p>"
+    }
+  },
+  {
     "id": "arcade",
     "title": { "en": "Data Cubes & Fragments", "de": "Datenwürfel & Fragmente" },
     "body": {


### PR DESCRIPTION
## What & why

Player-facing documentation for the **factories / ruins / access-code claiming** feature (merged in #79) was missing across the board. This fills the gaps and adds a canonical source-code URL to the README.

### Changes
- **README**
  - New *Explore & Claim* bullet in *Features at a Glance* + a factories/ruins/claiming mention in *Status*.
  - New **Source code** line in the License section — the canonical repo URL, useful for AGPL "where to get the source" wherever the README is mirrored (itch.io / website / bundled builds).
- **User manual** (`docs/user/USER_MANUAL.md`) — new **Factories** and **Ruins & treasure chests** sections under *Game mechanics*; bumped the "Last updated" date.
- **In-game wiki** (`web/wiki/articles.json`) — two new **bilingual (EN/DE)** Codex articles: `factories` and `ruins-and-treasure`, following the existing article HTML/cross-link pattern.

### Notes
- Docs/content only — no engine/client code touched. `web/` is synced to StreamingAssets at build time, so no Unity rebuild is required.
- `articles.json` validated as well-formed JSON (7 articles); cross-links use the registered `guide:<id>` / `cat:<id>` forms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)