### PR TITLE
fix(ci): re-install .NET before the Linux launcher build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -263,6 +263,13 @@ jobs:
           echo "Baked into player: '$baked' — expected: '${{ steps.ver.outputs.version }}'"
           test "$baked" = "${{ steps.ver.outputs.version }}"
 
+      # The "Free disk space" step above deletes /usr/share/dotnet to make room for the Unity image, so the
+      # SDK is gone by now. Re-install it before publishing the launcher (cheap; the heavy build is done).
+      - name: Re-install .NET (disk-cleanup removed it)
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '8.0.x'
+
       - name: Build Linux console launcher
         run: |
           dotnet publish src/BlocksBeyondTheStars.Launcher.Console/BlocksBeyondTheStars.Launcher.Console.csproj \


### PR DESCRIPTION
## Problem
The v0.6.0 release pipeline's **Linux** build failed at *Build Linux console launcher*:

```
/home/runner/...sh: line 1: dotnet: command not found
##[error]Process completed with exit code 127.
```

Root cause: the Linux job's *Free disk space* step runs `sudo rm -rf … /usr/share/dotnet …` to make room for the Unity Docker image, deleting the .NET SDK. The earlier `publish-local-server` step used dotnet **before** the cleanup (fine), but *Build Linux console launcher* runs `dotnet publish` **after** it → exit 127. This skipped *Package + release (Linux)*, so v0.6.0 shipped without its AppImage / Linux Portable.zip.

## Fix
Re-install the .NET 8 SDK right before the launcher build (after the Unity build, so the disk savings are no longer needed). One added step, no other changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)