### PR TITLE
fix(linux): make the Linux release packaging actually work

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -303,26 +303,19 @@ jobs:
           dotnet tool install -g vpk --version 1.2.0
           echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
 
-      # libSkiaSharp.so (used by the splash render below) links against fontconfig; install it so
-      # SKTypeface.FromFamilyName can resolve a system font on the runner.
-      - name: Install fontconfig (for SkiaSharp text rendering)
-        run: sudo apt-get update && sudo apt-get install -y libfontconfig1 fontconfig fonts-dejavu-core
-
       - name: Download Linux player artifact
         uses: actions/download-artifact@v7
         with:
           name: player-linux
           path: client/Build/Linux
 
-      # vpk can produce AppImage + portable zip for Linux.
+      # vpk can produce AppImage + portable zip for Linux. NOTE: the splash options
+      # (--splashImage / --splashProgressColor) are Windows-installer only — the Linux `vpk pack`
+      # rejects them ("Unrecognized command or argument"), so they are not passed here.
       - name: Package Linux AppImage + Portable
         run: |
           OUT="artifacts/installer-linux"
           mkdir -p "$OUT"
-
-          # Render installer splash
-          dotnet run --project src/BlocksBeyondTheStars.Launcher.Console/BlocksBeyondTheStars.Launcher.Console.csproj \
-            -- --render-install-splash "$OUT/splash.png" 560 320
 
           vpk pack \
             --packId BlocksBeyondTheStars \
@@ -331,8 +324,6 @@ jobs:
             --packAuthors 'JuMaVe Games' \
             --packDir client/Build/Linux \
             --mainExe BlocksBeyondTheStars.Launcher.Console \
-            --splashImage "$OUT/splash.png" \
-            --splashProgressColor '#7DDEEC' \
             --channel linux \
             --outputDir "$OUT"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -303,6 +303,11 @@ jobs:
           dotnet tool install -g vpk --version 1.2.0
           echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
 
+      # libSkiaSharp.so (used by the splash render below) links against fontconfig; install it so
+      # SKTypeface.FromFamilyName can resolve a system font on the runner.
+      - name: Install fontconfig (for SkiaSharp text rendering)
+        run: sudo apt-get update && sudo apt-get install -y libfontconfig1 fontconfig fonts-dejavu-core
+
       - name: Download Linux player artifact
         uses: actions/download-artifact@v7
         with:

--- a/src/BlocksBeyondTheStars.Launcher.Console/BlocksBeyondTheStars.Launcher.Console.csproj
+++ b/src/BlocksBeyondTheStars.Launcher.Console/BlocksBeyondTheStars.Launcher.Console.csproj
@@ -14,6 +14,11 @@
 
   <ItemGroup>
     <PackageReference Include="SkiaSharp" Version="3.116.1" />
+    <!-- Native libSkiaSharp.so for Linux (the base SkiaSharp package only ships Windows/macOS natives).
+         Needed both for the CI splash render (`dotnet run --render-install-splash`) and for the shipped
+         self-contained Linux launcher. The font-config variant is required because SplashRenderer resolves
+         fonts via SKTypeface.FromFamilyName, which needs fontconfig at runtime. -->
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.116.1" />
     <PackageReference Include="Velopack" Version="1.2.0" />
   </ItemGroup>
 

--- a/src/BlocksBeyondTheStars.Launcher.Console/BlocksBeyondTheStars.Launcher.Console.csproj
+++ b/src/BlocksBeyondTheStars.Launcher.Console/BlocksBeyondTheStars.Launcher.Console.csproj
@@ -15,9 +15,9 @@
   <ItemGroup>
     <PackageReference Include="SkiaSharp" Version="3.116.1" />
     <!-- Native libSkiaSharp.so for Linux (the base SkiaSharp package only ships Windows/macOS natives).
-         Needed both for the CI splash render (`dotnet run --render-install-splash`) and for the shipped
-         self-contained Linux launcher. The font-config variant is required because SplashRenderer resolves
-         fonts via SKTypeface.FromFamilyName, which needs fontconfig at runtime. -->
+         Needed both for the CI splash render and for the shipped self-contained Linux launcher. The
+         fontconfig variant is required because SplashRenderer resolves fonts via SKTypeface.FromFamilyName,
+         which needs fontconfig at runtime. -->
     <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.116.1" />
     <PackageReference Include="Velopack" Version="1.2.0" />
   </ItemGroup>


### PR DESCRIPTION
Fixes the Linux release packaging, validated end-to-end via a `workflow_dispatch` run (all jobs green, incl. *Package + release (Linux)*) without touching the public tag.

Three distinct pre-existing issues in the Linux path:

1. **SkiaSharp Linux natives** — the console launcher renders its splash with SkiaSharp, but the base package ships only Windows/macOS natives, so `libSkiaSharp.so` was missing. Added `SkiaSharp.NativeAssets.Linux` (needed for the shipped self-contained launcher's runtime splash).
2. **Invalid XML comment** — a csproj comment contained `--`, which XML forbids → MSB4025 broke the Linux player build. Reworded.
3. **Windows-only splash args on Linux** (the actual packaging blocker) — the Linux `vpk pack` was passed `--splashImage` / `--splashProgressColor`, which it rejects ("Unrecognized command or argument"), so the AppImage / portable zip were never produced. Removed the splash render step + args for Linux.

(Earlier, a separate fix — re-installing .NET after the disk-cleanup step — landed in #81.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)