### PR TITLE
feat: serve native Linux client (AppImage) from server portal, drop WebGL stub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,9 @@ RUN dotnet publish src/BlocksBeyondTheStars.GameServer/BlocksBeyondTheStars.Game
 FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime
 
 # tini = a proper PID 1 (reaps zombies + forwards signals to the entrypoint). curl = best-effort download
-# of the Windows client installer from GitHub Releases so the portal's /download works. python3 + venv =
-# the optional AI text backend (baked in, but only STARTED when a .env is provided — see the entrypoint).
+# of the client downloads from GitHub Releases so the portal's /download (Windows Setup.exe) and
+# /download-linux (Linux AppImage) work. python3 + venv = the optional AI text backend (baked in, but
+# only STARTED when a .env is provided — see the entrypoint).
 RUN apt-get update \
  && apt-get install -y --no-install-recommends tini curl ca-certificates python3 python3-venv \
  && rm -rf /var/lib/apt/lists/*
@@ -51,7 +52,7 @@ ENV BBS_ADMIN_BIND=0.0.0.0
 # 31415/udp native client · 31415/tcp browser WebSocket (when BBS_ENABLE_WEBSOCKET=true) · 31416/tcp admin+portal+download
 EXPOSE 31415/udp 31415/tcp 31416/tcp
 
-# saves/ = SQLite world + backups + logs + /bump bug reports (<world>/bumps) · config/ = server.json · clients/ = published installer
+# saves/ = SQLite world + backups + logs + /bump bug reports (<world>/bumps) · config/ = server.json · clients/ = published Windows Setup.exe + Linux AppImage
 VOLUME ["/app/saves", "/app/config", "/app/clients"]
 
 # Health = the public admin dashboard root (cheap static HTML, never password-gated unlike /api/*).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       BBS_ADMIN_BIND: "0.0.0.0"            # inside the container; reach it via the host port mapping above
       # BBS_ADMIN_PASSWORD: "change-me"    # REQUIRED before exposing 31416 publicly
       # BBS_ENABLE_WEBSOCKET: "true"       # also accept browser clients on the gameplay port
-      BBS_FETCH_CLIENT: "1"                # pull the latest Windows installer from GitHub Releases for /download
+      BBS_FETCH_CLIENT: "1"                # pull the latest Windows Setup.exe + Linux AppImage from GitHub Releases for /download + /download-linux
       # BBS_CLIENT_REPO: "marceld23/BlocksBeyondTheStars"
       # --- Optional AI text backend (NPC greetings / mission flavour / VEGA banter) ---
       # It is baked into the image but only STARTS when an ai-backend/.env is mounted (see volumes below)
@@ -37,7 +37,7 @@ services:
     volumes:
       - saves:/app/saves            # SQLite world + backups + logs + /bump bug reports (<world>/bumps)
       - config:/app/config          # server.json (created on first run)
-      - clients:/app/clients        # published Windows installer the portal hands out
+      - clients:/app/clients        # published clients the portal hands out (Windows Setup.exe + Linux AppImage)
       # Mount your AI config to enable the in-container LLM backend (copy ai-backend/.env.example -> .env):
       # - ./ai-backend/.env:/app/ai-backend/.env:ro
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -25,31 +25,45 @@ log() { echo "[entrypoint] $*"; }
 # child processes regardless of how the container was started.
 export BBS_ADMIN_BIND="${BBS_ADMIN_BIND:-0.0.0.0}"
 
-# --- best-effort: fetch the latest Windows client installer from GitHub Releases so /download works ---
-# A Linux container cannot build the Windows installer (that needs Unity + Windows), so the portal's
-# one-click download is populated from the published GitHub Release instead. Non-fatal: without it the
-# portal still runs and /download simply reports "no installer published yet".
-fetch_client() {
-  local repo="${BBS_CLIENT_REPO:-marceld23/BlocksBeyondTheStars}"
-  local api="https://api.github.com/repos/${repo}/releases/latest"
-  log "fetching latest client installer from ${repo} ..."
+# --- best-effort: fetch the latest client downloads from GitHub Releases so the portal works ---
+# A Linux container cannot build the clients (Unity + Windows are needed), so the portal's one-click
+# downloads are populated from the published GitHub Release instead: the Windows Setup.exe (served at
+# /download) and the Linux AppImage (served at /download-linux). Non-fatal: without them the portal
+# still runs and the download routes simply report "nothing published yet".
 
+# Fetch a single release asset whose download URL matches the given suffix pattern into $CLIENTS_DIR.
+# $1 = release JSON, $2 = grep pattern for the asset filename, $3 = human label.
+fetch_asset() {
+  local json="$1" pattern="$2" label="$3"
   local url
-  url=$(curl -fsSL "$api" \
-        | grep -o '"browser_download_url":[ ]*"[^"]*Setup\.exe"' \
-        | head -n1 | sed 's/.*"\(https[^"]*\)"/\1/') || return 1
-  [ -n "$url" ] || { log "no *Setup.exe asset in the latest release"; return 1; }
+  url=$(printf '%s' "$json" \
+        | grep -o "\"browser_download_url\":[ ]*\"[^\"]*${pattern}\"" \
+        | head -n1 | sed 's/.*"\(https[^"]*\)"/\1/')
+  [ -n "$url" ] || { log "no ${label} asset in the latest release"; return 1; }
 
   local target="$CLIENTS_DIR/$(basename "$url")"
   curl -fsSL "$url" -o "$target.partial" || return 1
   mv -f "$target.partial" "$target"
-  log "client installer ready: $(basename "$target")"
+  log "${label} ready: $(basename "$target")"
+}
+
+fetch_client() {
+  local repo="${BBS_CLIENT_REPO:-marceld23/BlocksBeyondTheStars}"
+  local api="https://api.github.com/repos/${repo}/releases/latest"
+  log "fetching latest client downloads from ${repo} ..."
+
+  local json
+  json=$(curl -fsSL "$api") || return 1
+
+  # Each asset is independent: a missing Windows or Linux build must not skip the other.
+  fetch_asset "$json" 'Setup\.exe' 'Windows installer' || true
+  fetch_asset "$json" '\.AppImage' 'Linux AppImage'     || true
 }
 
 if [ "${BBS_FETCH_CLIENT:-1}" = "1" ]; then
   fetch_client || log "client download skipped (continuing without it)"
 else
-  log "BBS_FETCH_CLIENT=0 -> skipping client installer download"
+  log "BBS_FETCH_CLIENT=0 -> skipping client download"
 fi
 
 # --- admin API: best-effort sidecar, auto-restarted, never fatal to the container ---

--- a/docs/developer/SELF_HOSTING.md
+++ b/docs/developer/SELF_HOSTING.md
@@ -148,8 +148,8 @@ Invoke-RestMethod http://127.0.0.1:31416/api/status -Headers @{ 'X-Admin-Passwor
 ```
 
 The host also serves a public-facing **`/portal`** landing page — a polished page with the
-JuMaVe Games + game logos, a one-click client download and the in-app update URL — plus the
-`/play` placeholder for the future browser client. See §9 for distributing the client this way.
+JuMaVe Games + game logos, one-click client downloads (Windows `Setup.exe` at `/download`, Linux
+`.AppImage` at `/download-linux`) and the in-app update URL. See §9 for distributing the client this way.
 
 ## 6. Backups & saves
 
@@ -241,13 +241,15 @@ That produces `BlocksBeyondTheStars-win-Setup.exe` plus an update feed
 
 **On the host:** start `BlocksBeyondTheStars.Api`, and (for LAN/internet reach) bind it beyond loopback —
 set `adminBindAddress` to the LAN IP or `0.0.0.0` **and** set an `adminPassword` first (§4). Only `/api/*`
-is password-gated; `/portal`, `/download` and `/updates` stay public so players can reach them.
+is password-gated; `/portal`, `/download`, `/download-linux` and `/updates` stay public so players can reach them.
 
 **Players:**
 
 1. Open `http://<server-ip>:<adminPort>/portal` (default port 31416) in a browser.
 2. Click **Download the Windows client** (served from `/download`) and run the installer
    (per-user, no admin rights; an unsigned build shows a one-time SmartScreen "More info → Run anyway").
+   On Linux, click **Download the Linux client (AppImage)** (served from `/download-linux`), then
+   `chmod +x` the `.AppImage` and run it.
 3. Launch the game and **Join** the server's IP on the gameplay port (default 31415).
 4. **Auto-update:** in **Settings → Software update**, paste the update URL shown on the portal
    (`http://<server-ip>:<adminPort>/updates`) and use **Check for updates**. Publishing a higher
@@ -344,15 +346,17 @@ docker run -d --name bbts \
 |---|---|
 | `/app/saves` | SQLite world + `backups/` + `logs/` **and `/bump` bug reports** (`<world>/bumps/`) |
 | `/app/config` | `server.json` (created on first run; env vars override it) |
-| `/app/clients` | the published Windows installer the portal serves at `/download` |
+| `/app/clients` | the published clients the portal serves: Windows `*Setup.exe` at `/download` + Linux `*.AppImage` at `/download-linux` |
 
 ### Client download from the container
 
-A Linux container can't *build* the Windows installer, so on start the entrypoint pulls the newest
-`*Setup.exe` from the latest GitHub Release into `/app/clients` (best-effort; controlled by
-`BBS_FETCH_CLIENT=1`/`0` and `BBS_CLIENT_REPO`). The portal (`/portal`) and one-click `/download` then
-work as in §9. Without it the portal still runs and `/download` reports "no installer published yet";
-you can instead drop a `Setup.exe` into the `clients` volume yourself.
+A Linux container can't *build* the clients, so on start the entrypoint pulls the newest `*Setup.exe`
+**and** `*.AppImage` from the latest GitHub Release into `/app/clients` (best-effort; each asset is
+fetched independently, so a missing one never blocks the other — controlled by `BBS_FETCH_CLIENT=1`/`0`
+and `BBS_CLIENT_REPO`). The portal (`/portal`) and the one-click `/download` (Windows) / `/download-linux`
+(Linux AppImage) routes then work as in §9. Without them the portal still runs and the download routes
+report "nothing published yet"; you can instead drop a `Setup.exe` / `.AppImage` into the `clients`
+volume yourself.
 
 ### Bug reports (`/bump`) in a container
 

--- a/src/BlocksBeyondTheStars.Api/PortalPage.cs
+++ b/src/BlocksBeyondTheStars.Api/PortalPage.cs
@@ -5,9 +5,10 @@ namespace BlocksBeyondTheStars.Api;
 
 /// <summary>
 /// The public server portal landing page (anf_webclient.md §7): a polished page carrying the
-/// <b>JuMaVe Games</b> studio logo and the <b>Blocks Beyond the Stars</b> game logo, a one-click
-/// Windows client download (the Velopack <c>Setup.exe</c> served at <c>/download</c>) and the in-app
-/// update-feed URL players paste into the game.
+/// <b>JuMaVe Games</b> studio logo and the <b>Blocks Beyond the Stars</b> game logo, one-click
+/// client downloads (the Velopack <c>Setup.exe</c> served at <c>/download</c> for Windows, the
+/// <c>.AppImage</c> served at <c>/download-linux</c> for Linux) and the in-app update-feed URL
+/// players paste into the game.
 ///
 /// Both logos are recreated as inline SVG/CSS so the page is fully self-contained — it needs no shipped
 /// art and renders on an offline LAN server. The studio emblem mirrors the in-game
@@ -118,7 +119,7 @@ a.ghost:hover{background:rgba(95,215,255,.1)}
  <div class='logo'><b>Blocks</b> Beyond the Stars</div>
  <div class='meta'>Server “__SERVER__” · World “__WORLD__” · native clients join on UDP __PORT__</div>
  <a class='btn primary' href='/download'>⬇&nbsp; Download the Windows client</a>
- <a class='btn ghost' href='/play'>▶&nbsp; Play in the browser</a>
+ <a class='btn ghost' href='/download-linux'>⬇&nbsp; Download the Linux client (AppImage)</a>
  <div class='hint'>Already installed? Updates come straight from this server — paste
   <code>__BASEURL__/updates</code> into <b>Settings → Software update</b> in the game.</div>
  <div class='foot'>JuMaVe Games · __SERVER__</div>

--- a/src/BlocksBeyondTheStars.Api/Program.cs
+++ b/src/BlocksBeyondTheStars.Api/Program.cs
@@ -81,12 +81,18 @@ app.MapMethods("/download", new[] { "GET", "HEAD" }, () =>
         : Results.File(setup, "application/octet-stream", Path.GetFileName(setup), enableRangeProcessing: true);
 });
 
-app.MapGet("/play", () => Results.Content(
-    "<!DOCTYPE html><html><head><meta charset=\"utf-8\"><title>Blocks Beyond the Stars - Browser</title></head>" +
-    "<body style=\"font-family:system-ui;background:#0b0f1a;color:#dfe6f3;padding:40px\">" +
-    "<h1>Browser client</h1><p>The WebGL build will be served here. The server exposes a WebSocket " +
-    "gateway on the gameplay port so the browser client uses the same protocol. " +
-    "See docs/developer/WEBCLIENT_FEASIBILITY.md.</p></body></html>", "text/html"));
+// One-click Linux download: hand out the newest published Linux AppImage from <install>/clients. Mirrors
+// /download above (GET + HEAD + range processing for a resumable, large self-contained download). The Docker
+// entrypoint best-effort fetches this asset from the latest GitHub Release alongside the Windows Setup.exe.
+app.MapMethods("/download-linux", new[] { "GET", "HEAD" }, () =>
+{
+    var appImage = Directory.Exists(clientsDir)
+        ? Directory.GetFiles(clientsDir, "*.AppImage").OrderByDescending(File.GetLastWriteTimeUtc).FirstOrDefault()
+        : null;
+    return appImage is null
+        ? Results.NotFound("No Linux client has been published yet. The latest GitHub Release ships a *.AppImage; drop it into the clients folder.")
+        : Results.File(appImage, "application/octet-stream", Path.GetFileName(appImage), enableRangeProcessing: true);
+});
 
 app.MapGet("/api/status", (AdminService a) => Results.Json(a.GetStatus()));
 


### PR DESCRIPTION
## What

The dedicated-server portal now offers a **Linux download** next to the Windows installer, and the dead **WebGL `/play` placeholder is removed** (WebGL is no longer on the roadmap). There is now a native Linux build published to GitHub Releases (`*.AppImage`), so the portal can hand it out directly.

## Changes

- **Api** ([Program.cs](src/BlocksBeyondTheStars.Api/Program.cs)): remove the `/play` WebGL stub route; add `/download-linux` mirroring `/download` to serve the newest `*.AppImage` (GET+HEAD, resumable range download).
- **Portal** ([PortalPage.cs](src/BlocksBeyondTheStars.Api/PortalPage.cs)): replace the "Play in the browser" button with a "Download the Linux client (AppImage)" button; refresh the doc comment + meta line.
- **Docker entrypoint** ([entrypoint.sh](docker/entrypoint.sh)): `fetch_client` now pulls both `*Setup.exe` **and** `*.AppImage` from the latest GitHub Release into `/app/clients` (new `fetch_asset` helper, each asset fetched independently/best-effort, same `BBS_FETCH_CLIENT` switch).
- **Docs + comments**: [SELF_HOSTING.md](docs/developer/SELF_HOSTING.md) §6/§9/§10, [Dockerfile](Dockerfile), [docker-compose.yml](docker-compose.yml) document the Linux download path.

The **WebSocket gateway** (`BBS_ENABLE_WEBSOCKET` / `WebSocketServerTransport`) is intentionally **kept** — it is the transport layer for a future browser client, separate from the removed WebGL stub.

## Verification

- API build: **0 warnings / 0 errors**
- Server tests: **759/759 passed**
- `bash -n docker/entrypoint.sh`: OK
- No `client/Assets` change → no Unity build needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)