### PR TITLE
feat(ci): experimental macOS client build (StandaloneOSX)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-# Builds the Windows player + loading-splash launcher and publishes a GitHub Release.
+# Builds the Windows, Linux + (experimental) macOS players and publishes a GitHub Release.
 #
 # Triggered ONLY by pushing a version tag (or the manual "Run workflow" button), never by
 # pull_request — so forked PRs can never reach the Unity license secret. In a PUBLIC repo,
@@ -13,10 +13,15 @@
 #        UNITY_PASSWORD = your Unity account password
 #   3. Push a tag:  git tag v1.0.0 && git push origin v1.0.0
 #
-# Why split jobs: the Unity build runs in GameCI's Linux Docker image (Windows player cross-built
-# with the Mono backend). The WinForms launcher needs the Windows Desktop SDK, so it is built on
-# a windows-latest runner and merged into the player afterwards. A third job builds the optional
-# dedicated-server Docker image (reusable docker.yml) and pushes it to GHCR on a tag.
+# Why split jobs: the Unity build runs in GameCI's Linux Docker image (Windows, Linux and macOS
+# players are all cross-built with the Mono backend — macOS too, so no Mac runner is needed). The
+# WinForms launcher needs the Windows Desktop SDK, so it is built on a windows-latest runner and
+# merged into the Windows player afterwards. Per-platform package jobs publish the installers/zips,
+# and a final job builds the optional dedicated-server Docker image (reusable docker.yml) and
+# pushes it to GHCR on a tag.
+#
+# macOS is EXPERIMENTAL: the .app is unsigned and un-notarized (Phase 1 = plain zip, no Velopack,
+# no splash launcher). Users clear the Gatekeeper quarantine once — see README "Platforms".
 
 name: Release
 
@@ -285,6 +290,115 @@ jobs:
           name: player-linux
           path: player-linux
 
+  # macOS player (experimental). Built on a Linux runner: the project uses the Mono scripting backend, so
+  # GameCI cross-compiles StandaloneOSX without Mac hardware. The result is an unsigned/un-notarized .app
+  # bundle (Phase 1: zipped as-is, no Velopack, no splash launcher). Mirrors build-player-linux step-for-step.
+  build-player-mac:
+    name: Build Unity player (macOS)
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.ver.outputs.version }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Resolve + validate version
+        id: ver
+        shell: bash
+        run: |
+          if [ "$GITHUB_REF_TYPE" = "tag" ]; then
+            v="${GITHUB_REF_NAME#v}"
+            if ! printf '%s' "$v" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$'; then
+              echo "::error::Tag '$GITHUB_REF_NAME' is not SemVer — expected vX.Y.Z (e.g. v0.3.0)."
+              exit 1
+            fi
+          else
+            v="0.1.0-dev"
+          fi
+          echo "version=$v" >> "$GITHUB_OUTPUT"
+          echo "Resolved build version: $v"
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Sync shared libs + content (bash)
+        run: ./scripts/sync-client-libs.sh
+
+      - name: Sync Velopack libs (bash)
+        run: ./scripts/sync-velopack-libs.sh
+
+      - name: Publish bundled local server (osx-x64)
+        run: ./scripts/publish-local-server.sh osx-x64
+
+      - name: Cache Unity Library
+        uses: actions/cache@v5
+        with:
+          path: client/Library
+          key: Library-macOS-${{ hashFiles('client/Assets/**', 'client/Packages/**', 'client/ProjectSettings/**') }}
+          restore-keys: |
+            Library-macOS-
+
+      - name: Free disk space for the Unity image
+        run: |
+          echo "Before:"; df -h /
+          sudo rm -rf /usr/local/lib/android /opt/ghc /usr/share/dotnet \
+                      /opt/hostedtoolcache/CodeQL /usr/local/share/boost /usr/local/.ghcup
+          sudo docker image prune --all --force || true
+          echo "After:"; df -h /
+
+      - name: Inject player-feedback API key
+        env:
+          WIX_BUGREPORT_API_KEY: ${{ secrets.WIX_BUGREPORT_API_KEY }}
+        run: |
+          if [ -z "$WIX_BUGREPORT_API_KEY" ]; then
+            echo "WIX_BUGREPORT_API_KEY not set — player feedback will be disabled in this build."
+            exit 0
+          fi
+          {
+            echo '// CI-generated from the WIX_BUGREPORT_API_KEY secret — not committed.'
+            echo 'namespace BlocksBeyondTheStars.Build'
+            echo '{'
+            echo '    public static partial class BugReportBuildSecrets'
+            echo '    {'
+            echo "        static partial void ApplyApiKey(ref string key) => key = \"$WIX_BUGREPORT_API_KEY\";"
+            echo '    }'
+            echo '}'
+          } > client/Assets/BlocksBeyondTheStars/Scripts/BugReportBuildSecrets.Generated.cs
+          echo "Injected feedback API key into the build."
+
+      - name: Build macOS player
+        uses: game-ci/unity-builder@d829bfc901f2347c8fe18898f06712b66916ef42 # v5
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+        with:
+          projectPath: client
+          unityVersion: 6000.4.9f1
+          targetPlatform: StandaloneOSX
+          buildMethod: BlocksBeyondTheStars.Client.EditorTools.BuildScript.BuildMacOS
+          versioning: Custom
+          version: ${{ steps.ver.outputs.version }}
+          customParameters: -buildOut /github/workspace/player-mac
+          allowDirtyBuild: true
+
+      - name: Fix output permissions
+        run: sudo chmod -R a+rwX player-mac
+
+      - name: Verify baked version matches the tag
+        shell: bash
+        run: |
+          baked="$(cat player-mac/version.txt)"
+          echo "Baked into player: '$baked' — expected: '${{ steps.ver.outputs.version }}'"
+          test "$baked" = "${{ steps.ver.outputs.version }}"
+
+      - name: Upload macOS player artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: player-mac
+          path: player-mac
+
   # Linux packaging
   package-linux:
     name: Package + release (Linux)
@@ -308,6 +422,14 @@ jobs:
         with:
           name: player-linux
           path: client/Build/Linux
+
+      # GitHub artifacts drop the Unix execute bit. Restore it on the main player AND the bundled local
+      # server before packing, otherwise Singleplayer's Process.Start on the server fails with EACCES
+      # inside the AppImage (see LocalServerLauncher.cs — it runs StreamingAssets/server/...GameServer).
+      - name: Restore execute bits (player + bundled server)
+        run: |
+          chmod +x client/Build/Linux/BlocksBeyondTheStars.x86_64
+          chmod +x client/Build/Linux/BlocksBeyondTheStars_Data/StreamingAssets/server/BlocksBeyondTheStars.GameServer
 
       # vpk can produce AppImage + portable zip for Linux. NOTE: the splash options
       # (--splashImage / --splashProgressColor) are Windows-installer only — the Linux `vpk pack`
@@ -340,6 +462,53 @@ jobs:
           files: |
             artifacts/installer-linux/*AppImage
             artifacts/installer-linux/*Portable.zip
+          generate_release_notes: false
+
+  # macOS packaging (experimental, no signing/notarization). Velopack is skipped on purpose: we just zip
+  # the .app and document the Gatekeeper quarantine workaround in the README/release notes. Mirrors the
+  # Linux packaging job; the only macOS-specific care is preserving the bundle's symlinks (zip -y) and the
+  # execute bits (artifacts strip them).
+  package-mac:
+    name: Package + release (macOS)
+    needs: build-player-mac
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Download macOS player artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: player-mac
+          path: client/Build/macOS
+
+      # Artifacts strip Unix perms — restore +x on the bundle's entry binary AND the bundled local server,
+      # otherwise Singleplayer can't spawn the server on macOS (LocalServerLauncher.cs).
+      - name: Restore execute bits (app + bundled server)
+        run: |
+          APP="client/Build/macOS/BlocksBeyondTheStars.app"
+          chmod +x "$APP/Contents/MacOS/"*
+          chmod +x "$APP/Contents/Resources/Data/StreamingAssets/server/BlocksBeyondTheStars.GameServer"
+
+      # zip -y preserves the symlinks inside the .app bundle; a plain upload-artifact re-zip would corrupt it.
+      - name: Zip the .app
+        run: |
+          OUT="artifacts/installer-mac"
+          mkdir -p "$OUT"
+          ( cd client/Build/macOS && \
+            zip -ry "$GITHUB_WORKSPACE/$OUT/BlocksBeyondTheStars-osx-${{ needs.build-player-mac.outputs.version }}-Portable.zip" \
+              "BlocksBeyondTheStars.app" )
+
+      - name: Upload macOS installer artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: mac-installers
+          path: artifacts/installer-mac
+
+      - name: Publish GitHub Release (macOS assets)
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3
+        with:
+          files: artifacts/installer-mac/*Portable.zip
           generate_release_notes: false
 
   # Optional dedicated-server Docker image. Reuses .github/workflows/docker.yml (workflow_call). It only

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Blocks Beyond the Stars is not a traditional indie game—it is an exploration o
 
 ## 🪐 What is it? (The Short Pitch)
 
-A block-based 3D space crafting game for Windows and Linux, built from day one as a persistent client/server multiplayer experience.
+A block-based 3D space crafting game for Windows and Linux (with an experimental macOS build), built from day one as a persistent client/server multiplayer experience.
 
 You wake aboard your own spaceship. Out there are procedurally generated star systems—each with its own sun, planets, moons, and asteroid fields. Land on unique worlds (from airless rocks to lava fields and floating skylands), mine resources, craft gear, and unlock blueprints.
 
@@ -108,9 +108,9 @@ The software is provided as-is under the terms of the [license](#-license) inclu
 
 ## System requirements
 
-The **game client ships as a Windows build** (with a **native Linux build** also available), but the
-**server is cross-platform** — so a Linux/macOS machine, a NAS or a VPS (including via Docker) can
-host a world that players join.
+The **game client ships as a Windows build** (with a **native Linux build** and an **experimental
+macOS build** also available), but the **server is cross-platform** — so a Linux/macOS machine, a
+NAS or a VPS (including via Docker) can host a world that players join.
 
 **Game client (to play)**
 
@@ -123,6 +123,10 @@ host a world that players join.
   If it feels sluggish, open **Settings → Graphics** and **turn VSync off** (optionally set a frame-rate
   limit), lower the **quality preset** (Potato/Low also disables the costlier screen-space effects)
   and the **view distance**. A recent Proton (e.g. Proton GE) generally gives the smoothest result.
+- **macOS (experimental):** a `StandaloneOSX` `.app` bundle (Intel x64; runs on Apple Silicon via
+  Rosetta 2) is published as `…-osx-…-Portable.zip`. It is **unsigned and un-notarized**, so macOS
+  Gatekeeper quarantines it — see the [macOS security notice](#macos-security-notice) below. Consider
+  it a preview: it builds green in CI but has had limited hands-on testing.
 - The client always talks to a server: a local one started automatically in singleplayer / "Host
   Game", or a remote dedicated server.
 
@@ -157,6 +161,25 @@ may need to allow these components through the firewall.
   network access.
 - Please **do not disable your firewall**.
 
+## macOS security notice
+
+The macOS build is **experimental** and **not code-signed or notarized**. macOS Gatekeeper will
+therefore quarantine the downloaded `.app` and refuse to open it on a double-click. If you trust the
+[official releases](https://github.com/marceld23/BlocksBeyondTheStars/releases), there are two ways
+to run it after unzipping:
+
+- **Right-click the app → "Open"**, then confirm **"Open"** in the dialog (only needed once), or
+- clear the quarantine flag from a terminal:
+
+  ```bash
+  xattr -dr com.apple.quarantine "BlocksBeyondTheStars.app"
+  ```
+
+The bundle is **Intel x64**; on Apple Silicon (M-series) it runs through Rosetta 2. Singleplayer
+launches a bundled local server inside the app the same way the Windows/Linux builds do. As with the
+other platforms, macOS may ask you to allow the game/server through the firewall on first launch —
+allowing **private networks only** is recommended.
+
 ## Guiding principle
 
 > **The Unity client is presentation and input. The .NET server is the truth of the game world.**
@@ -169,7 +192,7 @@ oxygen, damage, blueprints or travel.
 
 | Area | Choice |
 |---|---|
-| Client | Unity 6 LTS (6000.4.x), URP + C# (Windows, Linux) — see [`client/`](client/) |
+| Client | Unity 6 LTS (6000.4.x), URP + C# (Windows, Linux, experimental macOS) — see [`client/`](client/) |
 | Server | .NET 8, standalone console host (no Unity runtime) |
 | Admin UI | ASP.NET Core 8 minimal API + HTML dashboard |
 | Database | SQLite (default, portable); PostgreSQL later |

--- a/TODO.md
+++ b/TODO.md
@@ -60,6 +60,17 @@ Per-item detail lives in the dated work log below.
 
 ---
 
+### ★ Experimental macOS client build (2026-06-27) — ⚠️ CI + docs done, NOT built/run yet, on branch `feat/macos-experimental-build` (NOT committed to main)
+Adds an unsigned/un-notarized macOS player (doc [docs/developer/MACOS_BUILD.md](docs/developer/MACOS_BUILD.md)). The Mono scripting backend
+cross-compiles `StandaloneOSX` on the Linux runner — no Mac hardware in CI; UWB/CEF is already gone and there are no native plugins, so
+there were no real blockers. Changes: `BuildScript.BuildMacOS()` (StandaloneOSX → `.app`); two `release.yml` jobs (`build-player-mac`
+mirrors `build-player-linux`; `package-mac` zips the bundle, no Velopack/launcher = Phase 1); `publish-local-server.sh osx-x64` for the
+bundled singleplayer server. Also fixed a latent bug: GitHub artifacts strip the Unix `+x` bit, so **both** package jobs now `chmod +x` the
+player **and** the bundled server before packing (Linux AppImage was likely affected too — see [LINUX_PORT.md](docs/developer/LINUX_PORT.md)).
+- **Open / next:** no Mac in CI, so this is verified to *compile + package* only. Smoke-test on a real Mac (Singleplayer + bundled-server
+  launch = the `+x` failure mode) before promoting past "experimental". Phase 2: signing/notarization, Velopack/auto-update, splash launcher,
+  native `osx-arm64`/Universal, itch.io osx channel.
+
 ### ★ Factories, ruins, treasure chests & access-code claiming (2026-06-27) — ✅ server 759 tests green + local Unity build green, on branch `feat/factories-ruins-claiming` (NOT committed)
 A four-part content feature, all deterministic from the world seed (doc [docs/developer/FACTORIES_RUINS_AND_CLAIMING.md](docs/developer/FACTORIES_RUINS_AND_CLAIMING.md)):
 - **Factories** — rare procedural industrial halls (`FactoryGenerator`) with **animated machines** (piston/rotor/conveyor via `FactoryView`, overlaid on the voxel housings) and a **production terminal**. Each factory offers only a seeded **roster** (1–4 of the factory recipes — never all). Factory recipes (`station: factory` in recipes.json) turn **cheaper/less-rare raw into the same output but more of it** in one step; excluded from disassembly. Protected until claimed. Stamper `StampFactories` (`PlaceFactories`), networking `FactoryList` (tag 172).

--- a/client/Assets/BlocksBeyondTheStars/Editor/BuildScript.cs
+++ b/client/Assets/BlocksBeyondTheStars/Editor/BuildScript.cs
@@ -60,6 +60,15 @@ namespace BlocksBeyondTheStars.Client.EditorTools
         public static void BuildLinux()
             => BuildPlayer(BuildTarget.StandaloneLinux64, "BlocksBeyondTheStars.x86_64", "Build/Linux");
 
+        /// <summary>Builds the macOS player (StandaloneOSX) as a <c>.app</c> bundle. Because the project uses the
+        /// Mono scripting backend (not IL2CPP), GameCI cross-builds this on a Linux runner — no Mac hardware needed.
+        /// Experimental: the resulting bundle is unsigned/un-notarized, so macOS Gatekeeper quarantines it (users
+        /// run <c>xattr -dr com.apple.quarantine</c> once). Headless: same path with
+        /// <c>-buildMethod BlocksBeyondTheStars.Client.EditorTools.BuildScript.BuildMacOS -buildOut &lt;dir&gt;</c>.</summary>
+        [MenuItem("BlocksBeyondTheStars/Build macOS Player")]
+        public static void BuildMacOS()
+            => BuildPlayer(BuildTarget.StandaloneOSX, "BlocksBeyondTheStars.app", "Build/macOS");
+
         private static void BuildPlayer(BuildTarget target, string exeName, string defaultOutDir)
         {
             EnsureLauncherScene();

--- a/docs/developer/DEVELOPER.md
+++ b/docs/developer/DEVELOPER.md
@@ -266,6 +266,25 @@ vpk pack --packId BlocksBeyondTheStars --packVersion <semver> \
   --outputDir artifacts/installer-linux
 ```
 
+## Building the macOS client (experimental)
+
+The macOS build uses the same Unity project, targets `StandaloneOSX`, and produces a `.app` bundle. The
+Mono backend cross-compiles it, so it builds on Linux/Windows/macOS Editors alike — no Mac hardware
+required. There is no one-command wrapper script yet; run the steps directly:
+
+```bash
+./scripts/sync-client-libs.sh
+./scripts/sync-velopack-libs.sh
+./scripts/publish-local-server.sh osx-x64     # bundles the osx-x64 singleplayer server
+# Unity batch build with the macOS build method:
+<Unity> -batchmode -quit -nographics -projectPath client \
+  -buildMethod BlocksBeyondTheStars.Client.EditorTools.BuildScript.BuildMacOS \
+  -buildOut client/Build/macOS
+```
+
+The result is **unsigned and un-notarized** — for the full picture (the CI job pair, the artifact
+execute-bit fix, and how to run an unsigned `.app` past Gatekeeper) see [MACOS_BUILD.md](MACOS_BUILD.md).
+
 ### Build log, exit codes and duration
 
 - The Unity log is written to **`client/build.log`**.
@@ -319,7 +338,7 @@ not locally. Cut one by pushing a SemVer tag:
 git tag v0.3.0 && git push origin v0.3.0
 ```
 
-The workflow has four parallel jobs, building for Windows **and** Linux:
+The workflow builds for Windows, Linux **and** (experimentally) macOS in parallel jobs:
 
 1. **Build Unity player (Windows)** — GameCI (`game-ci/unity-builder`) in a Linux Docker image
    cross-builds the `StandaloneWindows64` player (Mono backend). It first runs the same prereqs as
@@ -327,13 +346,19 @@ The workflow has four parallel jobs, building for Windows **and** Linux:
    caches `client/Library`, and frees runner disk space before the ~6 GB editor image pull.
 2. **Build Unity player (Linux)** — same GameCI builder, targets `StandaloneLinux64`. Produces a
    native `BlocksBeyondTheStars.x86_64` player.
-3. **Package + release (Windows)** — builds the WinForms launcher, downloads the Windows player from job 1,
+3. **Build Unity player (macOS, experimental)** — same GameCI builder, targets `StandaloneOSX` (the Mono
+   backend cross-builds it on the Linux runner — no Mac hardware). Publishes the `osx-x64` bundled server
+   first and produces a `.app` bundle. See [MACOS_BUILD.md](MACOS_BUILD.md).
+4. **Package + release (Windows)** — builds the WinForms launcher, downloads the Windows player from job 1,
    and runs `publish-client-installer.ps1 -Msi` to produce three assets for the GitHub Release:
    **`…-win-Setup.exe`** (per-user, no admin), **`…-win.msi`** (machine-wide, for IT/MDM) and
    **`…-win-Portable.zip`**. The same three assets are mirrored to **itch.io** (see below).
-4. **Package + release (Linux)** — builds the console launcher, downloads the Linux player from job 2,
+5. **Package + release (Linux)** — builds the console launcher, downloads the Linux player from job 2,
    and packages it with Velopack (`vpk`) into an **AppImage** + **portable zip**, attached to the same
    GitHub Release.
+6. **Package + release (macOS, experimental)** — downloads the `.app` from job 3, restores the artifact's
+   stripped execute bits (entry binary + bundled server), and `zip`s the bundle into a **portable zip**
+   (`…-osx-…-Portable.zip`). Unsigned/un-notarized; no Velopack. See [MACOS_BUILD.md](MACOS_BUILD.md).
 
 The workflow triggers **only** on tag pushes and manual dispatch (never `pull_request`), so the Unity license
 secrets (`UNITY_LICENSE`/`UNITY_EMAIL`/`UNITY_PASSWORD`) are never exposed — safe even with a public repo. A
@@ -388,9 +413,11 @@ When working on this pipeline, three non-obvious gotchas already cost a debuggin
 - **`gh workflow run` right after `git push`** can dispatch the *previous* commit (tag/branch HEAD hasn't
   propagated yet) — wait ~20 s and verify the run's `headSha`.
 
-macOS **client** installers are intentionally not built: it is out of scope for now and would need its
-own work (Metal/Vulkan graphics, cross-compilation, and Apple code-signing/notarization). Linux **client** installers (AppImage + portable zip)
-are now produced alongside the Windows builds — see the release pipeline above.
+An **experimental** macOS **client** build is now produced too — a `StandaloneOSX` `.app` bundle shipped as a
+portable zip. It is **unsigned and un-notarized** (a preview): no Apple code-signing/notarization, no
+Velopack, Intel x64 only (Apple Silicon via Rosetta 2), and it has had limited hands-on testing. See
+[MACOS_BUILD.md](MACOS_BUILD.md). Linux **client** installers (AppImage + portable zip) are produced
+alongside the Windows builds — see the release pipeline above.
 The .NET **server** also cross-builds (`publish-server.ps1` / `.sh`: win-x64/linux-x64/linux-arm64).
 
 ## Troubleshooting: works in the Editor, silently broken in the build

--- a/docs/developer/LINUX_PORT.md
+++ b/docs/developer/LINUX_PORT.md
@@ -70,6 +70,13 @@ The `release.yml` workflow gained two new jobs alongside the existing Windows jo
 The `BlocksBeyondTheStars.CI.slnf` solution filter now includes `Launcher.Console` (it targets plain net8.0
 and builds on Linux, unlike the WinForms launcher which is net8.0-windows).
 
+**Execute-bit fix:** GitHub's `upload-/download-artifact` strips the Unix execute bit, so after the player
+artifact round-trips into `package-linux` the bundled local server (and the player binary) lose `+x`.
+`package-linux` therefore `chmod +x`s `BlocksBeyondTheStars.x86_64` **and**
+`…_Data/StreamingAssets/server/BlocksBeyondTheStars.GameServer` before `vpk pack`, otherwise Singleplayer's
+`Process.Start` on the server fails with `EACCES` inside the AppImage. The same fix applies to the macOS
+package job — see [MACOS_BUILD.md](MACOS_BUILD.md).
+
 ## How to build
 
 See [DEVELOPER.md](DEVELOPER.md) (§ Building the Linux client) for the full guide.

--- a/docs/developer/MACOS_BUILD.md
+++ b/docs/developer/MACOS_BUILD.md
@@ -1,0 +1,118 @@
+# macOS Build — How It Works (Experimental)
+
+Status: **Experimental** (2026-06-27). The Unity client can be built as a `StandaloneOSX` `.app` bundle and
+is published as a portable zip from the release CI. It is **unsigned and un-notarized** — a preview build.
+
+This builds directly on the [Linux port](LINUX_PORT.md): all the cross-platform groundwork (non-`.exe`
+binary names, the console launcher, the bundled-server flow) already covers macOS. Only the build target,
+a CI job pair and the packaging differ.
+
+## Why it was cheap to add
+
+- **Mono scripting backend.** The client uses Unity's Mono backend (`scriptingBackend: {}` is empty in
+  `client/ProjectSettings/ProjectSettings.asset` → the default, Mono). Mono **cross-compiles** the
+  `StandaloneOSX` target, so GameCI builds the `.app` on the existing **Linux** runner — no Mac hardware in
+  CI. (If anyone ever switches the backend to IL2CPP, this breaks: IL2CPP for macOS requires a `macos-latest`
+  runner.)
+- **No native plugins.** Everything in `client/Assets/Plugins/` is managed .NET (Concentus is pure C#), so
+  there is nothing to port to `.dylib`/`.bundle`.
+- **UWB/CEF is gone.** The embedded browser (Windows-only) was removed in the Stream-D refactor
+  (see [adr/0009](adr/0009-embedded-browser-wiki-arcade.md)); the Wiki/Arcade are now native uGUI/Canvas2D,
+  which is platform-agnostic.
+
+## What was done
+
+### 1. BuildScript.cs — BuildMacOS()
+
+A new editor build method, parallel to `BuildWindows()`/`BuildLinux()`:
+
+```csharp
+[MenuItem("BlocksBeyondTheStars/Build macOS Player")]
+public static void BuildMacOS()
+    => BuildPlayer(BuildTarget.StandaloneOSX, "BlocksBeyondTheStars.app", "Build/macOS");
+```
+
+The shared `BuildPlayer()` handles version injection, shader prewarming, scene generation and icon embedding
+for all three targets. `version.txt` is written next to the `.app` (the CI version guard reads it there).
+
+### 2. Bundled local server (osx-x64)
+
+`publish-local-server.sh` already takes a runtime argument (`${1:-linux-x64}`), so `publish-local-server.sh
+osx-x64` publishes the self-contained single-file `BlocksBeyondTheStars.GameServer` into
+`client/Assets/StreamingAssets/server/`. Unity bakes `StreamingAssets/` into the `.app` under
+`Contents/Resources/Data/StreamingAssets/`. At runtime `LocalServerLauncher.cs` resolves the non-`.exe`
+binary name on macOS and launches it for Singleplayer — the same path Linux uses.
+
+### 3. CI/CD Pipeline
+
+`release.yml` gained two jobs alongside the Windows/Linux ones:
+
+- **build-player-mac:** builds the Unity `StandaloneOSX` player via GameCI's Docker image (Mono cross-build),
+  publishes the `osx-x64` bundled server first, produces the `player-mac` artifact. A step-for-step clone of
+  `build-player-linux` (only the target, build method, server runtime, cache key and out-dir differ). The
+  Phase-1 build deliberately **omits the console-splash launcher**.
+- **package-mac:** restores the Unix execute bits (artifacts strip them — see below), then `zip -ry`s the
+  `.app` into `…-osx-…-Portable.zip` and attaches it to the GitHub Release on a tag. No Velopack.
+
+### 4. The execute-bit fix (important)
+
+GitHub's `upload-/download-artifact` **does not preserve the Unix execute bit**. After the player artifact
+round-trips through `package-mac` (and `package-linux`), both the entry binary and the **bundled local
+server** lose `+x`. Nothing in the launcher or `LocalServerLauncher.cs` restores it, so without a fix the
+server would fail to start with `EACCES` even though the file is present. Both package jobs therefore
+`chmod +x` the entry binary **and** the bundled server before packing:
+
+```bash
+# package-mac
+APP="client/Build/macOS/BlocksBeyondTheStars.app"
+chmod +x "$APP/Contents/MacOS/"*
+chmod +x "$APP/Contents/Resources/Data/StreamingAssets/server/BlocksBeyondTheStars.GameServer"
+```
+
+The macOS zip uses `zip -y` to preserve the symlinks inside the `.app` bundle (a plain re-zip would corrupt
+the bundle).
+
+## How to build locally
+
+```bash
+# Prerequisites: Unity 6000.4.x with the Mac-Mono build module + .NET 8 SDK
+./scripts/sync-client-libs.sh
+./scripts/sync-velopack-libs.sh
+./scripts/publish-local-server.sh osx-x64
+# Then run the Unity batch build with the macOS build method, e.g.:
+#   <Unity> -batchmode -quit -nographics -projectPath client \
+#     -buildMethod BlocksBeyondTheStars.Client.EditorTools.BuildScript.BuildMacOS \
+#     -buildOut <out-dir>
+```
+
+## Running an unsigned build
+
+The `.app` is not signed or notarized, so macOS Gatekeeper quarantines it. After unzipping, either
+right-click the app → **Open** (confirm once), or clear the quarantine flag:
+
+```bash
+xattr -dr com.apple.quarantine "BlocksBeyondTheStars.app"
+```
+
+The bundle is **Intel x64**; it runs on Apple Silicon through Rosetta 2.
+
+## Known limitations / next steps
+
+- **Limited hands-on testing.** There is no Mac in CI, so the build is verified to *compile and package*, not
+  to *run*. The bundled-server launch (the `+x` failure mode) and Singleplayer should be smoke-tested on a
+  real Mac before this is promoted beyond "experimental".
+- **No signing/notarization.** Required for friction-free distribution outside the App Store; needs an Apple
+  Developer account and a CI signing step. Out of scope for the experimental phase.
+- **No Velopack / no auto-update / no splash launcher** on macOS yet (Phase 1 ships a plain zip).
+- **Intel-only.** A native `osx-arm64` or Universal binary is a later step; for now Apple Silicon uses
+  Rosetta 2.
+- **itch.io.** `publish-itch.ps1` only has Windows channels; a macOS channel can be added later.
+
+## Architecture decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Cross-build on Linux, no Mac runner | The Mono backend cross-compiles `StandaloneOSX`; keeps CI cost/complexity flat |
+| Plain zip, not Velopack (Phase 1) | Velopack's macOS packaging leans on signing; a zip ships something runnable today |
+| Explicit `chmod +x` in packaging | Deterministic; does not rely on artifact round-trip or `appimagetool`/`vpk` preserving perms |
+| Reuse the console launcher path later | The cross-platform launcher already exists; the bundle-vs-exe handoff is deferred to Phase 2 |

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -15,6 +15,8 @@ belongs in TODO.md). Each doc states its own status near the top. Last reorganis
   pipeline, freshness checks, "works in the Editor, broken in the build" pitfalls).
 - [LINUX_PORT.md](LINUX_PORT.md) — how the Linux port works: cross-platform changes, the console launcher,
   bash build scripts, CI/CD and known limitations.
+- [MACOS_BUILD.md](MACOS_BUILD.md) — the experimental macOS build: `StandaloneOSX` cross-built on Linux (Mono),
+  the CI job pair, the artifact execute-bit fix, and running an unsigned/un-notarized `.app`.
 - [CLIENT_TESTING.md](CLIENT_TESTING.md) — how the Unity client is tested against the **real** game server
   (the `Client.Core` split, the three test tiers, the selectable `run-tests.ps1` runner).
 - [SELF_HOSTING.md](SELF_HOSTING.md) — run and host a dedicated server, config keys, the web portal & updates.


### PR DESCRIPTION
## Summary

Adds an **experimental**, unsigned/un-notarized macOS client build (`StandaloneOSX` → `.app`). It cross-builds on the existing **Linux** GameCI runner — the project uses the **Mono** scripting backend, which cross-compiles macOS, so **no Mac hardware** is needed in CI. UWB/CEF is already gone (Stream-D refactor) and there are no native plugins, so there were no real blockers.

## Changes

- **`BuildScript.BuildMacOS()`** — `StandaloneOSX` → `BlocksBeyondTheStars.app`, parallel to Windows/Linux.
- **`release.yml`** — two new jobs: `build-player-mac` (mirrors `build-player-linux`) and `package-mac` (zips the `.app`; **no Velopack/launcher = Phase 1**). Bundled server via `publish-local-server.sh osx-x64`.
- **Execute-bit fix (latent bug):** GitHub `upload-/download-artifact` strips the Unix `+x` bit, so after the artifact round-trip the bundled local server (and the player binary) lost `+x` — Singleplayer's `Process.Start` would fail with `EACCES`. **Both** `package-mac` and `package-linux` now `chmod +x` the player **and** the bundled server before packing. (The Linux AppImage was likely affected too.)
- **Docs:** new `docs/developer/MACOS_BUILD.md`; README macOS security notice + platform notes; `DEVELOPER.md` / `LINUX_PORT.md` / docs index / `TODO.md` updated.

## ⚠️ Verification status

There is **no Mac in CI**, so this is verified to **compile and package only — not to run**. Before promoting past "experimental", smoke-test on a real Mac:
- Singleplayer loads, **and**
- the bundled local server actually spawns (the `+x` failure mode).

The macOS Release job only attaches assets on a tag push, exactly like the other platforms.

## Out of scope (Phase 2)

Code-signing/notarization, Velopack/auto-update, splash launcher, native `osx-arm64`/Universal (Phase 1 is Intel x64 via Rosetta 2), itch.io osx channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)