### PR TITLE
fix(macos): Microphone Usage Description + slim macOS CI workflow

### DIFF
--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -1,0 +1,102 @@
+# Slim, targeted macOS build — for iterating on the experimental Mac client WITHOUT running the full
+# release.yml (Windows + Linux + Docker). It builds only the StandaloneOSX player, packages the .app into
+# a portable zip and uploads it as a run artifact. Nothing is published.
+#
+# Why this exists: in release.yml the macOS job runs in parallel with the others, but GitHub only frees a
+# job's logs once the WHOLE run finishes — so debugging a Mac build meant waiting on the Windows/Linux jobs
+# too. Here the Mac job is the only job, so the run completes (and logs unlock) the moment it does.
+#
+# Trigger: the Actions tab -> "macOS build (experimental)" -> Run workflow. Dispatch-only; uses the same
+# Unity license secrets as release.yml, so it only runs on the main repo (not forks).
+
+name: macOS build (experimental)
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to stamp into the build (test value; not a release)."
+        type: string
+        default: 0.1.0-dev
+
+permissions:
+  contents: read
+
+jobs:
+  build-mac:
+    name: Build + package macOS player
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Sync shared libs + content (bash)
+        run: ./scripts/sync-client-libs.sh
+
+      - name: Sync Velopack libs (bash)
+        run: ./scripts/sync-velopack-libs.sh
+
+      - name: Publish bundled local server (osx-x64)
+        run: ./scripts/publish-local-server.sh osx-x64
+
+      - name: Cache Unity Library
+        uses: actions/cache@v5
+        with:
+          path: client/Library
+          key: Library-macOS-${{ hashFiles('client/Assets/**', 'client/Packages/**', 'client/ProjectSettings/**') }}
+          restore-keys: |
+            Library-macOS-
+
+      - name: Free disk space for the Unity image
+        run: |
+          echo "Before:"; df -h /
+          sudo rm -rf /usr/local/lib/android /opt/ghc /usr/share/dotnet \
+                      /opt/hostedtoolcache/CodeQL /usr/local/share/boost /usr/local/.ghcup
+          sudo docker image prune --all --force || true
+          echo "After:"; df -h /
+
+      - name: Build macOS player
+        uses: game-ci/unity-builder@d829bfc901f2347c8fe18898f06712b66916ef42 # v5
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+        with:
+          projectPath: client
+          unityVersion: 6000.4.9f1
+          targetPlatform: StandaloneOSX
+          buildMethod: BlocksBeyondTheStars.Client.EditorTools.BuildScript.BuildMacOS
+          versioning: Custom
+          version: ${{ inputs.version }}
+          customParameters: -buildOut /github/workspace/player-mac
+          allowDirtyBuild: true
+
+      - name: Fix output permissions
+        run: sudo chmod -R a+rwX player-mac
+
+      # Artifacts strip Unix perms — restore +x on the bundle's entry binary AND the bundled local server,
+      # otherwise Singleplayer can't spawn the server on macOS (LocalServerLauncher.cs). Same as package-mac.
+      - name: Restore execute bits (app + bundled server)
+        run: |
+          APP="player-mac/BlocksBeyondTheStars.app"
+          chmod +x "$APP/Contents/MacOS/"*
+          chmod +x "$APP/Contents/Resources/Data/StreamingAssets/server/BlocksBeyondTheStars.GameServer"
+
+      # zip -y preserves the symlinks inside the .app bundle; a plain upload-artifact re-zip would corrupt it.
+      - name: Zip the .app
+        run: |
+          OUT="artifacts/installer-mac"
+          mkdir -p "$OUT"
+          ( cd player-mac && \
+            zip -ry "$GITHUB_WORKSPACE/$OUT/BlocksBeyondTheStars-osx-${{ inputs.version }}-Portable.zip" \
+              "BlocksBeyondTheStars.app" )
+
+      - name: Upload macOS portable zip
+        uses: actions/upload-artifact@v6
+        with:
+          name: mac-portable-zip
+          path: artifacts/installer-mac

--- a/client/Assets/BlocksBeyondTheStars/Editor/BuildScript.cs
+++ b/client/Assets/BlocksBeyondTheStars/Editor/BuildScript.cs
@@ -83,6 +83,17 @@ namespace BlocksBeyondTheStars.Client.EditorTools
                 Debug.Log($"BlocksBeyondTheStars version set from -buildVersion: {version}");
             }
 
+            // macOS (and iOS) require a non-empty usage description for any Apple "Usage Description" API the
+            // player touches, or the StandaloneOSX post-processor fails the build with
+            // "Microphone class is used but Microphone Usage Description is empty in Player Settings."
+            // Voice chat (BBS_VOICE) uses the Microphone API, so set the Info.plist string here. No-op on
+            // Windows/Linux, which don't gate on it. Idempotent; safe to set on every build.
+            if (target == BuildTarget.StandaloneOSX)
+            {
+                PlayerSettings.macOS.microphoneUsageDescription =
+                    "Used for in-game voice chat with other players.";
+            }
+
             string outDir = GetArg("-buildOut") ?? defaultOutDir;
             Directory.CreateDirectory(outDir);
 

--- a/docs/developer/MACOS_BUILD.md
+++ b/docs/developer/MACOS_BUILD.md
@@ -35,6 +35,13 @@ public static void BuildMacOS()
 The shared `BuildPlayer()` handles version injection, shader prewarming, scene generation and icon embedding
 for all three targets. `version.txt` is written next to the `.app` (the CI version guard reads it there).
 
+**macOS gotcha — Microphone Usage Description.** Voice chat (`BBS_VOICE`) uses Unity's `Microphone` API.
+On macOS/iOS, Apple requires a non-empty `NSMicrophoneUsageDescription`; if it is empty, the `StandaloneOSX`
+post-processor **fails the build** with *"Microphone class is used but Microphone Usage Description is empty
+in Player Settings."* (Windows/Linux don't gate on it, so this only surfaces on a real macOS build.)
+`BuildPlayer()` therefore sets `PlayerSettings.macOS.microphoneUsageDescription` for the `StandaloneOSX`
+target before building — idempotent, and a no-op on the other platforms.
+
 ### 2. Bundled local server (osx-x64)
 
 `publish-local-server.sh` already takes a runtime argument (`${1:-linux-x64}`), so `publish-local-server.sh
@@ -85,6 +92,24 @@ the bundle).
 #     -buildOut <out-dir>
 ```
 
+## Fast CI iteration — the slim `macos-build.yml`
+
+`release.yml` builds all platforms in parallel, but GitHub only frees a job's logs once the **whole** run
+finishes — so debugging a Mac build there means waiting on the Windows/Linux jobs too. For a tight loop,
+use **`.github/workflows/macos-build.yml`**: a dispatch-only workflow with a **single** job that builds just
+the `StandaloneOSX` player, packages the `.app` into a portable zip and uploads it as a run artifact
+(`mac-portable-zip`). Nothing is published. Because it is the only job, the run completes — and the logs
+unlock — the moment the Mac build does.
+
+Trigger it from the Actions tab ("macOS build (experimental)" → Run workflow), or:
+
+```bash
+gh workflow run macos-build.yml --ref <branch>
+```
+
+(It is a trimmed clone of `release.yml`'s `build-player-mac` + `package-mac`. The cleaner long-term shape is
+a reusable `workflow_call` shared by both; the clone is the pragmatic interim.)
+
 ## Running an unsigned build
 
 The `.app` is not signed or notarized, so macOS Gatekeeper quarantines it. After unzipping, either
@@ -100,7 +125,8 @@ The bundle is **Intel x64**; it runs on Apple Silicon through Rosetta 2.
 
 - **Limited hands-on testing.** There is no Mac in CI, so the build is verified to *compile and package*, not
   to *run*. The bundled-server launch (the `+x` failure mode) and Singleplayer should be smoke-tested on a
-  real Mac before this is promoted beyond "experimental".
+  real Mac before this is promoted beyond "experimental". (MacOS-only build-time issues do still surface in
+  CI — e.g. the Microphone Usage Description failure above was caught by the first dry-run, not on a Mac.)
 - **No signing/notarization.** Required for friction-free distribution outside the App Store; needs an Apple
   Developer account and a CI signing step. Out of scope for the experimental phase.
 - **No Velopack / no auto-update / no splash launcher** on macOS yet (Phase 1 ships a plain zip).


### PR DESCRIPTION
## Summary

Two things, both from the first macOS dry-run (#84's build attempt):

1. **Fixes the macOS build failure.** The `StandaloneOSX` post-processor failed with *"Microphone class is used but Microphone Usage Description is empty in Player Settings."* Voice chat (`BBS_VOICE`) uses Unity's `Microphone` API, and Apple requires a non-empty `NSMicrophoneUsageDescription` on macOS/iOS (Windows/Linux don't gate on it — that's why it only surfaced on a real Mac build). `BuildPlayer()` now sets `PlayerSettings.macOS.microphoneUsageDescription` for the `StandaloneOSX` target (idempotent, no-op elsewhere).

2. **Adds `.github/workflows/macos-build.yml`** — a dispatch-only, single-job workflow that builds + packages **only** the Mac player and uploads the `.app` zip as a run artifact (nothing published). It lets the Mac build be iterated without running the full `release.yml` (Windows + Linux + Docker), and — being the only job — its logs unlock the moment it finishes (in `release.yml`, GitHub only frees a job's logs once the whole run completes).

Docs: `MACOS_BUILD.md` documents the Microphone gotcha and the slim workflow.

## Validation

Triggering `macos-build.yml` on this branch to confirm the build now goes green and produces the `.app` zip artifact. (Runtime/Singleplayer still needs a real Mac — out of CI's reach.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)