### PR TITLE
feat(portal): offer the macOS client download via server portal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,8 @@ RUN dotnet publish src/BlocksBeyondTheStars.GameServer/BlocksBeyondTheStars.Game
 FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime
 
 # tini = a proper PID 1 (reaps zombies + forwards signals to the entrypoint). curl = best-effort download
-# of the client downloads from GitHub Releases so the portal's /download (Windows Setup.exe) and
-# /download-linux (Linux AppImage) work. python3 + venv = the optional AI text backend (baked in, but
+# of the client downloads from GitHub Releases so the portal's /download (Windows Setup.exe),
+# /download-linux (Linux AppImage) and /download-mac (macOS zip) work. python3 + venv = the optional AI text backend (baked in, but
 # only STARTED when a .env is provided — see the entrypoint).
 RUN apt-get update \
  && apt-get install -y --no-install-recommends tini curl ca-certificates python3 python3-venv \
@@ -52,7 +52,7 @@ ENV BBS_ADMIN_BIND=0.0.0.0
 # 31415/udp native client · 31415/tcp browser WebSocket (when BBS_ENABLE_WEBSOCKET=true) · 31416/tcp admin+portal+download
 EXPOSE 31415/udp 31415/tcp 31416/tcp
 
-# saves/ = SQLite world + backups + logs + /bump bug reports (<world>/bumps) · config/ = server.json · clients/ = published Windows Setup.exe + Linux AppImage
+# saves/ = SQLite world + backups + logs + /bump bug reports (<world>/bumps) · config/ = server.json · clients/ = published Windows Setup.exe + Linux AppImage + macOS zip
 VOLUME ["/app/saves", "/app/config", "/app/clients"]
 
 # Health = the public admin dashboard root (cheap static HTML, never password-gated unlike /api/*).

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -55,9 +55,11 @@ fetch_client() {
   local json
   json=$(curl -fsSL "$api") || return 1
 
-  # Each asset is independent: a missing Windows or Linux build must not skip the other.
-  fetch_asset "$json" 'Setup\.exe' 'Windows installer' || true
-  fetch_asset "$json" '\.AppImage' 'Linux AppImage'     || true
+  # Each asset is independent: a missing build for one platform must not skip the others. The macOS
+  # pattern is anchored on "osx-" so it does not also match the Windows/Linux *Portable.zip assets.
+  fetch_asset "$json" 'Setup\.exe' 'Windows installer'      || true
+  fetch_asset "$json" '\.AppImage' 'Linux AppImage'         || true
+  fetch_asset "$json" 'osx-[^"]*Portable\.zip' 'macOS zip'  || true
 }
 
 if [ "${BBS_FETCH_CLIENT:-1}" = "1" ]; then

--- a/docs/developer/SELF_HOSTING.md
+++ b/docs/developer/SELF_HOSTING.md
@@ -149,7 +149,8 @@ Invoke-RestMethod http://127.0.0.1:31416/api/status -Headers @{ 'X-Admin-Passwor
 
 The host also serves a public-facing **`/portal`** landing page — a polished page with the
 JuMaVe Games + game logos, one-click client downloads (Windows `Setup.exe` at `/download`, Linux
-`.AppImage` at `/download-linux`) and the in-app update URL. See §9 for distributing the client this way.
+`.AppImage` at `/download-linux`, experimental macOS zip at `/download-mac`) and the in-app update URL.
+See §9 for distributing the client this way.
 
 ## 6. Backups & saves
 
@@ -241,7 +242,7 @@ That produces `BlocksBeyondTheStars-win-Setup.exe` plus an update feed
 
 **On the host:** start `BlocksBeyondTheStars.Api`, and (for LAN/internet reach) bind it beyond loopback —
 set `adminBindAddress` to the LAN IP or `0.0.0.0` **and** set an `adminPassword` first (§4). Only `/api/*`
-is password-gated; `/portal`, `/download`, `/download-linux` and `/updates` stay public so players can reach them.
+is password-gated; `/portal`, `/download`, `/download-linux`, `/download-mac` and `/updates` stay public so players can reach them.
 
 **Players:**
 
@@ -249,7 +250,9 @@ is password-gated; `/portal`, `/download`, `/download-linux` and `/updates` stay
 2. Click **Download the Windows client** (served from `/download`) and run the installer
    (per-user, no admin rights; an unsigned build shows a one-time SmartScreen "More info → Run anyway").
    On Linux, click **Download the Linux client (AppImage)** (served from `/download-linux`), then
-   `chmod +x` the `.AppImage` and run it.
+   `chmod +x` the `.AppImage` and run it. On macOS, click **Download the macOS client (experimental)**
+   (served from `/download-mac`), unzip it and clear the Gatekeeper quarantine
+   (`xattr -dr com.apple.quarantine BlocksBeyondTheStars.app`) since the build is unsigned.
 3. Launch the game and **Join** the server's IP on the gameplay port (default 31415).
 4. **Auto-update:** in **Settings → Software update**, paste the update URL shown on the portal
    (`http://<server-ip>:<adminPort>/updates`) and use **Check for updates**. Publishing a higher
@@ -346,17 +349,17 @@ docker run -d --name bbts \
 |---|---|
 | `/app/saves` | SQLite world + `backups/` + `logs/` **and `/bump` bug reports** (`<world>/bumps/`) |
 | `/app/config` | `server.json` (created on first run; env vars override it) |
-| `/app/clients` | the published clients the portal serves: Windows `*Setup.exe` at `/download` + Linux `*.AppImage` at `/download-linux` |
+| `/app/clients` | the published clients the portal serves: Windows `*Setup.exe` at `/download` + Linux `*.AppImage` at `/download-linux` + experimental macOS `*-osx-*-Portable.zip` at `/download-mac` |
 
 ### Client download from the container
 
-A Linux container can't *build* the clients, so on start the entrypoint pulls the newest `*Setup.exe`
-**and** `*.AppImage` from the latest GitHub Release into `/app/clients` (best-effort; each asset is
-fetched independently, so a missing one never blocks the other — controlled by `BBS_FETCH_CLIENT=1`/`0`
-and `BBS_CLIENT_REPO`). The portal (`/portal`) and the one-click `/download` (Windows) / `/download-linux`
-(Linux AppImage) routes then work as in §9. Without them the portal still runs and the download routes
-report "nothing published yet"; you can instead drop a `Setup.exe` / `.AppImage` into the `clients`
-volume yourself.
+A Linux container can't *build* the clients, so on start the entrypoint pulls the newest `*Setup.exe`,
+`*.AppImage` **and** the experimental `*-osx-*-Portable.zip` from the latest GitHub Release into
+`/app/clients` (best-effort; each asset is fetched independently, so a missing one never blocks the
+others — controlled by `BBS_FETCH_CLIENT=1`/`0` and `BBS_CLIENT_REPO`). The portal (`/portal`) and the
+one-click `/download` (Windows) / `/download-linux` (Linux AppImage) / `/download-mac` (macOS zip) routes
+then work as in §9. Without them the portal still runs and the download routes report "nothing published
+yet"; you can instead drop a `Setup.exe` / `.AppImage` / macOS zip into the `clients` volume yourself.
 
 ### Bug reports (`/bump`) in a container
 

--- a/src/BlocksBeyondTheStars.Api/PortalPage.cs
+++ b/src/BlocksBeyondTheStars.Api/PortalPage.cs
@@ -7,8 +7,8 @@ namespace BlocksBeyondTheStars.Api;
 /// The public server portal landing page (anf_webclient.md §7): a polished page carrying the
 /// <b>JuMaVe Games</b> studio logo and the <b>Blocks Beyond the Stars</b> game logo, one-click
 /// client downloads (the Velopack <c>Setup.exe</c> served at <c>/download</c> for Windows, the
-/// <c>.AppImage</c> served at <c>/download-linux</c> for Linux) and the in-app update-feed URL
-/// players paste into the game.
+/// <c>.AppImage</c> at <c>/download-linux</c> for Linux, and the experimental macOS zip at
+/// <c>/download-mac</c>) and the in-app update-feed URL players paste into the game.
 ///
 /// Both logos are recreated as inline SVG/CSS so the page is fully self-contained — it needs no shipped
 /// art and renders on an offline LAN server. The studio emblem mirrors the in-game
@@ -120,6 +120,7 @@ a.ghost:hover{background:rgba(95,215,255,.1)}
  <div class='meta'>Server “__SERVER__” · World “__WORLD__” · native clients join on UDP __PORT__</div>
  <a class='btn primary' href='/download'>⬇&nbsp; Download the Windows client</a>
  <a class='btn ghost' href='/download-linux'>⬇&nbsp; Download the Linux client (AppImage)</a>
+ <a class='btn ghost' href='/download-mac'>⬇&nbsp; Download the macOS client (experimental)</a>
  <div class='hint'>Already installed? Updates come straight from this server — paste
   <code>__BASEURL__/updates</code> into <b>Settings → Software update</b> in the game.</div>
  <div class='foot'>JuMaVe Games · __SERVER__</div>

--- a/src/BlocksBeyondTheStars.Api/Program.cs
+++ b/src/BlocksBeyondTheStars.Api/Program.cs
@@ -94,6 +94,20 @@ app.MapMethods("/download-linux", new[] { "GET", "HEAD" }, () =>
         : Results.File(appImage, "application/octet-stream", Path.GetFileName(appImage), enableRangeProcessing: true);
 });
 
+// One-click macOS download: hand out the newest published macOS portable zip from <install>/clients.
+// Mirrors /download-linux. The glob is anchored on "osx" so it never picks the Windows/Linux *Portable.zip.
+// EXPERIMENTAL: the .app inside is unsigned/un-notarized (the portal page labels it as such). The Docker
+// entrypoint best-effort fetches this asset from the latest GitHub Release alongside the other clients.
+app.MapMethods("/download-mac", new[] { "GET", "HEAD" }, () =>
+{
+    var macZip = Directory.Exists(clientsDir)
+        ? Directory.GetFiles(clientsDir, "*osx*Portable.zip").OrderByDescending(File.GetLastWriteTimeUtc).FirstOrDefault()
+        : null;
+    return macZip is null
+        ? Results.NotFound("No macOS client has been published yet. The latest GitHub Release ships a *-osx-*-Portable.zip; drop it into the clients folder.")
+        : Results.File(macZip, "application/octet-stream", Path.GetFileName(macZip), enableRangeProcessing: true);
+});
+
 app.MapGet("/api/status", (AdminService a) => Results.Json(a.GetStatus()));
 
 app.MapGet("/api/config", (AdminService a) => Results.Json(a.LoadConfig()));

--- a/tests/BlocksBeyondTheStars.Tests/PortalPageTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/PortalPageTests.cs
@@ -1,0 +1,36 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using BlocksBeyondTheStars.Api;
+using Xunit;
+
+namespace BlocksBeyondTheStars.Tests;
+
+public sealed class PortalPageTests
+{
+    [Theory]
+    [InlineData("/download")]        // Windows
+    [InlineData("/download-linux")]  // Linux AppImage
+    [InlineData("/download-mac")]    // macOS zip (experimental)
+    public void Render_OffersEveryPlatformDownloadLink(string route)
+    {
+        string html = PortalPage.Render("TestServer", "TestWorld", 31415, "http://localhost:31416");
+
+        Assert.Contains($"href='{route}'", html);
+    }
+
+    [Fact]
+    public void Render_SubstitutesServerWorldAndBaseUrl()
+    {
+        string html = PortalPage.Render("MyServer", "MyWorld", 31415, "http://example:31416");
+
+        Assert.Contains("MyServer", html);
+        Assert.Contains("MyWorld", html);
+        Assert.Contains("http://example:31416/updates", html);
+        // The known placeholder tokens must all be replaced in the served page.
+        Assert.DoesNotContain("__SERVER__", html);
+        Assert.DoesNotContain("__WORLD__", html);
+        Assert.DoesNotContain("__PORT__", html);
+        Assert.DoesNotContain("__BASEURL__", html);
+    }
+}


### PR DESCRIPTION
## Summary

Completes the macOS rollout on the **server side**: the dedicated-server portal now offers the experimental macOS client, exactly like Windows/Linux. Client installers are fetched at container start from the latest GitHub Release (runtime, not baked into the image), so this needs the experimental `*-osx-*-Portable.zip` asset (from the `package-mac` job) on a Release.

## Changes

- **`docker/entrypoint.sh`** — best-effort fetch of the `*-osx-*-Portable.zip` asset, pattern anchored on `osx-` so it never matches the Windows/Linux `*Portable.zip`. Independent of the other downloads (a missing one doesn't block the rest).
- **`Api/Program.cs`** — new `/download-mac` route mirroring `/download-linux`; serves the newest `*osx*Portable.zip` from the clients folder (GET+HEAD, resumable), with a clear NotFound message.
- **`PortalPage.cs`** — a **"Download the macOS client (experimental)"** button.
- **`Dockerfile`** — comments updated (third client + clients volume).
- **Tests** — `PortalPageTests` assert all three platform download links render and the page's placeholders are substituted. (4 tests, green locally.)
- **Docs** — `SELF_HOSTING.md` updated (portal routes, player steps incl. the Gatekeeper note, clients volume, entrypoint fetch).

## Notes

- The macOS zip is unsigned/un-notarized; the portal labels it **experimental** and the docs include the `xattr -dr com.apple.quarantine` step.
- As with Linux, the feature takes effect only once the **server image is rebuilt** with this entrypoint (the fetch logic is baked in).

🤖 Generated with [Claude Code](https://claude.com/claude-code)