### PR TITLE
fix(webgl): drop non-existent Client.Core from link.xml

### DIFF
--- a/client/Assets/link.xml
+++ b/client/Assets/link.xml
@@ -1,7 +1,6 @@
 <linker>
   <assembly fullname="BlocksBeyondTheStars.Shared" preserve="all" />
   <assembly fullname="BlocksBeyondTheStars.Networking" preserve="all" />
-  <assembly fullname="BlocksBeyondTheStars.Client.Core" preserve="all" />
   <assembly fullname="BlocksBeyondTheStars.Client" preserve="all" />
   <assembly fullname="UnityEngine.PhysicsModule">
     <type fullname="UnityEngine.SphereCollider" preserve="all" />


### PR DESCRIPTION
## Summary
Removes the `BlocksBeyondTheStars.Client.Core` entry from `client/Assets/link.xml` (added in #116). That assembly does not exist — the real runtime assembly is `BlocksBeyondTheStars.Client`, which is already listed — so the entry was a harmless no-op against IL2CPP stripping. Removed for clarity.

Follow-up cleanup to #116 (the contributor's fork is org-owned, so maintainer edits to their branch were blocked; tidying on `main` instead, as noted on that PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)