### PR TITLE
feat(docker): serve the WebGL browser client from the dedicated-server image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -379,6 +379,95 @@ jobs:
           name: player-mac
           path: player-mac
 
+  # WebGL (browser) player. Unlike the standalone builds it bundles no local server and needs no Velopack
+  # or console launcher — it only ever joins a hosted server over WebSocket (issue #121). The output is a
+  # static folder served at /play by the dedicated-server image.
+  build-player-webgl:
+    name: Build Unity player (WebGL)
+    needs: version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '8.0.x'
+
+      # Shared libs + content only: the WebGL build strips the bundled native-server StreamingAssets, so no
+      # publish-local-server / Velopack steps. sync-client-libs makes data/ present so the build writes the
+      # StreamingAssets manifest the browser fetches at runtime.
+      - name: Sync shared libs + content (bash)
+        run: ./scripts/sync-client-libs.sh
+
+      - name: Cache Unity Library
+        uses: actions/cache@v5
+        with:
+          path: client/Library
+          key: Library-WebGL-${{ hashFiles('client/Assets/**', 'client/Packages/**', 'client/ProjectSettings/**') }}
+          restore-keys: |
+            Library-WebGL-
+
+      - name: Free disk space for the Unity image
+        run: |
+          echo "Before:"; df -h /
+          sudo rm -rf /usr/local/lib/android /opt/ghc /usr/share/dotnet \
+                      /opt/hostedtoolcache/CodeQL /usr/local/share/boost /usr/local/.ghcup
+          sudo docker image prune --all --force || true
+          echo "After:"; df -h /
+
+      - name: Inject player-feedback API key
+        env:
+          WIX_BUGREPORT_API_KEY: ${{ secrets.WIX_BUGREPORT_API_KEY }}
+        run: |
+          if [ -z "$WIX_BUGREPORT_API_KEY" ]; then
+            echo "WIX_BUGREPORT_API_KEY not set — player feedback will be disabled in this build."
+            exit 0
+          fi
+          {
+            echo '// CI-generated from the WIX_BUGREPORT_API_KEY secret — not committed.'
+            echo 'namespace BlocksBeyondTheStars.Build'
+            echo '{'
+            echo '    public static partial class BugReportBuildSecrets'
+            echo '    {'
+            echo "        static partial void ApplyApiKey(ref string key) => key = \"$WIX_BUGREPORT_API_KEY\";"
+            echo '    }'
+            echo '}'
+          } > client/Assets/BlocksBeyondTheStars/Scripts/BugReportBuildSecrets.Generated.cs
+          echo "Injected feedback API key into the build."
+
+      - name: Build WebGL player
+        uses: game-ci/unity-builder@d829bfc901f2347c8fe18898f06712b66916ef42 # v5
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+        with:
+          projectPath: client
+          unityVersion: 6000.4.9f1
+          targetPlatform: WebGL
+          buildMethod: BlocksBeyondTheStars.Client.EditorTools.BuildScript.BuildWebGL
+          versioning: Custom
+          version: ${{ needs.version.outputs.version }}
+          customParameters: -buildOut /github/workspace/player-webgl
+          allowDirtyBuild: true
+
+      - name: Fix output permissions
+        run: sudo chmod -R a+rwX player-webgl
+
+      - name: Verify baked version matches the tag
+        shell: bash
+        run: |
+          baked="$(cat player-webgl/version.txt)"
+          echo "Baked into player: '$baked' — expected: '${{ needs.version.outputs.version }}'"
+          test "$baked" = "${{ needs.version.outputs.version }}"
+
+      - name: Upload WebGL player artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: player-webgl
+          path: player-webgl
+
   # Linux packaging
   package-linux:
     name: Package + release (Linux)
@@ -494,6 +583,40 @@ jobs:
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3
         with:
           files: artifacts/installer-mac/*Portable.zip
+          generate_release_notes: false
+
+  # WebGL packaging: just zip the static build folder and attach it to the release. The dedicated-server
+  # image's entrypoint fetches this `webgl*.zip` (BBS_FETCH_WEBGL=1) and serves it at /play (issue #121).
+  package-webgl:
+    name: Package + release (WebGL)
+    needs: [version, build-player-webgl]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download WebGL player artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: player-webgl
+          path: player-webgl
+
+      # Zip the CONTENTS (index.html at the zip root) so the entrypoint can unzip straight into /app/webgl.
+      - name: Zip the WebGL build
+        run: |
+          OUT="artifacts/webgl"
+          mkdir -p "$OUT"
+          ( cd player-webgl && \
+            zip -ry "$GITHUB_WORKSPACE/$OUT/BlocksBeyondTheStars-webgl-${{ needs.version.outputs.version }}.zip" . )
+
+      - name: Upload WebGL package artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: webgl-package
+          path: artifacts/webgl
+
+      - name: Publish GitHub Release (WebGL asset)
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3
+        with:
+          files: artifacts/webgl/*.zip
           generate_release_notes: false
 
   # Optional dedicated-server Docker image. Reuses .github/workflows/docker.yml (workflow_call). It only

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime
 # /download-linux (Linux AppImage) and /download-mac (macOS zip) work. python3 + venv = the optional AI text backend (baked in, but
 # only STARTED when a .env is provided — see the entrypoint).
 RUN apt-get update \
- && apt-get install -y --no-install-recommends tini curl ca-certificates python3 python3-venv \
+ && apt-get install -y --no-install-recommends tini curl ca-certificates unzip python3 python3-venv \
  && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
@@ -49,11 +49,11 @@ RUN chmod +x /usr/local/bin/entrypoint.sh
 # unreachable from outside the container). ALWAYS pair a public admin port with BBS_ADMIN_PASSWORD.
 ENV BBS_ADMIN_BIND=0.0.0.0
 
-# 31415/udp native client · 31415/tcp browser WebSocket (when BBS_ENABLE_WEBSOCKET=true) · 31416/tcp admin+portal+download
+# 31415/udp native client · 31415/tcp browser WebSocket (when BBS_ENABLE_WEBSOCKET=true) · 31416/tcp admin+portal+download+/play
 EXPOSE 31415/udp 31415/tcp 31416/tcp
 
-# saves/ = SQLite world + backups + logs + /bump bug reports (<world>/bumps) · config/ = server.json · clients/ = published Windows Setup.exe + Linux AppImage + macOS zip
-VOLUME ["/app/saves", "/app/config", "/app/clients"]
+# saves/ = SQLite world + backups + logs + /bump bug reports (<world>/bumps) · config/ = server.json · clients/ = published Windows Setup.exe + Linux AppImage + macOS zip · webgl/ = Unity WebGL browser build served at /play (mount a local Build/WebGL, or set BBS_FETCH_WEBGL=1)
+VOLUME ["/app/saves", "/app/config", "/app/clients", "/app/webgl"]
 
 # Health = the public admin dashboard root (cheap static HTML, never password-gated unlike /api/*).
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \

--- a/README.md
+++ b/README.md
@@ -151,6 +151,9 @@ NAS or a VPS (including via Docker) can host a world that players join.
   it a preview: it builds green in CI but has had limited hands-on testing.
 - The client always talks to a server: a local one started automatically in singleplayer / "Host
   Game", or a remote dedicated server.
+- **Browser (WebGL, experimental):** a dedicated server can also serve a **play-in-the-browser** build —
+  no install, just open the server's `/play` page. Browser play only joins a hosted server (no
+  singleplayer), so it is opt-in on the host side; see [self-hosting](#self-hosting-packages) below.
 
 **Dedicated server (to host)**
 
@@ -323,6 +326,13 @@ Players can also download and install the Windows client **from the running serv
 `scripts/publish-client-installer.ps1` builds a [Velopack](https://velopack.io) installer + auto-update
 feed, the admin host serves it at `/download` + `/updates`, and the `/portal` page links it. See
 [docs/developer/SELF_HOSTING.md](docs/developer/SELF_HOSTING.md) §9.
+
+The server can also host a **play-in-the-browser (WebGL)** build at `/play` — players just open the link,
+no install. Drop a Unity WebGL build on the `webgl` volume (or let `BBS_FETCH_WEBGL=1` pull it from a
+release) and enable `BBS_ENABLE_WEBSOCKET=true`. localhost and LAN work over plain http; a **public**
+deployment needs TLS for `wss://`, for which a ready-made Caddy setup ships (`docker-compose.tls.yml`).
+SQLite stays the default; an optional `postgres` profile is available for larger realms. See
+[docs/developer/SELF_HOSTING.md](docs/developer/SELF_HOSTING.md) §9–§10.
 
 ## Adding content (data-driven)
 

--- a/TODO.md
+++ b/TODO.md
@@ -112,8 +112,14 @@ stripping stale native-server StreamingAssets from browser builds.
   start menu (no singleplayer/host/editors/quit); a name is required so nobody joins the public realm
   anonymously, while a curated `?auto_join=1&player_name=…` link stays zero-click. Native menu unchanged
   (all changes behind `#if UNITY_WEBGL`).
-- **Open follow-up — #121:** serve the WebGL build from the Docker image (`/play` route + volume / release-asset
-  fetch + portal deep-link; public https needs a `wss://` TLS proxy). Analysis done, implementation pending.
+- **Docker browser play (2026-06-29) — #121:** the dedicated-server image now serves the WebGL client at
+  `/play` (same-origin static mount with Brotli/immutable-cache headers + a friendly "not installed" page),
+  the portal has a **Play in the browser** deep-link, and `X-Forwarded-*` is honored so it works behind a
+  proxy. The build is injected out-of-band: bind-mount `/app/webgl` (phase 1) or `BBS_FETCH_WEBGL=1` pulls a
+  release `webgl*.zip` (phase 2 — new `build-player-webgl`/`package-webgl` jobs in `release.yml`). Public
+  https/`wss://` uses the new Caddy profile (`docker-compose.tls.yml` + `docker/Caddyfile`); localhost/LAN
+  need none. SELF_HOSTING.md documents the TLS matrix + hosting/cost options. Note: the GameCI WebGL build
+  job is untested and may need iteration on the first tagged release (Unity can't build in CI without it).
 
 ---
 

--- a/docker-compose.postgres.yml
+++ b/docker-compose.postgres.yml
@@ -1,0 +1,38 @@
+# Optional PostgreSQL backend for the dedicated server (opt-in — SQLite is and stays the default).
+#
+# Use it as an OVERLAY on top of the base compose file (or the TLS one). It adds a postgres service and
+# points the server at it; nothing else changes:
+#
+#   docker compose -f docker-compose.yml -f docker-compose.postgres.yml up -d
+#   # public TLS:  docker compose -f docker-compose.tls.yml -f docker-compose.postgres.yml up -d
+#
+# The world then lives in PostgreSQL instead of the SQLite world.db on the saves volume — back it up with
+# pg_dump (the saves volume still holds logs + /bump reports). Override the credentials via a .env file or
+# the shell (POSTGRES_DB / POSTGRES_USER / POSTGRES_PASSWORD); the defaults below are fine for a private host.
+
+services:
+  server:
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      BBS_DATABASE_PROVIDER: "postgresql"
+      BBS_POSTGRES_CONNECTION_STRING: "Host=postgres;Port=5432;Database=${POSTGRES_DB:-bbstars};Username=${POSTGRES_USER:-bbstars};Password=${POSTGRES_PASSWORD:-bbstars}"
+
+  postgres:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: "${POSTGRES_DB:-bbstars}"
+      POSTGRES_USER: "${POSTGRES_USER:-bbstars}"
+      POSTGRES_PASSWORD: "${POSTGRES_PASSWORD:-bbstars}"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-bbstars} -d ${POSTGRES_DB:-bbstars}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  pgdata:

--- a/docker-compose.tls.yml
+++ b/docker-compose.tls.yml
@@ -1,0 +1,67 @@
+# Blocks Beyond the Stars — public HTTPS browser play (issue #121): the dedicated server fronted by Caddy
+# for automatic TLS. This is the standalone compose file for exposing the browser client on the public
+# internet, where an https page MUST use wss:// (a plain ws:// is blocked as mixed content).
+#
+# You do NOT need this for localhost or a home LAN over http — use the plain docker-compose.yml there.
+#
+#   BBS_DOMAIN=play.example.com BBS_ADMIN_PASSWORD=change-me \
+#     docker compose -f docker-compose.tls.yml up -d
+#
+# Requirements: DNS for $BBS_DOMAIN points at this host, and ports 80, 443 and 31415 are reachable from the
+# internet (Caddy needs 80/443 for the ACME challenge + web, and 31415 for the TLS-terminated gameplay WS).
+#
+# How traffic flows:
+#   browser  https://$BBS_DOMAIN        -> Caddy :443   -> server:31416   (portal, /play, /updates, /api)
+#   browser  wss://$BBS_DOMAIN:31415    -> Caddy :31415 -> server:31415   (gameplay WebSocket)
+#   native   udp  $BBS_DOMAIN:31415     -> server:31415  (bypasses Caddy)
+
+services:
+  server:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: blocks-beyond-the-stars-server:local
+    restart: unless-stopped
+    stop_grace_period: 60s        # give the world time to drain + save on SIGTERM
+    ports:
+      - "31415:31415/udp"          # native UDP clients connect directly; Caddy only fronts the TCP/web/WS
+    environment:
+      BBS_SERVER_NAME: "Blocks Beyond the Stars Server"
+      BBS_WORLD: "world_001"
+      BBS_MAX_PLAYERS: "12"
+      BBS_ADMIN_BIND: "0.0.0.0"            # inside the container; only Caddy reaches it on the internal network
+      BBS_ADMIN_PASSWORD: "${BBS_ADMIN_PASSWORD:?set BBS_ADMIN_PASSWORD for a public deployment}"
+      BBS_ENABLE_WEBSOCKET: "true"         # browser clients over WebSocket (Caddy terminates TLS in front)
+      BBS_WEBSOCKET_BIND: "+"              # bind the WS gateway to all interfaces inside the container
+      BBS_FETCH_CLIENT: "1"                # pull native client downloads for the portal
+      # BBS_FETCH_WEBGL: "1"               # auto-pull the browser build from GitHub Releases (once one ships it)
+    volumes:
+      - saves:/app/saves
+      - config:/app/config
+      - clients:/app/clients
+      - webgl:/app/webgl                   # or bind-mount ./client/Build/WebGL:/app/webgl:ro to serve a local build
+
+  caddy:
+    image: caddy:2-alpine
+    restart: unless-stopped
+    depends_on:
+      - server
+    ports:
+      - "80:80"                    # ACME HTTP challenge + http->https redirect
+      - "443:443"                  # web (portal / /play / /updates / /api)
+      - "443:443/udp"              # HTTP/3 (QUIC)
+      - "31415:31415/tcp"          # TLS-terminated gameplay WebSocket (wss://$BBS_DOMAIN:31415)
+    environment:
+      BBS_DOMAIN: "${BBS_DOMAIN:?set BBS_DOMAIN to your public hostname}"
+    volumes:
+      - ./docker/Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data           # persisted certificates — keep this volume so Let's Encrypt isn't re-hit
+      - caddy_config:/config
+
+volumes:
+  saves:
+  config:
+  clients:
+  webgl:
+  caddy_data:
+  caddy_config:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,8 @@ services:
     ports:
       - "31415:31415/udp"          # native client (UDP)
       - "31415:31415/tcp"          # browser client over WebSocket (only when BBS_ENABLE_WEBSOCKET=true)
-      - "127.0.0.1:31416:31416/tcp" # admin + portal + download — bound to localhost on the HOST by default
+      - "127.0.0.1:31416:31416/tcp" # admin + portal + browser /play — bound to localhost on the HOST by default
+      # - "31416:31416/tcp"          # expose portal + /play on the LAN/internet for browser play — REQUIRES BBS_ADMIN_PASSWORD
     environment:
       BBS_SERVER_NAME: "Blocks Beyond the Stars Server"
       BBS_WORLD: "world_001"
@@ -27,7 +28,9 @@ services:
       # BBS_PASSWORD: "join-secret"        # required to join the game (optional)
       BBS_ADMIN_BIND: "0.0.0.0"            # inside the container; reach it via the host port mapping above
       # BBS_ADMIN_PASSWORD: "change-me"    # REQUIRED before exposing 31416 publicly
-      # BBS_ENABLE_WEBSOCKET: "true"       # also accept browser clients on the gameplay port
+      # BBS_ENABLE_WEBSOCKET: "true"       # also accept browser clients on the gameplay port (needed for /play)
+      # BBS_WEBSOCKET_BIND: "+"            # bind the WS gateway to all interfaces (needed for LAN/remote browser play)
+      # BBS_FETCH_WEBGL: "0"               # pull webgl*.zip from GitHub Releases into /app/webgl (needs a release that ships it)
       BBS_FETCH_CLIENT: "1"                # pull the latest Windows Setup.exe + Linux AppImage from GitHub Releases for /download + /download-linux
       # BBS_CLIENT_REPO: "marceld23/BlocksBeyondTheStars"
       # --- Optional AI text backend (NPC greetings / mission flavour / VEGA banter) ---
@@ -38,6 +41,9 @@ services:
       - saves:/app/saves            # SQLite world + backups + logs + /bump bug reports (<world>/bumps)
       - config:/app/config          # server.json (created on first run)
       - clients:/app/clients        # published clients the portal hands out (Windows Setup.exe + Linux AppImage)
+      - webgl:/app/webgl            # Unity WebGL browser build served at /play (issue #121); empty until you fill it
+      # To serve a LOCALLY-built browser client, bind-mount it here INSTEAD of the named volume above:
+      # - ./client/Build/WebGL:/app/webgl:ro
       # Mount your AI config to enable the in-container LLM backend (copy ai-backend/.env.example -> .env):
       # - ./ai-backend/.env:/app/ai-backend/.env:ro
 
@@ -45,3 +51,4 @@ volumes:
   saves:
   config:
   clients:
+  webgl:

--- a/docker/Caddyfile
+++ b/docker/Caddyfile
@@ -1,0 +1,23 @@
+# Blocks Beyond the Stars — public HTTPS reverse proxy for browser play (issue #121).
+#
+# Caddy auto-provisions and renews a Let's Encrypt certificate for $BBS_DOMAIN, then fronts two things:
+#   * the admin / portal / static web + the /play browser client   -> server:31416
+#   * the TLS-terminated gameplay WebSocket (wss://)                -> server:31415
+#
+# Why two site blocks: an https page cannot open a plain ws:// (browsers block it as mixed content), so the
+# gameplay WebSocket needs TLS too. The WebGL client opens `wss://$BBS_DOMAIN:31415` (that is what the portal
+# "Play in the browser" deep-link sets: server_host=$BBS_DOMAIN, server_port=31415, and the client picks wss
+# from the https page). So the gameplay port gets its own TLS site here. Native UDP clients bypass Caddy
+# entirely and still connect directly on udp/31415.
+#
+# Used by docker-compose.tls.yml. Set BBS_DOMAIN to your public hostname; DNS must point at this host and
+# ports 80 + 443 + 31415 must be reachable from the internet.
+
+{$BBS_DOMAIN} {
+	encode zstd gzip
+	reverse_proxy server:31416
+}
+
+{$BBS_DOMAIN}:31415 {
+	reverse_proxy server:31415
+}

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -16,7 +16,8 @@ APP_DIR=/app
 CONFIG_DIR="$APP_DIR/config"
 CLIENTS_DIR="$APP_DIR/clients"
 SAVES_DIR="$APP_DIR/saves"
-mkdir -p "$CONFIG_DIR" "$CLIENTS_DIR" "$SAVES_DIR"
+WEBGL_DIR="$APP_DIR/webgl"
+mkdir -p "$CONFIG_DIR" "$CLIENTS_DIR" "$SAVES_DIR" "$WEBGL_DIR"
 
 log() { echo "[entrypoint] $*"; }
 
@@ -66,6 +67,50 @@ if [ "${BBS_FETCH_CLIENT:-1}" = "1" ]; then
   fetch_client || log "client download skipped (continuing without it)"
 else
   log "BBS_FETCH_CLIENT=0 -> skipping client download"
+fi
+
+# --- best-effort: fetch + unzip the Unity WebGL browser build (webgl*.zip) for /play (issue #121) ---
+# Like the native clients, a Linux container cannot build the WebGL player (Unity needed), so it is pulled
+# from the latest GitHub Release into $WEBGL_DIR and served by the admin API at /play. Off by default
+# (BBS_FETCH_WEBGL=0) because the release only carries this asset once the WebGL build job ships it; a
+# bind-mounted /app/webgl with an existing index.html always wins and is left untouched. Non-fatal.
+fetch_webgl() {
+  if [ -f "$WEBGL_DIR/index.html" ]; then
+    log "webgl: /app/webgl already has a build (mounted?) -> leaving it as-is"
+    return 0
+  fi
+
+  local repo="${BBS_CLIENT_REPO:-marceld23/BlocksBeyondTheStars}"
+  local api="https://api.github.com/repos/${repo}/releases/latest"
+  local json url tmp
+  json=$(curl -fsSL "$api") || return 1
+  url=$(printf '%s' "$json" \
+        | grep -o '"browser_download_url":[ ]*"[^"]*webgl[^"]*\.zip"' \
+        | head -n1 | sed 's/.*"\(https[^"]*\)"/\1/')
+  [ -n "$url" ] || { log "no webgl asset in the latest release"; return 1; }
+
+  tmp="$WEBGL_DIR/.webgl.zip"
+  curl -fsSL "$url" -o "$tmp" || return 1
+  rm -rf "$WEBGL_DIR.new" && mkdir -p "$WEBGL_DIR.new"
+  unzip -q "$tmp" -d "$WEBGL_DIR.new" || { rm -rf "$WEBGL_DIR.new" "$tmp"; return 1; }
+
+  # The release zip should hold the Build/WebGL contents at its root; if it nested a single top-level dir,
+  # flatten it so index.html lands directly in $WEBGL_DIR.
+  if [ ! -f "$WEBGL_DIR.new/index.html" ]; then
+    local inner
+    inner=$(find "$WEBGL_DIR.new" -maxdepth 2 -name index.html | head -n1)
+    [ -n "$inner" ] && mv "$(dirname "$inner")"/* "$WEBGL_DIR.new/" 2>/dev/null || true
+  fi
+
+  rm -rf "$WEBGL_DIR" && mv "$WEBGL_DIR.new" "$WEBGL_DIR"
+  rm -f "$WEBGL_DIR/.webgl.zip"
+  log "webgl build ready at $WEBGL_DIR"
+}
+
+if [ "${BBS_FETCH_WEBGL:-0}" = "1" ]; then
+  fetch_webgl || log "webgl fetch skipped (continuing without it)"
+else
+  log "BBS_FETCH_WEBGL=0 -> skipping webgl download (mount /app/webgl to serve a local build)"
 fi
 
 # --- admin API: best-effort sidecar, auto-restarted, never fatal to the container ---

--- a/docs/developer/SELF_HOSTING.md
+++ b/docs/developer/SELF_HOSTING.md
@@ -286,6 +286,52 @@ is password-gated; `/portal`, `/download`, `/download-linux`, `/download-mac` an
 Updates only apply to an *installed* client (not a dev/Editor or portable-zip run). Each published
 version must be higher than the last.
 
+### Play in the browser (no install)
+
+The server can also serve the **WebGL browser client** at `http://<server>:<adminPort>/play`. The portal's
+**Play in the browser** button deep-links to it with the server host/port pre-filled (`/play?server_host=…&server_port=31415`).
+No download, no install — players just open the link. Singleplayer/host are unavailable in the browser (it
+only joins a hosted server over WebSocket), so `BBS_ENABLE_WEBSOCKET=true` is required.
+
+The browser build is **not** baked into the server image (it needs Unity, which can't run in the image). You
+get it onto the server one of two ways:
+
+- **Mount a locally-built folder** (works today): build the WebGL player on a machine with Unity
+  (`BlocksBeyondTheStars → Build WebGL Player`, or headless `-buildMethod …BuildScript.BuildWebGL`), then
+  bind-mount `client/Build/WebGL` at `/app/webgl` (see the Docker section below).
+- **Auto-fetch from a release** (`BBS_FETCH_WEBGL=1`): once a release ships a `webgl*.zip` asset, the
+  entrypoint downloads and unzips it into `/app/webgl`. A mounted build always wins.
+
+If no build is present, `/play` shows a friendly "not installed yet" page instead of a blank 404.
+
+**The TLS rule (read this before exposing it publicly):** a browser will only open the gameplay WebSocket
+if the scheme is allowed for the page it is on.
+
+| Where the page is reached | Gameplay WebSocket | Works? |
+|---|---|---|
+| `http://localhost:31416/play` (same machine) | `ws://localhost:31415` | ✅ browsers exempt `localhost` |
+| `http://<lan-ip>:31416/play` (home LAN over http) | `ws://<lan-ip>:31415` | ✅ page is http, so `ws://` is not mixed content |
+| `https://<domain>/play` (public, https) | **must be `wss://`** | ❌ unless the WebSocket has TLS — an https page **cannot** open a plain `ws://` |
+
+The server's WebSocket gateway has **no built-in TLS**, so **public browser play needs a TLS-terminating
+reverse proxy in front of the gameplay port.** Use the ready-made Caddy setup
+(`docker-compose.tls.yml` + `docker/Caddyfile`, see below) which auto-provisions a Let's Encrypt
+certificate, or front it with Cloudflare Tunnel / a PaaS ingress (Fly.io, Railway, Azure Container Apps —
+the latter is what the original Glitch web build used). localhost and LAN-over-http need none of this.
+
+**Where to host it (rough cost):** you do **not** need Azure or any specific cloud, and SQLite (the default)
+is fine — no managed database required.
+
+| Option | Cost (approx.) | TLS | Notes |
+|---|---|---|---|
+| Home PC/NAS + Cloudflare Tunnel | free (electricity) | free (Cloudflare) | the machine must stay on while people play |
+| Small EU VPS (e.g. Hetzner/Netcup) | ~€4–6/month | free (Caddy + Let's Encrypt) | the typical hobby choice; `docker-compose.tls.yml` is built for this |
+| PaaS (Fly.io / Railway) | free–~€10/month | free (managed) | an always-on WebSocket server may exceed free tiers |
+| Azure Container Apps + managed PostgreSQL | ~€20–40+/month | free (managed ingress) | only worth it for a large always-on realm |
+
+You can also host just the **server** on a cheap VPS and serve the static browser build for free elsewhere
+(itch.io, GitHub Pages, Glitch) pointed at it with `?server_host=…` — then you only pay for the server.
+
 ## 10. Running in Docker
 
 The dedicated server (game server **and** admin/portal/download UI, plus the optional AI text backend)
@@ -386,6 +432,36 @@ docker run -d --name bbts \
 | `/app/saves` | SQLite world + `backups/` + `logs/` **and `/bump` bug reports** (`<world>/bumps/`) |
 | `/app/config` | `server.json` (created on first run; env vars override it) |
 | `/app/clients` | the published clients the portal serves: Windows `*Setup.exe` at `/download` + Linux `*.AppImage` at `/download-linux` + experimental macOS `*-osx-*-Portable.zip` at `/download-mac` |
+| `/app/webgl` | the Unity WebGL browser build served at `/play` — bind-mount a local `client/Build/WebGL`, or let `BBS_FETCH_WEBGL=1` fetch the release `webgl*.zip` |
+
+### Browser play from the container
+
+To serve the in-browser client (§"Play in the browser"), put a WebGL build on the `/app/webgl` volume —
+either bind-mount a locally-built `client/Build/WebGL` (`-v "$PWD/client/Build/WebGL:/app/webgl:ro"`) or set
+`BBS_ENABLE_WEBSOCKET=true` + `BBS_FETCH_WEBGL=1` to auto-pull it from the release. Then open
+`http://localhost:31416/play`. For a **public** deployment (https), use `docker-compose.tls.yml` — it adds a
+Caddy reverse proxy that auto-provisions TLS so `wss://` works (a plain `docker run` over the public internet
+will fail the WebSocket on https). See the TLS table in §9.
+
+```bash
+BBS_DOMAIN=play.example.com BBS_ADMIN_PASSWORD=change-me \
+  docker compose -f docker-compose.tls.yml up -d
+```
+
+### PostgreSQL instead of SQLite (optional)
+
+SQLite (the default) needs no setup and is right for most self-hosted realms. For a larger/long-running
+realm you can switch the authoritative world store to **PostgreSQL** with the overlay compose file — it adds
+a `postgres:16-alpine` service and points the server at it (`BBS_DATABASE_PROVIDER=postgresql` +
+`BBS_POSTGRES_CONNECTION_STRING`):
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.postgres.yml up -d
+# public TLS: docker compose -f docker-compose.tls.yml -f docker-compose.postgres.yml up -d
+```
+
+Override `POSTGRES_DB` / `POSTGRES_USER` / `POSTGRES_PASSWORD` via a `.env` file or the shell. The world then
+lives in Postgres (back it up with `pg_dump`); the `saves` volume still holds logs and `/bump` reports.
 
 ### Client download from the container
 

--- a/src/BlocksBeyondTheStars.Api/PortalPage.cs
+++ b/src/BlocksBeyondTheStars.Api/PortalPage.cs
@@ -19,10 +19,27 @@ public static class PortalPage
 {
     public static string Render(string serverName, string worldName, int gameplayPort, string baseUrl)
     {
+        // server_host for the WebGL deep-link is the bare hostname (no scheme, no port): the browser client
+        // (BrowserWebSocketClientTransport) picks ws/wss from the /play page's own scheme and appends
+        // server_port. Strip the scheme and any port from baseUrl.
+        string wsHost = baseUrl ?? string.Empty;
+        int schemeIdx = wsHost.IndexOf("://", StringComparison.Ordinal);
+        if (schemeIdx >= 0)
+        {
+            wsHost = wsHost.Substring(schemeIdx + 3);
+        }
+
+        int portIdx = wsHost.IndexOf(':');
+        if (portIdx >= 0)
+        {
+            wsHost = wsHost.Substring(0, portIdx);
+        }
+
         return Template
             .Replace("__SERVER__", System.Net.WebUtility.HtmlEncode(serverName ?? string.Empty))
             .Replace("__WORLD__", System.Net.WebUtility.HtmlEncode(worldName ?? string.Empty))
             .Replace("__PORT__", gameplayPort.ToString())
+            .Replace("__WSHOST__", System.Net.WebUtility.HtmlEncode(wsHost))
             .Replace("__BASEURL__", System.Net.WebUtility.HtmlEncode(baseUrl ?? string.Empty));
     }
 
@@ -118,7 +135,8 @@ a.ghost:hover{background:rgba(95,215,255,.1)}
  <div class='rule'></div>
  <div class='logo'><b>Blocks</b> Beyond the Stars</div>
  <div class='meta'>Server “__SERVER__” · World “__WORLD__” · native clients join on UDP __PORT__</div>
- <a class='btn primary' href='/download'>⬇&nbsp; Download the Windows client</a>
+ <a class='btn primary' href='/play?server_host=__WSHOST__&amp;server_port=__PORT__&amp;bbs_auto_join=0'>▶&nbsp; Play in the browser</a>
+ <a class='btn ghost' href='/download'>⬇&nbsp; Download the Windows client</a>
  <a class='btn ghost' href='/download-linux'>⬇&nbsp; Download the Linux client (AppImage)</a>
  <a class='btn ghost' href='/download-mac'>⬇&nbsp; Download the macOS client (experimental)</a>
  <div class='hint'>Already installed? Updates come straight from this server — paste

--- a/src/BlocksBeyondTheStars.Api/Program.cs
+++ b/src/BlocksBeyondTheStars.Api/Program.cs
@@ -3,7 +3,9 @@
 // This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
 using BlocksBeyondTheStars.Api;
 using BlocksBeyondTheStars.Shared.Configuration;
+using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.Extensions.FileProviders;
+using Microsoft.Net.Http.Headers;
 
 // BlocksBeyondTheStars admin web UI / meta backend (technical requirements §13). Lightweight
 // ASP.NET Core app over a server installation directory. Bound to localhost/LAN by
@@ -18,7 +20,20 @@ builder.Logging.ClearProviders();
 builder.Services.AddSingleton(admin);
 builder.WebHost.UseUrls($"http://{startupConfig.AdminBindAddress}:{startupConfig.AdminPort}");
 
+// Honor X-Forwarded-* so that, behind a TLS reverse proxy (the optional Caddy profile for public browser
+// play, issue #121), req.Scheme/req.Host reflect the public https host rather than the internal container
+// address — the portal's "Play in the browser" deep-link and the WebGL client's ws/wss choice depend on it.
+// The proxy is a trusted sibling container on an arbitrary IP, so clear the default loopback-only allow-list.
+builder.Services.Configure<ForwardedHeadersOptions>(options =>
+{
+    options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto | ForwardedHeaders.XForwardedHost;
+    options.KnownNetworks.Clear();
+    options.KnownProxies.Clear();
+});
+
 var app = builder.Build();
+
+app.UseForwardedHeaders();
 
 // Admin authentication: when an admin password is configured, every /api request must
 // present it via the X-Admin-Password header. With no password set we rely on the bind
@@ -54,6 +69,74 @@ app.UseStaticFiles(new StaticFileOptions
     FileProvider = new PhysicalFileProvider(clientsDir),
     RequestPath = "/updates",
     ServeUnknownFileTypes = true,
+});
+
+// Browser client (issue #121): serve a Unity WebGL build at /play, same-origin with the portal so the
+// content fetch needs no CORS. The image can't build WebGL (no Unity), so the folder is filled out-of-band:
+// a mounted volume in phase 1, an entrypoint GitHub-Release fetch in phase 2. Public (no admin password),
+// like /portal and /updates — the gameplay server still enforces its own join password.
+string webglDir = Path.Combine(installDir, "webgl");
+Directory.CreateDirectory(webglDir);
+
+// Friendly page when no build is installed yet (volume not mounted / fetch disabled), so /play never
+// 404s blankly. Registered BEFORE UseStaticFiles so it only fires when index.html is absent.
+app.MapGet("/play", () =>
+{
+    if (File.Exists(Path.Combine(webglDir, "index.html")))
+    {
+        return Results.File(Path.Combine(webglDir, "index.html"), "text/html; charset=utf-8");
+    }
+
+    return Results.Content(
+        "<!DOCTYPE html><meta charset='utf-8'><title>Browser client not installed</title>" +
+        "<body style='font-family:system-ui;background:#070a12;color:#dfe9f7;padding:40px;line-height:1.5'>" +
+        "<h2>No browser build is installed on this server yet.</h2>" +
+        "<p>Mount a Unity <code>Build/WebGL/</code> folder at <code>/app/webgl</code>, " +
+        "or set <code>BBS_FETCH_WEBGL=1</code> once a release ships a <code>webgl*.zip</code> asset.</p>" +
+        "<p><a style='color:#5fd7ff' href='/portal'>Back to the server portal</a></p></body>",
+        "text/html; charset=utf-8");
+});
+
+app.UseStaticFiles(new StaticFileOptions
+{
+    FileProvider = new PhysicalFileProvider(webglDir),
+    RequestPath = "/play",
+    ServeUnknownFileTypes = true, // Unity emits .data/.wasm/.symbols.json without standard MIME types
+    OnPrepareResponse = ctx =>
+    {
+        var headers = ctx.Context.Response.Headers;
+        var name = ctx.File.Name;
+
+        // Unity Brotli builds emit *.br files (e.g. build.wasm.br). UseStaticFiles serves them as opaque
+        // bytes; announce the encoding + the decoded MIME so the browser inflates them natively instead of
+        // falling back to Unity's slow JS decompressor.
+        if (name.EndsWith(".br", StringComparison.OrdinalIgnoreCase))
+        {
+            headers[HeaderNames.ContentEncoding] = "br";
+            if (name.EndsWith(".wasm.br", StringComparison.OrdinalIgnoreCase))
+            {
+                headers[HeaderNames.ContentType] = "application/wasm";
+            }
+            else if (name.EndsWith(".js.br", StringComparison.OrdinalIgnoreCase))
+            {
+                headers[HeaderNames.ContentType] = "application/javascript";
+            }
+            else
+            {
+                headers[HeaderNames.ContentType] = "application/octet-stream";
+            }
+        }
+        else if (name.EndsWith(".gz", StringComparison.OrdinalIgnoreCase))
+        {
+            headers[HeaderNames.ContentEncoding] = "gzip";
+        }
+
+        // index.html references hash-named build files, so it must never be cached; everything else under
+        // the Build/ folder is content-addressed and safe to cache immutably.
+        headers[HeaderNames.CacheControl] = string.Equals(name, "index.html", StringComparison.OrdinalIgnoreCase)
+            ? "no-cache"
+            : "public, max-age=31536000, immutable";
+    },
 });
 
 app.MapGet("/", () => Results.Content(AdminDashboard.Html, "text/html"));

--- a/tests/BlocksBeyondTheStars.Tests/PortalPageTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/PortalPageTests.cs
@@ -31,6 +31,17 @@ public sealed class PortalPageTests
         Assert.DoesNotContain("__SERVER__", html);
         Assert.DoesNotContain("__WORLD__", html);
         Assert.DoesNotContain("__PORT__", html);
+        Assert.DoesNotContain("__WSHOST__", html);
         Assert.DoesNotContain("__BASEURL__", html);
+    }
+
+    [Fact]
+    public void Render_OffersBrowserPlayDeepLinkWithBareHostAndGameplayPort()
+    {
+        string html = PortalPage.Render("MyServer", "MyWorld", 31415, "http://example:31416");
+
+        // The "Play in the browser" deep-link uses the bare host (no scheme/port) for server_host and the
+        // gameplay port for server_port; the WebGL client picks ws/wss from the page scheme.
+        Assert.Contains("href='/play?server_host=example&amp;server_port=31415&amp;bbs_auto_join=0'", html);
     }
 }


### PR DESCRIPTION
## Summary
Implements **#121** — play **Blocks Beyond the Stars** in a browser, served from the optional Docker server.

- **API `/play`**: same-origin static mount of a Unity WebGL build, with `Content-Encoding: br` for Unity Brotli files, immutable caching (`no-cache` for `index.html`), and a friendly "not installed yet" page. Added `ForwardedHeaders` so the portal link + `wss` scheme are correct behind a reverse proxy.
- **Portal**: a primary **Play in the browser** deep-link (`/play?server_host=…&server_port=31415&bbs_auto_join=0`).
- **Build injection** (Unity can'\''t build in the image): bind-mount `client/Build/WebGL` at `/app/webgl`, or `BBS_FETCH_WEBGL=1` pulls a release `webgl*.zip` via the entrypoint.
- **Public https / `wss://`**: new Caddy TLS profile (`docker-compose.tls.yml` + `docker/Caddyfile`) — auto Let'\''s Encrypt. localhost/LAN-http need none.
- **Optional PostgreSQL** overlay (`docker-compose.postgres.yml`); **SQLite stays the default**.
- **release.yml**: `build-player-webgl` + `package-webgl` jobs ship the `webgl*.zip` asset.
- **Docs**: SELF_HOSTING "Play in the browser" + the TLS matrix + hosting/cost options + Postgres; README mentions browser play.

## Verification
- `dotnet build BlocksBeyondTheStars.CI.slnf -warnaserror` → 0 warnings.
- `dotnet format --verify-no-changes` → clean.
- `PortalPageTests` → 5/5 pass (incl. the new deep-link assertion).
- `bash -n docker/entrypoint.sh` OK; `docker compose config` OK for the base, TLS and Postgres overlays.

## Caveats
- The **GameCI WebGL build job is untested** and may need iteration on the first tagged release. It is an independent job, so a failure there does not block the Windows/Linux/macOS/Docker release assets.
- End-to-end browser play needs a local Unity WebGL build to mount (none is produced in this PR).

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)