### PR TITLE
fix(webgl): strip the bundled native server from the WebGL build output

### DIFF
--- a/client/Assets/BlocksBeyondTheStars/Editor/BuildScript.cs
+++ b/client/Assets/BlocksBeyondTheStars/Editor/BuildScript.cs
@@ -135,9 +135,35 @@ namespace BlocksBeyondTheStars.Client.EditorTools
             if (target == BuildTarget.WebGL)
             {
                 RemoveAutoFullscreen(outDir);
+                StripBundledServerFromWebGLOutput(outDir);
             }
 
             File.WriteAllText(Path.Combine(outDir, "version.txt"), PlayerSettings.bundleVersion);
+        }
+
+        /// <summary>Strips the bundled native game server from a WebGL build's output StreamingAssets. On desktop
+        /// the client launches this server for Singleplayer/Host, so a prior desktop build leaves
+        /// <c>StreamingAssets/server/</c> in the project — and Unity copies the whole StreamingAssets folder into
+        /// every build, WebGL included. A browser can never run a native server, so it is ~70 MB of dead weight
+        /// (and a stray platform binary) that must not ride along in the web bundle. Only the build OUTPUT is
+        /// touched; the source project is left intact so a later desktop Singleplayer build/run still finds it.</summary>
+        private static void StripBundledServerFromWebGLOutput(string outDir)
+        {
+            string serverDir = Path.Combine(outDir, "StreamingAssets", "server");
+            if (!Directory.Exists(serverDir))
+            {
+                return;
+            }
+
+            try
+            {
+                Directory.Delete(serverDir, recursive: true);
+                Debug.Log($"WebGL: stripped the bundled native server from the build output ({serverDir}).");
+            }
+            catch (Exception ex)
+            {
+                Debug.LogWarning($"WebGL: could not strip the bundled native server at {serverDir}: {ex.Message}");
+            }
         }
 
         /// <summary>Best-effort WebGL production defaults. Reflection keeps this resilient across Unity 6 patch


### PR DESCRIPTION
## Summary
A WebGL build was including the desktop **bundled native server** (`StreamingAssets/server/BlocksBeyondTheStars.GameServer.exe` + `.pdb`, ~70 MB). Unity copies the whole `StreamingAssets/` folder into every build, so if a prior desktop build left `StreamingAssets/server/` in the project, it got baked into the WebGL bundle too.

- A browser can never run a native server, and it is **not** in the content manifest (so players never fetch it) — but it bloats the web bundle and ships a stray platform binary.
- `BuildScript.BuildWebGL` now deletes `<output>/StreamingAssets/server` after the build. **Only the build output is touched**; the source project keeps the bundled server so a later desktop Singleplayer build/run still finds it.

## Scope / impact
- **CI was already clean** (fresh checkout + the WebGL job does not run `publish-local-server`); this hardens **local** builds where a prior desktop build populated `StreamingAssets/server/`.
- `BuildScript.cs` is Unity editor code (not compiled by the .NET CI), so this is verified by inspection + a local WebGL build. The change uses only already-imported namespaces and is a guarded `Directory.Delete`.

Re #121.

🤖 Generated with [Claude Code](https://claude.com/claude-code)