### PR TITLE
fix(station): guard flora stamp paths + close enclosure ledge hole

### DIFF
--- a/src/BlocksBeyondTheStars.GameServer/GameServerFlora.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerFlora.cs
@@ -124,42 +124,71 @@ public sealed partial class GameServer
         new(1, 0, 0), new(-1, 0, 0), new(0, 0, 1), new(0, 0, -1),
     };
 
-    /// <summary>True if the cell holds a solid (collision) block — confirms flora has real ground/walls
-    /// backing it rather than open space.</summary>
-    private bool IsSolidCell(Vector3i p)
-    {
-        var b = _world.GetBlock(p);
-        return !b.IsAir && (_world.Definition(b)?.Solid ?? false);
-    }
+    // Cap on the void-enclosure flood-fill: a plant boxed in by this many reachable floor cells without finding
+    // an open drop is treated as enclosed. Far larger than any single station room, so real interiors always pass.
+    private const int FloraEnclosureFloodBudget = 512;
 
-    /// <summary>On a void world (a space station floating in the void) flora may only sit fully INSIDE the hull:
-    /// a solid block directly below AND no horizontal side opening onto floorless space. Otherwise the billboard
-    /// plant (rendered with no opaque face and no collider) shows the void behind it and lets the player walk
-    /// through it out into space. On normal worlds terrain always backs the plant, so this is a no-op there.</summary>
-    private bool IsFloraEnclosedForVoidWorld(Vector3i pos)
+    /// <summary>Core void-enclosure test, shared by live placement and the void-world stamp paths. Returns true if
+    /// the flora cell is NOT fully enclosed — i.e. a billboard plant there would show the void behind it and let the
+    /// player walk out into space. <paramref name="get"/> reads the block id at a cell (0 = empty) over whichever
+    /// space is being checked (the live world, or a structure's own cell map at stamp time).
+    ///
+    /// A flora cell is exposed when either the floor directly under it is not solid, OR a bounded flood-fill of the
+    /// walkable space at foot level (stepping through non-solid cells) reaches a cell with nothing solid beneath it
+    /// — a drop the player would fall through into the void. The flood-fill (rather than the old single-neighbour
+    /// check) also catches a plant standing one or more cells in from an open ledge, which the one-cell test missed.</summary>
+    private bool FloraCellOpensToVoid(System.Func<Vector3i, ushort> get, Vector3i flora)
     {
-        if (!_world.Planet.Void)
+        bool Solid(Vector3i p)
+        {
+            ushort id = get(p);
+            return id != 0 && (_content.BlockById(new BlockId(id))?.Solid ?? false);
+        }
+
+        // The plant must stand on a solid floor; nothing under it is an immediate fall-through.
+        if (!Solid(new Vector3i(flora.X, flora.Y - 1, flora.Z)))
         {
             return true;
         }
 
-        if (!IsSolidCell(new Vector3i(pos.X, pos.Y - 1, pos.Z)))
+        // Flood-fill the reachable walkable cells at the plant's own level. Any reachable open cell with no solid
+        // floor below opens onto the void (you would walk off the edge and fall). Bounded so this stays cheap.
+        var seen = new HashSet<Vector3i> { flora };
+        var queue = new Queue<Vector3i>();
+        queue.Enqueue(flora);
+        while (queue.Count > 0 && seen.Count <= FloraEnclosureFloodBudget)
         {
-            return false; // no solid floor under the plant
-        }
-
-        foreach (var d in FloraHorizontalDirs)
-        {
-            var n = new Vector3i(pos.X + d.X, pos.Y + d.Y, pos.Z + d.Z);
-            // A side that is open (non-solid) AND has no floor beneath it opens onto the void — reject.
-            if (!IsSolidCell(n) && !IsSolidCell(new Vector3i(n.X, n.Y - 1, n.Z)))
+            var c = queue.Dequeue();
+            foreach (var d in FloraHorizontalDirs)
             {
-                return false;
+                var n = new Vector3i(c.X + d.X, c.Y + d.Y, c.Z + d.Z);
+                if (Solid(n) || !seen.Add(n))
+                {
+                    continue; // a wall blocks movement here, or the cell was already visited
+                }
+
+                if (!Solid(new Vector3i(n.X, n.Y - 1, n.Z)))
+                {
+                    return true; // a reachable floorless cell — open to the void
+                }
+
+                queue.Enqueue(n);
             }
         }
 
-        return true;
+        return false; // boxed in within the budget — no escape to the void
     }
+
+    /// <summary>On a void world (a space station floating in the void) flora may only sit fully INSIDE the hull, so
+    /// the billboard plant (no opaque face, no collider) never shows the void behind it nor lets the player walk
+    /// out into space. On normal worlds terrain always backs the plant, so this is a no-op there.</summary>
+    private bool IsFloraEnclosedForVoidWorld(Vector3i pos)
+        => !_world.Planet.Void || !FloraCellOpensToVoid(p => _world.GetBlock(p).Value, pos);
+
+    /// <summary>Test seam: run the void-enclosure predicate against an arbitrary cell map, so the flood-fill /
+    /// ledge logic can be unit-tested without boarding a full void world. Returns true if the cell opens to the void.</summary>
+    public bool FloraCellOpensToVoidForTest(System.Func<int, int, int, ushort> get, int x, int y, int z)
+        => FloraCellOpensToVoid(p => get(p.X, p.Y, p.Z), new Vector3i(x, y, z));
 
     /// <summary>Test/diagnostic: whether a flora block could be planted at a cell.</summary>
     public bool CanPlantFlora(string floraKey, int x, int y, int z)

--- a/src/BlocksBeyondTheStars.GameServer/GameServerPlayerStations.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerPlayerStations.cs
@@ -361,10 +361,19 @@ public sealed partial class GameServer
 
         // Stamp the whole build in one transaction: a station can be hundreds of voxels and each SetBlock is
         // otherwise its own WAL commit — that loop stalls the tick thread for as long as it runs.
+        ushort GetCell(Vector3i p) => src.Get(p).Value;
         _repo.RunInTransaction(() =>
         {
             foreach (var kv in src.Cells)
             {
+                // A plant that opens onto the void (no opaque face, no collider) would be see-through and let a
+                // boarder walk out into space — drop it rather than stamp it. Evaluated against the build's own
+                // cells, so the verdict is independent of how it was authored (editor palette, import, etc.).
+                if (IsFlora(kv.Value.Value) && FloraCellOpensToVoid(GetCell, kv.Key))
+                {
+                    continue;
+                }
+
                 var w = new Vector3i(station.Origin.X + kv.Key.X - minX, station.Origin.Y + kv.Key.Y - minY, station.Origin.Z + kv.Key.Z - minZ);
                 _world.SetBlock(w, kv.Value);
             }

--- a/src/BlocksBeyondTheStars.GameServer/GameServerSpaceStations.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerSpaceStations.cs
@@ -440,6 +440,9 @@ public sealed partial class GameServer
         station.Structure = structure;
 
         // Stamp the whole station in one transaction (hundreds of voxels, otherwise one WAL commit each).
+        ushort GetStructureCell(Vector3i p) =>
+            (p.X >= 0 && p.Y >= 0 && p.Z >= 0 && p.X < structure.Width && p.Y < structure.Height && p.Z < structure.Length)
+                ? structure.Get(p.X, p.Y, p.Z) : (ushort)0;
         _repo.RunInTransaction(() =>
         {
             for (int x = 0; x < structure.Width; x++)
@@ -447,12 +450,21 @@ public sealed partial class GameServer
                     for (int z = 0; z < structure.Length; z++)
                     {
                         ushort b = structure.Get(x, y, z);
-                        if (b != 0)
+                        if (b == 0)
                         {
-                            var (tint, glow) = structure.GetModifier(x, y, z);
-                            _world.SetBlock(new Vector3i(station.Origin.X + x, station.Origin.Y + y, station.Origin.Z + z),
-                                new BlockId(b), tint, glow, structure.GetShape(x, y, z));
+                            continue;
                         }
+
+                        // Cheap insurance over the generator's own guarantee: never stamp a plant that opens onto
+                        // the void (see-through / walk-through into space) — also covers hand-authored templates.
+                        if (IsFlora(b) && FloraCellOpensToVoid(GetStructureCell, new Vector3i(x, y, z)))
+                        {
+                            continue;
+                        }
+
+                        var (tint, glow) = structure.GetModifier(x, y, z);
+                        _world.SetBlock(new Vector3i(station.Origin.X + x, station.Origin.Y + y, station.Origin.Z + z),
+                            new BlockId(b), tint, glow, structure.GetShape(x, y, z));
                     }
         });
 

--- a/tests/BlocksBeyondTheStars.Tests/FloraTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/FloraTests.cs
@@ -255,6 +255,59 @@ public sealed class FloraTests : IDisposable
         }
     }
 
+    /// <summary>The void-enclosure predicate that gates flora on a space station (and is reused by the void-world
+    /// stamp paths): a plant counts as "open to the void" unless it is boxed in by hull on every escape route.
+    /// Covers the sealed-room case (safe), the directly-adjacent drop, the deeper ledge the old single-neighbour
+    /// check missed (now caught by the flood-fill), and a plant standing on nothing.</summary>
+    [Fact]
+    public void FloraVoidEnclosure_FloodFill_DetectsExposedPlants_AcceptsSealedRooms()
+    {
+        var server = Started(out var repo);
+        using (repo)
+        {
+            ushort hull = _content.GetBlock("iron_wall")!.NumericId.Value;
+            ushort plant = _content.GetBlock("flora_plant")!.NumericId.Value;
+            Assert.NotEqual((ushort)0, hull);
+            Assert.NotEqual((ushort)0, plant);
+
+            var cells = new Dictionary<(int, int, int), ushort>();
+            ushort Get(int x, int y, int z) => cells.TryGetValue((x, y, z), out var b) ? b : (ushort)0;
+            void Solid(int x, int y, int z) => cells[(x, y, z)] = hull;
+
+            // (1) Fully sealed room: a 5x5 hull floor (y=0) under a hull wall ring (y=1); plant in the centre.
+            // Every foot-level escape hits a wall, so it is enclosed → NOT open to the void.
+            cells.Clear();
+            for (int x = 0; x <= 4; x++)
+                for (int z = 0; z <= 4; z++) Solid(x, 0, z);
+            for (int x = 0; x <= 4; x++) { Solid(x, 1, 0); Solid(x, 1, 4); }
+            for (int z = 0; z <= 4; z++) { Solid(0, 1, z); Solid(4, 1, z); }
+            cells[(2, 1, 2)] = plant;
+            Assert.False(server.FloraCellOpensToVoidForTest(Get, 2, 1, 2),
+                "A plant in a fully sealed room must not count as open to the void.");
+
+            // (2) Open drop right beside the plant: floor only under the plant → an immediate neighbour is floorless.
+            cells.Clear();
+            Solid(2, 0, 2);
+            cells[(2, 1, 2)] = plant;
+            Assert.True(server.FloraCellOpensToVoidForTest(Get, 2, 1, 2),
+                "A plant with an open drop right beside it must count as open to the void.");
+
+            // (3) Deeper ledge — the case the old single-neighbour check missed: the plant's four neighbours are all
+            // floored, but two cells out the floor stops. The flood-fill must still reach that drop → exposed.
+            cells.Clear();
+            Solid(2, 0, 2); Solid(1, 0, 2); Solid(3, 0, 2); Solid(2, 0, 1); Solid(2, 0, 3);
+            cells[(2, 1, 2)] = plant;
+            Assert.True(server.FloraCellOpensToVoidForTest(Get, 2, 1, 2),
+                "A plant one cell in from an open ledge must still count as open to the void (flood-fill).");
+
+            // (4) Nothing solid beneath the plant at all → trivially open to the void.
+            cells.Clear();
+            cells[(5, 1, 5)] = plant;
+            Assert.True(server.FloraCellOpensToVoidForTest(Get, 5, 1, 5),
+                "A plant with nothing solid beneath it must count as open to the void.");
+        }
+    }
+
     [Fact]
     public void HarvestedFlora_RegrowsWhenHostIntact()
     {


### PR DESCRIPTION
Closes #134.

## Problem

Flora is a non-solid, transparent billboard (no collider, no opaque face), so a plant cell exposed to the void is both **see-through** and **walk-through into space**. Two gaps let such plants reach a station:

1. **Stamp paths** wrote flora verbatim with no enclosure guard — `StampPlayerStation` (player-built station), and `StampStation` relied solely on the generator.
2. **Ledge hole** in the live-placement check (`IsFloraEnclosedForVoidWorld`): it only required a solid floor *beneath each open side*, so a plant standing one or more cells in from an open ledge passed the one-cell test yet still opened onto the void.

## Change

- New shared predicate **`FloraCellOpensToVoid`** (`GameServerFlora.cs`): from the plant cell, a bounded flood-fill walks the reachable foot-level space through non-solid cells; if any reachable cell has nothing solid beneath it, the plant opens onto the void. This replaces the single-neighbour test and also catches the deeper-ledge case.
- `IsFloraEnclosedForVoidWorld` now delegates to the predicate (live placement).
- `StampPlayerStation` and `StampStation` run the predicate over the structure's own cells and **drop** any flora cell that opens to the void — independent of how it was authored (editor palette, import, template).

Note: the landed ship is a client-rendered structure object (not a block-grid stamp) since the ship-as-object refactor, so there is no ship-interior void-world stamp to guard.

## Out of scope (per #134, accepted)

No retroactive cleanup of worlds where a station was first boarded before the original fix — those keep their persisted grass until the cell is overwritten. **A brand-new world is unaffected.**

## Tests

- `FloraTests.FloraVoidEnclosure_FloodFill_DetectsExposedPlants_AcceptsSealedRooms`: sealed room = safe; adjacent drop, deeper ledge, and floorless plant all flagged.
- Existing structural generator regression (`DecorativePlants_StayInsideTheHull_NeverOpenToTheVoid`) still green.
- Full server suite **794 passed, 0 warnings**. No `client/Assets` changes → no Unity build needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
