### PR TITLE
fix(client): make Codex navigable + list descriptions + fix scan names (#176, #177)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -97,6 +97,24 @@ Per-item detail lives in the dated work log below.
 
 ---
 
+### ★ Codex (in-game Wiki) navigation + scan-name fixes (2026-06-30) — ✅ code done, local Unity build green
+Three player-reported client fixes on `fix/codex-wiki-buttons-unclickable-176` (#176, #177):
+- **#176 — Codex buttons unclickable.** `GameMenu.Update` calls `WikiUI.Show()` every frame while the Codex is
+  open, and `Show()` rebuilt the whole screen unconditionally — destroying and recreating every button each
+  frame, so a uGUI click (pointer-down + pointer-up on the *same* surviving object) never completed. Sidebar
+  chapter nav, "Back to menu" and "Close" were all dead; only Esc (polled in `GameMenu`) worked. Fix: `Show()`
+  now rebuilds only on the disabled→enabled transition (mirrors `ArcadeUI`/`CraftingTechShipUI`); `SelectChapter`
+  still rebuilds on a chapter click.
+- **Codex list descriptions (folded into #176).** The reference chapters listed names only. They now render each
+  entry's `DescriptionKey` text under the name — full coverage for Tech (57/57) and Modules (24/24), partial for
+  Items (64/163) and Ships (4/4); Blocks/Planets stay name-only (no description text in the data yet).
+- **#177 — scan readout showed `[creature.<name>.name]`.** The server already resolves a scanned creature/flora
+  to its coined, language-neutral display name (`CreatureSpecies.Name` etc.) in `ScanResult.Subject`, but the
+  client re-processed it: `HudUi.ScanSubjectName` ran a `creature.{subject}.name` localizer lookup that missed
+  (no such key — by design) and the broken `StartsWith("creature.")` guard let the bracketed `[…]` key through.
+  Fix: show the subject as-is when it is not a known block/item key; only localize a per-species key when
+  `Localizer.Has` confirms it exists. Client-only.
+
 ### ★ Gameplay fixes: shape icons, ladders, shape auto-step & tool-gated mining (2026-06-29) — ✅ code done, 792 server tests green, local Unity build pending
 Four player-reported issues fixed on `feat/gameplay-fixes-shapes-ladders-mining` (#125–#128):
 - **#125 — per-shape hotbar/inventory icons.** Crafted forms (sphere/pyramid/slab/ramp/stairs/dome/cone/cylinder)

--- a/client/Assets/BlocksBeyondTheStars/Scripts/HudUi.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/HudUi.cs
@@ -882,8 +882,13 @@ namespace BlocksBeyondTheStars.Client
                 return loc.Get(it.NameKey);
             }
 
-            string creatureName = loc.Get($"creature.{key}.name");
-            return creatureName.StartsWith("creature.") ? key : creatureName; // fall back to the raw key
+            // Not a block/item key: the server already resolved creatures/flora/trees to their coined,
+            // language-neutral display name (CreatureSpecies.Name etc.) and asteroids to a plain label, so
+            // the subject IS the display name — show it as-is. (A real per-species localization key is
+            // honoured if one exists; Localizer.Get returns "[key]" for a missing key, so we must probe
+            // with Has() rather than inspect the returned string.)
+            string creatureKey = $"creature.{key}.name";
+            return loc.Has(creatureKey) ? loc.Get(creatureKey) : key;
         }
 
         private void RefreshWreck(BlocksBeyondTheStars.Shared.Localization.Localizer loc)

--- a/client/Assets/BlocksBeyondTheStars/Scripts/WikiUI.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/WikiUI.cs
@@ -57,10 +57,16 @@ namespace BlocksBeyondTheStars.Client
         public void Show()
         {
             EnsureCanvas();
-            Rebuild();
+
+            // Rebuild ONLY on the disabled→enabled transition (mirrors ArcadeUI/CraftingTechShipUI).
+            // GameMenu.Update calls Show() every frame while the Codex is open; rebuilding each frame
+            // destroyed and recreated every button, so a uGUI click (pointer-down + pointer-up on the
+            // SAME surviving object) never completed — sidebar nav, Back and Close were all dead and
+            // only Esc (polled in GameMenu) worked. SelectChapter() rebuilds itself on a chapter click.
             if (!_canvas.enabled)
             {
                 _canvas.enabled = true;
+                Rebuild();
                 UiKit.TransitionIn(_canvas.gameObject);
             }
         }
@@ -176,44 +182,61 @@ namespace BlocksBeyondTheStars.Client
         private string BuildChapterText(string chapter) => chapter switch
         {
             "guide" => BuildGuide(),
-            "blocks" => BuildList(L("ui.wiki.blocks"), Names(Game?.Content?.Blocks?.Values, d => d.NameKey)),
-            "items" => BuildList(L("ui.wiki.items"), Names(Game?.Content?.Items?.Values, d => d.NameKey)),
-            "tech" => BuildList(L("ui.wiki.tech"), Names(Game?.Content?.Blueprints?.Values, d => d.NameKey)),
-            "ships" => BuildList(L("ui.wiki.ships"), Names(Game?.Content?.Ships?.Values, d => d.NameKey)),
-            "modules" => BuildList(L("ui.wiki.modules"), Names(Game?.Content?.ShipModules?.Values, d => d.NameKey)),
-            "planets" => BuildList(L("ui.wiki.planets"), Names(Game?.Content?.Planets?.Values, d => d.NameKey)),
+            // Items/Tech/Ships/Modules carry a DescriptionKey (shown under each name); Blocks/Planets have no
+            // description text in the content data yet, so they list names only (pass a null description selector).
+            "blocks" => BuildEntries(L("ui.wiki.blocks"), Entries(Game?.Content?.Blocks?.Values, d => d.NameKey, null)),
+            "items" => BuildEntries(L("ui.wiki.items"), Entries(Game?.Content?.Items?.Values, d => d.NameKey, d => d.DescriptionKey)),
+            "tech" => BuildEntries(L("ui.wiki.tech"), Entries(Game?.Content?.Blueprints?.Values, d => d.NameKey, d => d.DescriptionKey)),
+            "ships" => BuildEntries(L("ui.wiki.ships"), Entries(Game?.Content?.Ships?.Values, d => d.NameKey, d => d.DescriptionKey)),
+            "modules" => BuildEntries(L("ui.wiki.modules"), Entries(Game?.Content?.ShipModules?.Values, d => d.NameKey, d => d.DescriptionKey)),
+            "planets" => BuildEntries(L("ui.wiki.planets"), Entries(Game?.Content?.Planets?.Values, d => d.NameKey, null)),
             _ => string.Empty,
         };
 
-        /// <summary>Localized, sorted display names for a content collection (each definition carries a NameKey).</summary>
-        private List<string> Names<T>(IEnumerable<T> defs, Func<T, string> nameKey)
+        /// <summary>Localized, name-sorted (name, description) entries for a content collection. Every definition
+        /// carries a NameKey; <paramref name="descKey"/> is null for collections without description text, and an
+        /// individual entry's description is empty when its key is blank or unknown (see <see cref="Desc"/>).</summary>
+        private List<(string Name, string Desc)> Entries<T>(IEnumerable<T> defs, Func<T, string> nameKey, Func<T, string> descKey)
         {
-            var result = new List<string>();
+            var result = new List<(string Name, string Desc)>();
             if (defs != null)
             {
                 foreach (var d in defs)
                 {
-                    result.Add(L(nameKey(d)));
+                    result.Add((L(nameKey(d)), descKey == null ? string.Empty : Desc(descKey(d))));
                 }
             }
 
-            result.Sort(StringComparer.CurrentCultureIgnoreCase);
+            result.Sort((a, b) => string.Compare(a.Name, b.Name, StringComparison.CurrentCultureIgnoreCase));
             return result;
         }
 
-        private string BuildList(string header, List<string> names)
+        /// <summary>Localized description text for a key, or empty when the key is blank or unknown — so an entry
+        /// renders a description line only when one actually exists (Localizer.Get returns "[key]" for a miss).</summary>
+        private string Desc(string key)
+            => string.IsNullOrEmpty(key) || Game?.Localizer == null || !Game.Localizer.Has(key)
+                ? string.Empty
+                : Game.Localizer.Get(key);
+
+        private string BuildEntries(string header, List<(string Name, string Desc)> entries)
         {
             var sb = new StringBuilder();
             sb.Append("<b><size=24>").Append(header).Append("</size></b>\n\n");
-            if (names.Count == 0)
+            if (entries.Count == 0)
             {
                 sb.Append(L("ui.wiki.empty"));
             }
             else
             {
-                foreach (var n in names)
+                foreach (var (name, desc) in entries)
                 {
-                    sb.Append("• ").Append(n).Append('\n');
+                    sb.Append("• <b>").Append(name).Append("</b>\n");
+                    if (!string.IsNullOrEmpty(desc))
+                    {
+                        sb.Append("<color=#9fb4c8>").Append(desc).Append("</color>\n");
+                    }
+
+                    sb.Append('\n');
                 }
             }
 


### PR DESCRIPTION
## What & why

Three player-reported client fixes for the in-game **Codex** (native Wiki) and the scanner.

### 1. Codex buttons unclickable — only Esc worked (#176)
`GameMenu.Update` calls `WikiUI.Show()` **every frame** while the Codex is open, and `Show()`
rebuilt the whole screen unconditionally — destroying and recreating every button each frame.
A uGUI click needs pointer-down **and** pointer-up on the *same surviving* object, so no click
ever completed: the left sidebar chapter nav, "Back to menu" and "Close" were all dead, and only
**Esc** (polled directly in `GameMenu`) closed the screen.

**Fix:** `Show()` now rebuilds only on the disabled→enabled transition, mirroring the sibling
screens (`ArcadeUI.Show`, `CraftingTechShipUI.ShowMode`). `SelectChapter` already rebuilds on a
chapter click, so chapter switching keeps working — and the scroll position no longer resets.

### 2. Codex list chapters now show descriptions (folded into #176)
The reference chapters listed names only. They now render each entry's existing `DescriptionKey`
text under the name:

| Chapter | Description coverage |
|---|---|
| Tech (Blueprints) | 57 / 57 ✅ |
| Modules | 24 / 24 ✅ |
| Items | 64 / 163 (partial) |
| Ships | 4 / 4 ✅ |
| Blocks / Planets | name-only (no description data yet) |

### 3. Scan readout showed `[creature.<name>.name]` for creatures/flora (#177)
The server already resolves a scanned creature/flora/tree to its coined, language-neutral display
name (`CreatureSpecies.Name` etc.) in `ScanResult.Subject`. The client then **re-processed** it:
`HudUi.ScanSubjectName` ran a `creature.{subject}.name` localizer lookup that missed (no such key —
by design), and the broken `StartsWith("creature.")` guard (the missing-key form returned by
`Localizer.Get` starts with `[`) let the bracketed key through.

**Fix:** show the subject as-is when it is not a known block/item key (the server already resolved
it); only localize a per-species key when `Localizer.Has` confirms it exists. Client-only.

## Testing
- Local Unity Windows build green (success marker, `Client.dll` recompiled, no new warnings).
- `src/` untouched, so the dotnet suites (794 server + 96 client, already green this session) are
  unaffected; these are Unity MonoBehaviour changes the headless suites don't cover.
- Manual in-game verification by the maintainer: Codex nav/back/close + descriptions, and a
  creature/flora scan showing the proper name.

Closes #176
Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)
