### PR TITLE
fix: helmet lamp off in space, opaque world-options modal, walkable ship door (#179, #180, #181)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -5315,6 +5315,22 @@ is **pre-approved** (keys in `tools/ai-assets/.env`, run via `uv`).
 
 ---
 
+## ✅ Done (2026-07-01): three reported bug fixes — helmet lamp, world-options modal, ship-exit door (#179, #180, #181)
+- **Helmet lamp stays on in space ([#179](https://github.com/marceld23/BlocksBeyondTheStars/issues/179)).** The suit
+  headlamp (toggle `L`) is a shader spotlight driven by `_Sc_LampColor` in `PlayerController.UpdateLamp()`. When the
+  space view took over, `Update()` returned early **before** `UpdateLamp()` ran, so the global kept its last "on"
+  value and the lamp stayed lit in space. Now the `SpaceViewActive` branch turns the lamp off once on the way in
+  (clears the global + hides the light cone), mirroring the existing clear-on-context-change in `Sky.cs`/`MenuBackground`.
+- **World-options modal too transparent ([#180](https://github.com/marceld23/BlocksBeyondTheStars/issues/180)).** The
+  "Weltoptionen" overlay (`UiWorldOptions.Build`) used a `0.72`-alpha dim scrim over the shared `0.80`-alpha
+  `UiKit.Panel`, so the animated menu shimmered through and hurt readability. Raised the scrim to `0.90` and gave this
+  panel its own near-opaque blue `(0.05,0.12,0.24,0.97)` (site-wide `UiKit.Panel` left untouched).
+- **Must jump to exit the ship ([#181](https://github.com/marceld23/BlocksBeyondTheStars/issues/181)).** The scout's
+  only door (`ship_scout.json` cell `(2,1,0)`) had its two `engine` blocks stacked **directly behind it** at
+  `(2,1,-1)`/`(2,2,-1)`, so walking out the centre door hit the engine and you had to jump onto it to get through.
+  The corvette/hauler already place engines **flanking** the central door; the scout now matches — its two engines
+  moved to `(1,1,-1)`/`(3,1,-1)`, clearing the exit path. Repro confirmed in-game before the fix.
+
 ## ✅ Done (2026-06-29): oxygen tank tiers + water-exit assist — SHIPPED in v0.6.2 (#133)
 - **Oxygen tank tiers I/II/III ([#129](https://github.com/marceld23/BlocksBeyondTheStars/issues/129)).** `oxygen_tank_1`
   was a dead consumable (no effect) whose description wrongly promised a capacity boost. It is now a worn

--- a/client/Assets/BlocksBeyondTheStars/Scripts/PlayerController.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/PlayerController.cs
@@ -236,6 +236,13 @@ namespace BlocksBeyondTheStars.Client
             if (Game != null && Game.SpaceViewActive)
             {
                 UpdateJetpack(false);
+                // Entering space skips the per-frame UpdateLamp() below, so the suit headlamp's
+                // shader global would otherwise stay lit. Turn it off once on the way in.
+                if (_lampOn)
+                {
+                    _lampOn = false;
+                    UpdateLamp();
+                }
                 return;
             }
 

--- a/client/Assets/BlocksBeyondTheStars/Scripts/UiWorldOptions.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/UiWorldOptions.cs
@@ -20,11 +20,13 @@ namespace BlocksBeyondTheStars.Client
         /// <summary>Builds the (initially hidden) overlay; returns its root for the caller to toggle.</summary>
         public static GameObject Build(AppShell shell, Transform root, WorldCreationOptions opt)
         {
-            var dim = UiKit.AddImage(root, 0f, 0f, 1920f, 1080f, UiKit.SolidSprite, new Color(0f, 0f, 0f, 0.72f));
+            // Near-opaque scrim + panel so the animated menu behind the dialog can't shimmer through and
+            // hurt readability (the shared UiKit.Panel alpha 0.80 is intentionally left untouched site-wide).
+            var dim = UiKit.AddImage(root, 0f, 0f, 1920f, 1080f, UiKit.SolidSprite, new Color(0f, 0f, 0f, 0.90f));
             dim.raycastTarget = true;
             var overlay = dim.gameObject;
 
-            var panel = UiKit.AddPanel(overlay.transform, 160f, 90f, 1600f, 900f, UiKit.Panel).transform;
+            var panel = UiKit.AddPanel(overlay.transform, 160f, 90f, 1600f, 900f, new Color(0.05f, 0.12f, 0.24f, 0.97f)).transform;
             UiKit.AddText(panel, 30f, 20f, 800f, 34f, shell.L("ui.worldopt.title"), 26, UiKit.Cyan, TextAnchor.MiddleLeft, FontStyle.Bold);
 
             // Stacked views inside the panel: the main sliders, the advanced per-type list, and the

--- a/data/ship_layouts/ship_scout.json
+++ b/data/ship_layouts/ship_scout.json
@@ -333,7 +333,7 @@
    "id": "iron_wall"
   },
   {
-   "x": 2,
+   "x": 1,
    "y": 1,
    "z": -1,
    "kind": "block",
@@ -375,8 +375,8 @@
    "id": "glass"
   },
   {
-   "x": 2,
-   "y": 2,
+   "x": 3,
+   "y": 1,
    "z": -1,
    "kind": "block",
    "id": "engine"


### PR DESCRIPTION
## Summary

Fixes three reported bugs. All client/content-only; verified with a clean Unity build (no warnings) plus 96 client + full server test suites passing.

### #179 — Helmet lamp stays on after launching into space
The suit headlamp (`L`) is a shader spotlight driven by the `_Sc_LampColor` global, applied each frame by `PlayerController.UpdateLamp()`. When the space view takes over, `Update()` returns early **before** `UpdateLamp()` runs, so the global kept its last "on" value and the lamp stayed lit in space. The `SpaceViewActive` branch now turns the lamp off once on entry (clears the global + hides the light cone), mirroring the existing cleanup in `Sky.cs`/`MenuBackground.cs`.

### #180 — World Options modal too transparent
The "Weltoptionen" overlay (`UiWorldOptions.Build`) used a `0.72`-alpha dim scrim over the shared `0.80`-alpha `UiKit.Panel`, so the animated menu shimmered through and hurt readability. Raised the scrim to `0.90` and gave this panel its own near-opaque blue `(0.05, 0.12, 0.24, 0.97)`. The site-wide `UiKit.Panel` is intentionally left untouched.

### #181 — Player must jump to exit the spaceship
The scout's only door (`ship_scout.json` cell `(2,1,0)`) had both `engine` blocks stacked **directly behind it** at `(2,1,-1)`/`(2,2,-1)`, so walking out the centre door hit the engine wall and you had to jump onto it to get through. The corvette and hauler already place their engines **flanking** the central door (clear space behind); the scout now matches — engines moved to `(1,1,-1)`/`(3,1,-1)`, clearing the exit path. Scope: scout only — the other two ships were never affected. In-game repro confirmed before the fix.

## Test plan
- [x] Clean local Unity Windows build — no warnings/errors
- [x] `./scripts/run-tests.sh` — 96 client + full server suites pass (incl. ship-layout/door tests)
- [x] #181 reproduced in-game before the fix; engine cells behind the door now verified clear

Closes #179
Closes #180
Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)
