### PR TITLE
feat(client): input abstraction + experimental gamepad/controller support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Design your ship block by block, fly real system-scale routes, dock at space sta
 *   **Rich Multiplayer:** Form alliances, share bases, and communicate via global radio.
 *   **The VEGA Protocol:** An optional story campaign narrated by your ship's AI companion.
 *   **Windows & Linux:** Native desktop clients — no Wine/Proton needed (an experimental macOS build exists too).
+*   **Keyboard, mouse & controller:** Play with keyboard + mouse or an Xbox/XInput gamepad — both work at once, and menus are pad-navigable (controller support is experimental).
 
 ## 🎬 Watch the Let's Play
 

--- a/TODO.md
+++ b/TODO.md
@@ -97,6 +97,25 @@ Per-item detail lives in the dated work log below.
 
 ---
 
+### ★ Input abstraction + gamepad/controller support (2026-07-01) — ✅ code done, local Unity build pending
+On `feat/input-abstraction-and-controller` (epic #193; P1 #194, P2 #195). Decouples gameplay from directly
+polling `UnityEngine.Input` and adds experimental Xbox/XInput controller support on the native desktop client.
+- **P1 — input abstraction.** New `IInputSource` (`Scripts/Input/`) with a `DesktopInputSource` (1:1 wrapper
+  over the legacy calls) behind a rewritten `InputMap` facade exposing the continuous/pointer core
+  (`MoveX/MoveY`, `LookX/LookY`, `HotbarScroll`, `Jump/Crouch/Primary/Secondary`, `HotbarSlotDown`). Migrated
+  the ~gameplay `Input.*` sites in `PlayerController` (on-foot + speeder) and `SpaceView` (flight + EVA +
+  turret). Behaviour-preserving on keyboard/mouse.
+- **P2 — controller.** `GamepadInputSource` (right stick = look, RB/LB = mine/place, (A) jump, (X) interact,
+  d-pad = hotbar; left stick already feeds the shared Horizontal/Vertical axes) + `RightStickX/Y`+`DPadX`
+  joystick axes added to `InputManager.asset`. `InputMap` **combines** keyboard+pad (both live at once) and
+  tracks the active device for glyphs. `UiNavFocus` (`Scripts/UiNav.cs`) makes menus pad-navigable (wired on
+  the main menu + Tab/Start menu). Device-aware HUD hint (`ui.hud.hint_pad`, DE+EN). Start toggles the menu.
+- **Docs:** `docs/developer/INPUT_AND_CONTROLLER.md`; USER_MANUAL gamepad table; README feature bullet.
+- **Tests:** EditMode `InputAbstractionEditModeTests` (inert-without-pad guarantee + mapping tables). NOTE: CI
+  is .NET-only and can't compile the Unity client or drive a pad — validated by local Unity build + manual
+  on-device test. Remaining (deferred to #195): on-screen pad **rebinding** group, full glyph coverage across
+  all prompts, broader menu-panel focus wiring, and stick/button **retuning on real hardware**.
+
 ### ★ Codex (in-game Wiki) navigation + scan-name fixes (2026-06-30) — ✅ code done, local Unity build green
 Three player-reported client fixes on `fix/codex-wiki-buttons-unclickable-176` (#176, #177):
 - **#176 — Codex buttons unclickable.** `GameMenu.Update` calls `WikiUI.Show()` every frame while the Codex is

--- a/client/Assets/BlocksBeyondTheStars/Scripts/GameMenu.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/GameMenu.cs
@@ -61,7 +61,9 @@ namespace BlocksBeyondTheStars.Client
 
                 // Don't let Tab open the menu while the death / ship-destruction prompt is up — only its
                 // "Weiter" button proceeds.
-                if (Input.GetKeyDown(KeyCode.Tab) && !Game.AwaitingRespawnConfirm && !Game.ChatTyping)
+                // Tab (keyboard) or Start (gamepad button 7) toggles the menu.
+                if ((Input.GetKeyDown(KeyCode.Tab) || Input.GetKeyDown(KeyCode.JoystickButton7))
+                    && !Game.AwaitingRespawnConfirm && !Game.ChatTyping)
                 {
                     Game.MarkMenuInputHandled();
                     SetOpen(!_open);
@@ -164,6 +166,7 @@ namespace BlocksBeyondTheStars.Client
             Cursor.visible = _open;
             if (_open)
             {
+                UiNav.Enable(gameObject); // gamepad can drive the menu (covers every tab; inert on KB/mouse)
                 SwitchTo(_tab); // refresh data for the current tab
             }
             else

--- a/client/Assets/BlocksBeyondTheStars/Scripts/HudUi.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/HudUi.cs
@@ -507,7 +507,7 @@ namespace BlocksBeyondTheStars.Client
 
             _toast.text = Game.LastMessage ?? string.Empty;
             _inSpace.text = Game.InSpace ? loc.Get("ui.hud.in_space") : string.Empty;
-            _hint.text = loc.Get("ui.hud.hint");
+            _hint.text = loc.Get(InputMap.ActiveDevice == InputDeviceKind.Gamepad ? "ui.hud.hint_pad" : "ui.hud.hint");
 
             // Prompts — on-foot only. While piloting/EVA the flight view draws its own prompts, so don't leak
             // a stale on-foot "Use: Cockpit" into the centre of the space view (you reach the cockpit/helm on

--- a/client/Assets/BlocksBeyondTheStars/Scripts/Input.meta
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/Input.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0f4879470f600964ea12e9a93a4a5c5e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/client/Assets/BlocksBeyondTheStars/Scripts/Input/DesktopInputSource.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/Input/DesktopInputSource.cs
@@ -1,0 +1,68 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+
+using UnityEngine;
+
+namespace BlocksBeyondTheStars.Client
+{
+    /// <summary>
+    /// Keyboard + mouse backend. This is a 1:1 wrapper over the exact legacy <c>UnityEngine.Input</c> calls
+    /// the gameplay code used before the abstraction existed, so routing a call site through
+    /// <see cref="InputMap"/> onto this source changes nothing: <see cref="MoveX"/> is
+    /// <c>GetAxis("Horizontal")</c> (which already merges WASD and, via the project's InputManager, the
+    /// gamepad left stick), the look deltas are the raw mouse axes the caller still scales by sensitivity,
+    /// and the standard buttons resolve to the same space / Ctrl / mouse buttons as before. Discrete actions
+    /// resolve through <see cref="InputMap.Key"/> so the rebinding UI keeps working unchanged.
+    /// </summary>
+    public sealed class DesktopInputSource : IInputSource
+    {
+        public InputDeviceKind Kind => InputDeviceKind.KeyboardMouse;
+
+        public float MoveX() => Input.GetAxis("Horizontal");
+        public float MoveY() => Input.GetAxis("Vertical");
+        public float LookX() => Input.GetAxis("Mouse X");
+        public float LookY() => Input.GetAxis("Mouse Y");
+        public float HotbarScroll() => Input.GetAxis("Mouse ScrollWheel");
+
+        public bool JumpHeld() => Input.GetButton("Jump");
+        public bool JumpDown() => Input.GetButtonDown("Jump");
+        public bool CrouchHeld() => Input.GetKey(KeyCode.LeftControl) || Input.GetKey(KeyCode.C);
+        public bool PrimaryDown() => Input.GetMouseButtonDown(0);
+        public bool PrimaryHeld() => Input.GetMouseButton(0);
+        public bool SecondaryDown() => Input.GetMouseButtonDown(1);
+
+        public int HotbarSlotDown()
+        {
+            for (int i = 0; i < 9; i++)
+            {
+                if (Input.GetKeyDown(KeyCode.Alpha1 + i))
+                {
+                    return i;
+                }
+            }
+
+            return -1;
+        }
+
+        public bool ActionDown(InputAction action) => Input.GetKeyDown(InputMap.Key(action));
+        public bool ActionHeld(InputAction action) => Input.GetKey(InputMap.Key(action));
+        public bool ActionUp(InputAction action) => Input.GetKeyUp(InputMap.Key(action));
+
+        /// <summary>Keyboard/mouse activity this frame — any key held or the mouse moved/clicked/scrolled.
+        /// Used only to decide whether to show keyboard glyphs; a tiny mouse jitter threshold avoids
+        /// flip-flopping the glyph set while the player rests a hand on the mouse.</summary>
+        public bool HadActivityThisFrame()
+        {
+            if (Input.anyKey || Input.GetMouseButton(0) || Input.GetMouseButton(1))
+            {
+                return true;
+            }
+
+            const float MouseMoveEps = 0.5f;
+            return Mathf.Abs(Input.GetAxis("Mouse X")) > MouseMoveEps
+                || Mathf.Abs(Input.GetAxis("Mouse Y")) > MouseMoveEps
+                || Mathf.Abs(Input.GetAxis("Mouse ScrollWheel")) > 0.01f;
+        }
+    }
+}

--- a/client/Assets/BlocksBeyondTheStars/Scripts/Input/DesktopInputSource.cs.meta
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/Input/DesktopInputSource.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 87415f3ad3e75b24c9e567a4dfc20355

--- a/client/Assets/BlocksBeyondTheStars/Scripts/Input/GamepadInputSource.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/Input/GamepadInputSource.cs
@@ -1,0 +1,186 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+
+using UnityEngine;
+
+namespace BlocksBeyondTheStars.Client
+{
+    /// <summary>
+    /// Gamepad backend (legacy Input Manager). Reads the joystick axes added to <c>InputManager.asset</c>
+    /// and the standard <see cref="KeyCode.JoystickButton0"/>… buttons. Mapping targets the common case —
+    /// an <b>Xbox / XInput</b> pad on Windows; the axis numbers (right stick = 4th/5th axis, d-pad = 6th/7th)
+    /// and the A/B/X/Y/LB/RB button order follow that layout. Other pad families (DirectInput / PlayStation
+    /// via some drivers) report different numbers, so the axis names and this button table are the single
+    /// place to retune — see issue #195 (needs a pass on real hardware; not verifiable in CI).
+    ///
+    /// The left stick is NOT read here: the project's InputManager already maps it onto the shared
+    /// "Horizontal"/"Vertical" axes, so movement flows through <see cref="DesktopInputSource.MoveX"/> for
+    /// free. This source therefore contributes the RIGHT stick (look), the face/shoulder buttons, and the
+    /// d-pad (hotbar). <see cref="InputMap"/> combines it with the keyboard/mouse source, so both are always
+    /// live; with no pad connected every getter here returns zero/false.
+    /// </summary>
+    public sealed class GamepadInputSource : IInputSource
+    {
+        // Axis names — must match the entries appended to client/ProjectSettings/InputManager.asset.
+        private const string AxisRightStickX = "RightStickX";
+        private const string AxisRightStickY = "RightStickY"; // inverted in the asset so up = look up (like Mouse Y)
+        private const string AxisDpadX = "DPadX";
+
+        // XInput button layout (Windows).
+        private const KeyCode BtnA = KeyCode.JoystickButton0;   // jump / submit
+        private const KeyCode BtnB = KeyCode.JoystickButton1;   // crouch / cancel
+        private const KeyCode BtnX = KeyCode.JoystickButton2;   // interact
+        private const KeyCode BtnY = KeyCode.JoystickButton3;   // toggle third-person
+        private const KeyCode BtnLb = KeyCode.JoystickButton4;  // place block
+        private const KeyCode BtnRb = KeyCode.JoystickButton5;  // mine / attack
+
+        // Tunables (see issue #195). Look is a rate (deg/sec at sensitivity 1) turned into a per-frame delta
+        // so it lands in the same space as a mouse delta — the caller still multiplies by MouseSensitivity,
+        // so pad turn speed also scales with that slider. Deadzone rejects stick drift at rest.
+        private const float StickDeadzone = 0.2f;
+        private const float LookYawSpeed = 75f;
+        private const float LookPitchSpeed = 60f;
+        private const float DpadRepeatSeconds = 0.25f;
+
+        private float _dpadCooldownUntil;
+
+        public InputDeviceKind Kind => InputDeviceKind.Gamepad;
+
+        /// <summary>Whether at least one joystick is connected (a non-empty name). Recomputed cheaply per
+        /// call; when false the source stays fully inert so an unplugged pad costs nothing.</summary>
+        public static bool Connected()
+        {
+            var names = Input.GetJoystickNames();
+            if (names == null)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < names.Length; i++)
+            {
+                if (!string.IsNullOrEmpty(names[i]))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static float Deadzoned(float v) => Mathf.Abs(v) < StickDeadzone ? 0f : v;
+
+        // Left stick already feeds the shared Horizontal/Vertical axes — don't double-count it here.
+        public float MoveX() => 0f;
+        public float MoveY() => 0f;
+
+        public float LookX()
+        {
+            if (!Connected())
+            {
+                return 0f;
+            }
+
+            return Deadzoned(Input.GetAxis(AxisRightStickX)) * LookYawSpeed * Time.deltaTime;
+        }
+
+        public float LookY()
+        {
+            if (!Connected())
+            {
+                return 0f;
+            }
+
+            return Deadzoned(Input.GetAxis(AxisRightStickY)) * LookPitchSpeed * Time.deltaTime;
+        }
+
+        /// <summary>D-pad left/right cycles the hotbar, edge-/repeat-gated so a held press steps at a steady
+        /// rate rather than flying through all nine slots in one frame. Sign matches the mouse wheel:
+        /// &gt;0 = previous slot, &lt;0 = next slot.</summary>
+        public float HotbarScroll()
+        {
+            if (!Connected())
+            {
+                return 0f;
+            }
+
+            float dx = Deadzoned(Input.GetAxis(AxisDpadX));
+            if (Mathf.Abs(dx) < 0.5f)
+            {
+                _dpadCooldownUntil = 0f; // released → ready to fire immediately on next press
+                return 0f;
+            }
+
+            if (Time.unscaledTime < _dpadCooldownUntil)
+            {
+                return 0f;
+            }
+
+            _dpadCooldownUntil = Time.unscaledTime + DpadRepeatSeconds;
+            return dx > 0f ? -1f : 1f; // right = next (<0), left = previous (>0)
+        }
+
+        public bool JumpHeld() => Connected() && Input.GetKey(BtnA);
+        public bool JumpDown() => Connected() && Input.GetKeyDown(BtnA);
+        public bool CrouchHeld() => Connected() && Input.GetKey(BtnB);
+        public bool PrimaryDown() => Connected() && Input.GetKeyDown(BtnRb);
+        public bool PrimaryHeld() => Connected() && Input.GetKey(BtnRb);
+        public bool SecondaryDown() => Connected() && Input.GetKeyDown(BtnLb);
+
+        // No direct 1..9 pick on a pad — the hotbar is cycled via HotbarScroll (d-pad) instead.
+        public int HotbarSlotDown() => -1;
+
+        /// <summary>The pad button bound to a discrete action, or <see cref="KeyCode.None"/> if this action
+        /// isn't on the pad yet (it then stays keyboard-only — sources are combined, so nothing is lost).
+        /// A fuller binding set is follow-up work (issue #195).</summary>
+        public static KeyCode ButtonFor(InputAction action) => action switch
+        {
+            InputAction.Interact => BtnX,
+            InputAction.ToggleThirdPerson => BtnY,
+            InputAction.FlightEnterInterior => BtnY,
+            _ => KeyCode.None,
+        };
+
+        public bool ActionDown(InputAction action)
+        {
+            var b = ButtonFor(action);
+            return b != KeyCode.None && Connected() && Input.GetKeyDown(b);
+        }
+
+        public bool ActionHeld(InputAction action)
+        {
+            var b = ButtonFor(action);
+            return b != KeyCode.None && Connected() && Input.GetKey(b);
+        }
+
+        public bool ActionUp(InputAction action)
+        {
+            var b = ButtonFor(action);
+            return b != KeyCode.None && Connected() && Input.GetKeyUp(b);
+        }
+
+        public bool HadActivityThisFrame()
+        {
+            if (!Connected())
+            {
+                return false;
+            }
+
+            // Any of our mapped buttons, or a stick/d-pad pushed past the deadzone.
+            if (Input.GetKey(BtnA) || Input.GetKey(BtnB) || Input.GetKey(BtnX) || Input.GetKey(BtnY)
+                || Input.GetKey(BtnLb) || Input.GetKey(BtnRb))
+            {
+                return true;
+            }
+
+            // Left stick shows up on the shared Horizontal/Vertical axes; sample those too so simply
+            // steering with the stick flips the glyphs to the pad set.
+            bool moved = Mathf.Abs(Deadzoned(Input.GetAxis("Horizontal"))) > 0f
+                      || Mathf.Abs(Deadzoned(Input.GetAxis("Vertical"))) > 0f
+                      || Mathf.Abs(Deadzoned(Input.GetAxis(AxisRightStickX))) > 0f
+                      || Mathf.Abs(Deadzoned(Input.GetAxis(AxisRightStickY))) > 0f
+                      || Mathf.Abs(Deadzoned(Input.GetAxis(AxisDpadX))) > 0f;
+            return moved;
+        }
+    }
+}

--- a/client/Assets/BlocksBeyondTheStars/Scripts/Input/GamepadInputSource.cs.meta
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/Input/GamepadInputSource.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 76d2437a82c55b146a68edcd251b5e4d

--- a/client/Assets/BlocksBeyondTheStars/Scripts/Input/IInputSource.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/Input/IInputSource.cs
@@ -1,0 +1,58 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+
+namespace BlocksBeyondTheStars.Client
+{
+    /// <summary>Which family of hardware last drove input — used only to pick which button glyphs to show
+    /// (keyboard letters vs pad face buttons). It never gates input: every source stays live at once
+    /// (see <see cref="InputMap"/>), so a player can mix mouse + pad freely.</summary>
+    public enum InputDeviceKind
+    {
+        KeyboardMouse,
+        Gamepad,
+    }
+
+    /// <summary>
+    /// One hardware input backend, expressed as the game's control verbs rather than raw keys/axes. The
+    /// gameplay code (<see cref="PlayerController"/>, <see cref="SpaceView"/>) reads these through
+    /// <see cref="InputMap"/> instead of polling <c>UnityEngine.Input</c> directly, so a new backend
+    /// (gamepad, touch) is added by implementing this interface — no gameplay changes.
+    ///
+    /// Continuous getters return the SAME units the legacy call sites expected, so the keyboard+mouse
+    /// implementation is behaviour-preserving: move axes are −1..1 (like <c>GetAxis("Horizontal")</c>),
+    /// and the look deltas are raw per-frame deltas (like <c>GetAxis("Mouse X"/"Mouse Y")</c>) that the
+    /// caller still multiplies by its own sensitivity. A gamepad backend scales its stick into the same
+    /// space (rate × <c>Time.deltaTime</c>) so the caller math is untouched.
+    /// </summary>
+    public interface IInputSource
+    {
+        InputDeviceKind Kind { get; }
+
+        /// <summary>True if this backend saw ANY input this frame — drives the active-device glyph choice.</summary>
+        bool HadActivityThisFrame();
+
+        // Continuous — locomotion + camera.
+        float MoveX();        // strafe, −1 (left) .. +1 (right)   — mirrors GetAxis("Horizontal")
+        float MoveY();        // forward, −1 (back) .. +1 (fwd)    — mirrors GetAxis("Vertical")
+        float LookX();        // yaw delta, caller multiplies by sensitivity   — mirrors GetAxis("Mouse X")
+        float LookY();        // pitch delta, caller multiplies by sensitivity — mirrors GetAxis("Mouse Y")
+        float HotbarScroll(); // >0 = previous slot, <0 = next slot — mirrors GetAxis("Mouse ScrollWheel")
+
+        // Standard action buttons — the continuous/pointer core that was NOT rebindable before.
+        bool JumpHeld();
+        bool JumpDown();
+        bool CrouchHeld();    // descend / climb-down (Ctrl/C on keyboard)
+        bool PrimaryDown();   // mine / attack / scan tap (left mouse)
+        bool PrimaryHeld();   // keep-mining hold (left mouse held)
+        bool SecondaryDown(); // place block / use held item (right mouse)
+
+        /// <summary>The hotbar slot 0..8 selected THIS frame by a direct pick (number keys / d-pad), or −1.</summary>
+        int HotbarSlotDown();
+
+        // Discrete, rebindable actions (the pre-existing InputMap set: Interact, PrimaryFire, …).
+        bool ActionDown(InputAction action);
+        bool ActionHeld(InputAction action);
+        bool ActionUp(InputAction action);
+    }
+}

--- a/client/Assets/BlocksBeyondTheStars/Scripts/Input/IInputSource.cs.meta
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/Input/IInputSource.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5af1ea5bd6021834b8dd21edd14d3dbb

--- a/client/Assets/BlocksBeyondTheStars/Scripts/InputMap.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/InputMap.cs
@@ -41,15 +41,57 @@ namespace BlocksBeyondTheStars.Client
     }
 
     /// <summary>
-    /// Central indirection over Unity's legacy Input so every key flows through the player's bindings
-    /// (<see cref="ClientSettings"/>) instead of a hardcoded <see cref="KeyCode"/> — the foundation for
-    /// rebindable controls. Call <see cref="Use"/> once at startup with the loaded settings; an unbound action
-    /// falls back to <see cref="DefaultKey"/> (the key it had before remapping existed), so migrating a call
-    /// site is behaviour-preserving until the player actually rebinds it.
+    /// Central indirection over the game's input. Two things flow through here: (1) discrete rebindable
+    /// actions (<see cref="InputAction"/>) resolved to a <see cref="KeyCode"/> through the player's bindings
+    /// (<see cref="ClientSettings"/>), and (2) the continuous locomotion/camera/interaction core (move, look,
+    /// jump, mine/place, hotbar) that used to poll <c>UnityEngine.Input</c> directly.
+    ///
+    /// Rather than switching between input devices (a mode that could strand the keyboard), the map
+    /// <b>combines</b> a keyboard/mouse backend and a gamepad backend: every getter reads BOTH and merges
+    /// them, so a player can mix mouse and pad and neither can lock the other out. With no pad connected the
+    /// gamepad backend returns zero/false, so this is exactly the legacy behaviour — the abstraction is
+    /// behaviour-preserving on keyboard+mouse. <see cref="ActiveDevice"/> tracks which family was used most
+    /// recently, purely to choose which button glyphs to show (see <see cref="Glyph"/>).
+    ///
+    /// Call <see cref="Use"/> once at startup with the loaded settings; an unbound action falls back to
+    /// <see cref="DefaultKey"/> (the key it had before remapping existed).
     /// </summary>
     public static class InputMap
     {
         private static ClientSettings _settings;
+
+        // The two live backends. Both are polled every frame and merged; see the class summary.
+        private static readonly IInputSource _desktop = new DesktopInputSource();
+        private static readonly IInputSource _pad = new GamepadInputSource();
+
+        private static int _deviceFrame = -1;
+        private static InputDeviceKind _activeDevice = InputDeviceKind.KeyboardMouse;
+
+        /// <summary>The input family used most recently — drives which glyphs the HUD shows. Recomputed at
+        /// most once per frame; sticks to the last device when neither backend is active this frame.</summary>
+        public static InputDeviceKind ActiveDevice
+        {
+            get
+            {
+                if (Time.frameCount != _deviceFrame)
+                {
+                    _deviceFrame = Time.frameCount;
+                    if (_pad.HadActivityThisFrame())
+                    {
+                        _activeDevice = InputDeviceKind.Gamepad;
+                    }
+                    else if (_desktop.HadActivityThisFrame())
+                    {
+                        _activeDevice = InputDeviceKind.KeyboardMouse;
+                    }
+                }
+
+                return _activeDevice;
+            }
+        }
+
+        /// <summary>True if a gamepad is connected (any slot). Cheap; safe to poll from UI.</summary>
+        public static bool GamepadConnected => GamepadInputSource.Connected();
 
         /// <summary>On-foot actions exposed in the controls-rebinding UI, in display order.</summary>
         public static readonly InputAction[] Remappable =
@@ -114,8 +156,81 @@ namespace BlocksBeyondTheStars.Client
             return !string.IsNullOrEmpty(name) && System.Enum.TryParse<KeyCode>(name, out var kc) ? kc : def;
         }
 
-        public static bool Down(InputAction action) => Input.GetKeyDown(Key(action));
-        public static bool Held(InputAction action) => Input.GetKey(Key(action));
-        public static bool Up(InputAction action) => Input.GetKeyUp(Key(action));
+        // Discrete rebindable actions — now combined across both backends so a pad button and the bound key
+        // both fire the action. The keyboard resolution is unchanged (DesktopInputSource calls Key(action)).
+        public static bool Down(InputAction action) => _desktop.ActionDown(action) || _pad.ActionDown(action);
+        public static bool Held(InputAction action) => _desktop.ActionHeld(action) || _pad.ActionHeld(action);
+        public static bool Up(InputAction action) => _desktop.ActionUp(action) || _pad.ActionUp(action);
+
+        // ---- Continuous locomotion / camera / interaction core -------------------------------------------
+        // Each merges the two backends. Movement + look are additive (mouse delta + stick delta); the
+        // button verbs OR together. This is what the migrated PlayerController/SpaceView call sites read
+        // instead of Input.GetAxis / GetButton / GetMouseButton.
+
+        /// <summary>Strafe axis, −1..1 — replaces <c>Input.GetAxis("Horizontal")</c>.</summary>
+        public static float MoveX() => Mathf.Clamp(_desktop.MoveX() + _pad.MoveX(), -1f, 1f);
+
+        /// <summary>Forward axis, −1..1 — replaces <c>Input.GetAxis("Vertical")</c>.</summary>
+        public static float MoveY() => Mathf.Clamp(_desktop.MoveY() + _pad.MoveY(), -1f, 1f);
+
+        /// <summary>Yaw look delta (caller still multiplies by sensitivity) — replaces <c>GetAxis("Mouse X")</c>.</summary>
+        public static float LookX() => _desktop.LookX() + _pad.LookX();
+
+        /// <summary>Pitch look delta (caller still multiplies by sensitivity) — replaces <c>GetAxis("Mouse Y")</c>.</summary>
+        public static float LookY() => _desktop.LookY() + _pad.LookY();
+
+        /// <summary>Hotbar scroll: &gt;0 = previous slot, &lt;0 = next — replaces <c>GetAxis("Mouse ScrollWheel")</c>.
+        /// Mouse wheel takes precedence; the pad d-pad fills in when the wheel is idle.</summary>
+        public static float HotbarScroll()
+        {
+            float d = _desktop.HotbarScroll();
+            return Mathf.Abs(d) > 0.0001f ? d : _pad.HotbarScroll();
+        }
+
+        public static bool JumpHeld() => _desktop.JumpHeld() || _pad.JumpHeld();
+        public static bool JumpDown() => _desktop.JumpDown() || _pad.JumpDown();
+        public static bool CrouchHeld() => _desktop.CrouchHeld() || _pad.CrouchHeld();
+        public static bool PrimaryDown() => _desktop.PrimaryDown() || _pad.PrimaryDown();
+        public static bool PrimaryHeld() => _desktop.PrimaryHeld() || _pad.PrimaryHeld();
+        public static bool SecondaryDown() => _desktop.SecondaryDown() || _pad.SecondaryDown();
+
+        /// <summary>Hotbar slot 0..8 picked directly this frame (number keys), or −1. The pad has no direct
+        /// pick (it cycles via <see cref="HotbarScroll"/>), so this is the keyboard's answer.</summary>
+        public static int HotbarSlotDown()
+        {
+            int s = _desktop.HotbarSlotDown();
+            return s >= 0 ? s : _pad.HotbarSlotDown();
+        }
+
+        // ---- Glyphs -------------------------------------------------------------------------------------
+
+        /// <summary>A short on-screen label for an action's control, matched to the <see cref="ActiveDevice"/>:
+        /// the pad face-button letter when a pad is in use and the action is mapped, otherwise the bound
+        /// keyboard key. Used for HUD control hints so they read correctly whichever device is in hand.</summary>
+        public static string Glyph(InputAction action)
+        {
+            if (ActiveDevice == InputDeviceKind.Gamepad)
+            {
+                string pad = PadGlyph(GamepadInputSource.ButtonFor(action));
+                if (pad != null)
+                {
+                    return pad;
+                }
+            }
+
+            return Key(action).ToString();
+        }
+
+        /// <summary>Human label for a pad button, or null if it isn't one of the mapped face buttons.</summary>
+        private static string PadGlyph(KeyCode button) => button switch
+        {
+            KeyCode.JoystickButton0 => "(A)",
+            KeyCode.JoystickButton1 => "(B)",
+            KeyCode.JoystickButton2 => "(X)",
+            KeyCode.JoystickButton3 => "(Y)",
+            KeyCode.JoystickButton4 => "LB",
+            KeyCode.JoystickButton5 => "RB",
+            _ => null,
+        };
     }
 }

--- a/client/Assets/BlocksBeyondTheStars/Scripts/PlayerController.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/PlayerController.cs
@@ -649,7 +649,7 @@ namespace BlocksBeyondTheStars.Client
         /// plants) — hard materials need a drill. (#128)</summary>
         private void HandleDrillAudio()
         {
-            if (Camera == null || !Input.GetMouseButton(0))
+            if (Camera == null || !InputMap.PrimaryHeld())
             {
                 return;
             }
@@ -1111,15 +1111,13 @@ namespace BlocksBeyondTheStars.Client
                 return;
             }
 
-            for (int i = 0; i < HotbarSlots; i++)
+            int pick = InputMap.HotbarSlotDown();
+            if (pick >= 0 && pick < HotbarSlots)
             {
-                if (Input.GetKeyDown(KeyCode.Alpha1 + i))
-                {
-                    SelectSlot(i);
-                }
+                SelectSlot(pick);
             }
 
-            float scroll = Input.GetAxis("Mouse ScrollWheel");
+            float scroll = InputMap.HotbarScroll();
             if (scroll > 0f)
             {
                 SelectSlot((Game.SelectedHotbarSlot + HotbarSlots - 1) % HotbarSlots);
@@ -1167,7 +1165,7 @@ namespace BlocksBeyondTheStars.Client
 
         /// <summary>Cinematic-capture hooks (<see cref="ClipDirector"/>): drive the on-foot player's walk + look
         /// without keyboard input so a recorded clip shows the character actually moving. <see cref="_captureWalk"/>
-        /// gates this — when false the normal <c>Input.GetAxis</c> path is untouched in regular play.</summary>
+        /// gates this — when false the normal <c>InputMap.MoveX/MoveY</c> path is untouched in regular play.</summary>
         private bool _captureWalk;
         private float _captureH, _captureV;
         public void SetWalkInput(float horizontal, float vertical)
@@ -1287,8 +1285,8 @@ namespace BlocksBeyondTheStars.Client
 
         private void LookAround()
         {
-            float mx = Input.GetAxis("Mouse X") * MouseSensitivity;
-            float my = Input.GetAxis("Mouse Y") * MouseSensitivity * (InvertY ? -1f : 1f);
+            float mx = InputMap.LookX() * MouseSensitivity;
+            float my = InputMap.LookY() * MouseSensitivity * (InvertY ? -1f : 1f);
             transform.Rotate(0f, mx, 0f);
             _pitch = Mathf.Clamp(_pitch - my, -89f, 89f);
             if (Camera != null)
@@ -1338,7 +1336,7 @@ namespace BlocksBeyondTheStars.Client
             }
 
             // Chase camera behind + above the speeder; mouse Y tilts it.
-            float my = Input.GetAxis("Mouse Y") * MouseSensitivity * (InvertY ? -1f : 1f);
+            float my = InputMap.LookY() * MouseSensitivity * (InvertY ? -1f : 1f);
             _speederCamPitch = Mathf.Clamp(_speederCamPitch - my, -8f, 35f);
             if (Camera != null)
             {
@@ -1349,8 +1347,8 @@ namespace BlocksBeyondTheStars.Client
             var driven = Game.DrivenSpeeder;
             bool outOfFuel = driven != null && driven.Fuel <= 0.01f;
 
-            float throttle = Input.GetAxis("Vertical");   // W = +1, S = -1 (brake / reverse)
-            float steer = Input.GetAxis("Horizontal");    // A = -1, D = +1
+            float throttle = InputMap.MoveY();   // W = +1, S = -1 (brake / reverse)
+            float steer = InputMap.MoveX();    // A = -1, D = +1
             bool boosting = InputMap.Held(InputAction.SpeederBoost) && !outOfFuel && throttle > 0.1f;
 
             // Steering scales with speed (no pirouetting while parked).
@@ -1374,7 +1372,7 @@ namespace BlocksBeyondTheStars.Client
                 vSpeed = -Gravity * 0.2f;
             }
 
-            if (Input.GetButtonDown("Jump") && !outOfFuel)
+            if (InputMap.JumpDown() && !outOfFuel)
             {
                 vSpeed = SpeederHopSpeed; // a quick hover-hop over a low obstacle
             }
@@ -1512,8 +1510,8 @@ namespace BlocksBeyondTheStars.Client
 
         private void Move()
         {
-            float h = _captureWalk ? _captureH : Input.GetAxis("Horizontal");
-            float v = _captureWalk ? _captureV : Input.GetAxis("Vertical");
+            float h = _captureWalk ? _captureH : InputMap.MoveX();
+            float v = _captureWalk ? _captureV : InputMap.MoveY();
             Vector3 move = (transform.right * h + transform.forward * v) * _effMoveSpeed;
 
             float prevVy = _verticalVelocity; // captured before the grounded reset (for landing shake)
@@ -1533,14 +1531,14 @@ namespace BlocksBeyondTheStars.Client
                 // full forward speed so you mount the land instead.
                 bool pushing = Mathf.Abs(h) + Mathf.Abs(v) > 0.1f;
                 bool atSurface = BlockKeyAt(transform.position + Vector3.up * 1.9f) != "water"; // open air above the head
-                bool climbingOut = pushing && atSurface && (Input.GetButton("Jump") || LedgeAhead(move));
+                bool climbingOut = pushing && atSurface && (InputMap.JumpHeld() || LedgeAhead(move));
                 if (climbingOut)
                 {
                     _verticalVelocity = _effJumpSpeed; // real hop out of the water (full forward speed kept below)
                 }
                 else
                 {
-                    float target = Input.GetButton("Jump") ? SwimUpSpeed : -SwimSinkSpeed;
+                    float target = InputMap.JumpHeld() ? SwimUpSpeed : -SwimSinkSpeed;
                     _verticalVelocity = Mathf.MoveTowards(_verticalVelocity, target, SwimAccel * Time.deltaTime);
                     move *= SwimSpeedMul;
                 }
@@ -1549,25 +1547,25 @@ namespace BlocksBeyondTheStars.Client
             {
                 // Climbing (Minecraft-style): no gravity while on a ladder. Hold Jump or push forward to go up,
                 // crouch (Ctrl/C) or pull back to go down; otherwise cling with a gentle slide. (#126)
-                bool up = Input.GetButton("Jump") || v > 0.1f;
-                bool down = Input.GetKey(KeyCode.LeftControl) || Input.GetKey(KeyCode.C) || v < -0.1f;
+                bool up = InputMap.JumpHeld() || v > 0.1f;
+                bool down = InputMap.CrouchHeld() || v < -0.1f;
                 _verticalVelocity = up ? ClimbSpeed : (down ? -ClimbSpeed : -1f);
             }
             else if (grounded)
             {
-                if (Input.GetButtonDown("Jump"))
+                if (InputMap.JumpDown())
                 {
                     ClientAudio.Instance?.Cue("jump", 0.6f);
                 }
 
-                _verticalVelocity = Input.GetButton("Jump") ? _effJumpSpeed : -1f;
+                _verticalVelocity = InputMap.JumpHeld() ? _effJumpSpeed : -1f;
             }
             else if (Game != null && Game.OnFootInSpace)
             {
                 // Above the atmosphere there is no gravity: float, never fall. Jump rises, crouch (Ctrl/C)
                 // sinks, otherwise the suit drifts to a gentle stop. (Set by item 10 — building up into space.)
-                float lift = (Input.GetButton("Jump") ? SpaceFloatSpeed : 0f)
-                           - ((Input.GetKey(KeyCode.LeftControl) || Input.GetKey(KeyCode.C)) ? SpaceFloatSpeed : 0f);
+                float lift = (InputMap.JumpHeld() ? SpaceFloatSpeed : 0f)
+                           - ((InputMap.CrouchHeld()) ? SpaceFloatSpeed : 0f);
                 _verticalVelocity = Mathf.MoveTowards(_verticalVelocity, lift, SpaceFloatAccel * Time.deltaTime);
             }
             else
@@ -1576,7 +1574,7 @@ namespace BlocksBeyondTheStars.Client
 
                 // Jetpack: hold Jump in the air to thrust upward (needs the item + suit energy). The server
                 // drains energy on the reported state and forces it off when empty (SuitEnergy then hits 0).
-                if (Input.GetButton("Jump") && CanJetpack())
+                if (InputMap.JumpHeld() && CanJetpack())
                 {
                     jetpacking = true;
                     _verticalVelocity += _effJetpackAccel * Time.deltaTime;
@@ -1765,8 +1763,8 @@ namespace BlocksBeyondTheStars.Client
                 return;
             }
 
-            bool mine = Input.GetMouseButtonDown(0);
-            bool place = Input.GetMouseButtonDown(1);
+            bool mine = InputMap.PrimaryDown();
+            bool place = InputMap.SecondaryDown();
             if (!mine && !place)
             {
                 return;

--- a/client/Assets/BlocksBeyondTheStars/Scripts/SpaceView.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/SpaceView.cs
@@ -34,7 +34,7 @@ namespace BlocksBeyondTheStars.Client
         private float _captureThrottle = -1f;
         public void SetFlightThrottle(float throttle) => _captureThrottle = throttle < 0f ? -1f : Mathf.Clamp01(throttle);
         public void SetFlightPitch(float pitchDeg) => _pitch = Mathf.Clamp(pitchDeg, -80f, 80f);
-        private float CaptureForward() => _captureThrottle >= 0f ? _captureThrottle : Input.GetAxis("Vertical");
+        private float CaptureForward() => _captureThrottle >= 0f ? _captureThrottle : InputMap.MoveY();
 
         // --- Cinematic landing hooks (ClipDirector): a hands-off version of the player's fly-in → pick-pad → land. ---
         public bool CaptureLandMapShowing => _landMapGo != null;
@@ -1029,7 +1029,7 @@ namespace BlocksBeyondTheStars.Client
             if (_autopilot && TryAutopilotTarget(out var apTarget, out float apArriveSq))
             {
                 // Manual input takes the helm back instantly.
-                if (Mathf.Abs(Input.GetAxis("Vertical")) > 0.25f || Mathf.Abs(Input.GetAxis("Horizontal")) > 0.25f)
+                if (Mathf.Abs(InputMap.MoveY()) > 0.25f || Mathf.Abs(InputMap.MoveX()) > 0.25f)
                 {
                     SetAutopilot(false);
                 }
@@ -1055,10 +1055,10 @@ namespace BlocksBeyondTheStars.Client
             }
             else
             {
-                _yaw += Input.GetAxis("Mouse X") * LookSpeed * _shipTurnMul;
-                _pitch = Mathf.Clamp(_pitch - Input.GetAxis("Mouse Y") * LookSpeed * _shipTurnMul, -80f, 80f);
+                _yaw += InputMap.LookX() * LookSpeed * _shipTurnMul;
+                _pitch = Mathf.Clamp(_pitch - InputMap.LookY() * LookSpeed * _shipTurnMul, -80f, 80f);
                 fwd = CaptureForward();
-                strafe = Input.GetAxis("Horizontal");
+                strafe = InputMap.MoveX();
             }
 
             var rot = Quaternion.Euler(_pitch, _yaw, 0f);
@@ -1200,7 +1200,7 @@ namespace BlocksBeyondTheStars.Client
             {
                 var target = BestFireTarget();
                 _fireTargetId = target?.Id;
-                if (target != null && _fireCd <= 0f && Input.GetMouseButton(0))
+                if (target != null && _fireCd <= 0f && InputMap.PrimaryHeld())
                 {
                     _fireCd = FireRate;
                     FireAt(target, sys.WeaponKey);
@@ -1212,7 +1212,7 @@ namespace BlocksBeyondTheStars.Client
                 // a blind radius sweep was impossible to aim in 3D, where depth is hard to judge.
                 var drop = BestTractorTarget();
                 _fireTargetId = drop?.Id;
-                if (_fireCd <= 0f && Input.GetMouseButtonDown(0))
+                if (_fireCd <= 0f && InputMap.PrimaryDown())
                 {
                     _fireCd = 0.6f;
                     ActivateTractor(drop);
@@ -1619,15 +1619,15 @@ namespace BlocksBeyondTheStars.Client
             }
 
             // Free-look.
-            _evaYaw += Input.GetAxis("Mouse X") * LookSpeed;
-            _evaPitch = Mathf.Clamp(_evaPitch - Input.GetAxis("Mouse Y") * LookSpeed, -89f, 89f);
+            _evaYaw += InputMap.LookX() * LookSpeed;
+            _evaPitch = Mathf.Clamp(_evaPitch - InputMap.LookY() * LookSpeed, -89f, 89f);
             var rot = Quaternion.Euler(_evaPitch, _evaYaw, 0f);
 
             // 6-DOF thrust: WASD in the look plane, Space/Ctrl for world up/down.
-            float fwd = Input.GetAxis("Vertical");
-            float strafe = Input.GetAxis("Horizontal");
-            float lift = (Input.GetKey(KeyCode.Space) ? 1f : 0f)
-                       - ((Input.GetKey(KeyCode.LeftControl) || Input.GetKey(KeyCode.C)) ? 1f : 0f);
+            float fwd = InputMap.MoveY();
+            float strafe = InputMap.MoveX();
+            float lift = (InputMap.JumpHeld() ? 1f : 0f)
+                       - ((InputMap.CrouchHeld()) ? 1f : 0f);
             Vector3 dir = rot * (Vector3.forward * fwd + Vector3.right * strafe) + Vector3.up * lift;
             Vector3 delta = dir * (EvaSpeed * Time.deltaTime);
 
@@ -1910,7 +1910,7 @@ namespace BlocksBeyondTheStars.Client
                 }
             }
 
-            float scroll = Input.GetAxis("Mouse ScrollWheel");
+            float scroll = InputMap.HotbarScroll();
             if (scroll > 0f) { SelectEvaSlot((Game.SelectedHotbarSlot + slots - 1) % slots); }
             else if (scroll < 0f) { SelectEvaSlot((Game.SelectedHotbarSlot + 1) % slots); }
         }
@@ -1932,11 +1932,11 @@ namespace BlocksBeyondTheStars.Client
                 return;
             }
 
-            if (Input.GetMouseButtonDown(0))
+            if (InputMap.PrimaryDown())
             {
                 Game.Network?.SendStructureEdit(_evaAimStructId, _evaAimHit.x, _evaAimHit.y, _evaAimHit.z, mine: true);
             }
-            else if (Input.GetMouseButtonDown(1))
+            else if (InputMap.SecondaryDown())
             {
                 string item = Game.ItemInSlot(Game.SelectedHotbarSlot) ?? string.Empty;
                 var def = string.IsNullOrEmpty(item) ? null : Game.Content?.GetItem(item);
@@ -4021,7 +4021,7 @@ namespace BlocksBeyondTheStars.Client
             _instLastCamPos = Camera.transform.position;
             _instSpeed = Mathf.Lerp(_instSpeed, Mathf.Min(raw, 999f), 0.15f);
 
-            int thr = Mathf.RoundToInt(Mathf.Clamp01(Input.GetAxis("Vertical")) * 100f);
+            int thr = Mathf.RoundToInt(Mathf.Clamp01(InputMap.MoveY()) * 100f);
             int hdg = Mathf.RoundToInt(Mathf.Repeat(_yaw, 360f));
             string text = $"SPD {_instSpeed:0.0}   THR {thr}%   HDG {hdg:000}°";
             var combat = Game?.ShipCombat;

--- a/client/Assets/BlocksBeyondTheStars/Scripts/UiMainMenu.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/UiMainMenu.cs
@@ -19,6 +19,7 @@ namespace BlocksBeyondTheStars.Client
         {
             var canvas = UiKit.CreateCanvas("MainMenuUI");
             var root = canvas.transform;
+            UiNav.Enable(canvas.gameObject); // let a gamepad drive the menu (inert on keyboard/mouse)
 
             // --- SYSTEM CHECK panel (decorative flavour) ---
             UiKit.AddPanel(root, 40f, 40f, 280f, 220f, UiKit.PanelFill);

--- a/client/Assets/BlocksBeyondTheStars/Scripts/UiNav.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/UiNav.cs
@@ -1,0 +1,83 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.UI;
+
+namespace BlocksBeyondTheStars.Client
+{
+    /// <summary>
+    /// Makes a menu navigable by gamepad. uGUI's <c>StandaloneInputModule</c> already turns the pad into
+    /// directional navigation + Submit(A)/Cancel(B) via the project's InputManager axes, and buttons built by
+    /// <see cref="UiKit.AddButton"/> default to <c>Navigation.Automatic</c> — so the ONE missing piece is that
+    /// a mouse-built menu has nothing selected, leaving the stick with no cursor to move. This component fixes
+    /// exactly that: while a gamepad is the active device and this menu has no valid selection, it selects the
+    /// first interactable control in its own subtree. It is completely inert on keyboard/mouse (so it never
+    /// steals the pointer), and self-healing (re-focuses if the selected control is hidden or destroyed).
+    ///
+    /// Attach with <see cref="UiNav.Enable"/> on a menu's root object. Full coverage across every panel is
+    /// tracked as follow-up (issue #195) and wants on-device validation — CI can't test a pad.
+    /// </summary>
+    [DisallowMultipleComponent]
+    public sealed class UiNavFocus : MonoBehaviour
+    {
+        private void Update()
+        {
+            if (InputMap.ActiveDevice != InputDeviceKind.Gamepad)
+            {
+                return; // keyboard/mouse in hand — leave selection entirely to the pointer.
+            }
+
+            var es = EventSystem.current;
+            if (es == null)
+            {
+                return;
+            }
+
+            var current = es.currentSelectedGameObject;
+            if (current != null && current.activeInHierarchy)
+            {
+                var sel = current.GetComponent<Selectable>();
+                if (sel != null && sel.IsInteractable())
+                {
+                    return; // a valid control is focused — nothing to do.
+                }
+            }
+
+            var first = FirstInteractable();
+            if (first != null)
+            {
+                es.SetSelectedGameObject(first.gameObject);
+            }
+        }
+
+        private Selectable FirstInteractable()
+        {
+            var all = GetComponentsInChildren<Selectable>(includeInactive: false);
+            for (int i = 0; i < all.Length; i++)
+            {
+                if (all[i].IsInteractable() && all[i].gameObject.activeInHierarchy)
+                {
+                    return all[i];
+                }
+            }
+
+            return null;
+        }
+    }
+
+    /// <summary>Helpers for wiring gamepad menu navigation onto a menu root.</summary>
+    public static class UiNav
+    {
+        /// <summary>Ensures <paramref name="menuRoot"/> auto-focuses its first control for a gamepad. Idempotent.</summary>
+        public static void Enable(GameObject menuRoot)
+        {
+            if (menuRoot != null && menuRoot.GetComponent<UiNavFocus>() == null)
+            {
+                menuRoot.AddComponent<UiNavFocus>();
+            }
+        }
+    }
+}

--- a/client/Assets/BlocksBeyondTheStars/Scripts/UiNav.cs.meta
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/UiNav.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 594c1f187b4a8c54585e53dea7fa0320

--- a/client/Assets/Tests/EditMode/InputAbstractionEditModeTests.cs
+++ b/client/Assets/Tests/EditMode/InputAbstractionEditModeTests.cs
@@ -1,0 +1,90 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using BlocksBeyondTheStars.Client;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace BlocksBeyondTheStars.Client.Tests.EditMode
+{
+    /// <summary>
+    /// Headless (no graphics, no hardware) tests for the input abstraction. They pin the two guarantees that
+    /// CAN be checked without a physical pad: (1) the gamepad source is fully inert when no joystick is
+    /// connected — the property that makes the keyboard/mouse path behaviour-preserving — and (2) the pure
+    /// mapping tables (button-for-action, key resolution, glyphs) are correct. The actual on-hardware feel of
+    /// sticks/buttons is a manual pass (issue #195); CI cannot exercise a controller. See
+    /// docs/developer/CLIENT_TESTING.md.
+    /// </summary>
+    public sealed class InputAbstractionEditModeTests
+    {
+        // ---- Gamepad source is inert with no pad connected (behaviour-preservation guarantee) -------------
+
+        [Test]
+        public void GamepadSource_WithNoPad_ProducesNoMovementOrLook()
+        {
+            // The test runner has no joystick, so Connected() is false and every continuous getter must be 0.
+            Assume.That(GamepadInputSource.Connected(), Is.False, "test host unexpectedly has a joystick");
+            var pad = new GamepadInputSource();
+
+            Assert.AreEqual(0f, pad.MoveX());
+            Assert.AreEqual(0f, pad.MoveY());
+            Assert.AreEqual(0f, pad.LookX());
+            Assert.AreEqual(0f, pad.LookY());
+            Assert.AreEqual(0f, pad.HotbarScroll());
+        }
+
+        [Test]
+        public void GamepadSource_WithNoPad_ReportsNoButtonsAndNoActivity()
+        {
+            Assume.That(GamepadInputSource.Connected(), Is.False);
+            var pad = new GamepadInputSource();
+
+            Assert.IsFalse(pad.JumpHeld());
+            Assert.IsFalse(pad.JumpDown());
+            Assert.IsFalse(pad.CrouchHeld());
+            Assert.IsFalse(pad.PrimaryDown());
+            Assert.IsFalse(pad.PrimaryHeld());
+            Assert.IsFalse(pad.SecondaryDown());
+            Assert.AreEqual(-1, pad.HotbarSlotDown());
+            Assert.IsFalse(pad.HadActivityThisFrame());
+            Assert.IsFalse(pad.ActionDown(InputAction.Interact));
+        }
+
+        // ---- Pure mapping tables --------------------------------------------------------------------------
+
+        [Test]
+        public void ButtonFor_MapsInteractToX_AndLeavesUnmappedActionsUnbound()
+        {
+            Assert.AreEqual(KeyCode.JoystickButton2, GamepadInputSource.ButtonFor(InputAction.Interact));
+            Assert.AreEqual(KeyCode.JoystickButton3, GamepadInputSource.ButtonFor(InputAction.ToggleThirdPerson));
+            // An action with no pad binding stays keyboard-only (KeyCode.None) — the combined map keeps it usable.
+            Assert.AreEqual(KeyCode.None, GamepadInputSource.ButtonFor(InputAction.LootContainer));
+        }
+
+        [Test]
+        public void Key_UsesDefault_WhenUnbound_AndOverride_WhenBound()
+        {
+            var settings = new ClientSettings();
+            InputMap.Use(settings);
+            Assert.AreEqual(KeyCode.E, InputMap.Key(InputAction.Interact), "default should hold when unbound");
+
+            settings.SetBoundKey(InputAction.Interact.ToString(), KeyCode.Q.ToString());
+            InputMap.Use(settings);
+            Assert.AreEqual(KeyCode.Q, InputMap.Key(InputAction.Interact), "player override should win");
+
+            // Reset so later tests / play sessions see stock bindings.
+            settings.SetBoundKey(InputAction.Interact.ToString(), "");
+            InputMap.Use(settings);
+        }
+
+        [Test]
+        public void Glyph_ShowsBoundKey_OnKeyboardMouse()
+        {
+            InputMap.Use(new ClientSettings());
+            // No hardware activity in the headless runner, so the active device stays keyboard/mouse and the
+            // glyph is the bound key name rather than a pad face-button label.
+            Assert.AreEqual(InputDeviceKind.KeyboardMouse, InputMap.ActiveDevice);
+            Assert.AreEqual("E", InputMap.Glyph(InputAction.Interact));
+        }
+    }
+}

--- a/client/Assets/Tests/EditMode/InputAbstractionEditModeTests.cs.meta
+++ b/client/Assets/Tests/EditMode/InputAbstractionEditModeTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a8bbf1561e1fa4f41afb01daa937efb1

--- a/client/ProjectSettings/InputManager.asset
+++ b/client/ProjectSettings/InputManager.asset
@@ -485,4 +485,52 @@ InputManager:
     type: 2
     axis: 5
     joyNum: 0
+  - serializedVersion: 3
+    m_Name: RightStickX
+    descriptiveName:
+    descriptiveNegativeName:
+    negativeButton:
+    positiveButton:
+    altNegativeButton:
+    altPositiveButton:
+    gravity: 0
+    dead: 0.19
+    sensitivity: 1
+    snap: 0
+    invert: 0
+    type: 2
+    axis: 3
+    joyNum: 0
+  - serializedVersion: 3
+    m_Name: RightStickY
+    descriptiveName:
+    descriptiveNegativeName:
+    negativeButton:
+    positiveButton:
+    altNegativeButton:
+    altPositiveButton:
+    gravity: 0
+    dead: 0.19
+    sensitivity: 1
+    snap: 0
+    invert: 1
+    type: 2
+    axis: 4
+    joyNum: 0
+  - serializedVersion: 3
+    m_Name: DPadX
+    descriptiveName:
+    descriptiveNegativeName:
+    negativeButton:
+    positiveButton:
+    altNegativeButton:
+    altPositiveButton:
+    gravity: 0
+    dead: 0.19
+    sensitivity: 1
+    snap: 0
+    invert: 0
+    type: 2
+    axis: 5
+    joyNum: 0
   m_UsePhysicalKeys: 1

--- a/data/locales/de.json
+++ b/data/locales/de.json
@@ -451,6 +451,7 @@
   "mission.settlement.gather.title": "Versorgungsauftrag der Siedlung",
   "mission.settlement.gather.desc": "Liefere die geforderten Rohstoffe am Missionsboard der Siedlung ab und erhalte eine Belohnung.",
   "ui.hud.hint": "WASD bewegen · LMT abbauen · RMT setzen · 1-9 Hotbar · F angreifen · G plündern · R reparieren · L Lampe · M Karte · Enter Chat · E benutzen · V Ansicht · Tab Menü · F1 Feedback · Esc beenden",
+  "ui.hud.hint_pad": "Linker Stick bewegen · Rechter Stick umsehen · RB abbauen · LB setzen · Steuerkreuz Hotbar · (A) springen · (X) benutzen · (Y) Ansicht · Start Menü",
   "ui.door.hint": "E: Tür",
   "ui.tab.tech": "Technik",
   "ui.tab.ship": "Schiff",

--- a/data/locales/en.json
+++ b/data/locales/en.json
@@ -450,6 +450,7 @@
   "mission.settlement.gather.title": "Settlement Supply Request",
   "mission.settlement.gather.desc": "Deliver the requested resources to the settlement's mission board for a reward.",
   "ui.hud.hint": "WASD move · LMB mine · RMB place · 1-9 hotbar · F attack · G loot · R repair · L lamp · M map · Enter chat · E use · V view · Tab menu · F1 feedback · Esc quit",
+  "ui.hud.hint_pad": "Left stick move · Right stick look · RB mine · LB place · D-pad hotbar · (A) jump · (X) use · (Y) view · Start menu",
   "ui.door.hint": "E: Door",
   "ui.tab.tech": "Tech",
   "ui.tab.ship": "Ship",

--- a/docs/developer/INPUT_AND_CONTROLLER.md
+++ b/docs/developer/INPUT_AND_CONTROLLER.md
@@ -1,0 +1,57 @@
+# Input abstraction & controller support
+
+Gameplay input flows through **`InputMap`** (a static facade), not through direct `UnityEngine.Input`
+polling. This is the seam that lets a new input device be added without touching gameplay code — it is
+how controller support was built and how touch (tablet-web) will be.
+
+## Layers
+
+- **`IInputSource`** (`client/Assets/BlocksBeyondTheStars/Scripts/Input/IInputSource.cs`) — one hardware
+  backend expressed as the game's control verbs: `MoveX/MoveY`, `LookX/LookY`, `HotbarScroll`,
+  `Jump/Crouch/Primary/Secondary`, `HotbarSlotDown`, and the discrete `ActionDown/Held/Up(InputAction)`.
+- **`DesktopInputSource`** — a 1:1 wrapper over the exact legacy calls the code used before (`GetAxis`,
+  `GetButton`, mouse buttons). Routing a call site onto it is behaviour-preserving.
+- **`GamepadInputSource`** — reads the joystick axes + `KeyCode.JoystickButton*` buttons.
+- **`InputMap`** — **combines** both sources (it does not switch between them): axes are summed/clamped and
+  the button verbs OR together, so keyboard+mouse and a pad are always live at once and neither can lock
+  the other out. With no pad connected the gamepad source returns zero/false, so the combined result equals
+  the pure keyboard/mouse behaviour. `InputMap.ActiveDevice` tracks the most recently used family purely to
+  pick HUD glyphs (`InputMap.Glyph(action)`).
+
+## Migrating a call site
+
+Replace the raw call with the `InputMap` verb, e.g. `Input.GetAxis("Horizontal")` → `InputMap.MoveX()`,
+`Input.GetMouseButtonDown(0)` → `InputMap.PrimaryDown()`, `Input.GetButton("Jump")` → `InputMap.JumpHeld()`.
+The migrated gameplay surface is `PlayerController` (on-foot + speeder) and `SpaceView` (flight + EVA + turret).
+A handful of number-key / Escape picks are intentionally still keyboard-only (secondary, not locomotion).
+
+## Retuning the gamepad (needs real hardware — issue #195)
+
+The mapping targets **Xbox / XInput on Windows**. Two places hold every tunable:
+
+1. **`GamepadInputSource`** — the button table (`BtnA`…`BtnRb`, `ButtonFor`), stick deadzone, and the look
+   rates (`LookYawSpeed` / `LookPitchSpeed`, applied as `rate × Time.deltaTime` so the value lands in the
+   same space as a mouse delta and the caller's sensitivity slider still scales it).
+2. **`client/ProjectSettings/InputManager.asset`** — the joystick **axes**. The left stick already feeds the
+   shared `Horizontal`/`Vertical` axes (so movement is free); this project adds `RightStickX` (axis 3),
+   `RightStickY` (axis 4, inverted so up = look up) and `DPadX` (axis 5). Other pad families report
+   different axis numbers — change them here.
+
+CI never compiles or runs the Unity client (`.github/workflows/ci.yml` is .NET-only), and it cannot drive a
+controller, so the pad path is validated by a **local Unity build + manual on-device test**. The
+Unity-free parts (inert-without-pad guarantee, mapping tables, key resolution, glyphs) have EditMode tests
+in `client/Assets/Tests/EditMode/InputAbstractionEditModeTests.cs`.
+
+## Menu navigation
+
+`UiNavFocus` (`Scripts/UiNav.cs`) makes a menu pad-navigable: uGUI's `StandaloneInputModule` already turns
+the stick/d-pad into directional nav and A/B into Submit/Cancel, so the only gap is that a mouse-built menu
+has nothing selected — this component selects (and re-selects, self-healing) the first interactable control
+while a pad is the active device, and is completely inert on keyboard/mouse. Wire it with `UiNav.Enable(root)`;
+it is currently on the main menu and the in-game (Tab/Start) menu. Broader panel coverage is follow-up.
+
+## Adding touch later (tablet-web)
+
+Implement a `TouchInputSource : IInputSource` (virtual joystick → `MoveX/MoveY`, drag zone → `LookX/LookY`,
+on-screen buttons → the verb methods) and add it to `InputMap`'s combine. No gameplay changes required —
+that is the point of this seam.

--- a/docs/user/USER_MANUAL.md
+++ b/docs/user/USER_MANUAL.md
@@ -76,6 +76,29 @@ Last updated: 2026-06-29.
 
 Interaction reach is ~6 m (extended by reach equipment).
 
+### Gamepad / controller (experimental)
+
+A connected controller works **alongside** keyboard + mouse — both stay live at once, so you can mix them
+freely and neither locks the other out. The HUD control hint swaps to controller labels while a pad is the
+device in hand. Mapping targets an **Xbox / XInput** pad on Windows (other pads may report different
+buttons — retuning is tracked in issue #195):
+
+| Control | Action |
+|---|---|
+| **Left stick** | Move |
+| **Right stick** | Look |
+| **RB** | Mine / attack (hold to keep mining) |
+| **LB** | Place the selected hotbar block / use the held gadget |
+| **D-pad ◄ ►** | Cycle hotbar slot |
+| **(A)** | Jump (hold in air = jetpack; in water = swim up) |
+| **(X)** | Use / board / interact |
+| **(Y)** | Toggle first / third-person camera |
+| **Start** | Open / close the gameplay menu |
+
+In menus, the left stick / d-pad navigates, **(A)** confirms and **(B)** goes back. The right stick also
+steers the ship in flight. Direct hotbar number-key picks and a few secondary actions remain
+keyboard-only for now; a full controller binding + on-screen rebinding pass is planned.
+
 ---
 
 ## 3. Space-flight controls


### PR DESCRIPTION
Implements **P1 + P2** of the input epic #193: an `IInputSource` abstraction and experimental Xbox/XInput **controller support** on the native desktop client. One seam unlocks the pad now and touch (tablet-web) later.

Closes #194 · part of #195 · epic #193.

## P1 — input abstraction (the spine)
- New `IInputSource` (`Scripts/Input/`) with `DesktopInputSource`, a 1:1 wrapper over the exact legacy `Input.*` calls — **behaviour-preserving** on keyboard+mouse.
- Rewritten `InputMap` facade exposes the continuous/pointer core (`MoveX/MoveY`, `LookX/LookY`, `HotbarScroll`, `Jump/Crouch/Primary/Secondary`, `HotbarSlotDown`) next to the existing discrete rebindable actions.
- Migrated the gameplay `Input.*` sites in `PlayerController` (on-foot + speeder) and `SpaceView` (flight + EVA + turret). A few number-key/Escape picks stay keyboard-only (secondary, not locomotion).

## P2 — controller (native desktop)
- `GamepadInputSource`: right stick = look, RB/LB = mine/place, (A) jump, (X) interact, d-pad = hotbar. The left stick already feeds the shared `Horizontal`/`Vertical` axes, so movement is free. New `RightStickX/Y` + `DPadX` axes added to `InputManager.asset`.
- `InputMap` **combines** keyboard+mouse and pad — both live at once, neither can lock the other out; with no pad connected the result equals the pure keyboard/mouse behaviour. Active device is tracked purely for glyphs.
- `UiNavFocus` makes menus pad-navigable (self-healing initial focus; inert on keyboard/mouse), wired on the main menu + the in-game menu. **Start** toggles the in-game menu. Device-aware HUD control hint (`ui.hud.hint_pad`, DE + EN).

## Docs & tests
- `docs/developer/INPUT_AND_CONTROLLER.md`, USER_MANUAL gamepad table, README feature bullet, TODO.md work-log entry.
- EditMode `InputAbstractionEditModeTests`: the inert-without-pad guarantee + the pure mapping tables.

## Verification
- ✅ 794/794 server tests pass (incl. en/de locale parity for the new key)
- ✅ `dotnet format --verify-no-changes` clean
- ✅ **local Unity build Succeeded** (client compiles — CI is .NET-only and never compiles the client)
- ⚠️ Controller/menu-nav **feel** and the exact XInput axis/button numbers need an **on-hardware pass** — CI cannot drive a pad. Tracked in #195.

## Deferred to #195
On-screen pad **rebinding** group, full glyph coverage across all prompts, broader menu-panel focus wiring, stick/button retuning on real hardware.