### PR TITLE
feat(client): on-screen touch controls + web Lite defaults (P3/P5)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -97,8 +97,23 @@ Per-item detail lives in the dated work log below.
 
 ---
 
-### ★ Input abstraction + gamepad/controller support (2026-07-01) — ✅ code done, local Unity build pending
-On `feat/input-abstraction-and-controller` (epic #193; P1 #194, P2 #195). Decouples gameplay from directly
+### ★ Touch controls + web polish (2026-07-01) — ✅ code done, local Unity build pending
+On `feat/touch-controls-and-web-polish` (epic #193; P3 #196, P4 #197, P5 #198). Adds the tablet/browser touch
+layer on top of the input abstraction — **inert on desktop** (built only on a touch device; the source reads
+zero otherwise, so keyboard/mouse + pad are unaffected).
+- **P3 — touch (on-foot).** `TouchInputSource` (`Scripts/Input/`) reads `TouchControlsUi`
+  (`Scripts/TouchControlsUi.cs`): left virtual joystick (move), full-screen right look pad (look), buttons
+  JUMP / MINE-hold / PLACE / USE / DOWN / hotbar ◄► / menu. Built on uGUI pointer handlers (`TouchStick`,
+  `TouchLookPad`, `TouchButton`) so the scaler + multitouch are the EventSystem's job. Added to `InputMap`'s
+  combine + `InputDeviceKind.Touch`; HUD hint blanks on touch. `TouchButton.DownThisFrame` is a
+  frame-idempotent edge (matches `GetKeyDown`; an action is polled at >1 site/frame). Instantiated in `WorldRig`.
+- **P5 — web polish.** Fresh install on a tablet / WebGL starts the graphics `Preset` at `Low` (heavy scene).
+- **Docs:** INPUT_AND_CONTROLLER touch + web sections; USER_MANUAL touch table.
+- **Deferred to playtest issues** (need on-device testing; CI can't drive touch/WebGL): flight/speeder/EVA
+  touch layouts + contextual labels + text entry (#197), browser gamepad axis/button remap (#198).
+
+### ★ Input abstraction + gamepad/controller support (2026-07-01) — ✅ MERGED to main (PR #199, `75a3788`; closes #194)
+On `feat/input-abstraction-and-controller` (epic #193; P1 #194, P2 #195 core). Decouples gameplay from directly
 polling `UnityEngine.Input` and adds experimental Xbox/XInput controller support on the native desktop client.
 - **P1 — input abstraction.** New `IInputSource` (`Scripts/Input/`) with a `DesktopInputSource` (1:1 wrapper
   over the legacy calls) behind a rewritten `InputMap` facade exposing the continuous/pointer core
@@ -113,8 +128,8 @@ polling `UnityEngine.Input` and adds experimental Xbox/XInput controller support
 - **Docs:** `docs/developer/INPUT_AND_CONTROLLER.md`; USER_MANUAL gamepad table; README feature bullet.
 - **Tests:** EditMode `InputAbstractionEditModeTests` (inert-without-pad guarantee + mapping tables). NOTE: CI
   is .NET-only and can't compile the Unity client or drive a pad — validated by local Unity build + manual
-  on-device test. Remaining (deferred to #195): on-screen pad **rebinding** group, full glyph coverage across
-  all prompts, broader menu-panel focus wiring, and stick/button **retuning on real hardware**.
+  on-device test. Remaining: dev follow-ups (pad rebinding UI, full glyph coverage, broader menu focus-nav) →
+  #200; on-hardware verify + axis/button retuning → #201 (`playtest`). P2 issue #195 closed.
 
 ### ★ Codex (in-game Wiki) navigation + scan-name fixes (2026-06-30) — ✅ code done, local Unity build green
 Three player-reported client fixes on `fix/codex-wiki-buttons-unclickable-176` (#176, #177):

--- a/client/Assets/BlocksBeyondTheStars/Scripts/ClientSettings.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/ClientSettings.cs
@@ -308,6 +308,14 @@ namespace BlocksBeyondTheStars.Client
                 // German Windows starts in German; everything else falls back to English. The chosen value
                 // is persisted by the Save below, so the pre-engine launcher splash picks it up next launch.
                 settings.Language = Application.systemLanguage == SystemLanguage.German ? "de" : "en";
+
+                // Tablets and the browser build are GPU-weak next to a desktop, and the scene is heavy (custom
+                // URP, SSAO, SMAA, PBR). Start those on a Lite preset so the first run is playable; the player
+                // can still raise it in Settings. Only on a genuine first run — a returning player keeps theirs.
+                if (Application.isMobilePlatform || Application.platform == RuntimePlatform.WebGLPlayer)
+                {
+                    settings.Preset = QualityPreset.Low;
+                }
             }
 
             if (string.IsNullOrEmpty(settings.PlayerToken))

--- a/client/Assets/BlocksBeyondTheStars/Scripts/HudUi.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/HudUi.cs
@@ -507,7 +507,13 @@ namespace BlocksBeyondTheStars.Client
 
             _toast.text = Game.LastMessage ?? string.Empty;
             _inSpace.text = Game.InSpace ? loc.Get("ui.hud.in_space") : string.Empty;
-            _hint.text = loc.Get(InputMap.ActiveDevice == InputDeviceKind.Gamepad ? "ui.hud.hint_pad" : "ui.hud.hint");
+            _hint.text = InputMap.ActiveDevice switch
+            {
+                // On touch the on-screen buttons are self-labelling, so the text hint just adds clutter.
+                InputDeviceKind.Touch => string.Empty,
+                InputDeviceKind.Gamepad => loc.Get("ui.hud.hint_pad"),
+                _ => loc.Get("ui.hud.hint"),
+            };
 
             // Prompts — on-foot only. While piloting/EVA the flight view draws its own prompts, so don't leak
             // a stale on-foot "Use: Cockpit" into the centre of the space view (you reach the cockpit/helm on

--- a/client/Assets/BlocksBeyondTheStars/Scripts/Input/IInputSource.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/Input/IInputSource.cs
@@ -11,6 +11,7 @@ namespace BlocksBeyondTheStars.Client
     {
         KeyboardMouse,
         Gamepad,
+        Touch,
     }
 
     /// <summary>

--- a/client/Assets/BlocksBeyondTheStars/Scripts/Input/TouchInputSource.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/Input/TouchInputSource.cs
@@ -1,0 +1,66 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+
+using UnityEngine;
+
+namespace BlocksBeyondTheStars.Client
+{
+    /// <summary>
+    /// Touch backend (tablet / touch browser). It is a thin reader over <see cref="TouchControlsUi"/>: the
+    /// on-screen joystick, look pad and buttons live in that MonoBehaviour, and this maps them onto the
+    /// <see cref="IInputSource"/> verbs. When no touch UI is active (desktop, or the controls are hidden
+    /// during flight/menus) every getter returns zero/false, so <see cref="InputMap"/>'s combined read is
+    /// unaffected — the abstraction stays behaviour-preserving on non-touch devices.
+    ///
+    /// Look conversion: the pad reports a pixel drag delta; <see cref="LookYawScale"/> maps it into the same
+    /// space as a mouse delta (the caller still multiplies by MouseSensitivity, so the sensitivity slider
+    /// scales touch look too). The exact scale is a feel tunable that needs an on-device pass (issue #196).
+    /// </summary>
+    public sealed class TouchInputSource : IInputSource
+    {
+        // Pixels → mouse-delta-equivalent. Roughly matches the InputManager's 0.1 mouse sensitivity so a drag
+        // feels similar to a mouse move after the caller applies MouseSensitivity.
+        private const float LookYawScale = 0.08f;
+        private const float LookPitchScale = 0.08f;
+
+        public InputDeviceKind Kind => InputDeviceKind.Touch;
+
+        private static TouchControlsUi Ui => TouchControlsUi.Active;
+        private static bool Live => Ui != null && Ui.Visible;
+
+        public float MoveX() => Live ? Ui.Move.x : 0f;
+        public float MoveY() => Live ? Ui.Move.y : 0f;
+        public float LookX() => Live ? Ui.LookDelta.x * LookYawScale : 0f;
+        public float LookY() => Live ? Ui.LookDelta.y * LookPitchScale : 0f;
+        public float HotbarScroll() => Live ? Ui.HotbarStep() : 0f;
+
+        public bool JumpHeld() => Live && Ui.JumpHeld;
+        public bool JumpDown() => Live && Ui.JumpDown;
+        public bool CrouchHeld() => Live && Ui.DescendHeld;
+        public bool PrimaryDown() => Live && Ui.MineDown;
+        public bool PrimaryHeld() => Live && Ui.MineHeld;
+        public bool SecondaryDown() => Live && Ui.PlaceDown;
+
+        // No 1..9 pick on touch — the hotbar is cycled via the ◄ ► buttons (HotbarScroll).
+        public int HotbarSlotDown() => -1;
+
+        // Only "Interact" (the USE button) is on the touch layer for now; everything else stays keyboard-only
+        // (harmless, since sources are combined). A fuller contextual button set is follow-up (issue #197).
+        public bool ActionDown(InputAction action) => Live && action == InputAction.Interact && Ui.UseDown;
+        public bool ActionHeld(InputAction action) => false;
+        public bool ActionUp(InputAction action) => false;
+
+        public bool HadActivityThisFrame()
+        {
+            if (!Live)
+            {
+                return false;
+            }
+
+            return Ui.Move.sqrMagnitude > 0.0001f
+                || Ui.LookDelta.sqrMagnitude > 0.0001f
+                || Ui.JumpHeld || Ui.MineHeld || Ui.DescendHeld;
+        }
+    }
+}

--- a/client/Assets/BlocksBeyondTheStars/Scripts/Input/TouchInputSource.cs.meta
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/Input/TouchInputSource.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b5c3906720f66a348b5791d4b95e4f5b

--- a/client/Assets/BlocksBeyondTheStars/Scripts/InputMap.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/InputMap.cs
@@ -60,9 +60,11 @@ namespace BlocksBeyondTheStars.Client
     {
         private static ClientSettings _settings;
 
-        // The two live backends. Both are polled every frame and merged; see the class summary.
+        // The live backends. All are polled every frame and merged; see the class summary. The touch source
+        // is inert unless a touch UI is active (tablet / touch browser), so it contributes nothing on desktop.
         private static readonly IInputSource _desktop = new DesktopInputSource();
         private static readonly IInputSource _pad = new GamepadInputSource();
+        private static readonly IInputSource _touch = new TouchInputSource();
 
         private static int _deviceFrame = -1;
         private static InputDeviceKind _activeDevice = InputDeviceKind.KeyboardMouse;
@@ -76,7 +78,11 @@ namespace BlocksBeyondTheStars.Client
                 if (Time.frameCount != _deviceFrame)
                 {
                     _deviceFrame = Time.frameCount;
-                    if (_pad.HadActivityThisFrame())
+                    if (_touch.HadActivityThisFrame())
+                    {
+                        _activeDevice = InputDeviceKind.Touch;
+                    }
+                    else if (_pad.HadActivityThisFrame())
                     {
                         _activeDevice = InputDeviceKind.Gamepad;
                     }
@@ -156,46 +162,53 @@ namespace BlocksBeyondTheStars.Client
             return !string.IsNullOrEmpty(name) && System.Enum.TryParse<KeyCode>(name, out var kc) ? kc : def;
         }
 
-        // Discrete rebindable actions — now combined across both backends so a pad button and the bound key
-        // both fire the action. The keyboard resolution is unchanged (DesktopInputSource calls Key(action)).
-        public static bool Down(InputAction action) => _desktop.ActionDown(action) || _pad.ActionDown(action);
-        public static bool Held(InputAction action) => _desktop.ActionHeld(action) || _pad.ActionHeld(action);
-        public static bool Up(InputAction action) => _desktop.ActionUp(action) || _pad.ActionUp(action);
+        // Discrete rebindable actions — combined across all backends so a pad button, the touch USE button, or
+        // the bound key all fire the action. The keyboard resolution is unchanged (DesktopInputSource calls Key).
+        public static bool Down(InputAction action) => _desktop.ActionDown(action) || _pad.ActionDown(action) || _touch.ActionDown(action);
+        public static bool Held(InputAction action) => _desktop.ActionHeld(action) || _pad.ActionHeld(action) || _touch.ActionHeld(action);
+        public static bool Up(InputAction action) => _desktop.ActionUp(action) || _pad.ActionUp(action) || _touch.ActionUp(action);
 
         // ---- Continuous locomotion / camera / interaction core -------------------------------------------
-        // Each merges the two backends. Movement + look are additive (mouse delta + stick delta); the
+        // Each merges the backends. Movement + look are additive (mouse delta + stick delta + touch); the
         // button verbs OR together. This is what the migrated PlayerController/SpaceView call sites read
-        // instead of Input.GetAxis / GetButton / GetMouseButton.
+        // instead of Input.GetAxis / GetButton / GetMouseButton. The touch source is zero unless a touch UI
+        // is live, so on desktop these equal the keyboard/mouse (+ pad) behaviour exactly.
 
         /// <summary>Strafe axis, −1..1 — replaces <c>Input.GetAxis("Horizontal")</c>.</summary>
-        public static float MoveX() => Mathf.Clamp(_desktop.MoveX() + _pad.MoveX(), -1f, 1f);
+        public static float MoveX() => Mathf.Clamp(_desktop.MoveX() + _pad.MoveX() + _touch.MoveX(), -1f, 1f);
 
         /// <summary>Forward axis, −1..1 — replaces <c>Input.GetAxis("Vertical")</c>.</summary>
-        public static float MoveY() => Mathf.Clamp(_desktop.MoveY() + _pad.MoveY(), -1f, 1f);
+        public static float MoveY() => Mathf.Clamp(_desktop.MoveY() + _pad.MoveY() + _touch.MoveY(), -1f, 1f);
 
         /// <summary>Yaw look delta (caller still multiplies by sensitivity) — replaces <c>GetAxis("Mouse X")</c>.</summary>
-        public static float LookX() => _desktop.LookX() + _pad.LookX();
+        public static float LookX() => _desktop.LookX() + _pad.LookX() + _touch.LookX();
 
         /// <summary>Pitch look delta (caller still multiplies by sensitivity) — replaces <c>GetAxis("Mouse Y")</c>.</summary>
-        public static float LookY() => _desktop.LookY() + _pad.LookY();
+        public static float LookY() => _desktop.LookY() + _pad.LookY() + _touch.LookY();
 
         /// <summary>Hotbar scroll: &gt;0 = previous slot, &lt;0 = next — replaces <c>GetAxis("Mouse ScrollWheel")</c>.
-        /// Mouse wheel takes precedence; the pad d-pad fills in when the wheel is idle.</summary>
+        /// Mouse wheel takes precedence; the pad d-pad / touch ◄► buttons fill in when the wheel is idle.</summary>
         public static float HotbarScroll()
         {
             float d = _desktop.HotbarScroll();
-            return Mathf.Abs(d) > 0.0001f ? d : _pad.HotbarScroll();
+            if (Mathf.Abs(d) > 0.0001f)
+            {
+                return d;
+            }
+
+            float p = _pad.HotbarScroll();
+            return Mathf.Abs(p) > 0.0001f ? p : _touch.HotbarScroll();
         }
 
-        public static bool JumpHeld() => _desktop.JumpHeld() || _pad.JumpHeld();
-        public static bool JumpDown() => _desktop.JumpDown() || _pad.JumpDown();
-        public static bool CrouchHeld() => _desktop.CrouchHeld() || _pad.CrouchHeld();
-        public static bool PrimaryDown() => _desktop.PrimaryDown() || _pad.PrimaryDown();
-        public static bool PrimaryHeld() => _desktop.PrimaryHeld() || _pad.PrimaryHeld();
-        public static bool SecondaryDown() => _desktop.SecondaryDown() || _pad.SecondaryDown();
+        public static bool JumpHeld() => _desktop.JumpHeld() || _pad.JumpHeld() || _touch.JumpHeld();
+        public static bool JumpDown() => _desktop.JumpDown() || _pad.JumpDown() || _touch.JumpDown();
+        public static bool CrouchHeld() => _desktop.CrouchHeld() || _pad.CrouchHeld() || _touch.CrouchHeld();
+        public static bool PrimaryDown() => _desktop.PrimaryDown() || _pad.PrimaryDown() || _touch.PrimaryDown();
+        public static bool PrimaryHeld() => _desktop.PrimaryHeld() || _pad.PrimaryHeld() || _touch.PrimaryHeld();
+        public static bool SecondaryDown() => _desktop.SecondaryDown() || _pad.SecondaryDown() || _touch.SecondaryDown();
 
-        /// <summary>Hotbar slot 0..8 picked directly this frame (number keys), or −1. The pad has no direct
-        /// pick (it cycles via <see cref="HotbarScroll"/>), so this is the keyboard's answer.</summary>
+        /// <summary>Hotbar slot 0..8 picked directly this frame (number keys), or −1. Pad + touch have no
+        /// direct pick (they cycle via <see cref="HotbarScroll"/>), so this is the keyboard's answer.</summary>
         public static int HotbarSlotDown()
         {
             int s = _desktop.HotbarSlotDown();

--- a/client/Assets/BlocksBeyondTheStars/Scripts/TouchControlsUi.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/TouchControlsUi.cs
@@ -1,0 +1,299 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.UI;
+
+namespace BlocksBeyondTheStars.Client
+{
+    /// <summary>
+    /// On-screen touch controls for the tablet / browser build (P3): a left virtual joystick (move), a
+    /// full-screen right-side look pad (drag to look), and action buttons (jump, mine-hold, place, use,
+    /// descend, hotbar ◄►, menu). It reports state to <see cref="TouchInputSource"/>, which feeds it into
+    /// <see cref="InputMap"/>'s combined read alongside keyboard/mouse and gamepad.
+    ///
+    /// Built on uGUI pointer handlers (not raw <c>Input.touches</c>) so the canvas scaler and multitouch
+    /// routing are handled by the EventSystem. It is **inert on desktop**: the UI is only built when the
+    /// device actually has touch (<see cref="ShouldShow"/>), and while hidden the source reads zero — so the
+    /// shipped keyboard/mouse + pad experience cannot regress. Scoped to **on-foot**: the controls hide
+    /// during flight/EVA and while a menu is open (menus are tap-navigable via the EventSystem directly).
+    /// Flight/speeder/EVA touch layouts, contextual labels and text-input are follow-up (issue #197).
+    /// Geometry + feel need an on-device pass (CI can't test touch).
+    /// </summary>
+    [DefaultExecutionOrder(-100)] // resolve control state before gameplay reads it this frame
+    public sealed class TouchControlsUi : MonoBehaviour
+    {
+        public static TouchControlsUi Active { get; private set; }
+
+        public GameBootstrap Game;
+        public GameMenu Menu;
+
+        private GameObject _rootPanel;
+        private TouchStick _stick;
+        private TouchLookPad _lookPad;
+        private TouchButton _jump, _mine, _place, _use, _descend, _prev, _next, _menu;
+        private bool _built;
+
+        /// <summary>True on a touch device (tablet / touch-capable browser). Desktop mouse rigs report false,
+        /// so the whole feature stays dormant there. WebGL on a desktop browser also reports false → the
+        /// browser build uses keyboard/mouse or a pad, exactly as intended.</summary>
+        public static bool ShouldShow() => Application.isMobilePlatform || Input.touchSupported;
+
+        /// <summary>Whether the controls are currently live (built AND visible). The source reads zero when false.</summary>
+        public bool Visible => _built && _rootPanel != null && _rootPanel.activeSelf;
+
+        public Vector2 Move => Visible && _stick != null ? _stick.Value : Vector2.zero;
+        public Vector2 LookDelta => Visible && _lookPad != null ? _lookPad.Delta : Vector2.zero;
+        public bool JumpHeld => Visible && _jump != null && _jump.Pressed;
+        public bool JumpDown => Visible && _jump != null && _jump.DownThisFrame;
+        public bool MineHeld => Visible && _mine != null && _mine.Pressed;
+        public bool MineDown => Visible && _mine != null && _mine.DownThisFrame;
+        public bool PlaceDown => Visible && _place != null && _place.DownThisFrame;
+        public bool UseDown => Visible && _use != null && _use.DownThisFrame;
+        public bool DescendHeld => Visible && _descend != null && _descend.Pressed;
+
+        /// <summary>Hotbar step for this frame: &gt;0 = previous slot, &lt;0 = next (mirrors mouse-wheel sign).
+        /// Idempotent within the frame (reads the buttons' frame-stable edge).</summary>
+        public float HotbarStep()
+        {
+            if (!Visible)
+            {
+                return 0f;
+            }
+
+            if (_prev != null && _prev.DownThisFrame)
+            {
+                return 1f;
+            }
+
+            if (_next != null && _next.DownThisFrame)
+            {
+                return -1f;
+            }
+
+            return 0f;
+        }
+
+        private void Awake()
+        {
+            Active = this;
+            if (ShouldShow())
+            {
+                Build();
+            }
+        }
+
+        private void OnDestroy()
+        {
+            if (Active == this)
+            {
+                Active = null;
+            }
+        }
+
+        private void Update()
+        {
+            if (!_built)
+            {
+                return;
+            }
+
+            // On-foot only: hide while a menu is open (so taps reach the menu) or during flight/EVA.
+            bool show = Game != null && !Game.MenuOpen && !Game.SpaceViewActive;
+            if (_rootPanel.activeSelf != show)
+            {
+                _rootPanel.SetActive(show);
+            }
+
+            // The menu button toggles the gameplay menu (equivalent to Tab / the pad's Start).
+            if (show && _menu != null && _menu.DownThisFrame && Menu != null)
+            {
+                Menu.SetMenuOpen(!Game.MenuOpen);
+            }
+        }
+
+        private void LateUpdate()
+        {
+            // Clear the per-frame look accumulation after gameplay has read it this frame.
+            _lookPad?.ResetDelta();
+        }
+
+        private void Build()
+        {
+            var canvas = UiKit.CreateCanvas("TouchControls");
+            canvas.sortingOrder = 100; // above the HUD; menus hide these controls so no fight there
+            _rootPanel = canvas.gameObject;
+
+            // Full-screen look pad FIRST (bottom sibling) so buttons/stick placed after sit on top of it and
+            // win the touch; empty-area drags fall through to the look pad.
+            _lookPad = MakeLookPad(canvas.transform);
+
+            // Left virtual joystick.
+            _stick = MakeStick(canvas.transform);
+
+            // Right-hand action cluster (anchored bottom-right).
+            _jump = MakeButton(canvas.transform, new Vector2(1f, 0f), new Vector2(-140f, 150f), 120f, "JUMP");
+            _mine = MakeButton(canvas.transform, new Vector2(1f, 0f), new Vector2(-280f, 260f), 120f, "MINE");
+            _place = MakeButton(canvas.transform, new Vector2(1f, 0f), new Vector2(-140f, 300f), 120f, "PLACE");
+            _use = MakeButton(canvas.transform, new Vector2(1f, 0f), new Vector2(-300f, 130f), 110f, "USE");
+            _descend = MakeButton(canvas.transform, new Vector2(1f, 0f), new Vector2(-430f, 170f), 96f, "DOWN");
+
+            // Hotbar cycle, bottom-centre above the hotbar.
+            _prev = MakeButton(canvas.transform, new Vector2(0.5f, 0f), new Vector2(-360f, 130f), 90f, "◄");
+            _next = MakeButton(canvas.transform, new Vector2(0.5f, 0f), new Vector2(360f, 130f), 90f, "►");
+
+            // Menu button, top-right.
+            _menu = MakeButton(canvas.transform, new Vector2(1f, 1f), new Vector2(-90f, -90f), 96f, "≡");
+
+            _built = true;
+        }
+
+        // ---- Widget builders ------------------------------------------------------------------------------
+
+        private static TouchLookPad MakeLookPad(Transform parent)
+        {
+            var go = new GameObject("LookPad", typeof(RectTransform), typeof(Image), typeof(TouchLookPad));
+            var rt = (RectTransform)go.transform;
+            rt.SetParent(parent, false);
+            rt.anchorMin = Vector2.zero;
+            rt.anchorMax = Vector2.one; // full screen
+            rt.offsetMin = Vector2.zero;
+            rt.offsetMax = Vector2.zero;
+            var img = go.GetComponent<Image>();
+            img.color = new Color(0f, 0f, 0f, 0f); // invisible but raycast-catching
+            return go.GetComponent<TouchLookPad>();
+        }
+
+        private static TouchStick MakeStick(Transform parent)
+        {
+            const float baseSize = 320f;
+            var baseGo = new GameObject("MoveStick", typeof(RectTransform), typeof(Image), typeof(TouchStick));
+            var rt = (RectTransform)baseGo.transform;
+            rt.SetParent(parent, false);
+            rt.anchorMin = rt.anchorMax = new Vector2(0f, 0f); // bottom-left
+            rt.pivot = new Vector2(0.5f, 0.5f);
+            rt.sizeDelta = new Vector2(baseSize, baseSize);
+            rt.anchoredPosition = new Vector2(230f, 230f);
+            var baseImg = baseGo.GetComponent<Image>();
+            baseImg.sprite = UiKit.ButtonSprite;
+            baseImg.type = Image.Type.Sliced;
+            baseImg.color = new Color(0.4f, 0.7f, 0.9f, 0.18f);
+
+            var thumbGo = new GameObject("Thumb", typeof(RectTransform), typeof(Image));
+            var trt = (RectTransform)thumbGo.transform;
+            trt.SetParent(rt, false);
+            trt.sizeDelta = new Vector2(baseSize * 0.42f, baseSize * 0.42f);
+            trt.anchoredPosition = Vector2.zero;
+            var thumbImg = thumbGo.GetComponent<Image>();
+            thumbImg.sprite = UiKit.ButtonSprite;
+            thumbImg.color = new Color(0.5f, 0.85f, 1f, 0.45f);
+            thumbImg.raycastTarget = false;
+
+            var stick = baseGo.GetComponent<TouchStick>();
+            stick.Init(rt, trt);
+            return stick;
+        }
+
+        private static TouchButton MakeButton(Transform parent, Vector2 anchor, Vector2 anchoredPos, float size, string label)
+        {
+            var go = new GameObject("TouchBtn_" + label, typeof(RectTransform), typeof(Image), typeof(TouchButton));
+            var rt = (RectTransform)go.transform;
+            rt.SetParent(parent, false);
+            rt.anchorMin = rt.anchorMax = anchor;
+            rt.pivot = new Vector2(0.5f, 0.5f);
+            rt.sizeDelta = new Vector2(size, size);
+            rt.anchoredPosition = anchoredPos;
+            var img = go.GetComponent<Image>();
+            img.sprite = UiKit.ButtonSprite;
+            img.type = Image.Type.Sliced;
+            img.color = new Color(0.30f, 0.55f, 0.80f, 0.40f);
+
+            UiKit.AddText(rt, 0f, 0f, size, size, label, Mathf.RoundToInt(size * 0.28f),
+                new Color(0.9f, 0.97f, 1f, 0.95f), TextAnchor.MiddleCenter, FontStyle.Bold);
+
+            return go.GetComponent<TouchButton>();
+        }
+    }
+
+    /// <summary>A momentary/hold touch button. <see cref="Pressed"/> is the current hold; <see cref="DownThisFrame"/>
+    /// is the press edge, and — like <c>Input.GetKeyDown</c> — it is **idempotent within a frame**: every read
+    /// during the same frame returns the same value, and it is true on exactly one frame per press. That matters
+    /// because a single action (e.g. Interact) is polled at more than one call site per frame; a consume-on-read
+    /// latch would let the first site eat the edge. The edge is computed in an early Update (execution order
+    /// −100) from the pointer state the EventSystem set, so gameplay (default order) reads a stable value.</summary>
+    [DefaultExecutionOrder(-100)]
+    public sealed class TouchButton : MonoBehaviour, IPointerDownHandler, IPointerUpHandler
+    {
+        public bool Pressed { get; private set; }
+        public bool DownThisFrame { get; private set; }
+        private bool _pressedLast;
+
+        public void OnPointerDown(PointerEventData e) => Pressed = true;
+
+        public void OnPointerUp(PointerEventData e) => Pressed = false;
+
+        private void Update()
+        {
+            DownThisFrame = Pressed && !_pressedLast;
+            _pressedLast = Pressed;
+        }
+    }
+
+    /// <summary>Left virtual joystick: outputs a −1..1 vector from the drag offset, clamped to the base radius,
+    /// and drives the thumb visual. Snaps back to centre on release.</summary>
+    public sealed class TouchStick : MonoBehaviour, IPointerDownHandler, IDragHandler, IPointerUpHandler
+    {
+        public Vector2 Value { get; private set; }
+        private RectTransform _baseRect;
+        private RectTransform _thumb;
+
+        public void Init(RectTransform baseRect, RectTransform thumb)
+        {
+            _baseRect = baseRect;
+            _thumb = thumb;
+        }
+
+        public void OnPointerDown(PointerEventData e) => UpdateFrom(e);
+
+        public void OnDrag(PointerEventData e) => UpdateFrom(e);
+
+        public void OnPointerUp(PointerEventData e)
+        {
+            Value = Vector2.zero;
+            if (_thumb != null)
+            {
+                _thumb.anchoredPosition = Vector2.zero;
+            }
+        }
+
+        private void UpdateFrom(PointerEventData e)
+        {
+            if (_baseRect == null)
+            {
+                return;
+            }
+
+            RectTransformUtility.ScreenPointToLocalPointInRectangle(_baseRect, e.position, e.pressEventCamera, out var local);
+            float radius = _baseRect.rect.width * 0.5f;
+            Vector2 clamped = Vector2.ClampMagnitude(local, radius);
+            Value = radius > 0.01f ? clamped / radius : Vector2.zero;
+            if (_thumb != null)
+            {
+                _thumb.anchoredPosition = clamped;
+            }
+        }
+    }
+
+    /// <summary>Full-screen look area: accumulates drag delta (pixels) for the current frame. Owner clears it in
+    /// LateUpdate after gameplay has read it, so each frame reports only that frame's movement.</summary>
+    public sealed class TouchLookPad : MonoBehaviour, IDragHandler
+    {
+        public Vector2 Delta { get; private set; }
+
+        public void OnDrag(PointerEventData e) => Delta += e.delta;
+
+        public void ResetDelta() => Delta = Vector2.zero;
+    }
+}

--- a/client/Assets/BlocksBeyondTheStars/Scripts/TouchControlsUi.cs.meta
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/TouchControlsUi.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a40dd964b5bda924cb26c79092c78343

--- a/client/Assets/BlocksBeyondTheStars/Scripts/WorldRig.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/WorldRig.cs
@@ -191,6 +191,12 @@ namespace BlocksBeyondTheStars.Client
             menu.Avatar = avatar;
             pc.Menu = menu;
 
+            // On-screen touch controls (tablet / touch browser). Inert on desktop: builds its UI only on a
+            // touch device and reads zero otherwise, so keyboard/mouse + pad are unaffected.
+            var touch = root.AddComponent<TouchControlsUi>();
+            touch.Game = boot;
+            touch.Menu = menu;
+
             // Render other players (multiplayer presence).
             var remotes = root.AddComponent<RemotePlayers>();
             remotes.Game = boot;

--- a/docs/developer/INPUT_AND_CONTROLLER.md
+++ b/docs/developer/INPUT_AND_CONTROLLER.md
@@ -50,8 +50,35 @@ has nothing selected — this component selects (and re-selects, self-healing) t
 while a pad is the active device, and is completely inert on keyboard/mouse. Wire it with `UiNav.Enable(root)`;
 it is currently on the main menu and the in-game (Tab/Start) menu. Broader panel coverage is follow-up.
 
-## Adding touch later (tablet-web)
+## Touch controls (tablet-web)
 
-Implement a `TouchInputSource : IInputSource` (virtual joystick → `MoveX/MoveY`, drag zone → `LookX/LookY`,
-on-screen buttons → the verb methods) and add it to `InputMap`'s combine. No gameplay changes required —
-that is the point of this seam.
+`TouchInputSource` (`Scripts/Input/`) + `TouchControlsUi` (`Scripts/TouchControlsUi.cs`) implement the touch
+layer, added to `InputMap`'s combine exactly like the pad — no gameplay changes.
+
+- **`TouchControlsUi`** builds the on-screen UI (left virtual joystick, full-screen right look pad, and
+  buttons: JUMP / MINE-hold / PLACE / USE / DOWN / hotbar ◄► / menu) on its own overlay canvas, using uGUI
+  pointer handlers (`TouchStick`, `TouchLookPad`, `TouchButton`) so the canvas scaler and multitouch routing
+  are the EventSystem's job. It is created in `WorldRig` on `root`.
+- **Inert on desktop / behaviour-preserving:** the UI is only built when the device has touch
+  (`TouchControlsUi.ShouldShow()` = `Application.isMobilePlatform || Input.touchSupported`), and
+  `TouchInputSource` reads zero whenever the controls aren't `Visible`. A desktop mouse rig (and a desktop
+  browser, which reports no touch) never builds it.
+- **Scope:** on-foot only — the controls hide during flight/EVA and while a menu is open (menus are
+  tap-navigable through the EventSystem directly). `TouchButton.DownThisFrame` is a frame-idempotent edge
+  (like `GetKeyDown`) computed in an early `Update` (order −100), because a single action is polled at more
+  than one call site per frame — a consume-on-read latch would let the first site eat the edge.
+- **Device glyphs:** `InputDeviceKind.Touch` is tracked; the HUD text hint blanks on touch (the on-screen
+  buttons are self-labelling).
+
+Deferred (need on-device testing — issue #197): flight/speeder/EVA touch layouts, contextual button labels
+(board/loot/dock), on-screen **text entry** (name/chat need a soft-keyboard — uGUI's custom text capture
+doesn't open one), and menu touch-sizing.
+
+## Web / performance (P5)
+
+- **Lite graphics default:** on a fresh install on a tablet or the WebGL build, `ClientSettings.Load` starts
+  the quality `Preset` at `Low` (the scene is heavy: custom URP, SSAO, SMAA, PBR). Only on a genuine first
+  run — a returning player keeps their choice.
+- **Browser gamepad:** the same `GamepadInputSource` runs under WebGL, but the browser Gamepad API's axis /
+  button numbering can differ from native XInput; verifying + remapping it is a playtest item (issue #198),
+  not shipped as an untested guess.

--- a/docs/user/USER_MANUAL.md
+++ b/docs/user/USER_MANUAL.md
@@ -99,6 +99,26 @@ In menus, the left stick / d-pad navigates, **(A)** confirms and **(B)** goes ba
 steers the ship in flight. Direct hotbar number-key picks and a few secondary actions remain
 keyboard-only for now; a full controller binding + on-screen rebinding pass is planned.
 
+### Touch controls (experimental — tablet / touch browser)
+
+On a touch device (tablet, or a touch-capable browser) on-screen controls appear automatically:
+
+| On-screen control | Action |
+|---|---|
+| **Left stick** (bottom-left) | Move |
+| **Drag** anywhere on the right | Look |
+| **JUMP** | Jump |
+| **MINE** (hold) | Mine the targeted block |
+| **PLACE** | Place the selected hotbar block |
+| **USE** | Use / board / interact |
+| **DOWN** | Descend (swim/float/climb down) |
+| **◄ ►** | Cycle hotbar slot |
+| **≡** (top-right) | Open / close the gameplay menu |
+
+Menus are tapped directly. This is a first, **on-foot** pass: flight/speeder/EVA touch layouts, contextual
+button labels, and on-screen text entry (for your name / chat) are still being built — on a desktop or a
+desktop browser nothing changes, controls stay keyboard + mouse (or a gamepad).
+
 ---
 
 ## 3. Space-flight controls


### PR DESCRIPTION
Adds the **tablet / touch-browser** input layer on top of the input abstraction (#199), plus a Lite graphics default for weak devices. **Fully inert on desktop** — the shipped keyboard/mouse + pad experience can't regress.

Epic #193 · closes #196 (P3 on-foot touch) · part of #197, #198.

## P3 — touch (on-foot)
- `TouchInputSource : IInputSource` reads `TouchControlsUi`: a left **virtual joystick** (move), a full-screen right **look pad** (drag to look), and buttons **JUMP / MINE**-hold **/ PLACE / USE / DOWN / hotbar ◄► / menu**.
- Built on uGUI pointer handlers (`TouchStick`, `TouchLookPad`, `TouchButton`) so the canvas scaler + multitouch routing are the EventSystem's job.
- `TouchButton.DownThisFrame` is a **frame-idempotent edge** (like `GetKeyDown`) — a single action (e.g. Interact) is polled at more than one call site per frame, so a consume-on-read latch would eat the edge.
- Added to `InputMap`'s combined read + a new `InputDeviceKind.Touch`; the HUD text hint blanks on touch (on-screen buttons are self-labelling). Instantiated in `WorldRig`.

## P5 — web polish
- Fresh install on a tablet or the WebGL build starts the graphics `Preset` at **Low** (heavy scene). Returning players keep their choice.

## Inert on desktop
The UI is only built on a touch device (`Application.isMobilePlatform || Input.touchSupported`), and the source reads zero when the controls aren't visible. A desktop mouse rig — and a desktop browser (no touch) — never build it. Scoped to **on-foot**: controls hide during flight/EVA and while a menu is open (menus are tap-navigable directly).

## Verification
- ✅ **local Unity build Succeeded** (client compiles)
- ✅ `dotnet format` clean; the .NET side is untouched (no locale changes)
- ⚠️ Touch/WebGL **behaviour** can't be tested in CI — see playtest issues **#202** (touch on a tablet) and **#203** (WebGL perf + browser gamepad).

## Deferred (playtest / follow-up)
Flight/speeder/EVA touch layouts, contextual button labels, on-screen **text entry** (name/chat soft keyboard), menu touch-sizing → **#197 / #202**. Browser gamepad axis/button remap → **#198 / #203**.