### PR TITLE
fix(webgl): stop player falling through terrain on landing (Closes #205)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -97,6 +97,26 @@ Per-item detail lives in the dated work log below.
 
 ---
 
+### ★ WebGL fall-through: land on a planet then drop into the void (2026-07-02) — ✅ code done, local WebGL build green, browser E2E pending
+On `fix/webgl-fall-through-synchronous-meshing` (closes #205). The browser client (#116) let you land on a
+planet and then fall straight through the terrain into nothing. Root cause is **WebGL-specific and not
+PostgreSQL** (Postgres always generates terrain server-side before applying edits, so it never yields empty
+chunks; and a full 16³ chunk is ~8–25 KB of JSON, far under the 1 MB codec cap — the data path is intact).
+- **Cause.** The chunk pipeline offloads its two heaviest per-chunk steps to a worker via `Task.Run` —
+  geometry build (`GameBootstrap.DispatchChunkBuild`) and collision cook (`Physics.BakeMesh` in
+  `ApplyChunkMesh`). But the WebGL player ships with `webGLThreadsSupport: 0`, so those `Task.Run` bodies
+  never run: the world is never meshed/collided, and the player — released from the spawn *settle* freeze
+  after its 8 s grace — falls through the un-collided ground. (The same main-thread-only constraint is why
+  `BrowserWebSocketClientTransport` already pumps its queue via `Poll()`.)
+- **Fix.** Behind `#if UNITY_WEBGL && !UNITY_EDITOR`, build the geometry inline and cook the collider by
+  assigning `MeshCollider.sharedMesh` directly (a synchronous cook, live in the same frame) — every other
+  platform keeps the off-thread fast path. `MeshChunksPerFrame` drops 4→2 on WebGL so the now-synchronous
+  builds spread over more frames. Used `#if` rather than a `const bool` flag to avoid CS0162 unreachable-code
+  warnings. Hardening: `OnChunk` now drops a malformed chunk (`Blocks.Length != BlocksPerChunk`) with a
+  warning instead of throwing out of the network dispatch — the warning doubles as the diagnostic to watch.
+- **Verified.** 890 .NET tests green (96 client + 794 server); local `-buildTarget WebGL` build **Succeeded**
+  (0 errors, no new warnings). Still open: a hands-on browser playtest to confirm the ground now holds (#205).
+
 ### ★ Input epic completion: pad rebinding, glyphs, context touch layouts, browser text entry (2026-07-02) — ✅ code done, local Unity build pending
 On `feat/input-epic-completion` (epic #193; closes #197, #198, #200). Finishes every implementable item of
 the input epic; what remains open is on-device playtesting (#201 pad, #202 touch, #203 WebGL).

--- a/client/Assets/BlocksBeyondTheStars/Scripts/GameBootstrap.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/GameBootstrap.cs
@@ -783,7 +783,14 @@ namespace BlocksBeyondTheStars.Client
         // Performance (P1): cap how many chunk meshes are (re)built per frame so a burst of chunks arriving
         // while moving fast spreads over several frames instead of stalling one. Nearest chunks build first;
         // the rest stay queued in _dirty. Tunable — raise for less pop-in, lower for smoother frame times.
+#if UNITY_WEBGL && !UNITY_EDITOR
+        // WebGL has no worker threads, so each build + collider cook runs synchronously on the main thread
+        // (see DispatchChunkBuild / ApplyChunkMesh). Cap dispatches lower so a burst of arriving chunks spreads
+        // over more frames instead of spiking a single one.
+        public int MeshChunksPerFrame = 2;
+#else
         public int MeshChunksPerFrame = 4;
+#endif
         private readonly List<ChunkCoord> _dirtyScratch = new List<ChunkCoord>();
 
         // Distance culling (A4): chunks farther than this (blocks, seam-aware 3D distance) have their renderer
@@ -824,6 +831,13 @@ namespace BlocksBeyondTheStars.Client
         private readonly Dictionary<ChunkCoord, int> _meshGen = new Dictionary<ChunkCoord, int>();
         private readonly System.Collections.Concurrent.ConcurrentQueue<(ChunkCoord Coord, ChunkMeshData Data, int Gen, int Epoch)> _builtChunks
             = new System.Collections.Concurrent.ConcurrentQueue<(ChunkCoord Coord, ChunkMeshData Data, int Gen, int Epoch)>();
+
+        // WebGL ships without worker threads (ProjectSettings webGLThreadsSupport:0), so Task.Run bodies never
+        // execute there — the two heavy per-chunk steps above (geometry build + Physics.BakeMesh) would never
+        // complete, leaving the world un-meshed and un-collided. The player, released from the spawn settle
+        // after its grace, then falls straight through into the void. On WebGL we therefore build the geometry
+        // and cook the collider synchronously on the main thread (see the #if UNITY_WEBGL branches in
+        // DispatchChunkBuild + ApplyChunkMesh); every other platform keeps the off-thread fast path.
 
         /// <summary>Bumped each time the world is rebuilt (travel); the player re-snaps to the new spawn.</summary>
         public int WorldEpoch { get; private set; }
@@ -1352,6 +1366,19 @@ namespace BlocksBeyondTheStars.Client
         private void OnChunk(BlocksBeyondTheStars.Networking.Messages.ChunkDataMessage m)
         {
             var coord = new ChunkCoord(m.Cx, m.Cy, m.Cz);
+
+            // Reject a malformed/short chunk payload: ChunkData.FromRaw requires exactly BlocksPerChunk cells and
+            // throws otherwise, which would bubble out of the network dispatch. Drop + warn instead, so a bad
+            // packet can neither crash the client nor be stored as solid terrain (which the player would read as
+            // a floor and then fall through). A normal chunk is ~8-25 KB of JSON — well under the codec cap, so
+            // this only fires on a genuinely truncated/dropped payload; the warning is the diagnostic to watch.
+            int expected = WorldConstants.BlocksPerChunk;
+            if (m.Blocks == null || m.Blocks.Length != expected)
+            {
+                Debug.LogWarning($"[Chunk] Dropped malformed chunk {coord}: expected {expected} blocks, got {(m.Blocks?.Length ?? 0)}.");
+                return;
+            }
+
             World.StoreChunk(coord, m.Blocks, m.ModIndex, m.ModTint, m.ModGlow, m.ShapeIndex, m.ShapeData);
             MarkChunkAndNeighborsDirty(coord);
         }
@@ -1655,7 +1682,8 @@ namespace BlocksBeyondTheStars.Client
             var content = Content;
             var atlas = Atlas;
             var capturedCoord = coord;
-            System.Threading.Tasks.Task.Run(() =>
+
+            void Build()
             {
                 ChunkMeshData data = null;
                 try
@@ -1668,7 +1696,16 @@ namespace BlocksBeyondTheStars.Client
                 }
 
                 _builtChunks.Enqueue((capturedCoord, data, gen, epoch));
-            });
+            }
+
+#if UNITY_WEBGL && !UNITY_EDITOR
+            // WebGL: no worker threads — build inline on the main thread. DrainBuiltChunks still uploads the
+            // result next frame, exactly as it does for the async path on every other platform.
+            Build();
+#else
+            System.Threading.Tasks.Task.Run(Build);
+#endif
+
             return true;
         }
 
@@ -1782,6 +1819,15 @@ namespace BlocksBeyondTheStars.Client
             }
             else
             {
+#if UNITY_WEBGL && !UNITY_EDITOR
+                // WebGL: no worker threads to bake on, so cook synchronously by assigning the mesh directly —
+                // MeshCollider.sharedMesh cooks the collision mesh on the spot. The collider is live in THIS
+                // frame, so the spawn ground-check raycast finds footing and the player never falls through.
+                if (mcol != null)
+                {
+                    mcol.sharedMesh = collider;
+                }
+#else
                 int meshId = collider.GetInstanceID();
                 var capturedCoord = coord;
                 var capturedCollider = collider;
@@ -1799,6 +1845,7 @@ namespace BlocksBeyondTheStars.Client
 
                     _bakedColliders.Enqueue((capturedCoord, capturedCollider, bakeGen, epoch));
                 });
+#endif
             }
         }
 


### PR DESCRIPTION
Closes #205.

## Problem
On the hosted **WebGL** build (Devin Dixon's browser client, PR #116), the player lands on a planet and then **falls straight through the terrain into the void**. Native desktop builds are unaffected.

## Root cause — WebGL threading, not PostgreSQL
The client chunk pipeline offloads its two heaviest per-chunk steps to a worker thread via `Task.Run`:
- **Geometry build** — `GameBootstrap.DispatchChunkBuild`
- **Collision cook** — `Physics.BakeMesh` in `ApplyChunkMesh`

Results are collected on the main thread in `DrainBuiltChunks` / `DrainBakedColliders`.

But the WebGL player ships with `webGLThreadsSupport: 0` (`client/ProjectSettings/ProjectSettings.asset`) — **no worker threads** — so those `Task.Run` bodies never run. The world is never meshed/collided, and the player, released from the spawn *settle* freeze after its 8 s grace (`PlayerController.cs`), falls through the un-collided ground. (The same main-thread-only constraint is already why `BrowserWebSocketClientTransport` pumps its queue via `Poll()`.)

### Ruled out
- **PostgreSQL is a red herring** — `ServerWorld.GetOrLoadChunk` always generates terrain procedurally first, then layers persisted *edits* on top; a fresh DB never yields empty terrain.
- **JSON payload size** is not the cause — a full 16³ chunk (`ushort[4096]`) serializes to ~8–25 KB, far under the 1 MB `NetCodec.MaxJsonPayloadBytes` cap. The server→browser data path is intact.

## Fix
Behind `#if UNITY_WEBGL && !UNITY_EDITOR`:
1. **`DispatchChunkBuild`** — build the geometry inline on the main thread (extracted to a local `Build()`); every other platform keeps `Task.Run(Build)`. `DrainBuiltChunks` still uploads next frame.
2. **`ApplyChunkMesh`** — cook the collider by assigning `MeshCollider.sharedMesh = collider` directly (a synchronous cook), so it is live in the same frame and the spawn ground-check raycast finds footing.
3. **`MeshChunksPerFrame`** — 4 → 2 on WebGL so the now-synchronous builds spread over more frames.

Used `#if` directives rather than a `const bool` flag to avoid CS0162 unreachable-code warnings on both targets.

### Hardening (independent of the cause)
`OnChunk` now drops a malformed chunk (`Blocks.Length != WorldConstants.BlocksPerChunk`) with a `Debug.LogWarning` instead of letting `ChunkData.FromRaw` throw out of the network dispatch. The warning doubles as the diagnostic to watch if a data-path issue ever does occur.

## Verification
- ✅ **890 .NET tests** pass (96 client + 794 server/shared), 0 failed.
- ✅ Local **`-buildTarget WebGL`** build **Succeeded** (271 MB), 0 `error CS`, no new warnings (the two `GameBootstrap.cs` CS0618 obsolete-API warnings are pre-existing, in the unchanged desktop `#else` branch).
- ⏳ **Still open:** a hands-on browser playtest to confirm the ground now holds on landing (the compile-green build proves it builds, not that the fall-through is gone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)