### PR TITLE
ci: two-tier test gate — fast PR checks, full suite on main + before release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,11 @@
 #   tests/BlocksBeyondTheStars.Client.Tests (real NetworkClient vs in-process GameServer, no Unity/sockets)
 # The Unity Edit/PlayMode suites need the editor and stay opt-in/local (see scripts/run-tests.ps1).
 #
+# TWO-TIER TEST GATE: pull requests run only the fast tier (--filter Category!=Slow); pushes to main run
+# the full suite, and release.yml re-runs the full suite on the tagged commit before publishing anything.
+# So a PR check is fast (~6 min instead of ~13), while every commit that lands on main — and every
+# release — is still covered by all tests. See the Test step below for details.
+#
 # We target the test projects directly (not the whole .sln) on purpose: the .sln also contains the
 # WinForms launcher (net8.0-windows), which cannot build on the Linux runner. Building the test
 # projects pulls in exactly their dependencies (server/shared/client.core) and nothing Windows-only.
@@ -70,10 +75,18 @@ jobs:
           dotnet build tests/BlocksBeyondTheStars.Tests/BlocksBeyondTheStars.Tests.csproj --no-restore -warnaserror
           dotnet build tests/BlocksBeyondTheStars.Client.Tests/BlocksBeyondTheStars.Client.Tests.csproj --no-restore -warnaserror
 
+      # Two-tier test gate: PRs skip the ~31 tests marked [Trait("Category", "Slow")] — the statistical
+      # worldgen/simulation heavies (10 s–320 s each) that make up ~55% of the suite's CPU time — cutting
+      # the PR check from ~13 min to ~6 min. Full coverage is still guaranteed twice downstream: every
+      # push to main runs the COMPLETE suite here (empty filter), and release.yml runs it again on the
+      # tagged commit before anything is published.
       - name: Test
+        env:
+          # xUnit maps [Trait("Category", ...)] to the vstest Category property.
+          FILTER: ${{ github.event_name == 'pull_request' && 'Category!=Slow' || '' }}
         run: |
-          dotnet test tests/BlocksBeyondTheStars.Tests/BlocksBeyondTheStars.Tests.csproj --no-build --logger "trx;LogFileName=server.trx" --results-directory TestResults
-          dotnet test tests/BlocksBeyondTheStars.Client.Tests/BlocksBeyondTheStars.Client.Tests.csproj --no-build --logger "trx;LogFileName=clientcore.trx" --results-directory TestResults
+          dotnet test tests/BlocksBeyondTheStars.Tests/BlocksBeyondTheStars.Tests.csproj --no-build ${FILTER:+--filter "$FILTER"} --logger "trx;LogFileName=server.trx" --results-directory TestResults
+          dotnet test tests/BlocksBeyondTheStars.Client.Tests/BlocksBeyondTheStars.Client.Tests.csproj --no-build ${FILTER:+--filter "$FILTER"} --logger "trx;LogFileName=clientcore.trx" --results-directory TestResults
 
       # Keep the .trx results even when a suite fails, so failures are inspectable from the run page.
       - name: Upload test results

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,43 @@ jobs:
           echo "version=$v" >> "$GITHUB_OUTPUT"
           echo "Resolved build version: $v"
 
+  # RELEASE TEST GATE: the FULL headless test suite on the exact tagged commit. ci.yml's PR check runs
+  # only the fast tier (Category!=Slow), and nothing ties a tag to a green CI run on main — this job
+  # closes that gap: every package/publish job (installers, itch.io, Docker image) `needs` it, so no
+  # asset ships unless all tests pass. It runs in parallel with the ~15+ min Unity player builds, so it
+  # adds no wall-clock time to a release. Mirrors ci.yml's build-test but without -warnaserror (warnings
+  # are a PR-gate concern; this gate is about behaviour).
+  test:
+    name: Full test suite (release gate)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Restore + build test projects
+        run: |
+          dotnet restore tests/BlocksBeyondTheStars.Tests/BlocksBeyondTheStars.Tests.csproj
+          dotnet restore tests/BlocksBeyondTheStars.Client.Tests/BlocksBeyondTheStars.Client.Tests.csproj
+          dotnet build tests/BlocksBeyondTheStars.Tests/BlocksBeyondTheStars.Tests.csproj --no-restore
+          dotnet build tests/BlocksBeyondTheStars.Client.Tests/BlocksBeyondTheStars.Client.Tests.csproj --no-restore
+
+      - name: Test (full suite, Slow tier included)
+        run: |
+          dotnet test tests/BlocksBeyondTheStars.Tests/BlocksBeyondTheStars.Tests.csproj --no-build --logger "trx;LogFileName=server.trx" --results-directory TestResults
+          dotnet test tests/BlocksBeyondTheStars.Client.Tests/BlocksBeyondTheStars.Client.Tests.csproj --no-build --logger "trx;LogFileName=clientcore.trx" --results-directory TestResults
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: release-test-results
+          path: TestResults/*.trx
+          if-no-files-found: ignore
+
   build-player:
     name: Build Unity player (Windows)
     needs: version
@@ -468,10 +505,11 @@ jobs:
           name: player-webgl
           path: player-webgl
 
-  # Linux packaging
+  # Linux packaging. `needs: test` (like every package/publish job below): nothing ships unless the
+  # full suite passed on this commit.
   package-linux:
     name: Package + release (Linux)
-    needs: [version, build-player-linux]
+    needs: [version, build-player-linux, test]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -539,7 +577,7 @@ jobs:
   # execute bits (artifacts strip them).
   package-mac:
     name: Package + release (macOS)
-    needs: [version, build-player-mac]
+    needs: [version, build-player-mac, test]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -589,7 +627,7 @@ jobs:
   # image's entrypoint fetches this `webgl*.zip` (BBS_FETCH_WEBGL=1) and serves it at /play (issue #121).
   package-webgl:
     name: Package + release (WebGL)
-    needs: [version, build-player-webgl]
+    needs: [version, build-player-webgl, test]
     runs-on: ubuntu-latest
     steps:
       - name: Download WebGL player artifact
@@ -626,7 +664,9 @@ jobs:
   # workflow_dispatch run just build-validates it — same publish gating as the GitHub Release / itch.io steps.
   docker:
     name: Dedicated-server image
-    needs: version
+    # `test` gates the GHCR push like every other publish job. It costs the image ~14 min of start delay
+    # (it no longer launches immediately), but that stays well inside the Unity-build wall time.
+    needs: [version, test]
     permissions:
       contents: read
       packages: write
@@ -640,7 +680,7 @@ jobs:
 
   package:
     name: Package + release (Windows)
-    needs: [version, build-player]
+    needs: [version, build-player, test]
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v5

--- a/TODO.md
+++ b/TODO.md
@@ -6,7 +6,8 @@ plans live under [docs/](docs/) (committed); this file is the high-level status.
 keep it current when controls/features change. Last consolidated 2026-06-04.
 
 **Build:** `scripts/build-client.ps1` (Windows) or `scripts/build-client.sh` (Linux) — publishes shared libs + bundled server + Unity player.
-**Test:** `./scripts/run-tests.sh` — currently **783 server + 96 client passing** (2026-06-28). Locale parity (en/de) is enforced by a test.
+**Test:** `./scripts/run-tests.sh` — currently **794 server + 96 client passing** (2026-07-02). Locale parity (en/de) is enforced by a test.
+CI runs two tiers: PRs skip the 31 tests marked `[Trait("Category", "Slow")]` (~6 min gate); pushes to `main` and the release workflow run the full suite.
 **Conventions:** English docs/comments; in-game text bilingual DE+EN; commit to `main` with the
 Claude `Co-Authored-By` trailer; OpenAI texture + ElevenLabs sound generation is blanket-approved
 (no per-batch gate).
@@ -96,6 +97,22 @@ Per-item detail lives in the dated work log below.
   single-source-of-truth working end-to-end (validated: published the initial Windows zip).
 
 ---
+
+### ★ CI two-tier test gate: fast PRs, full coverage on main + release (2026-07-02)
+On `ci/fast-pr-test-gate`. The PR check took ~13 min, ~12.5 of which was `dotnet test` — dominated by 27
+server + 4 client tests over 10 s each (statistical worldgen/simulation heavies; the top two alone are
+320 s + 311 s). Restore/build/caching were already optimal (~55 s combined), and xUnit already saturates
+the runner's 4 cores, so the fix is tiering, not more parallelism.
+- **Fast PR tier.** The 31 heavies are marked `[Trait("Category", "Slow")]`; ci.yml's Test step filters
+  `Category!=Slow` on `pull_request` only (~6 min gate). Every test class still runs its fast tests on PRs.
+- **Full coverage guaranteed twice.** Pushes to `main` run the complete suite (unchanged trigger, empty
+  filter), and release.yml gains a `test` job — the full suite on the exact tagged commit — that every
+  package/publish job (installers, itch.io, Docker/GHCR) now `needs`. Previously release.yml ran no tests
+  at all; nothing tied a tag to a green CI run. The job runs parallel to the ~15 min Unity builds, so a
+  release gets its full-coverage guarantee at no wall-clock cost.
+- **Not the PR size.** Test time is constant per PR regardless of diff size — small PRs only cost total
+  compute minutes, never per-PR latency. Follow-up candidates: shrink the two 300 s tests (sample counts /
+  possible real-time waits in `WebSocketTransport_JoinsAndStreamsChunksAsync`) and run tests in Release config.
 
 ### ★ WebGL fall-through: land on a planet then drop into the void (2026-07-02) — ✅ code done, local WebGL build green, browser E2E pending
 On `fix/webgl-fall-through-synchronous-meshing` (closes #205). The browser client (#116) let you land on a

--- a/tests/BlocksBeyondTheStars.Client.Tests/JoinAndStreamingTests.cs
+++ b/tests/BlocksBeyondTheStars.Client.Tests/JoinAndStreamingTests.cs
@@ -67,6 +67,7 @@ public sealed class JoinAndStreamingTests
     }
 
     [Fact]
+    [Trait("Category", "Slow")]
     public void ClientViewDistance_ExtendsTheStreamedTerrain_OverTheWire()
     {
         // Host default is radius 1 (ClientServerHarness); the client asks for radius 3 via the JoinRequest.

--- a/tests/BlocksBeyondTheStars.Client.Tests/MinigamePortTests.cs
+++ b/tests/BlocksBeyondTheStars.Client.Tests/MinigamePortTests.cs
@@ -49,6 +49,7 @@ public sealed class MinigamePortTests
     [InlineData(1)]
     [InlineData(7)]
     [InlineData(42)]
+    [Trait("Category", "Slow")]
     public void DataFishing_RunsAndReachesAResult(int seed)
     {
         var host = RunToEnd(new DataFishingGame(), seed);
@@ -115,6 +116,7 @@ public sealed class MinigamePortTests
     [Theory]
     [InlineData(1)]
     [InlineData(7)]
+    [Trait("Category", "Slow")]
     public void Blockfall_RunsToResult(int seed)
     {
         var host = RunToEnd(new BlockfallGame(), seed, maxSeconds: 300f);
@@ -256,6 +258,7 @@ public sealed class MinigamePortTests
     }
 
     [Fact]
+    [Trait("Category", "Slow")]
     public void SignalTuner_TimesOutToAResult()
     {
         var host = new MinigameHost(new SignalTunerGame(), seed: 1);

--- a/tests/BlocksBeyondTheStars.Tests/ChunkStreamingTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/ChunkStreamingTests.cs
@@ -64,6 +64,7 @@ public sealed class ChunkStreamingTests : IDisposable
     }
 
     [Fact]
+    [Trait("Category", "Slow")]
     public void Sweep_EvictsFarChunks_ButKeepsThePlayersOwnRegion()
     {
         using var repo = new SqliteWorldRepository(new SaveGamePaths(_root, "sweep"));
@@ -114,6 +115,7 @@ public sealed class ChunkStreamingTests : IDisposable
     }
 
     [Fact]
+    [Trait("Category", "Slow")]
     public void ClientViewDistance_ExtendsStreamingRadius_BeyondHostDefault()
     {
         using var repo = new SqliteWorldRepository(new SaveGamePaths(_root, "vd"));
@@ -150,6 +152,7 @@ public sealed class ChunkStreamingTests : IDisposable
     }
 
     [Fact]
+    [Trait("Category", "Slow")]
     public void FarColumns_StreamOnlyTheSurfaceBand_WhileNearColumnsStreamTheFullVerticalSpan()
     {
         using var repo = new SqliteWorldRepository(new SaveGamePaths(_root, "lod"));

--- a/tests/BlocksBeyondTheStars.Tests/CreatureTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/CreatureTests.cs
@@ -627,6 +627,7 @@ public sealed class CreatureTests : IDisposable
     // ---------------- Give-up leash (aggressors don't hound the player forever) ----------------
 
     [Fact]
+    [Trait("Category", "Slow")]
     public void Aggressor_GivesUpAfterChasingTooLong_ThenItsCooldownDecays()
     {
         var server = Started("jungle", out var repo);

--- a/tests/BlocksBeyondTheStars.Tests/FloraTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/FloraTests.cs
@@ -200,6 +200,7 @@ public sealed class FloraTests : IDisposable
     }
 
     [Fact]
+    [Trait("Category", "Slow")]
     public void Worldgen_SeedsFlora_OnAFloraPlanet()
     {
         var planet = _content.GetPlanet("jungle")!; // grass surface, floraDensity 0.14

--- a/tests/BlocksBeyondTheStars.Tests/FloraVarietyTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/FloraVarietyTests.cs
@@ -159,6 +159,7 @@ public sealed class FloraVarietyTests
     }
 
     [Fact]
+    [Trait("Category", "Slow")]
     public void Worldgen_ConiferWorld_GrowsPines_NotBroadleafCrowns()
     {
         var planet = _content.GetPlanet("highland")!; // alpine theme → conifers only

--- a/tests/BlocksBeyondTheStars.Tests/GameServerCouplingTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/GameServerCouplingTests.cs
@@ -91,6 +91,7 @@ public sealed class GameServerCouplingTests : IDisposable
     }
 
     [Fact]
+    [Trait("Category", "Slow")]
     public void Machines_cluster_at_a_wreck_when_coupling_is_on()
     {
         var server = StartedWithWreck(coupling: true, out var repo);
@@ -104,6 +105,7 @@ public sealed class GameServerCouplingTests : IDisposable
     }
 
     [Fact]
+    [Trait("Category", "Slow")]
     public void Machines_do_not_cluster_at_a_wreck_when_coupling_is_off()
     {
         var server = StartedWithWreck(coupling: false, out var repo);
@@ -118,6 +120,7 @@ public sealed class GameServerCouplingTests : IDisposable
     }
 
     [Fact]
+    [Trait("Category", "Slow")]
     public void Coupling_does_not_change_how_many_machines_spawn()
     {
         int on = FillToCap(coupling: true);

--- a/tests/BlocksBeyondTheStars.Tests/PlaytimeTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/PlaytimeTests.cs
@@ -78,6 +78,7 @@ public sealed class PlaytimeTests : IDisposable
     }
 
     [Fact]
+    [Trait("Category", "Slow")]
     public void Playtime_PersistsAcrossReload()
     {
         var server = Start(out var repo, "persist");

--- a/tests/BlocksBeyondTheStars.Tests/SettlementNpcTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/SettlementNpcTests.cs
@@ -127,6 +127,7 @@ public sealed class SettlementNpcTests : IDisposable
     }
 
     [Fact]
+    [Trait("Category", "Slow")]
     public void Npcs_Stroll_ButStayNearHome_WhilePlayerPresent()
     {
         // Search inhabited settlements for one that demonstrates strolling. Some settlements are cramped or sit

--- a/tests/BlocksBeyondTheStars.Tests/SettlementOverhaulTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/SettlementOverhaulTests.cs
@@ -63,6 +63,7 @@ public sealed class SettlementOverhaulTests : IDisposable
     }
 
     [Fact]
+    [Trait("Category", "Slow")]
     public void Settlements_NeverSitOnALandingPad()
     {
         for (long seed = 1; seed <= 30; seed++)
@@ -148,6 +149,7 @@ public sealed class SettlementOverhaulTests : IDisposable
     }
 
     [Fact]
+    [Trait("Category", "Slow")]
     public void HarshWorlds_SkewToRuins_MoreThanLushWorlds()
     {
         var (iceInhab, iceRuin) = CountKinds("ice", 60);

--- a/tests/BlocksBeyondTheStars.Tests/StructureInteractionTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/StructureInteractionTests.cs
@@ -55,6 +55,7 @@ public sealed class StructureInteractionTests : IDisposable
     // ---------------- Wreck loot ----------------
 
     [Fact]
+    [Trait("Category", "Slow")]
     public void Wreck_SpawnsScavengeableLootContainers()
     {
         for (long seed = 1; seed <= 60; seed++)
@@ -82,6 +83,7 @@ public sealed class StructureInteractionTests : IDisposable
     }
 
     [Fact]
+    [Trait("Category", "Slow")]
     public void StructureLoot_DoesNotRespawn_OnReload()
     {
         // Find a wreck seed, loot all its containers, then restart the same world and confirm the

--- a/tests/BlocksBeyondTheStars.Tests/WebSocketTransportTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/WebSocketTransportTests.cs
@@ -28,6 +28,7 @@ public sealed class WebSocketTransportTests : IDisposable
     }
 
     [Fact]
+    [Trait("Category", "Slow")]
     public async Task WebSocketTransport_JoinsAndStreamsChunksAsync()
     {
         int port = FreeTcpPort();

--- a/tests/BlocksBeyondTheStars.Tests/WorldGenerationTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/WorldGenerationTests.cs
@@ -30,6 +30,7 @@ public class WorldGenerationTests
     }
 
     [Fact]
+    [Trait("Category", "Slow")]
     public void CrateredWorld_FlatRegolithWithPits_AndRareMetalInSomeCraters()
     {
         // Item 33: landable asteroids (and airless moons) are mostly flat regolith pocked with round impact
@@ -88,6 +89,7 @@ public class WorldGenerationTests
     }
 
     [Fact]
+    [Trait("Category", "Slow")]
     public void WateryWorld_GeneratesUplandPonds_AboveSeaLevel()
     {
         // B7: a watery (atmospheric) world should scatter swimmable upland ponds — water ABOVE the global sea
@@ -124,6 +126,7 @@ public class WorldGenerationTests
     }
 
     [Fact]
+    [Trait("Category", "Slow")]
     public void Trees_DoNotStandInUplandPonds()
     {
         // B35: a tree must never spawn in the water — its trunk base sitting directly on a pond/sea cell. Scan a
@@ -296,6 +299,7 @@ public class WorldGenerationTests
     }
 
     [Fact]
+    [Trait("Category", "Slow")]
     public void MultiBiomeWorld_HasSeveralSurfaceBlocks()
     {
         var content = Content();

--- a/tests/BlocksBeyondTheStars.Tests/WreckRepairTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/WreckRepairTests.cs
@@ -57,6 +57,7 @@ public sealed class WreckRepairTests : IDisposable
     }
 
     [Fact]
+    [Trait("Category", "Slow")]
     public void RepairWreck_RequiresMatchingBlockItem()
     {
         var server = StartedWithWreck(out var repo);
@@ -75,6 +76,7 @@ public sealed class WreckRepairTests : IDisposable
     }
 
     [Fact]
+    [Trait("Category", "Slow")]
     public void RepairWreck_ConsumesItem_AndRestoresHullCell()
     {
         var server = StartedWithWreck(out var repo);
@@ -97,6 +99,7 @@ public sealed class WreckRepairTests : IDisposable
     }
 
     [Fact]
+    [Trait("Category", "Slow")]
     public void ClaimWreck_RejectedUntilFullyRepaired()
     {
         var server = StartedWithWreck(out var repo);
@@ -111,6 +114,7 @@ public sealed class WreckRepairTests : IDisposable
     }
 
     [Fact]
+    [Trait("Category", "Slow")]
     public void ClaimWreck_AddsOwnedShip_WhenFullyRepaired()
     {
         var server = StartedWithWreck(out var repo);

--- a/tests/BlocksBeyondTheStars.Tests/WreckStampTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/WreckStampTests.cs
@@ -63,6 +63,7 @@ public sealed class WreckStampTests : IDisposable
     }
 
     [Fact]
+    [Trait("Category", "Slow")]
     public void Wreck_StampsWithName_AndLootMarkers()
     {
         var server = StartedWithWreck("rocky", out var repo);
@@ -76,6 +77,7 @@ public sealed class WreckStampTests : IDisposable
     }
 
     [Fact]
+    [Trait("Category", "Slow")]
     public void Wreck_StampsRealBlocksIntoTheWorld()
     {
         var server = StartedWithWreck("rocky", out var repo);
@@ -100,6 +102,7 @@ public sealed class WreckStampTests : IDisposable
     }
 
     [Fact]
+    [Trait("Category", "Slow")]
     public void Wreck_IsNotProtected_CanBeMined()
     {
         var server = StartedWithWreck("rocky", out var repo);


### PR DESCRIPTION
## Why

A PR test run took **~13 min**, of which ~12.5 min was `dotnet test` itself — restore/build/caching were already optimal (~55 s combined) and xUnit already saturates the runner's 4 vCPUs (2654 s of test CPU in a 645 s wall). The time sink is **31 statistical worldgen/simulation tests of 10–320 s each** (65 % of the suite's CPU; the top two alone are 320 s + 311 s).

At the same time, `release.yml` ran **no tests at all** — nothing tied a release tag to a green CI run.

## What

- **Fast PR tier**: the 27 server + 4 client heavies are marked `[Trait("Category", "Slow")]`; `ci.yml` filters `Category!=Slow` on `pull_request` only. Every test class still runs its fast tests on PRs.
- **Full suite on main**: pushes to `main` keep running everything (unchanged trigger, empty filter).
- **Release gate**: new `test` job in `release.yml` runs the FULL suite on the exact tagged commit; all package/publish jobs (`package`, `package-linux`, `package-mac`, `package-webgl`, `docker`) now `need` it — no installer, itch.io upload or GHCR image ships untested. It runs in parallel with the ~15 min Unity builds, so it adds no wall-clock time to a release.

## Expected effect

| Gate | Before | After |
|---|---|---|
| PR check | ~13–15 min | **~6 min** |
| Push to main | full suite | full suite (unchanged) |
| Release | no tests | full suite, blocking publish |

## Verification

- Fast tier local run: **767/767 server + 89/89 client passing** (= exactly 794−27 and 96−7 theory cases)
- Both test projects build with 0 warnings (`-warnaserror`-safe)
- `dotnet format --verify-no-changes` clean; `actionlint` 1.7.12 clean on both workflows

Follow-up candidates (not in this PR): shrink the two 300 s tests (sample counts; possible real-time waits in `WebSocketTransport_JoinsAndStreamsChunksAsync`), run tests in Release config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)