### PR TITLE
fix(ships): make the hatch opening 3 tall — the step-up sweep jammed under the 2-tall lintel (#211)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -98,6 +98,21 @@ Per-item detail lives in the dated work log below.
 
 ---
 
+### ★ Ship hatch exit, part 3 — THE actual cause: 2-tall hatch vs step-up headroom (#211, 2026-07-02)
+Parts 1+2 removed real pinches but the jump-to-exit persisted. A /bump on the fixed build nailed it: the
+player froze with the capsule front EXACTLY at the door wall's inner face plane, grounded, doorway
+geometrically clear (no stations/engines/terrain/water — nearest water 8 blocks away, below pad level;
+the "underwater look" was night + rain + the open door's energy field across the camera). Root cause:
+the **ship hatch opening is only 2 blocks tall** (settlement doorways are 3): the capsule is 1.88 m
+(1.8 + 0.08 skin) and since auto-step (#127/#130) the grounded CharacterController sweeps the capsule UP
+by `stepOffset` 0.6 before moving forward → needs ~2.4 m of passage → the sweep hits the lintel and the
+walk jams. Jumping goes airborne (no step sweep) → glides under the lintel — exactly the workaround.
+- **Fix:** hatch openings are now **3 tall** like settlement doors (which the 2.8-tall door panels were
+  designed for): box ship carves y=1..3 (guarded for very low hulls); scout/corvette/hauler layouts drop
+  the wall cells directly above the 3-wide door gap.
+- **Tests:** the corridor checks now demand THREE rows of height (feet/head/step headroom) at the door
+  plane, both approach rows inside and the exit row outside — they fail on the 2-tall geometry.
+
 ### ★ Ship hatch exit, part 2: station blocks no longer pinch the doorway approach (#211, 2026-07-02)
 The engine-nozzle fix below was correct but incomplete — in-game the player STILL snagged at the open
 hatch. A structure dump revealed a **second pinch just inside the door**: the box ship's `medbay (1,1,1)`

--- a/data/ship_layouts/ship_corvette.json
+++ b/data/ship_layouts/ship_corvette.json
@@ -517,13 +517,6 @@
   {
    "x": 2,
    "y": 3,
-   "z": 0,
-   "kind": "block",
-   "id": "iron_wall"
-  },
-  {
-   "x": 2,
-   "y": 3,
    "z": 6,
    "kind": "block",
    "id": "iron_wall"
@@ -692,13 +685,6 @@
   {
    "x": 3,
    "y": 3,
-   "z": 0,
-   "kind": "block",
-   "id": "iron_wall"
-  },
-  {
-   "x": 3,
-   "y": 3,
    "z": 6,
    "kind": "block",
    "id": "iron_wall"
@@ -863,13 +849,6 @@
    "z": 6,
    "kind": "block",
    "id": "glass"
-  },
-  {
-   "x": 4,
-   "y": 3,
-   "z": 0,
-   "kind": "block",
-   "id": "iron_wall"
   },
   {
    "x": 4,

--- a/data/ship_layouts/ship_hauler.json
+++ b/data/ship_layouts/ship_hauler.json
@@ -615,13 +615,6 @@
   {
    "x": 2,
    "y": 3,
-   "z": 0,
-   "kind": "block",
-   "id": "iron_wall"
-  },
-  {
-   "x": 2,
-   "y": 3,
    "z": 8,
    "kind": "block",
    "id": "iron_wall"
@@ -811,13 +804,6 @@
   {
    "x": 3,
    "y": 3,
-   "z": 0,
-   "kind": "block",
-   "id": "iron_wall"
-  },
-  {
-   "x": 3,
-   "y": 3,
    "z": 8,
    "kind": "block",
    "id": "iron_wall"
@@ -996,13 +982,6 @@
    "z": 8,
    "kind": "block",
    "id": "glass"
-  },
-  {
-   "x": 4,
-   "y": 3,
-   "z": 0,
-   "kind": "block",
-   "id": "iron_wall"
   },
   {
    "x": 4,

--- a/data/ship_layouts/ship_scout.json
+++ b/data/ship_layouts/ship_scout.json
@@ -251,13 +251,6 @@
   {
    "x": 1,
    "y": 3,
-   "z": 0,
-   "kind": "block",
-   "id": "iron_wall"
-  },
-  {
-   "x": 1,
-   "y": 3,
    "z": 4,
    "kind": "block",
    "id": "iron_wall"
@@ -405,13 +398,6 @@
   {
    "x": 2,
    "y": 3,
-   "z": 0,
-   "kind": "block",
-   "id": "iron_wall"
-  },
-  {
-   "x": 2,
-   "y": 3,
    "z": 4,
    "kind": "block",
    "id": "iron_wall"
@@ -499,13 +485,6 @@
    "z": 4,
    "kind": "block",
    "id": "glass"
-  },
-  {
-   "x": 3,
-   "y": 3,
-   "z": 0,
-   "kind": "block",
-   "id": "iron_wall"
   },
   {
    "x": 3,

--- a/src/BlocksBeyondTheStars.GameServer/GameServerSpaceStructure.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerSpaceStructure.cs
@@ -227,10 +227,16 @@ public sealed partial class GameServer
                         continue; // hollow interior
                     }
 
-                    bool door = z == 0 && (x == halfX - 1 || x == halfX || x == halfX + 1) && (y == 1 || y == 2);
+                    // Rear hatch opening (a slide door fills it, see DoorCells below). THREE tall like every
+                    // settlement doorway: the player capsule is 1.88 m and the grounded step-up sweep
+                    // (stepOffset 0.6) needs that much headroom on top — a 2-tall hatch jammed the walk-out
+                    // against the lintel until the player jumped (#211). Very low hulls keep a 2-tall hatch
+                    // rather than cutting into the roof rim.
+                    int doorTop = System.Math.Min(3, height - 1);
+                    bool door = z == 0 && (x == halfX - 1 || x == halfX || x == halfX + 1) && y >= 1 && y <= doorTop;
                     if (door)
                     {
-                        continue; // rear hatch opening (a slide door fills it, see DoorCells below)
+                        continue;
                     }
 
                     // Window panes at eye height: a band along the front (+Z) and both side walls (matching the

--- a/tests/BlocksBeyondTheStars.Tests/ShipStructureTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/ShipStructureTests.cs
@@ -283,13 +283,13 @@ public sealed class ShipStructureTests : IDisposable
     [Fact]
     public void BoxShipHatch_ExitCorridorIsClear_AcrossTheFullDoorwayGap()
     {
-        // #211: the box ship's rear engine nozzles used to sit at halfX∓1 — inside the 3-wide hatch gap on the
-        // 5-wide starter hull — so the open door still blocked the player at knee height unless they walked out
-        // dead-centre (or jumped onto a nozzle). And the medbay/quarters station blocks used to sit in the rear
-        // cabin corners (z=1), pinching the doorway approach to a single 1-wide lane the same way. The full
-        // doorway gap must have a clear corridor OUTSIDE (z=-1) and on the two APPROACH rows INSIDE (z=+1,+2),
-        // at feet AND head height. (The hatch faces -Z on every ship — the rear-wall convention RegisterDoors
-        // relies on too.)
+        // #211: the box ship's hatch used to jam the walk-out three ways — engine nozzles in the gap (outside),
+        // medbay/quarters station blocks behind it (inside), and finally a 2-tall opening: the player capsule
+        // is 1.88 m and the grounded step-up sweep (stepOffset 0.6) needs that much headroom on top, so the
+        // sweep hit the lintel and only a jump (airborne — no step sweep) got through. The full doorway gap
+        // must be clear for THREE rows of height (feet/head/step headroom) at the door plane (dz=0), the two
+        // approach rows inside (dz=+1,+2) and the exit row outside (dz=-1). (The hatch faces -Z on every
+        // ship — the rear-wall convention RegisterDoors relies on too.)
         var server = Started(placeShip: true, out var repo);
         using (repo)
         {
@@ -300,12 +300,13 @@ public sealed class ShipStructureTests : IDisposable
             {
                 foreach (var gx in DoorwayGapColumns(x => !s.Get(new Vector3i(x, door.Y, door.Z)).IsAir, door.X))
                 {
-                    foreach (int dz in new[] { -1, 1, 2 })
+                    foreach (int dz in new[] { -1, 0, 1, 2 })
                     {
-                        Assert.True(s.Get(new Vector3i(gx, door.Y, door.Z + dz)).IsAir,
-                            $"box ship: doorway corridor blocked at feet height, x={gx} dz={dz}");
-                        Assert.True(s.Get(new Vector3i(gx, door.Y + 1, door.Z + dz)).IsAir,
-                            $"box ship: doorway corridor blocked at head height, x={gx} dz={dz}");
+                        for (int dy = 0; dy <= 2; dy++)
+                        {
+                            Assert.True(s.Get(new Vector3i(gx, door.Y + dy, door.Z + dz)).IsAir,
+                                $"box ship: doorway corridor blocked, x={gx} dy={dy} dz={dz}");
+                        }
                     }
                 }
             }
@@ -316,9 +317,10 @@ public sealed class ShipStructureTests : IDisposable
     public void DesignedShipLayouts_ExitCorridorIsClear_AcrossTheFullDoorwayGap()
     {
         // #211 (and the incomplete #181/#182 fix): authored layouts placed engine blocks directly in front of
-        // doorway columns — and station marker blocks (cargo/medbay) directly behind them. For every ship
-        // layout in content, the door's full air gap must have a clear corridor just OUTSIDE (z-1, beyond the
-        // rear wall the hatch sits in) and on the two APPROACH rows INSIDE (z+1, z+2), at feet + head height.
+        // doorway columns, station marker blocks (cargo/medbay) directly behind them, and capped the doorway
+        // at 2 blocks — too low for the 1.88 m player capsule plus the 0.6 grounded step-up sweep. For every
+        // ship layout in content, the door's full air gap must be clear for THREE rows of height at the door
+        // plane (z), the approach rows inside (z+1, z+2) and the exit row outside (z-1).
         int layoutsChecked = 0;
         foreach (var ship in _content.Ships.Values)
         {
@@ -341,12 +343,13 @@ public sealed class ShipStructureTests : IDisposable
             {
                 foreach (var gx in DoorwayGapColumns(x => solid.Contains((x, door.Y, door.Z)), door.X))
                 {
-                    foreach (int dz in new[] { -1, 1, 2 })
+                    foreach (int dz in new[] { -1, 0, 1, 2 })
                     {
-                        Assert.False(solid.Contains((gx, door.Y, door.Z + dz)),
-                            $"{ship.Key}: doorway corridor blocked at feet height, x={gx} dz={dz}");
-                        Assert.False(solid.Contains((gx, door.Y + 1, door.Z + dz)),
-                            $"{ship.Key}: doorway corridor blocked at head height, x={gx} dz={dz}");
+                        for (int dy = 0; dy <= 2; dy++)
+                        {
+                            Assert.False(solid.Contains((gx, door.Y + dy, door.Z + dz)),
+                                $"{ship.Key}: doorway corridor blocked, x={gx} dy={dy} dz={dz}");
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Problem

After #212 (engine nozzles) and #214 (station blocks), exiting the starter ship STILL required a jump.

## Confirmed root cause (from a /bump snapshot on the fixed build)

The player froze with the capsule front **exactly at the door wall's inner face plane** (z = −2.0), grounded on the cabin floor, with the doorway **geometrically clear** — no stations, engines, terrain or water anywhere in the gap (nearest water: 8 blocks away, below pad level; the "underwater look" in the screenshot is night + rain + the open door's energy field across the camera — the engine nozzle at its new corner position is visible through the open door).

The hatch opening is only **2 blocks tall** (2.0 m) while every settlement doorway is 3. The player capsule is 1.88 m (height 1.8 + skinWidth 0.08). Since auto-step (#127/#130) set `stepOffset = 0.6`, the grounded CharacterController **sweeps the capsule up by 0.6 before moving it forward** — effectively needing ~2.4 m of passage height. The sweep hits the hatch lintel → walking jams at the wall plane. **Jumping goes airborne, the step sweep is skipped, and you glide under the lintel** — exactly the reported workaround, including its timing sensitivity ("jump at the right spot"). Timeline matches: stepOffset 0.6 landed ~June 29 (#130); the hatch complaint (#181) was filed July 1.

## Fix

Ship hatch openings are now **3 blocks tall**, matching settlement doorways (which the 2.8-tall door panels were designed for):

- Fallback box ship: rear hatch carved at y = 1..3 (clamped for very low hulls).
- `ship_scout.json` / `ship_corvette.json` / `ship_hauler.json`: wall cells directly above the 3-wide door gap removed.

## Tests

The corridor regression tests now demand **three rows of clear height** (feet / head / step headroom) across the full doorway gap at the door plane, both approach rows inside, and the exit row outside. Verified via stash: they **fail on the 2-tall geometry**. Fast suite: 769/769.

## Merge gate

**Do not merge yet** — waiting for the reporter's in-game verification with a local build (issue #211 stays open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)