### PR TITLE
fix(browser-play): compose name, /play redirect, touch latch, dark template, required player name

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -5482,6 +5482,28 @@ is **pre-approved** (keys in `tools/ai-assets/.env`, run via `uv`).
 
 ---
 
+## ✅ Done (2026-07-03): browser-play polish — five bugs from the first local Docker browser test (#217–#221)
+Found by building the dedicated-server Docker image locally and playing at `/play`:
+- **Compose project name ([#217](https://github.com/marceld23/BlocksBeyondTheStars/issues/217)).** `docker compose`
+  branded containers/volumes after the checkout folder (`spacecraft-*`); a top-level `name: blocks-beyond-the-stars`
+  in `docker-compose.yml` pins it. Existing local `spacecraft_*` volumes are orphaned by the rename — remove or migrate once.
+- **Portal browser-play link broken ([#218](https://github.com/marceld23/BlocksBeyondTheStars/issues/218)).** The
+  portal linked `/play?…` (slashless); the Unity page's RELATIVE asset URLs then resolved against `/` → 404 → white
+  broken page. The Api now 302-redirects `/play` → `/play/` keeping the query, and the portal links `/play/` directly.
+- **Touch overlay on desktop browsers ([#219](https://github.com/marceld23/BlocksBeyondTheStars/issues/219)).**
+  `Input.touchSupported` is capability, not usage (true on Windows ≥ 8 / desktop Chrome without a touchscreen).
+  `TouchControlsUi.ShouldShow()` now latches on the first REAL touch (`Input.touchCount > 0`) or mobile platform;
+  mouse-only desktops never see the overlay, touch laptops/iPad-desktop-UA get it on first tap.
+- **White `/play` page ([#220](https://github.com/marceld23/BlocksBeyondTheStars/issues/220)).** The build used
+  Unity's default white template. New self-contained dark template `client/Assets/WebGLTemplates/BlocksBeyondTheStars`
+  (starfield, branded cyan loading bar, full-viewport canvas, fullscreen button); `webGLTemplate: PROJECT:BlocksBeyondTheStars`.
+- **Player name & browser menu ([#221](https://github.com/marceld23/BlocksBeyondTheStars/issues/221)).** Nobody was
+  ever forced to pick a name (silent `Pilot` default → multiplayer collisions). `PlayerName` now defaults empty; the
+  native main menu gained the pilot-name field and Singleplayer/Host/Join require it (the connect dialog too); the
+  browser menu already required one. `TryGetConfiguredServer` no longer requires the Glitch config, so the portal's
+  `?server_host=` deep-link finally works in plain self-host builds — and a deep-linked browser menu hides the manual
+  server picker. Server-side duplicate-name rejection existed already (online-name + per-install token claim).
+
 ## ✅ Done (2026-07-02): world-options overlay footer — no more overlapping buttons (#209)
 - **"Done" partially covered the "Advanced: planet types…" button ([#209](https://github.com/marceld23/BlocksBeyondTheStars/issues/209), PR [#210](https://github.com/marceld23/BlocksBeyondTheStars/pull/210)).**
   In `UiWorldOptions` the main page's two page-nav buttons flowed below the 770-px content view into the footer

--- a/client/Assets/BlocksBeyondTheStars/Scripts/AppShell.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/AppShell.cs
@@ -42,7 +42,7 @@ namespace BlocksBeyondTheStars.Client
         // ClientSettings (Awake / the connect dialog); Password is session-only.
         public string Host = "127.0.0.1";
         public string Port = "31415";
-        public string PlayerName = "Pilot";
+        public string PlayerName = ""; // empty until chosen — the menu gates play actions on it (#221)
         public string Password = "";
 
         /// <summary>One-shot notice shown on the main menu (e.g. why the last join was refused).</summary>

--- a/client/Assets/BlocksBeyondTheStars/Scripts/ClientSettings.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/ClientSettings.cs
@@ -157,8 +157,11 @@ namespace BlocksBeyondTheStars.Client
         /// Empty = no in-app updates. Only effective in an installed build (see <see cref="ClientUpdater"/>).</summary>
         public string UpdateFeedUrl = "";
 
-        /// <summary>The player's name — shown to other players and keying the server-side player state.</summary>
-        public string PlayerName = "Pilot";
+        /// <summary>The player's name — shown to other players and keying the server-side player state.
+        /// Empty by default ON PURPOSE (#221): the main menu forces a choice before playing — a silent
+        /// "Pilot" default made everyone collide as Pilot in multiplayer. Existing installs keep the
+        /// name their settings file already carries.</summary>
+        public string PlayerName = "";
 
         /// <summary>Per-install secret backing name verification: sent with every join; the first join
         /// under a name claims it, later joins must match. Generated once on load, never shown in UI.</summary>

--- a/client/Assets/BlocksBeyondTheStars/Scripts/GlitchIntegration.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/GlitchIntegration.cs
@@ -64,7 +64,10 @@ namespace BlocksBeyondTheStars.Client
                 GlitchIntegrationSecrets.ServerPassword,
                 GetEnv("GLITCH_SERVER_PASSWORD"));
 
-            return IsConfigured && !string.IsNullOrWhiteSpace(host);
+            // A host is enough: the portal's /play deep-link (?server_host=…) must work in plain
+            // open-source/self-host builds too — gating on the Glitch config made the params dead there,
+            // so "Play" silently joined the default 127.0.0.1 (#221).
+            return !string.IsNullOrWhiteSpace(host);
         }
 
         public static void InstallIfConfigured()

--- a/client/Assets/BlocksBeyondTheStars/Scripts/TouchControlsUi.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/TouchControlsUi.cs
@@ -46,10 +46,15 @@ namespace BlocksBeyondTheStars.Client
         private readonly List<(InputAction Action, TouchButton Button)> _heldActions = new();
         private bool _built;
 
-        /// <summary>True on a touch device (tablet / touch-capable browser). Desktop mouse rigs report false,
-        /// so the whole feature stays dormant there. WebGL on a desktop browser also reports false → the
-        /// browser build uses keyboard/mouse or a pad, exactly as intended.</summary>
-        public static bool ShouldShow() => Application.isMobilePlatform || Input.touchSupported;
+        // Input.touchSupported is capability, not usage: Windows ≥8 standalone and desktop browsers
+        // report it without any touchscreen (the OS/browser merely exposes the touch API), which popped
+        // the overlay on plain desktops (#219). Evidence latch instead: the first REAL touch flips it.
+        private static bool s_touchSeen;
+
+        /// <summary>True on a device where touch is in use: mobile platforms immediately, everything else
+        /// (desktop, WebGL in a desktop browser) only once an actual touch has been seen — so mouse-only
+        /// rigs stay dormant while touch laptops and iPad-Safari's desktop UA get controls on first tap.</summary>
+        public static bool ShouldShow() => Application.isMobilePlatform || s_touchSeen;
 
         /// <summary>Whether the controls are currently live (built AND visible). The source reads zero when false.</summary>
         public bool Visible => _built && _rootPanel != null && _rootPanel.activeSelf;
@@ -142,6 +147,11 @@ namespace BlocksBeyondTheStars.Client
 
         private void Update()
         {
+            if (!s_touchSeen && Input.touchCount > 0)
+            {
+                s_touchSeen = true;
+            }
+
             if (!_built)
             {
                 // Lazy build on the first frame: WorldRig assigns Game/Menu/Chat after AddComponent (so Awake

--- a/client/Assets/BlocksBeyondTheStars/Scripts/UiMainMenu.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/UiMainMenu.cs
@@ -39,7 +39,9 @@ namespace BlocksBeyondTheStars.Client
             UiKit.AddText(root, 1700f, 44f, 180f, 24f, "VER. " + AppShell.Version, 16, UiKit.CyanDim, TextAnchor.MiddleRight);
 
             // Connect-to-server dialog (built below; the JOIN button reveals it). Captured by the button.
+            // dlgName mirrors the dialog's name input so openers can carry the menu's name field over.
             GameObject connect = null;
+            InputField dlgName = null;
 
             // --- One-shot notice (e.g. why the last join was refused) ---
             if (!string.IsNullOrEmpty(shell.MenuNotice))
@@ -77,29 +79,69 @@ namespace BlocksBeyondTheStars.Client
                 shell.Settings.Save();
                 shell.StartJoin();
             }, "btn_join");
-            UiKit.AddButton(root, bx, wby + gap, bw, bh, shell.L("ui.menu.connect_manual"), () =>
+
+            // The manual server picker only helps when /play was opened WITHOUT a deep-linked server —
+            // players arriving through the portal already have host/port preconfigured, so the extra
+            // choice is just noise for them (#221).
+            float wextra = 0f;
+            if (!GlitchIntegration.TryGetConfiguredServer(out _, out _, out _))
             {
-                if (connect != null)
+                UiKit.AddButton(root, bx, wby + gap, bw, bh, shell.L("ui.menu.connect_manual"), () =>
                 {
-                    connect.SetActive(true);
-                }
-            }, "btn_join");
-            UiKit.AddButton(root, bx, wby + gap * 2f, bw, bh, shell.L("ui.menu.settings"), shell.OpenSettings, "btn_settings");
-            UiKit.AddButton(root, bx, wby + gap * 3f, bw, bh, shell.L("ui.menu.credits"), () => shell.GoTo(ShellPhase.Credits), "btn_credits");
+                    if (connect != null)
+                    {
+                        dlgName.text = webName[0]; // carry the menu's name over (fires the input's onChange)
+                        connect.SetActive(true);
+                    }
+                }, "btn_join");
+                wextra = gap;
+            }
+
+            UiKit.AddButton(root, bx, wby + wextra + gap, bw, bh, shell.L("ui.menu.settings"), shell.OpenSettings, "btn_settings");
+            UiKit.AddButton(root, bx, wby + wextra + gap * 2f, bw, bh, shell.L("ui.menu.credits"), () => shell.GoTo(ShellPhase.Credits), "btn_credits");
 #else
-            UiKit.AddButton(root, bx, by, bw, bh, shell.L("ui.menu.singleplayer"), shell.StartSingleplayer, "btn_singleplayer");
-            UiKit.AddButton(root, bx, by + gap, bw, bh, shell.L("ui.menu.host"), shell.StartHost, "btn_join");
-            UiKit.AddButton(root, bx, by + gap * 2f, bw, bh, shell.L("ui.menu.join"), () =>
+            // Pilot name on the menu itself (#221): play actions require a chosen name — the old silent
+            // "Pilot" default meant nobody ever picked one and multiplayer names collided. The value is
+            // persisted on use; the connect dialog's own name field stays as a per-join override.
+            string[] natName = { shell.PlayerName };
+            UiKit.AddText(root, bx, by, bw, 22f, shell.L("ui.menu.connect_name"), 15, UiKit.TextCol, TextAnchor.MiddleLeft);
+            UiKit.AddInput(root, bx, by + 28f, bw, 44f, natName[0], v => natName[0] = v);
+            var natWarn = UiKit.AddText(root, bx, by + 80f, bw, 22f, "", 14,
+                new Color(1f, 0.55f, 0.4f), TextAnchor.MiddleLeft, FontStyle.Bold);
+            float nby = by + 112f;
+
+            // True when a name is present (warns + blocks otherwise); commits it to the shell + settings.
+            bool CommitName()
             {
-                if (connect != null)
+                if (string.IsNullOrWhiteSpace(natName[0]))
                 {
+                    natWarn.text = shell.L("ui.webgl.need_name");
+                    return false;
+                }
+
+                natWarn.text = "";
+                shell.PlayerName = natName[0].Trim();
+                shell.Settings.PlayerName = shell.PlayerName; // remember the identity across sessions
+                shell.Settings.Save();
+                return true;
+            }
+
+            UiKit.AddButton(root, bx, nby, bw, bh, shell.L("ui.menu.singleplayer"),
+                () => { if (CommitName()) { shell.StartSingleplayer(); } }, "btn_singleplayer");
+            UiKit.AddButton(root, bx, nby + gap, bw, bh, shell.L("ui.menu.host"),
+                () => { if (CommitName()) { shell.StartHost(); } }, "btn_join");
+            UiKit.AddButton(root, bx, nby + gap * 2f, bw, bh, shell.L("ui.menu.join"), () =>
+            {
+                if (CommitName() && connect != null)
+                {
+                    dlgName.text = shell.PlayerName; // carry the menu's name over (fires the input's onChange)
                     connect.SetActive(true);
                 }
             }, "btn_join");
-            UiKit.AddButton(root, bx, by + gap * 3f, bw, bh, shell.L("ui.menu.editors"), () => shell.GoTo(ShellPhase.Editors), "btn_singleplayer");
-            UiKit.AddButton(root, bx, by + gap * 4f, bw, bh, shell.L("ui.menu.settings"), shell.OpenSettings, "btn_settings");
-            UiKit.AddButton(root, bx, by + gap * 5f, bw, bh, shell.L("ui.menu.credits"), () => shell.GoTo(ShellPhase.Credits), "btn_credits");
-            UiKit.AddButton(root, bx, by + gap * 6f, bw, bh, shell.L("ui.menu.quit"), shell.Quit, "btn_exit");
+            UiKit.AddButton(root, bx, nby + gap * 3f, bw, bh, shell.L("ui.menu.editors"), () => shell.GoTo(ShellPhase.Editors), "btn_singleplayer");
+            UiKit.AddButton(root, bx, nby + gap * 4f, bw, bh, shell.L("ui.menu.settings"), shell.OpenSettings, "btn_settings");
+            UiKit.AddButton(root, bx, nby + gap * 5f, bw, bh, shell.L("ui.menu.credits"), () => shell.GoTo(ShellPhase.Credits), "btn_credits");
+            UiKit.AddButton(root, bx, nby + gap * 6f, bw, bh, shell.L("ui.menu.quit"), shell.Quit, "btn_exit");
 #endif
 
             // --- World / server info panel (bottom-right, decorative) ---
@@ -129,21 +171,29 @@ namespace BlocksBeyondTheStars.Client
             var dlg = UiKit.AddPanel(connect.transform, 660f, 280f, 600f, 520f, UiKit.Panel).transform;
             UiKit.AddText(dlg, 30f, 24f, 540f, 30f, shell.L("ui.menu.connect_title"), 22, UiKit.Cyan, TextAnchor.MiddleCenter, FontStyle.Bold);
             UiKit.AddText(dlg, 30f, 80f, 540f, 22f, shell.L("ui.menu.connect_name"), 15, UiKit.TextCol, TextAnchor.MiddleLeft);
-            UiKit.AddInput(dlg, 30f, 106f, 540f, 38f, name[0], v => name[0] = v);
+            dlgName = UiKit.AddInput(dlg, 30f, 106f, 540f, 38f, name[0], v => name[0] = v);
             UiKit.AddText(dlg, 30f, 160f, 540f, 22f, shell.L("ui.menu.connect_host"), 15, UiKit.TextCol, TextAnchor.MiddleLeft);
             UiKit.AddInput(dlg, 30f, 186f, 540f, 38f, host[0], v => host[0] = v);
             UiKit.AddText(dlg, 30f, 240f, 540f, 22f, shell.L("ui.menu.connect_port"), 15, UiKit.TextCol, TextAnchor.MiddleLeft);
             UiKit.AddInput(dlg, 30f, 266f, 260f, 38f, port[0], v => port[0] = v);
             UiKit.AddText(dlg, 30f, 320f, 540f, 22f, shell.L("ui.menu.connect_password"), 15, UiKit.TextCol, TextAnchor.MiddleLeft);
             UiKit.AddInput(dlg, 30f, 346f, 540f, 38f, pass[0], v => pass[0] = v);
+            var dlgWarn = UiKit.AddText(dlg, 30f, 396f, 540f, 22f, "", 14,
+                new Color(1f, 0.55f, 0.4f), TextAnchor.MiddleLeft, FontStyle.Bold);
             UiKit.AddButton(dlg, 30f, 432f, 270f, 54f, shell.L("ui.menu.connect"), () =>
             {
-                if (!string.IsNullOrWhiteSpace(name[0]))
+                // A name is required (#221): joining anonymously fell back to a server-assigned
+                // "player_N" identity nobody recognizes, and shared "Pilot" names collide.
+                if (string.IsNullOrWhiteSpace(name[0]))
                 {
-                    shell.PlayerName = name[0].Trim();
-                    shell.Settings.PlayerName = shell.PlayerName; // remember the identity across sessions
-                    shell.Settings.Save();
+                    dlgWarn.text = shell.L("ui.webgl.need_name");
+                    return;
                 }
+
+                dlgWarn.text = "";
+                shell.PlayerName = name[0].Trim();
+                shell.Settings.PlayerName = shell.PlayerName; // remember the identity across sessions
+                shell.Settings.Save();
 
                 shell.Host = string.IsNullOrWhiteSpace(host[0]) ? "127.0.0.1" : host[0].Trim();
                 shell.Port = string.IsNullOrWhiteSpace(port[0]) ? shell.Port : port[0].Trim();

--- a/client/Assets/Scenes/Launcher.unity
+++ b/client/Assets/Scenes/Launcher.unity
@@ -150,7 +150,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: BlocksBeyondTheStars.Client::BlocksBeyondTheStars.Client.AppShell
   Host: 127.0.0.1
   Port: 31415
-  PlayerName: Pilot
+  PlayerName:
 --- !u!4 &401903626
 Transform:
   m_ObjectHideFlags: 0

--- a/client/Assets/WebGLTemplates.meta
+++ b/client/Assets/WebGLTemplates.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 74702e8b7991369481df910209d96618
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/client/Assets/WebGLTemplates/BlocksBeyondTheStars.meta
+++ b/client/Assets/WebGLTemplates/BlocksBeyondTheStars.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3111b4ec270672f4b08e577ecb806663
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/client/Assets/WebGLTemplates/BlocksBeyondTheStars/index.html
+++ b/client/Assets/WebGLTemplates/BlocksBeyondTheStars/index.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html lang="en-us">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <title>{{{ PRODUCT_NAME }}}</title>
+    <style>
+      /* Space-themed shell (#220): black page, subtle starfield, branded loading UI. Fully
+         self-contained — no TemplateData images, so the template is a single file. */
+      html, body { padding: 0; margin: 0; width: 100%; height: 100%; background: #05070d; overflow: hidden }
+      #bbs-sky { position: fixed; inset: 0; pointer-events: none;
+        background:
+          radial-gradient(1.4px 1.4px at 20% 30%, #bfe7ff88, transparent),
+          radial-gradient(1.2px 1.2px at 75% 22%, #ffffff66, transparent),
+          radial-gradient(1.6px 1.6px at 60% 70%, #bfe7ff55, transparent),
+          radial-gradient(1.2px 1.2px at 35% 80%, #ffffff44, transparent),
+          radial-gradient(1.3px 1.3px at 88% 62%, #bfe7ff66, transparent),
+          radial-gradient(1100px 640px at 50% -12%, #15243f 0%, #05070d 58%) }
+      #unity-container { position: fixed; inset: 0 }
+      #unity-canvas { width: 100%; height: 100%; display: block; background: #05070d }
+      #unity-loading-bar { position: absolute; left: 50%; top: 50%; transform: translate(-50%, -50%);
+        display: none; text-align: center; font-family: 'Rajdhani', system-ui, 'Segoe UI', sans-serif }
+      #bbs-title { color: #eaf6ff; font-size: 28px; font-weight: 700; letter-spacing: .18em;
+        text-transform: uppercase; text-shadow: 0 0 20px rgba(95,215,255,.5), 0 0 3px rgba(95,215,255,.85);
+        margin-bottom: 26px; white-space: nowrap }
+      #bbs-title b { color: #5fd7ff; font-weight: 700 }
+      #unity-progress-bar-empty { width: 280px; height: 10px; margin: 0 auto; border: 1px solid #21304c;
+        border-radius: 6px; background: rgba(95,215,255,.06) }
+      #unity-progress-bar-full { width: 0%; height: 100%; border-radius: 5px;
+        background: linear-gradient(90deg, #2b9fd6, #5fd7ff); box-shadow: 0 0 12px rgba(95,215,255,.55) }
+      #bbs-loading-hint { color: #8aa0bd; font-size: 12px; letter-spacing: .22em; text-transform: uppercase; margin-top: 14px }
+      #unity-warning { position: absolute; left: 50%; top: 5%; transform: translate(-50%);
+        background: white; padding: 10px; display: none; font-family: system-ui, sans-serif }
+      #unity-fullscreen-button { position: absolute; right: 14px; bottom: 12px; width: 34px; height: 34px;
+        cursor: pointer; opacity: .35; transition: opacity .15s; color: #bfe7ff; font-size: 24px;
+        line-height: 34px; text-align: center; user-select: none }
+      #unity-fullscreen-button:hover { opacity: 1 }
+    </style>
+  </head>
+  <body>
+    <div id="bbs-sky"></div>
+    <div id="unity-container">
+      <canvas id="unity-canvas" tabindex="-1"></canvas>
+      <div id="unity-loading-bar">
+        <div id="bbs-title"><b>Blocks</b> Beyond the Stars</div>
+        <div id="unity-progress-bar-empty">
+          <div id="unity-progress-bar-full"></div>
+        </div>
+        <div id="bbs-loading-hint">Loading</div>
+      </div>
+      <div id="unity-warning"> </div>
+      <div id="unity-fullscreen-button" title="Fullscreen">⛶</div>
+    </div>
+    <script>
+      var canvas = document.querySelector("#unity-canvas");
+
+      // Shows a temporary message banner/ribbon for a few seconds, or
+      // a permanent error message on top of the canvas if type=='error'.
+      // If type=='warning', a yellow highlight color is used.
+      function unityShowBanner(msg, type) {
+        var warningBanner = document.querySelector("#unity-warning");
+        function updateBannerVisibility() {
+          warningBanner.style.display = warningBanner.children.length ? 'block' : 'none';
+        }
+        var div = document.createElement('div');
+        div.innerHTML = msg;
+        warningBanner.appendChild(div);
+        if (type == 'error') div.style = 'background: red; padding: 10px;';
+        else {
+          if (type == 'warning') div.style = 'background: yellow; padding: 10px;';
+          setTimeout(function() {
+            warningBanner.removeChild(div);
+            updateBannerVisibility();
+          }, 5000);
+        }
+        updateBannerVisibility();
+      }
+
+      var buildUrl = "Build";
+      var loaderUrl = buildUrl + "/{{{ LOADER_FILENAME }}}";
+      var config = {
+        arguments: [],
+        dataUrl: buildUrl + "/{{{ DATA_FILENAME }}}",
+        frameworkUrl: buildUrl + "/{{{ FRAMEWORK_FILENAME }}}",
+        codeUrl: buildUrl + "/{{{ CODE_FILENAME }}}",
+#if MEMORY_FILENAME
+        memoryUrl: buildUrl + "/{{{ MEMORY_FILENAME }}}",
+#endif
+#if SYMBOLS_FILENAME
+        symbolsUrl: buildUrl + "/{{{ SYMBOLS_FILENAME }}}",
+#endif
+        streamingAssetsUrl: "StreamingAssets",
+        companyName: {{{ JSON.stringify(COMPANY_NAME) }}},
+        productName: {{{ JSON.stringify(PRODUCT_NAME) }}},
+        productVersion: {{{ JSON.stringify(PRODUCT_VERSION) }}},
+        showBanner: unityShowBanner,
+      };
+
+      if (/iPhone|iPad|iPod|Android/i.test(navigator.userAgent)) {
+        // Mobile: lock the visual viewport so the canvas maps 1:1 to CSS pixels (no pinch zoom).
+        var meta = document.createElement('meta');
+        meta.name = 'viewport';
+        meta.content = 'width=device-width, height=device-height, initial-scale=1.0, user-scalable=no, shrink-to-fit=yes';
+        document.getElementsByTagName('head')[0].appendChild(meta);
+      }
+      // Desktop and mobile alike fill the whole browser client area (the CSS pins the canvas to the
+      // viewport); Unity keeps the render target matched to the DOM size, so no manual resize handling.
+
+      document.querySelector("#unity-loading-bar").style.display = "block";
+
+      var script = document.createElement("script");
+      script.src = loaderUrl;
+      script.onload = () => {
+        createUnityInstance(canvas, config, (progress) => {
+          document.querySelector("#unity-progress-bar-full").style.width = 100 * progress + "%";
+        }).then((unityInstance) => {
+          document.querySelector("#unity-loading-bar").style.display = "none";
+          document.querySelector("#unity-fullscreen-button").onclick = () => {
+            unityInstance.SetFullscreen(1);
+          };
+        }).catch((message) => {
+          alert(message);
+        });
+      };
+
+      document.body.appendChild(script);
+    </script>
+  </body>
+</html>

--- a/client/Assets/WebGLTemplates/BlocksBeyondTheStars/index.html.meta
+++ b/client/Assets/WebGLTemplates/BlocksBeyondTheStars/index.html.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: f49848e637220b1a3f67c647eb4d71fb
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/client/ProjectSettings/ProjectSettings.asset
+++ b/client/ProjectSettings/ProjectSettings.asset
@@ -609,7 +609,7 @@ PlayerSettings:
   webGLDebugSymbols: 0
   webGLEmscriptenArgs: 
   webGLModulesDirectory: 
-  webGLTemplate: APPLICATION:Default
+  webGLTemplate: PROJECT:BlocksBeyondTheStars
   webGLAnalyzeBuildSize: 0
   webGLUseEmbeddedResources: 0
   webGLCompressionFormat: 0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,10 @@
 # Config precedence is server.json < BBS_* env vars < CLI; in a container you normally use the env vars
 # below. ALWAYS set BBS_ADMIN_PASSWORD before exposing the admin port (31416) beyond your LAN.
 
+# Pin the Compose project name: without it Compose brands every container/volume/network after the
+# checkout FOLDER (historically "SpaceCraft"), not the game (#217).
+name: blocks-beyond-the-stars
+
 services:
   server:
     build:

--- a/docs/developer/INPUT_AND_CONTROLLER.md
+++ b/docs/developer/INPUT_AND_CONTROLLER.md
@@ -80,10 +80,12 @@ layer, added to `InputMap`'s combine exactly like the pad — no gameplay change
   FIRE-hold / LAND / SHIP / AUTO / VIEW / USE / UP / DOWN) and **speeder** (`Game.DrivenSpeeder != null`:
   BOOST-hold / JUMP / EXIT / FUEL). Discrete buttons map to `InputAction`s through a lookup the
   `TouchInputSource.ActionDown/ActionHeld` methods read, so rebind-consuming call sites work unchanged.
-- **Inert on desktop / behaviour-preserving:** the UI is only built when the device has touch
-  (`TouchControlsUi.ShouldShow()` = `Application.isMobilePlatform || Input.touchSupported`), and
-  `TouchInputSource` reads zero whenever the controls aren't `Visible`. A desktop mouse rig (and a desktop
-  browser, which reports no touch) never builds it.
+- **Inert on desktop / behaviour-preserving:** the UI is only built when touch is actually in use
+  (`TouchControlsUi.ShouldShow()` = `Application.isMobilePlatform` OR a real touch has been seen —
+  `Input.touchCount > 0` latches once), and `TouchInputSource` reads zero whenever the controls aren't
+  `Visible`. `Input.touchSupported` is deliberately NOT consulted: it reports the OS/browser touch API
+  (true on Windows ≥ 8 and in desktop Chrome without any touchscreen, #219). A desktop mouse rig never
+  latches; touch laptops and iPad-Safari's desktop UA get the controls on the first tap.
 - **Edges:** `TouchButton.DownThisFrame` is a frame-idempotent edge (like `GetKeyDown`) computed in an early
   `Update` (order −100), because a single action is polled at more than one call site per frame — a
   consume-on-read latch would let the first site eat the edge. All widget state clears on disable, so a

--- a/docs/developer/SELF_HOSTING.md
+++ b/docs/developer/SELF_HOSTING.md
@@ -288,9 +288,11 @@ version must be higher than the last.
 
 ### Play in the browser (no install)
 
-The server can also serve the **WebGL browser client** at `http://<server>:<adminPort>/play`. The portal's
-**Play in the browser** button deep-links to it with the server host/port pre-filled (`/play?server_host=…&server_port=31415`).
-No download, no install — players just open the link. Singleplayer/host are unavailable in the browser (it
+The server can also serve the **WebGL browser client** at `http://<server>:<adminPort>/play/`. The portal's
+**Play in the browser** button deep-links to it with the server host/port pre-filled (`/play/?server_host=…&server_port=31415`;
+the slashless `/play` redirects there, keeping the query — the Unity page references its assets relatively, #218).
+No download, no install — players just open the link, pick a pilot name and press Play (the deep-linked
+menu hides the manual server picker, #221). Singleplayer/host are unavailable in the browser (it
 only joins a hosted server over WebSocket), so `BBS_ENABLE_WEBSOCKET=true` is required.
 
 The browser build is **not** baked into the server image (it needs Unity, which can't run in the image). You

--- a/src/BlocksBeyondTheStars.Api/PortalPage.cs
+++ b/src/BlocksBeyondTheStars.Api/PortalPage.cs
@@ -135,7 +135,7 @@ a.ghost:hover{background:rgba(95,215,255,.1)}
  <div class='rule'></div>
  <div class='logo'><b>Blocks</b> Beyond the Stars</div>
  <div class='meta'>Server “__SERVER__” · World “__WORLD__” · native clients join on UDP __PORT__</div>
- <a class='btn primary' href='/play?server_host=__WSHOST__&amp;server_port=__PORT__&amp;bbs_auto_join=0'>▶&nbsp; Play in the browser</a>
+ <a class='btn primary' href='/play/?server_host=__WSHOST__&amp;server_port=__PORT__&amp;bbs_auto_join=0'>▶&nbsp; Play in the browser</a>
  <a class='btn ghost' href='/download'>⬇&nbsp; Download the Windows client</a>
  <a class='btn ghost' href='/download-linux'>⬇&nbsp; Download the Linux client (AppImage)</a>
  <a class='btn ghost' href='/download-mac'>⬇&nbsp; Download the macOS client (experimental)</a>

--- a/src/BlocksBeyondTheStars.Api/Program.cs
+++ b/src/BlocksBeyondTheStars.Api/Program.cs
@@ -80,8 +80,16 @@ Directory.CreateDirectory(webglDir);
 
 // Friendly page when no build is installed yet (volume not mounted / fetch disabled), so /play never
 // 404s blankly. Registered BEFORE UseStaticFiles so it only fires when index.html is absent.
-app.MapGet("/play", () =>
+app.MapGet("/play", (HttpContext ctx) =>
 {
+    // The Unity index.html references its assets RELATIVELY (TemplateData/…, Build/…). Served at the
+    // slashless "/play" those resolve against "/" and 404 (#218) — canonicalize to "/play/" and keep the
+    // query string (the WebGL client reads server_host/server_port/bbs_auto_join from the page URL).
+    if (!ctx.Request.Path.Value!.EndsWith('/'))
+    {
+        return Results.Redirect("/play/" + ctx.Request.QueryString);
+    }
+
     if (File.Exists(Path.Combine(webglDir, "index.html")))
     {
         return Results.File(Path.Combine(webglDir, "index.html"), "text/html; charset=utf-8");

--- a/tests/BlocksBeyondTheStars.Tests/PortalPageTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/PortalPageTests.cs
@@ -41,7 +41,8 @@ public sealed class PortalPageTests
         string html = PortalPage.Render("MyServer", "MyWorld", 31415, "http://example:31416");
 
         // The "Play in the browser" deep-link uses the bare host (no scheme/port) for server_host and the
-        // gameplay port for server_port; the WebGL client picks ws/wss from the page scheme.
-        Assert.Contains("href='/play?server_host=example&amp;server_port=31415&amp;bbs_auto_join=0'", html);
+        // gameplay port for server_port; the WebGL client picks ws/wss from the page scheme. The trailing
+        // slash matters (#218): the Unity page references its assets relatively.
+        Assert.Contains("href='/play/?server_host=example&amp;server_port=31415&amp;bbs_auto_join=0'", html);
     }
 }


### PR DESCRIPTION
## Summary
Five fixes found in the first local Docker browser-play test (issues #217–#221):

- **#217 Compose project name** — top-level `name: blocks-beyond-the-stars` in `docker-compose.yml`; containers/volumes/network no longer inherit the checkout folder name (`spacecraft-*`). Existing local `spacecraft_*` volumes are orphaned by the rename (remove or migrate once).
- **#218 Broken portal play link** — the Unity WebGL page references its assets RELATIVELY, so the slashless `/play` 404ed them all. The Api now 302-redirects `/play` → `/play/` **keeping the query string** (`server_host`/`server_port`/`bbs_auto_join` live in the page URL), and the portal links `/play/` directly.
- **#219 Touch overlay on desktop browsers** — `Input.touchSupported` is capability, not usage (true on Windows ≥ 8 and desktop Chrome without any touchscreen). `TouchControlsUi.ShouldShow()` now latches on the **first real touch** (`Input.touchCount > 0`) or `Application.isMobilePlatform`. Mouse-only desktops never see the overlay; touch laptops / iPad-desktop-UA get it on first tap.
- **#220 White `/play` page** — new self-contained dark WebGL template (`client/Assets/WebGLTemplates/BlocksBeyondTheStars`): starfield, branded cyan loading bar, full-viewport canvas, fullscreen button; `webGLTemplate: PROJECT:BlocksBeyondTheStars`.
- **#221 Player name & browser menu** — a name is now required before playing:
  - `PlayerName` defaults empty in code **and in `Launcher.unity`** (the scene serialized the old `Pilot` and silently overrode the code default — found during browser verification).
  - Native main menu gains the pilot-name field; Singleplayer/Host/Join gate on it; the connect dialog requires a name too (opened dialogs carry the menu's name over).
  - `GlitchIntegration.TryGetConfiguredServer` no longer requires the Glitch config, so the portal's `?server_host=` deep-link finally works in plain open-source/self-host builds; a deep-linked browser menu hides the manual server picker.
  - Server-side duplicate-name rejection already existed (online-name check + per-install token claim) — no server change needed.

## Verification
- Full non-Slow test suite green (the portal deep-link test was updated for the trailing slash).
- Local Unity **Windows** and **WebGL** builds green; no new compiler warnings.
- **End-to-end in a real browser** (Playwright vs the locally built Docker stack):
  - `GET /play?query` → `302 /play/?query`; portal links `/play/`.
  - Page background `rgb(5, 7, 13)`, branded loading bar, Unity boots.
  - Console shows `[Glitch] Applied WebGL server defaults: localhost:31415.` (deep-link without Glitch config).
  - Menu shows the name field **empty**, no manual server picker; Play with empty name shows the localized inline warning and does not join; with a name typed, the client joins and reaches the ship interior — no touch overlay anywhere with a mouse.
- Container now runs as `blocks-beyond-the-stars-server-1`.

Closes #217, closes #218, closes #219, closes #220, closes #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)