### PR TITLE
ci: fleet CI/CD — WorldHost image, deploy/ infra-as-code, SSH deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,79 @@
+# Deploys the hosted-worlds fleet services to the VPS (bbs-host-1, see docs/developer/HOSTED_WORLDS.md
+# and deploy/README.md). Manual-only by design: run it from the Actions tab, pick the service and
+# optionally pin image tags. The `production` environment adds a required-reviewer approval gate.
+#
+# Secrets model (deliberate):
+#   * GitHub holds ONE secret — DEPLOY_SSH_KEY, a dedicated ed25519 key for the `bbs` user that exists
+#     only for this workflow (not the operator's personal key). The host key below is pinned.
+#   * All service secrets (claim code, report keys, admin credentials) live ONLY in /opt/bbs/*/.env on
+#     the host. This workflow never reads, writes or logs them — remote-deploy.sh rewrites only the
+#     *_TAG line of those files.
+
+name: Deploy (VPS)
+
+on:
+  workflow_dispatch:
+    inputs:
+      service:
+        description: "Which service to deploy."
+        type: choice
+        options: [all, caddy, worldhost, reports]
+        default: all
+      worldhost_tag:
+        description: "WorldHost image tag to pin (e.g. sha-abc1234). Empty = keep the currently pinned tag."
+        type: string
+        default: ""
+      reports_tag:
+        description: "ReportHost image tag to pin (e.g. sha-abc1234). Empty = keep the currently pinned tag."
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+
+# Never two deploys at once; a second run queues instead of cancelling a half-finished deploy.
+concurrency:
+  group: deploy-production
+
+jobs:
+  deploy:
+    name: Deploy to bbs-host-1
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Validate inputs
+        env:
+          WORLDHOST_TAG: ${{ inputs.worldhost_tag }}
+          REPORTS_TAG: ${{ inputs.reports_tag }}
+        run: |
+          for t in "$WORLDHOST_TAG" "$REPORTS_TAG"; do
+            if ! printf '%s' "$t" | grep -Eq '^[A-Za-z0-9._-]*$'; then
+              echo "invalid image tag: $t"; exit 1
+            fi
+          done
+
+      - name: Set up SSH (pinned host key)
+        env:
+          DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+        run: |
+          mkdir -p ~/.ssh
+          printf '%s\n' "$DEPLOY_SSH_KEY" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          echo '31.70.113.90 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICuF64bEL7WPCFjuC5jT91w0TOupsWe2VjMPUxFanFow' >> ~/.ssh/known_hosts
+
+      - name: Sync deploy files (never touches the host .env files)
+        run: |
+          rsync -rtv --exclude='.env' -e "ssh -i ~/.ssh/deploy_key" \
+            deploy/caddy deploy/worldhost deploy/reports \
+            bbs@31.70.113.90:/opt/bbs/
+
+      - name: Deploy + health check
+        env:
+          SERVICE: ${{ inputs.service }}
+          WORLDHOST_TAG: ${{ inputs.worldhost_tag }}
+          REPORTS_TAG: ${{ inputs.reports_tag }}
+        run: |
+          ssh -i ~/.ssh/deploy_key bbs@31.70.113.90 \
+            "bash -s -- '$SERVICE' '$WORLDHOST_TAG' '$REPORTS_TAG'" < deploy/remote-deploy.sh

--- a/.github/workflows/worldhost-image.yml
+++ b/.github/workflows/worldhost-image.yml
@@ -1,0 +1,95 @@
+# WorldHost Docker image — the hosted-worlds control plane (see docs/developer/HOSTED_WORLDS.md).
+# Deliberately its own small workflow (NOT part of release.yml), mirroring reports-image.yml: the
+# control plane is deployed independently of game releases, and its image only needs rebuilding when
+# the service (or the Shared library it references) changes.
+#
+# Two entry points:
+#   * push to main touching WorldHost files — builds AND publishes to GHCR as :latest + :sha-<short>,
+#     so a VPS deploy can pin an immutable tag (deploy.yml) or pull the current state of main.
+#   * workflow_dispatch — build it by hand from the Actions tab (build-validate by default; set `push`
+#     to publish, with a tag of your choice).
+
+name: WorldHost image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "src/BlocksBeyondTheStars.WorldHost/**"
+      - "src/BlocksBeyondTheStars.Shared/**"
+      - "Dockerfile.worldhost"
+      - ".github/workflows/worldhost-image.yml"
+  workflow_dispatch:
+    inputs:
+      push:
+        description: "Push the image to GHCR (ghcr.io). Leave off to only build/validate."
+        type: boolean
+        default: false
+      tag:
+        description: "Image tag to apply (e.g. dev, 0.1.0)."
+        type: string
+        default: dev
+      latest:
+        description: "Also tag the pushed image as :latest."
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: worldhost-image-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  image:
+    name: Build WorldHost image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      # Build the image tag list. The owner is lowercased — GHCR repository names must be lowercase, but
+      # github.repository_owner can contain uppercase letters. A main push always publishes :latest plus
+      # an immutable :sha-<short> (for pinning/rollback); a manual run uses the dispatch inputs.
+      - name: Compute image name + tags
+        id: img
+        run: |
+          name="ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/blocks-beyond-the-stars-worldhost"
+          if [ "${{ github.event_name }}" = "push" ]; then
+            push=true
+            tags="${name}:latest
+          ${name}:sha-${GITHUB_SHA::7}"
+          else
+            push="${{ inputs.push }}"
+            tags="${name}:${{ inputs.tag }}"
+            if [ "${{ inputs.latest }}" = "true" ]; then tags="${tags}
+          ${name}:latest"; fi
+          fi
+          {
+            echo "push=${push}"
+            echo "tags<<EOF"
+            echo "${tags}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+
+      - name: Log in to GHCR
+        if: ${{ steps.img.outputs.push == 'true' }}
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build (and optionally push)
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
+        with:
+          context: .
+          file: ./Dockerfile.worldhost
+          platforms: linux/amd64
+          push: ${{ steps.img.outputs.push == 'true' }}
+          tags: ${{ steps.img.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile.worldhost
+++ b/Dockerfile.worldhost
@@ -1,0 +1,48 @@
+# syntax=docker/dockerfile:1
+#
+# Blocks Beyond the Stars — hosted-worlds control plane ("WorldHost", NOT part of the GitHub release
+# and NOT part of the self-hosting server image). Accounts, world registry, wake-on-demand allocation
+# and join-token issuing for a fleet of one-container-per-world dedicated servers. See
+# docs/developer/HOSTED_WORLDS.md for the architecture and deploy/ for the fleet compose files.
+# Build context = repo root:
+#
+#   docker build -f Dockerfile.worldhost -t blocks-beyond-the-stars-worldhost:local .
+
+# ---- build ----
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+COPY . .
+RUN dotnet publish src/BlocksBeyondTheStars.WorldHost/BlocksBeyondTheStars.WorldHost.csproj -c Release -o /app
+
+# ---- runtime ----
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime
+
+# WorldHost shells out to the docker CLI (DockerCliLauncher) against the HOST's daemon through the
+# mounted /var/run/docker.sock — so it needs the CLI only, never a daemon of its own.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends curl ca-certificates gnupg \
+ && install -m 0755 -d /etc/apt/keyrings \
+ && curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc \
+ && . /etc/os-release \
+ && echo "deb [signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian ${VERSION_CODENAME} stable" > /etc/apt/sources.list.d/docker.list \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends docker-ce-cli \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY --from=build /app ./
+
+# In a container the app must bind all interfaces (its own default is loopback); reachability is then
+# controlled by the docker network / reverse proxy. The registry lives on the /data volume.
+ENV BBS_WH_BIND=0.0.0.0
+ENV BBS_WH_DATA_DIR=/data
+
+EXPOSE 31417/tcp
+
+# worldhost.db — per-world saves are bind-mounted separately (BBS_WH_WORLDS_DIR, see deploy/worldhost).
+VOLUME ["/data"]
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD curl -fsS "http://127.0.0.1:${BBS_WH_PORT:-31417}/healthz" >/dev/null || exit 1
+
+ENTRYPOINT ["dotnet", "BlocksBeyondTheStars.WorldHost.dll"]

--- a/TODO.md
+++ b/TODO.md
@@ -5500,6 +5500,26 @@ is **pre-approved** (keys in `tools/ai-assets/.env`, run via `uv`).
 
 ---
 
+## ✅ Done (2026-07-04): fleet CI/CD — WorldHost image, deploy/ infra-as-code, SSH deploy workflow
+The hosted-worlds VPS (`bbs-host-1`, prepared 2026-07-04: hardened Debian 13, Docker, ufw incl. UDP
+32000-32999, shared `bbs-hosted` network, caddy-docker-proxy live) is now wired into CI/CD:
+- **`Dockerfile.worldhost` + `worldhost-image.yml`**: builds `ghcr.io/marceld23/blocks-beyond-the-stars-worldhost`
+  (aspnet 8 + docker CLI for the host-socket launcher) on main pushes touching WorldHost/Shared —
+  `:latest` + immutable `:sha-<short>` for pinning, mirroring `reports-image.yml`.
+- **`deploy/`** = source of truth for `/opt/bbs/` on the VPS: compose files for caddy (proxy +
+  BaseCaddyfile with the on-demand-TLS `/ask` guard), worldhost (docker.sock, identical-path
+  `/opt/bbs/worldhost/worlds` bind mount — required because WorldHost passes host paths to `docker run -v`)
+  and reports (fleet variant behind Caddy; the repo-root sample stays for self-hosters). Plus
+  `.env.example` templates and `remote-deploy.sh` (tag pinning + health checks).
+- **`deploy.yml`**: manual dispatch (service: all|caddy|worldhost|reports, optional tag pins),
+  `production` environment with required-reviewer gate, pinned host key, rsync excludes `.env`.
+- **Secrets model**: GitHub holds ONE secret (`DEPLOY_SSH_KEY`, dedicated restricted ed25519 key for
+  `bbs`); all service secrets live only in `/opt/bbs/<service>/.env` (600, created on the host).
+- Verified: WorldHost image builds + `/healthz` smoke test green, all three compose files validate
+  against the real host `.env`s, deploy key + GitHub environment/secret configured live.
+- OPEN: first real deploy via Actions after merge (workflow_dispatch needs the file on main); Strato
+  DNS records (`play`, `*.play`, `reports`) still pending domain registration.
+
 ## ✅ Done (2026-07-04): bug-report inbox (ReportHost) — self-owned Docker service replacing the Wix dependency
 A standalone container (`src/BlocksBeyondTheStars.ReportHost/`) that receives the game's F1 feedback and
 automatic crash reports on the EXACT Wix wire contract (POST `/api/bugreport`, `x-bugreport-key`,

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,41 @@
+# Fleet deployment (`deploy/`) — VPS `bbs-host-1`
+
+This folder is the source of truth for what runs on the hosted-worlds VPS
+(31.70.113.90, Debian 13). `deploy.yml` (GitHub Actions, manual dispatch, `production`
+environment with an approval gate) rsyncs these folders to `/opt/bbs/` and runs
+`remote-deploy.sh` over SSH. Architecture: `docs/developer/HOSTED_WORLDS.md`; the
+bug-report inbox: `docs/developer/REPORT_HOST.md`.
+
+| Folder | Service | Image | Cadence |
+|---|---|---|---|
+| `caddy/` | caddy-docker-proxy (TLS + routing) | `lucaslorentz/caddy-docker-proxy` | rarely (config change) |
+| `worldhost/` | hosted-worlds control plane | `ghcr.io/marceld23/blocks-beyond-the-stars-worldhost` (`worldhost-image.yml`) | on service change |
+| `reports/` | bug-report inbox | `ghcr.io/marceld23/blocks-beyond-the-stars-reports` (`reports-image.yml`) | on service change |
+
+Per-world game containers are NOT deployed from here — WorldHost starts them on demand from the
+dedicated-server image pinned in `/opt/bbs/worldhost/.env` (`BBS_WH_SERVER_IMAGE`; that image is
+built by `docker.yml` on release tags).
+
+## Secrets model
+
+- GitHub holds exactly **one** deploy secret: `DEPLOY_SSH_KEY` (environment `production`), a
+  dedicated ed25519 key for the `bbs` user. The VPS host key is pinned in `deploy.yml`.
+- **All service secrets live only on the host** in `/opt/bbs/<service>/.env` (mode 600, owner
+  `bbs`) — created once from the `.env.example` files here. CI never reads or writes them;
+  `remote-deploy.sh` rewrites only the `*_TAG` line when a deploy pins a new image version.
+
+## Version pinning & rollback
+
+The image workflows publish `:latest` plus an immutable `:sha-<short>` on every main push that
+touches the service. Deploys should pin `sha-<short>` (dispatch input); rollback = rerun the deploy
+with the previous sha. Rolling the game-server fleet = edit `BBS_WH_SERVER_IMAGE` in
+`/opt/bbs/worldhost/.env` and redeploy `worldhost` — running worlds keep their image until their
+idle shutdown, new wakes use the new pin.
+
+## One-time host prerequisites (already done on bbs-host-1, 2026-07-04)
+
+Deploy user `bbs` (docker group), ufw (22, 80, 443/tcp+udp, 32000-32999/udp), Docker Engine +
+compose plugin, shared network `docker network create bbs-hosted`, `/opt/bbs/{caddy,worldhost,reports}`
+with the real `.env` files, and the deploy public key in `~bbs/.ssh/authorized_keys`
+(`no-agent-forwarding,no-port-forwarding,no-X11-forwarding`). DNS (Strato, manual): A `play`,
+wildcard A `*.play` and A `reports` → the VPS.

--- a/deploy/caddy/BaseCaddyfile
+++ b/deploy/caddy/BaseCaddyfile
@@ -1,0 +1,10 @@
+{
+	# On-demand TLS for w-<id>.play.blocksbeyondthestars.de (Strato has no DNS API, so no
+	# DNS-challenge wildcard certificate). WorldHost authorizes each subdomain via GET /ask —
+	# only the portal host and worlds that exist in the registry get certificates, so nobody can
+	# burn Let's Encrypt rate limits by aiming random names at the IP. Inert until the worldhost
+	# container exists on the bbs-hosted network.
+	on_demand_tls {
+		ask http://worldhost:31417/ask
+	}
+}

--- a/deploy/caddy/docker-compose.yml
+++ b/deploy/caddy/docker-compose.yml
@@ -1,0 +1,36 @@
+# Reverse proxy for the hosted-worlds fleet (docs/developer/HOSTED_WORLDS.md).
+# caddy-docker-proxy: services announce themselves via docker labels (caddy=<domain>), so routing
+# appears/disappears with containers — no static proxy config to maintain.
+#
+# Source of truth is THIS file in the repo; deploy.yml syncs it to /opt/bbs/caddy/ on the VPS.
+services:
+  caddy:
+    image: lucaslorentz/caddy-docker-proxy:2.13-alpine
+    container_name: bbs-caddy
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+      - "443:443/udp"   # HTTP/3
+    environment:
+      - CADDY_INGRESS_NETWORKS=bbs-hosted
+      - CADDY_DOCKER_CADDYFILE_PATH=/etc/caddy/BaseCaddyfile
+    networks:
+      - bbs-hosted
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - caddy-data:/data
+      - ./BaseCaddyfile:/etc/caddy/BaseCaddyfile:ro
+    labels:
+      # Plain-HTTP reachability probe (answers "BBS host up" on port 80). Harmless alongside the real
+      # sites — ACME HTTP-01 challenges are handled before routing — and useful to prove the host is
+      # reachable before DNS exists. Remove once the portal is public and monitored.
+      caddy: "http://:80"
+      caddy.respond: '"BBS host up" 200'
+
+volumes:
+  caddy-data:
+
+networks:
+  bbs-hosted:
+    external: true

--- a/deploy/remote-deploy.sh
+++ b/deploy/remote-deploy.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Runs ON the VPS as the `bbs` user — deploy.yml pipes this script through ssh after syncing the
+# deploy/ folders to /opt/bbs/. Args: <service: all|caddy|worldhost|reports> [worldhost_tag] [reports_tag]
+#
+# Tags pin immutable image versions (sha-<short> from the image workflows). An empty tag keeps
+# whatever is currently pinned in the service's .env — the .env files themselves (which also hold the
+# operator secrets) are never replaced, only their *_TAG line is rewritten.
+set -euo pipefail
+
+SERVICE="${1:?usage: remote-deploy.sh <all|caddy|worldhost|reports> [worldhost_tag] [reports_tag]}"
+WORLDHOST_TAG="${2:-}"
+REPORTS_TAG="${3:-}"
+
+pin_tag() { # <env-file> <key> <value> — rewrite one KEY= line, leave the rest (secrets!) untouched
+  local file="$1" key="$2" value="$3"
+  [ -z "$value" ] && return 0
+  if grep -q "^${key}=" "$file"; then
+    sed -i "s|^${key}=.*|${key}=${value}|" "$file"
+  else
+    echo "${key}=${value}" >> "$file"
+  fi
+  echo "pinned ${key}=${value}"
+}
+
+wait_healthy() { # <container> — wait for the image's HEALTHCHECK to report healthy
+  local name="$1" status
+  for _ in $(seq 1 45); do
+    status=$(docker inspect -f '{{.State.Health.Status}}' "$name" 2>/dev/null || echo missing)
+    if [ "$status" = "healthy" ]; then echo "${name}: healthy"; return 0; fi
+    if [ "$status" = "unhealthy" ]; then break; fi
+    sleep 2
+  done
+  echo "ERROR: ${name} did not become healthy (status: ${status})"
+  docker logs --tail 40 "$name" 2>&1 || true
+  return 1
+}
+
+require_env() { # <dir> — the operator .env must exist before the first deploy of that service
+  if [ ! -f "$1/.env" ]; then
+    echo "ERROR: $1/.env missing — create it from the .env.example in the repo's deploy/ folder."
+    return 1
+  fi
+}
+
+deploy_caddy() {
+  cd /opt/bbs/caddy
+  docker compose pull -q
+  docker compose up -d
+  sleep 3
+  curl -fsS -m 5 http://127.0.0.1/ >/dev/null && echo "caddy: port 80 OK"
+}
+
+deploy_worldhost() {
+  require_env /opt/bbs/worldhost
+  cd /opt/bbs/worldhost
+  pin_tag .env WORLDHOST_TAG "$WORLDHOST_TAG"
+  docker compose pull -q
+  docker compose up -d
+  wait_healthy bbs-worldhost
+}
+
+deploy_reports() {
+  require_env /opt/bbs/reports
+  cd /opt/bbs/reports
+  pin_tag .env REPORTS_TAG "$REPORTS_TAG"
+  docker compose pull -q
+  docker compose up -d
+  wait_healthy bbs-reports
+}
+
+case "$SERVICE" in
+  caddy)     deploy_caddy ;;
+  worldhost) deploy_worldhost ;;
+  reports)   deploy_reports ;;
+  all)       deploy_caddy; deploy_worldhost; deploy_reports ;;
+  *)         echo "unknown service: $SERVICE"; exit 2 ;;
+esac
+
+echo "DEPLOY OK (${SERVICE})"

--- a/deploy/reports/.env.example
+++ b/deploy/reports/.env.example
@@ -1,0 +1,19 @@
+# Operator configuration for the ReportHost fleet deployment — copy to /opt/bbs/reports/.env on the
+# VPS and fill in real values. The real .env is NEVER in git and NEVER touched by deploy.yml (it only
+# rewrites the REPORTS_TAG line when a deploy pins a new image tag).
+
+# Image tag to run — deploy.yml pins this to an immutable sha-<short> tag; rollback = previous tag.
+REPORTS_TAG=latest
+
+# Public domain (needs a Strato DNS A record -> the VPS; certificate is issued via plain HTTP-01
+# because this is an explicit Caddy site — the on-demand-TLS /ask flow is not involved).
+BBS_REPORTS_DOMAIN=reports.blocksbeyondthestars.de
+
+# SECRETS — generate long random values (e.g. `openssl rand -hex 24`); keep them only in this file.
+# The write key is what game clients send as x-bugreport-key (empty = ingest rejects everything).
+BBS_REPORTS_WRITE_KEY=
+# Read API key (delta sync / future triage tooling); empty = read API off.
+BBS_REPORTS_READ_KEY=
+# Admin UI Basic-Auth credentials; empty user = admin UI off.
+BBS_REPORTS_ADMIN_USER=
+BBS_REPORTS_ADMIN_PASSWORD=

--- a/deploy/reports/docker-compose.yml
+++ b/deploy/reports/docker-compose.yml
@@ -1,0 +1,27 @@
+# ReportHost — bug-report inbox (docs/developer/REPORT_HOST.md), fleet deployment behind the shared
+# Caddy. This is deliberately DIFFERENT from the self-hoster sample at the repo root
+# (docker-compose.reports.yml): no published port (network-internal, TLS via caddy-docker-proxy
+# labels) and a bind-mounted data dir. Secrets come from /opt/bbs/reports/.env on the host.
+services:
+  reports:
+    image: ghcr.io/marceld23/blocks-beyond-the-stars-reports:${REPORTS_TAG:-latest}
+    container_name: bbs-reports
+    restart: unless-stopped
+    networks:
+      - bbs-hosted
+    volumes:
+      - /opt/bbs/reports/data:/data   # reports.db + screenshots/
+    environment:
+      BBS_REPORTS_WRITE_KEY: ${BBS_REPORTS_WRITE_KEY:?set in /opt/bbs/reports/.env}
+      BBS_REPORTS_READ_KEY: ${BBS_REPORTS_READ_KEY:-}          # empty = read API off
+      BBS_REPORTS_ADMIN_USER: ${BBS_REPORTS_ADMIN_USER:-}      # empty = admin UI off
+      BBS_REPORTS_ADMIN_PASSWORD: ${BBS_REPORTS_ADMIN_PASSWORD:-}
+      BBS_REPORTS_TRUST_PROXY: "true"   # rate-limit on X-Forwarded-For — correct behind our own Caddy
+      # BBS_REPORTS_RETENTION_DAYS: "180"
+    labels:
+      caddy: ${BBS_REPORTS_DOMAIN:?set in /opt/bbs/reports/.env}
+      caddy.reverse_proxy: "{{upstreams 31418}}"
+
+networks:
+  bbs-hosted:
+    external: true

--- a/deploy/worldhost/.env.example
+++ b/deploy/worldhost/.env.example
@@ -1,0 +1,27 @@
+# Operator configuration for the WorldHost fleet deployment — copy to /opt/bbs/worldhost/.env on the
+# VPS and fill in real values. The real .env is NEVER in git and NEVER touched by deploy.yml (it only
+# rewrites the WORLDHOST_TAG line when a deploy pins a new image tag).
+
+# Image tag to run — deploy.yml pins this to an immutable sha-<short> tag; rollback = previous tag.
+WORLDHOST_TAG=latest
+
+# Portal/API domain; every world becomes w-<id>.<this>. Requires the Strato DNS records
+# (A play + wildcard A *.play -> the VPS).
+BBS_WH_BASE_DOMAIN=play.blocksbeyondthestars.de
+
+# Host native (UDP) game clients connect to. Until the DNS records exist this can be the raw VPS IP.
+BBS_WH_PUBLIC_HOST=play.blocksbeyondthestars.de
+
+# Dedicated-server image each world runs. Operator-controlled fleet version pin (WP14): update +
+# redeploy worldhost to roll the fleet — running worlds keep the old image until their idle stop.
+BBS_WH_SERVER_IMAGE=ghcr.io/marceld23/blocks-beyond-the-stars-server:0.6.2
+
+# SECRETS — generate long random values (e.g. `openssl rand -hex 24`); keep them only in this file.
+# Claim code developers present once at signup to register a reserved name (empty = unclaimable).
+BBS_WH_RESERVED_CLAIM_CODE=
+# Operator token for the admin endpoints (report review, account bans); empty = admin API off.
+BBS_WH_ADMIN_TOKEN=
+
+# Quotas are operator policy and default to the plan values (2 worlds/account, 12 players, 20 min
+# idle); override only deliberately: BBS_WH_MAX_WORLDS_PER_ACCOUNT / BBS_WH_MAX_PLAYERS /
+# BBS_WH_IDLE_MINUTES.

--- a/deploy/worldhost/docker-compose.yml
+++ b/deploy/worldhost/docker-compose.yml
@@ -1,0 +1,41 @@
+# WorldHost — the hosted-worlds control plane (docs/developer/HOSTED_WORLDS.md), fleet deployment.
+# Interpolation values + secrets come from /opt/bbs/worldhost/.env on the host (see .env.example);
+# deploy.yml syncs this file but NEVER touches the real .env.
+#
+# The service name doubles as the DNS alias on the bbs-hosted network — the caddy BaseCaddyfile's
+# on-demand-TLS ask endpoint (http://worldhost:31417/ask) depends on it, so don't rename it.
+services:
+  worldhost:
+    image: ghcr.io/marceld23/blocks-beyond-the-stars-worldhost:${WORLDHOST_TAG:-latest}
+    container_name: bbs-worldhost
+    restart: unless-stopped
+    networks:
+      - bbs-hosted
+    volumes:
+      # WorldHost drives the HOST docker daemon (one container per world) — root-equivalent by design.
+      - /var/run/docker.sock:/var/run/docker.sock
+      # Registry database (worldhost.db).
+      - /opt/bbs/worldhost/data:/data
+      # Per-world saves. MUST be the SAME absolute path inside and outside the container: WorldHost
+      # passes <worlds>/<id>/saves to `docker run -v`, and the host daemon resolves that path on the
+      # HOST filesystem (SavePaths.HostSavesDir).
+      - /opt/bbs/worldhost/worlds:/opt/bbs/worldhost/worlds
+    environment:
+      BBS_WH_BIND: 0.0.0.0
+      BBS_WH_DATA_DIR: /data
+      BBS_WH_WORLDS_DIR: /opt/bbs/worldhost/worlds
+      BBS_WH_DOCKER_NETWORK: bbs-hosted
+      BBS_WH_BASE_DOMAIN: ${BBS_WH_BASE_DOMAIN:?set in /opt/bbs/worldhost/.env}
+      BBS_WH_PUBLIC_HOST: ${BBS_WH_PUBLIC_HOST:?set in /opt/bbs/worldhost/.env}
+      BBS_WH_SERVER_IMAGE: ${BBS_WH_SERVER_IMAGE:?set in /opt/bbs/worldhost/.env}
+      BBS_WH_RESERVED_CLAIM_CODE: ${BBS_WH_RESERVED_CLAIM_CODE:-}   # empty = reserved names unclaimable
+      BBS_WH_ADMIN_TOKEN: ${BBS_WH_ADMIN_TOKEN:-}                   # empty = admin API off
+    labels:
+      # Portal + API domain. Worlds announce their own w-<id> subdomains via labels WorldHost puts on
+      # each instance container.
+      caddy: ${BBS_WH_BASE_DOMAIN:?set in /opt/bbs/worldhost/.env}
+      caddy.reverse_proxy: "{{upstreams 31417}}"
+
+networks:
+  bbs-hosted:
+    external: true

--- a/docs/developer/HOSTED_WORLDS.md
+++ b/docs/developer/HOSTED_WORLDS.md
@@ -168,15 +168,23 @@ The SP↔hosted round-trip. Instances bind-mount `<BBS_WH_WORLDS_DIR>/<worldId>/
 
 ## Operations quick reference
 
+Deployment is codified in **`deploy/`** (compose files for caddy / worldhost / reports — the source
+of truth for `/opt/bbs/` on the VPS, see `deploy/README.md`) and two GitHub Actions workflows:
+`worldhost-image.yml` builds `ghcr.io/marceld23/blocks-beyond-the-stars-worldhost` on main pushes
+(`:latest` + immutable `:sha-<short>`), and `deploy.yml` (manual dispatch, `production` environment
+with approval gate, single `DEPLOY_SSH_KEY` secret) rsyncs `deploy/` to the host and runs
+`remote-deploy.sh` with per-service health checks. All operator secrets (claim code, admin token,
+report keys) live only in `/opt/bbs/<service>/.env` on the host — never in CI.
+
 ```bash
 # One-time host setup: shared network + caddy-docker-proxy with on-demand TLS ask endpoint
 docker network create bbs-hosted
-# Caddy global option:  on_demand_tls { ask http://worldhost:31417/ask }
+# Caddy global option:  on_demand_tls { ask http://worldhost:31417/ask }   (deploy/caddy/BaseCaddyfile)
 
-# WorldHost env (systemd unit or compose service; needs /var/run/docker.sock)
+# WorldHost operator env → /opt/bbs/worldhost/.env (template: deploy/worldhost/.env.example)
 BBS_WH_BASE_DOMAIN=play.blocksbeyondthestars.de
 BBS_WH_PUBLIC_HOST=play.blocksbeyondthestars.de
-BBS_WH_SERVER_IMAGE=ghcr.io/marceld23/blocks-beyond-the-stars-server:latest
+BBS_WH_SERVER_IMAGE=ghcr.io/marceld23/blocks-beyond-the-stars-server:0.6.2   # fleet version pin (WP14)
 # quotas (operator policy): BBS_WH_MAX_WORLDS_PER_ACCOUNT=2, BBS_WH_MAX_PLAYERS=12, BBS_WH_IDLE_MINUTES=20
 ```
 


### PR DESCRIPTION
## What

Wires the freshly prepared VPS (`bbs-host-1`, 31.70.113.90) into CI/CD — implements the analysis agreed today. No game-code changes.

- **`Dockerfile.worldhost` + `worldhost-image.yml`** — builds `ghcr.io/marceld23/blocks-beyond-the-stars-worldhost` (aspnet 8 + docker CLI for the host-socket launcher; NOT part of the self-hosting server image). Main pushes touching WorldHost/Shared publish `:latest` + immutable `:sha-<short>`; mirrors `reports-image.yml`.
- **`deploy/`** — source of truth for `/opt/bbs/` on the VPS: compose files for **caddy** (proxy + on-demand-TLS `/ask` guard), **worldhost** (docker.sock; identical-path `/opt/bbs/worldhost/worlds` bind mount — WorldHost passes host paths to `docker run -v`) and **reports** (fleet variant behind the shared Caddy; the repo-root self-hoster sample is untouched). Plus `.env.example` templates and `remote-deploy.sh` (tag pinning + health-check gates).
- **`deploy.yml`** — manual dispatch (`service: all|caddy|worldhost|reports`, optional immutable tag pins), `production` environment with required-reviewer approval, pinned VPS host key, rsync excludes `.env`.

## Secrets model

GitHub holds exactly ONE deploy secret: `DEPLOY_SSH_KEY` (already configured in the `production` environment; dedicated restricted ed25519 key for the `bbs` user — not the personal Strato key). All service secrets (claim code, admin token, report keys) exist only in `/opt/bbs/<service>/.env` on the host (mode 600, already created); the workflow never reads or logs them and only rewrites the `*_TAG` line.

## Verified

- WorldHost image builds locally; smoke test green (docker CLI 29.6.1 present, `/healthz` → ok)
- All three compose files validate (`docker compose config`) against the real host `.env` files on the VPS
- Deploy key tested over SSH; GitHub `production` environment + secret configured live

## After merge

1. `worldhost-image.yml` runs once (publishes the first WorldHost image)
2. Run **Deploy (VPS)** from the Actions tab (service `all`) — works already; TLS/domains stay pending until the Strato DNS records (`play`, `*.play`, `reports`) exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)