### PR TITLE
Hosted worlds Phase 3: world archiving, rate limits, name hygiene, Prometheus metrics

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -5500,6 +5500,25 @@ is **pre-approved** (keys in `tools/ai-assets/.env`, run via `uv`).
 
 ---
 
+## ✅ Done (2026-07-04): hosted-worlds Phase 3 — archiving, rate limits, name hygiene, metrics
+Hardening of the WorldHost control plane (details: [HOSTED_WORLDS.md](docs/developer/HOSTED_WORLDS.md)).
+Multi-host placement stays deliberately deferred until one host stops being enough.
+- **Archive after inactivity** (`BBS_WH_ARCHIVE_MONTHS`, default 6, 0=off): hourly sweep moves a stopped
+  world's saves to `_archive/` and flips status to `archived` once `last_active_unix` (stamped on every
+  join/wake and by the reaper) ages out. **Joining an archived world restores it transparently** — never
+  destructive, deletion stays a separate owner action.
+- **Rate limits** (fixed-window, operator-configurable): signups 5/h + logins 10/min per client IP (the app
+  now honors X-Forwarded-For from Caddy), uploads 6/h + reports 10/h per account; HTTP 429 with friendly text.
+- **Blocked-name hygiene** on account names, world names and in-game player names (same normalization as the
+  reserved-name check, so "H-i-t-l-e-r" is caught); short unambiguous default list, extendable via
+  `BBS_WH_BLOCKED_WORDS` — deliberately minimal against Scunthorpe false positives ("Hilda" passes).
+- **Prometheus `GET /metrics`** (loopback only, not routed by Caddy): world/account/report gauges + counters
+  for joins, wakes, reaps, archives, rate-limited calls.
+- **Version policy documented** (fleet pins one image tag; Protocol.Version gates clients; save schema stays
+  one release load-compatible).
+- Tests: `WorldHostPhase3Tests` (8) — limiter window/reset/disable, blocked names across all three surfaces,
+  archive sweep + transparent restore round-trip, recently-active spared, sweep off, metrics rendering.
+
 ## ✅ Done (2026-07-04): bug-report inbox (ReportHost) — self-owned Docker service replacing the Wix dependency
 A standalone container (`src/BlocksBeyondTheStars.ReportHost/`) that receives the game's F1 feedback and
 automatic crash reports on the EXACT Wix wire contract (POST `/api/bugreport`, `x-bugreport-key`,

--- a/docs/developer/HOSTED_WORLDS.md
+++ b/docs/developer/HOSTED_WORLDS.md
@@ -194,6 +194,33 @@ when one of these becomes true: a second control-plane node (HA), multi-host pla
 or the wish to join registry + world data in one operational database. `HostRegistry` is a single
 class behind plain methods, so swapping the backend later is contained.
 
+## Phase 3 hardening (implemented)
+
+- **Archive after inactivity.** `BBS_WH_ARCHIVE_MONTHS` (default 6, 0 = off): an hourly sweep moves
+  a stopped world's saves to `<WorldsDir>/_archive/<id>/` and flips its status to `archived` once its
+  last activity (join/wake or reaper stamp — `world.last_active_unix`) is older than the window.
+  Joining an archived world **transparently restores it** (rename back + normal wake) — from the
+  player's side it is just a world that takes a moment longer. Deleting stays separate; archive never
+  destroys data. Ports remain allocated to archived worlds (the range bounds total worlds at
+  `PortRangeSize`; revisit only if that ever pinches).
+- **Rate limits** (fixed windows, in-memory, operator knobs): signups 5/h and logins 10/min per
+  client IP (real IP via X-Forwarded-For — the app now honors forwarded headers from Caddy), save
+  uploads 6/h and reports 10/h per account. Over-budget calls get HTTP 429 with a friendly text.
+- **Blocked-name hygiene** (kid-facing): a short, unambiguous word list (operator-extendable via
+  `BBS_WH_BLOCKED_WORDS`) is enforced on account names, world names AND in-game player names at the
+  join grant — matched with the same normalization as reserved names, so separator tricks are caught.
+  Deliberately minimal to avoid Scunthorpe-style false positives; the report button covers the rest.
+- **Prometheus metrics.** `GET /metrics` (loopback only — Caddy does not route it): gauges
+  (`bbs_accounts_total`, `bbs_worlds{status=…}`, `bbs_reports_open`) + counters (joins granted,
+  wakes, reaped, archived, rate-limited).
+
+## Version policy (fleet)
+
+The fleet pins one image tag (`BBS_WH_SERVER_IMAGE`) — all instances run the same server version.
+`Protocol.Version` gates incompatible clients at join (the server rejects mismatches with a clear
+message). Save-schema changes must remain load-compatible with saves one release older (uploads are
+validated but never migrated silently); document per release in the changelog.
+
 ## Open (tracked in the plan)
 
 - Browser play for hosted worlds: a central `/play` on the portal that deep-links the WebGL client
@@ -201,5 +228,4 @@ class behind plain methods, so swapping the backend later is contained.
 - **Impressum + Datenschutzerklärung** pages before public launch (operator-specific content).
 - End-to-end playtest against a real Docker fleet (everything below the HTTP layer is unit-tested;
   the docker CLI path and Caddy routing need one real run on the VPS).
-- Phase 3: archive-after-inactivity (6 months), rate limits, world-name profanity filter,
-  Prometheus metrics, multi-host placement (registry → Postgres if needed).
+- Multi-host placement when one host stops being enough (spawner agent per node; registry → Postgres).

--- a/src/BlocksBeyondTheStars.WorldHost/HostRegistry.cs
+++ b/src/BlocksBeyondTheStars.WorldHost/HostRegistry.cs
@@ -47,7 +47,17 @@ public static class WorldStatus
     public const string Stopped = "stopped";
     public const string Starting = "starting";
     public const string Running = "running";
+
+    /// <summary>Long-inactive: saves moved to the archive folder, instance claim ended. A join
+    /// transparently restores + wakes the world (it just takes a moment longer).</summary>
+    public const string Archived = "archived";
 }
+
+/// <summary>Registry gauges for the /metrics scrape.</summary>
+public sealed record RegistryCounts(
+    long Accounts,
+    long OpenReports,
+    IReadOnlyList<(string Status, long Count)> WorldsByStatus);
 
 /// <summary>
 /// The control plane's registry — accounts, bearer sessions and worlds in one SQLite file. Deliberately
@@ -104,7 +114,8 @@ public sealed class HostRegistry : IDisposable
                 status TEXT NOT NULL,
                 container_id TEXT NOT NULL DEFAULT '',
                 created_unix INTEGER NOT NULL,
-                last_started_unix INTEGER NOT NULL DEFAULT 0);
+                last_started_unix INTEGER NOT NULL DEFAULT 0,
+                last_active_unix INTEGER NOT NULL DEFAULT 0);
             CREATE TABLE IF NOT EXISTS report(
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 world_id TEXT NOT NULL,
@@ -125,6 +136,7 @@ public sealed class HostRegistry : IDisposable
             "ALTER TABLE account ADD COLUMN ban_reason TEXT NOT NULL DEFAULT '';",
             "ALTER TABLE account ADD COLUMN terms_version INTEGER NOT NULL DEFAULT 0;",
             "ALTER TABLE account ADD COLUMN terms_accepted_unix INTEGER NOT NULL DEFAULT 0;",
+            "ALTER TABLE world ADD COLUMN last_active_unix INTEGER NOT NULL DEFAULT 0;",
         })
         {
             try
@@ -152,6 +164,16 @@ public sealed class HostRegistry : IDisposable
     private static string NormalizeName(string? name)
         => new((name ?? string.Empty).ToLowerInvariant().Where(c => c is not (' ' or '-' or '_')).ToArray());
 
+    /// <summary>True when a name contains a blocked word (kid-facing name hygiene) — same normalization
+    /// as the reservation check, so separator tricks don't slip past. Substring match on a deliberately
+    /// short, unambiguous list.</summary>
+    public bool IsBlockedName(string? name)
+    {
+        string normalized = NormalizeName(name);
+        return normalized.Length > 0
+               && _config.BlockedNameWords.Any(w => NormalizeName(w) is { Length: > 0 } bad && normalized.Contains(bad));
+    }
+
     public static bool IsValidWorldId(string id) => WorldIdRx.IsMatch(id);
 
     // ---------------- Accounts & sessions ----------------
@@ -178,6 +200,11 @@ public sealed class HostRegistry : IDisposable
         if ((password ?? string.Empty).Length < 8)
         {
             return (false, "Password must be at least 8 characters.", string.Empty, string.Empty);
+        }
+
+        if (IsBlockedName(name))
+        {
+            return (false, "Please choose a different name.", string.Empty, string.Empty);
         }
 
         bool isDeveloper = false;
@@ -393,6 +420,11 @@ public sealed class HostRegistry : IDisposable
             return (false, "World name must be 1-40 printable characters.", null);
         }
 
+        if (IsBlockedName(displayName))
+        {
+            return (false, "Please choose a different world name.", null);
+        }
+
         lock (_gate)
         {
             using (var count = Cmd("SELECT COUNT(*) FROM world WHERE owner_account_id = $o"))
@@ -466,13 +498,15 @@ public sealed class HostRegistry : IDisposable
         }
     }
 
-    /// <summary>Worlds currently marked running/starting — the reaper reconciles these against Docker.</summary>
+    /// <summary>Worlds currently marked running/starting — the reaper reconciles these against Docker.
+    /// Explicitly excludes archived worlds (they have no container by definition).</summary>
     public IReadOnlyList<WorldRecord> ListActiveWorlds()
     {
         lock (_gate)
         {
-            using var cmd = Cmd(SelectWorld + " WHERE status != $st");
-            cmd.Parameters.AddWithValue("$st", WorldStatus.Stopped);
+            using var cmd = Cmd(SelectWorld + " WHERE status IN ($starting, $running)");
+            cmd.Parameters.AddWithValue("$starting", WorldStatus.Starting);
+            cmd.Parameters.AddWithValue("$running", WorldStatus.Running);
             using var reader = cmd.ExecuteReader();
             var list = new List<WorldRecord>();
             while (reader.Read())
@@ -511,6 +545,70 @@ public sealed class HostRegistry : IDisposable
             cmd.Parameters.AddWithValue("$now", NowUnix());
             cmd.Parameters.AddWithValue("$i", worldId);
             cmd.ExecuteNonQuery();
+        }
+    }
+
+    /// <summary>Stamps a world as active now — set on every successful join/wake so the archive sweep
+    /// measures real inactivity, not time since creation.</summary>
+    public void TouchWorldActive(string worldId)
+    {
+        lock (_gate)
+        {
+            using var cmd = Cmd("UPDATE world SET last_active_unix = $now WHERE id = $i");
+            cmd.Parameters.AddWithValue("$now", NowUnix());
+            cmd.Parameters.AddWithValue("$i", worldId);
+            cmd.ExecuteNonQuery();
+        }
+    }
+
+    /// <summary>Stopped worlds whose last activity (or creation, if never joined) predates the cutoff —
+    /// the archive sweep's work list.</summary>
+    public IReadOnlyList<WorldRecord> ListArchiveCandidates(long cutoffUnix)
+    {
+        lock (_gate)
+        {
+            using var cmd = Cmd(SelectWorld + " WHERE status = $st AND MAX(last_active_unix, created_unix) < $cutoff");
+            cmd.Parameters.AddWithValue("$st", WorldStatus.Stopped);
+            cmd.Parameters.AddWithValue("$cutoff", cutoffUnix);
+            using var reader = cmd.ExecuteReader();
+            var list = new List<WorldRecord>();
+            while (reader.Read())
+            {
+                list.Add(ReadWorld(reader));
+            }
+
+            return list;
+        }
+    }
+
+    /// <summary>Gauge snapshot for /metrics.</summary>
+    public RegistryCounts CountForMetrics()
+    {
+        lock (_gate)
+        {
+            long accounts;
+            using (var cmd = Cmd("SELECT COUNT(*) FROM account"))
+            {
+                accounts = Convert.ToInt64(cmd.ExecuteScalar());
+            }
+
+            long openReports;
+            using (var cmd = Cmd("SELECT COUNT(*) FROM report WHERE status = 'open'"))
+            {
+                openReports = Convert.ToInt64(cmd.ExecuteScalar());
+            }
+
+            var byStatus = new List<(string, long)>();
+            using (var cmd = Cmd("SELECT status, COUNT(*) FROM world GROUP BY status"))
+            using (var reader = cmd.ExecuteReader())
+            {
+                while (reader.Read())
+                {
+                    byStatus.Add((reader.GetString(0), reader.GetInt64(1)));
+                }
+            }
+
+            return new RegistryCounts(accounts, openReports, byStatus);
         }
     }
 

--- a/src/BlocksBeyondTheStars.WorldHost/Program.cs
+++ b/src/BlocksBeyondTheStars.WorldHost/Program.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
 using BlocksBeyondTheStars.WorldHost;
+using Microsoft.AspNetCore.HttpOverrides;
 
 // Hosted-worlds control plane ("WorldHost"): accounts, world registry, wake-on-demand allocation and
 // join-token issuing for a fleet of one-container-per-world dedicated servers. See
@@ -14,15 +15,42 @@ using BlocksBeyondTheStars.WorldHost;
 var config = WorldHostConfig.FromEnvironment();
 var registry = new HostRegistry(config);
 IInstanceLauncher launcher = new DockerCliLauncher(config);
-var orchestrator = new WorldOrchestrator(config, registry, launcher);
+var metrics = new WorldHostMetrics();
+var orchestrator = new WorldOrchestrator(config, registry, launcher, metrics: metrics);
+
+// Abuse limits (Phase 3). Signup/login key on the caller IP (real one via X-Forwarded-For — Caddy
+// fronts this service), uploads/reports on the account. See WorldHostConfig for the operator knobs.
+var signupLimit = new RateLimiter(config.SignupPerHourPerIp, TimeSpan.FromHours(1));
+var loginLimit = new RateLimiter(config.LoginPerMinutePerIp, TimeSpan.FromMinutes(1));
+var uploadLimit = new RateLimiter(config.UploadsPerHourPerAccount, TimeSpan.FromHours(1));
+var reportLimit = new RateLimiter(config.ReportsPerHourPerAccount, TimeSpan.FromHours(1));
 
 var builder = WebApplication.CreateBuilder(args);
 builder.Logging.ClearProviders();
 builder.Logging.AddConsole();
 builder.WebHost.UseUrls($"http://{config.BindAddress}:{config.Port}");
 
+// Honor X-Forwarded-* from the fronting Caddy so rate limits key on the real client IP, not the proxy.
+// The proxy is a trusted sibling container on an arbitrary IP, so clear the loopback-only allow-list.
+builder.Services.Configure<ForwardedHeadersOptions>(options =>
+{
+    options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
+    options.KnownNetworks.Clear();
+    options.KnownProxies.Clear();
+});
+
 var app = builder.Build();
+app.UseForwardedHeaders();
 var log = app.Logger;
+
+string CallerIp(HttpContext ctx) => ctx.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+
+IResult RateLimited()
+{
+    metrics.RateLimited();
+    return Results.Json(new { error = "Too many requests — please wait a bit and try again." },
+        statusCode: StatusCodes.Status429TooManyRequests);
+}
 
 // Resolves the caller's account from the Authorization: Bearer <session> header; null = not signed in.
 AccountRecord? Caller(HttpContext ctx)
@@ -70,6 +98,10 @@ bool IsAdmin(HttpContext ctx)
 
 app.MapGet("/healthz", () => Results.Text("ok\n"));
 
+// Prometheus scrape (Phase 3). Reachable only on the loopback bind — Caddy deliberately does not
+// route /metrics, so fleet numbers never leak publicly.
+app.MapGet("/metrics", () => Results.Text(metrics.Render(registry), "text/plain; version=0.0.4; charset=utf-8"));
+
 // ---------------- Portal pages (server-rendered shells; the JS talks to /api with a Bearer session) ----------------
 
 app.MapGet("/", () => Results.Content(WorldHostPortalPages.Landing(config), "text/html; charset=utf-8"));
@@ -103,8 +135,13 @@ app.MapGet("/ask", (string? domain) =>
 
 // ---------------- Accounts ----------------
 
-app.MapPost("/api/signup", (SignupRequest req) =>
+app.MapPost("/api/signup", (HttpContext ctx, SignupRequest req) =>
 {
+    if (!signupLimit.TryPass(CallerIp(ctx)))
+    {
+        return RateLimited();
+    }
+
     var (ok, error, accountId, session) = registry.CreateAccount(req.Name, req.Password, req.ClaimCode, req.AcceptedTermsVersion);
     if (!ok)
     {
@@ -117,8 +154,13 @@ app.MapPost("/api/signup", (SignupRequest req) =>
     return Results.Json(new { accountId, sessionToken = session });
 });
 
-app.MapPost("/api/login", (SignupRequest req) =>
+app.MapPost("/api/login", (HttpContext ctx, SignupRequest req) =>
 {
+    if (!loginLimit.TryPass(CallerIp(ctx)))
+    {
+        return RateLimited();
+    }
+
     if (registry.Login(req.Name, req.Password) is not { } login)
     {
         return Results.Unauthorized();
@@ -152,6 +194,11 @@ app.MapPost("/api/reports", (HttpContext ctx, ReportRequest req) =>
     if (Caller(ctx) is not { } account)
     {
         return Results.Unauthorized();
+    }
+
+    if (!reportLimit.TryPass(account.Id))
+    {
+        return RateLimited();
     }
 
     // Banned players may still file reports (they can't play, but silencing them buys nothing);
@@ -326,6 +373,11 @@ app.MapPost("/api/worlds/{id}/save", async (HttpContext ctx, string id) =>
         return Results.Forbid();
     }
 
+    if (!uploadLimit.TryPass(account.Id))
+    {
+        return RateLimited();
+    }
+
     // Only while stopped: the instance owns the file when it runs, and a mid-write copy would corrupt.
     if (registry.GetWorld(id)!.Status != WorldStatus.Stopped || launcher.IsRunning(world.ContainerId))
     {
@@ -420,6 +472,7 @@ app.MapGet("/api/worlds/{id}/save", (HttpContext ctx, string id) =>
 var reaper = Task.Run(async () =>
 {
     using var timer = new PeriodicTimer(TimeSpan.FromSeconds(30));
+    int ticks = 0;
     while (await timer.WaitForNextTickAsync())
     {
         try
@@ -428,6 +481,17 @@ var reaper = Task.Run(async () =>
             if (reaped > 0)
             {
                 log.LogInformation("Reaper: {Count} idle-stopped world(s) marked stopped.", reaped);
+            }
+
+            // Archive sweep once an hour (120 × 30 s): long-inactive stopped worlds move to the archive.
+            if (++ticks % 120 == 0)
+            {
+                int archived = orchestrator.ArchiveSweep(DateTimeOffset.UtcNow.ToUnixTimeSeconds());
+                if (archived > 0)
+                {
+                    log.LogInformation("Archive sweep: {Count} world(s) archived after {Months} months of inactivity.",
+                        archived, config.ArchiveAfterMonths);
+                }
             }
         }
         catch (Exception ex)

--- a/src/BlocksBeyondTheStars.WorldHost/RateLimiter.cs
+++ b/src/BlocksBeyondTheStars.WorldHost/RateLimiter.cs
@@ -1,0 +1,62 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using System.Collections.Concurrent;
+
+namespace BlocksBeyondTheStars.WorldHost;
+
+/// <summary>
+/// Fixed-window rate limiter keyed by an arbitrary string (caller IP, account id). Deliberately simple —
+/// it blunts scripted abuse (signup floods, upload hammering), it is not a fairness scheduler. Windows
+/// are tracked per key in memory; a process restart forgives everyone, which is fine at this scale.
+/// The clock is injectable so tests don't sleep.
+/// </summary>
+public sealed class RateLimiter
+{
+    private sealed class Window
+    {
+        public long StartUnix;
+        public int Count;
+    }
+
+    private readonly int _maxPerWindow;
+    private readonly long _windowSeconds;
+    private readonly Func<long> _nowUnix;
+    private readonly ConcurrentDictionary<string, Window> _windows = new();
+
+    public RateLimiter(int maxPerWindow, TimeSpan window, Func<long>? nowUnix = null)
+    {
+        _maxPerWindow = maxPerWindow;
+        _windowSeconds = (long)window.TotalSeconds;
+        _nowUnix = nowUnix ?? (() => DateTimeOffset.UtcNow.ToUnixTimeSeconds());
+    }
+
+    /// <summary>True when the caller may proceed; false when the key exhausted its window budget.
+    /// A non-positive limit disables the limiter (always true).</summary>
+    public bool TryPass(string key)
+    {
+        if (_maxPerWindow <= 0)
+        {
+            return true;
+        }
+
+        long now = _nowUnix();
+        var window = _windows.GetOrAdd(key ?? string.Empty, _ => new Window { StartUnix = now });
+        lock (window)
+        {
+            if (now - window.StartUnix >= _windowSeconds)
+            {
+                window.StartUnix = now;
+                window.Count = 0;
+            }
+
+            if (window.Count >= _maxPerWindow)
+            {
+                return false;
+            }
+
+            window.Count++;
+            return true;
+        }
+    }
+}

--- a/src/BlocksBeyondTheStars.WorldHost/SavePaths.cs
+++ b/src/BlocksBeyondTheStars.WorldHost/SavePaths.cs
@@ -19,6 +19,38 @@ public static class SavePaths
     public static string WorldDbPath(WorldHostConfig config, string worldId)
         => Path.Combine(HostSavesDir(config, worldId), worldId, "world.db");
 
+    /// <summary>Where an archived world's saves rest (<c>_archive</c> can't collide with world ids —
+    /// they are pure hex). Same volume as the live dir, so archiving is a rename, not a copy.</summary>
+    public static string ArchivedSavesDir(WorldHostConfig config, string worldId)
+        => Path.GetFullPath(Path.Combine(config.WorldsDir, "_archive", worldId, "saves"));
+
+    /// <summary>Moves a world's saves into the archive. True when something was moved; false when there
+    /// was nothing to move (a world that was never started has no saves — archiving it is just the
+    /// status flip).</summary>
+    public static bool MoveToArchive(WorldHostConfig config, string worldId)
+        => MoveDir(HostSavesDir(config, worldId), ArchivedSavesDir(config, worldId));
+
+    /// <summary>Restores an archived world's saves so the instance can be started again.</summary>
+    public static bool RestoreFromArchive(WorldHostConfig config, string worldId)
+        => MoveDir(ArchivedSavesDir(config, worldId), HostSavesDir(config, worldId));
+
+    private static bool MoveDir(string from, string to)
+    {
+        if (!Directory.Exists(from))
+        {
+            return false;
+        }
+
+        Directory.CreateDirectory(Path.GetDirectoryName(to)!);
+        if (Directory.Exists(to))
+        {
+            Directory.Delete(to, recursive: true); // stale leftover from an interrupted earlier move
+        }
+
+        Directory.Move(from, to);
+        return true;
+    }
+
     /// <summary>
     /// Validates an uploaded candidate file as a usable world save: real SQLite (magic header), passes
     /// <c>PRAGMA quick_check</c>, and carries the game's schema (the <c>world_meta</c> table — the anchor

--- a/src/BlocksBeyondTheStars.WorldHost/WorldHostConfig.cs
+++ b/src/BlocksBeyondTheStars.WorldHost/WorldHostConfig.cs
@@ -86,6 +86,34 @@ public sealed class WorldHostConfig
     /// disables the admin API entirely.</summary>
     public string AdminToken { get; set; } = string.Empty;
 
+    // --- Phase 3: lifecycle & abuse hardening (all operator policy) ---
+
+    /// <summary>Months of inactivity after which a stopped world is archived: its saves move to the
+    /// archive folder and its instance claim ends. Joining an archived world transparently restores it
+    /// (it just takes a moment longer to wake). 0 = never archive.</summary>
+    public int ArchiveAfterMonths { get; set; } = 6;
+
+    /// <summary>Words that may not appear in account names, world names or in-game player names —
+    /// matched against the same normalization as reserved names (lowercase, separators stripped), so
+    /// "H-i-t-l-e-r" is caught too. Kid-facing service: better safe. <c>BBS_WH_BLOCKED_WORDS</c>
+    /// (comma-separated) EXTENDS this list. Deliberately short and unambiguous to avoid Scunthorpe-style
+    /// false positives.</summary>
+    public List<string> BlockedNameWords { get; set; } = new()
+    {
+        "hitler", "nazi", "nigger", "neger", "fuck", "bitch", "hurensohn", "fotze", "wichser", "arschloch",
+    };
+
+    // Rate limits (fixed windows). Signup/login key on the caller IP, uploads/reports on the account —
+    // they exist to blunt scripted abuse, not to inconvenience players.
+
+    public int SignupPerHourPerIp { get; set; } = 5;
+
+    public int LoginPerMinutePerIp { get; set; } = 10;
+
+    public int UploadsPerHourPerAccount { get; set; } = 6;
+
+    public int ReportsPerHourPerAccount { get; set; } = 10;
+
     /// <summary>Loads config from BBS_WH_* environment variables over the defaults.</summary>
     public static WorldHostConfig FromEnvironment()
     {
@@ -121,6 +149,16 @@ public sealed class WorldHostConfig
         if (Env("BBS_WH_TERMS_VERSION") is { } tvStr && int.TryParse(tvStr, out var tv)) { c.TermsVersion = tv; }
         if (Env("BBS_WH_UPLOAD_MAX_BYTES") is { } upStr && long.TryParse(upStr, out var up)) { c.UploadMaxBytes = up; }
         if (Env("BBS_WH_ADMIN_TOKEN") is { } adminToken) { c.AdminToken = adminToken; }
+        if (Env("BBS_WH_ARCHIVE_MONTHS") is { } amStr && int.TryParse(amStr, out var am)) { c.ArchiveAfterMonths = am; }
+        if (Env("BBS_WH_BLOCKED_WORDS") is { } blocked)
+        {
+            c.BlockedNameWords.AddRange(blocked.Split(',').Select(w => w.Trim()).Where(w => w.Length > 0));
+        }
+
+        if (Env("BBS_WH_SIGNUPS_PER_HOUR") is { } suStr && int.TryParse(suStr, out var su)) { c.SignupPerHourPerIp = su; }
+        if (Env("BBS_WH_LOGINS_PER_MINUTE") is { } liStr && int.TryParse(liStr, out var li)) { c.LoginPerMinutePerIp = li; }
+        if (Env("BBS_WH_UPLOADS_PER_HOUR") is { } ulStr && int.TryParse(ulStr, out var ul)) { c.UploadsPerHourPerAccount = ul; }
+        if (Env("BBS_WH_REPORTS_PER_HOUR") is { } rpStr && int.TryParse(rpStr, out var rp)) { c.ReportsPerHourPerAccount = rp; }
 
         return c;
     }

--- a/src/BlocksBeyondTheStars.WorldHost/WorldHostMetrics.cs
+++ b/src/BlocksBeyondTheStars.WorldHost/WorldHostMetrics.cs
@@ -1,0 +1,62 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using System.Text;
+using System.Threading;
+
+namespace BlocksBeyondTheStars.WorldHost;
+
+/// <summary>
+/// Process-lifetime counters plus the Prometheus text exposition for <c>GET /metrics</c>. Hand-rolled
+/// (no client library): the format is trivial and the metric set is small — enough for a Prometheus
+/// scrape + capacity alerting on the single-host fleet. The endpoint stays on the loopback bind and is
+/// deliberately NOT routed through Caddy.
+/// </summary>
+public sealed class WorldHostMetrics
+{
+    private long _joinsGranted;
+    private long _wakes;
+    private long _reaped;
+    private long _archived;
+    private long _rateLimited;
+
+    public void JoinGranted() => Interlocked.Increment(ref _joinsGranted);
+
+    public void Woke() => Interlocked.Increment(ref _wakes);
+
+    public void Reaped(int count) => Interlocked.Add(ref _reaped, count);
+
+    public void Archived(int count) => Interlocked.Add(ref _archived, count);
+
+    public void RateLimited() => Interlocked.Increment(ref _rateLimited);
+
+    /// <summary>Renders the scrape body: live gauges from the registry + the process counters.</summary>
+    public string Render(HostRegistry registry)
+    {
+        var counts = registry.CountForMetrics();
+        var sb = new StringBuilder(512);
+
+        sb.Append("# TYPE bbs_accounts_total gauge\n");
+        sb.Append("bbs_accounts_total ").Append(counts.Accounts).Append('\n');
+        sb.Append("# TYPE bbs_reports_open gauge\n");
+        sb.Append("bbs_reports_open ").Append(counts.OpenReports).Append('\n');
+        sb.Append("# TYPE bbs_worlds gauge\n");
+        foreach (var (status, count) in counts.WorldsByStatus)
+        {
+            sb.Append("bbs_worlds{status=\"").Append(status).Append("\"} ").Append(count).Append('\n');
+        }
+
+        sb.Append("# TYPE bbs_joins_granted_total counter\n");
+        sb.Append("bbs_joins_granted_total ").Append(Interlocked.Read(ref _joinsGranted)).Append('\n');
+        sb.Append("# TYPE bbs_world_wakes_total counter\n");
+        sb.Append("bbs_world_wakes_total ").Append(Interlocked.Read(ref _wakes)).Append('\n');
+        sb.Append("# TYPE bbs_worlds_reaped_total counter\n");
+        sb.Append("bbs_worlds_reaped_total ").Append(Interlocked.Read(ref _reaped)).Append('\n');
+        sb.Append("# TYPE bbs_worlds_archived_total counter\n");
+        sb.Append("bbs_worlds_archived_total ").Append(Interlocked.Read(ref _archived)).Append('\n');
+        sb.Append("# TYPE bbs_rate_limited_total counter\n");
+        sb.Append("bbs_rate_limited_total ").Append(Interlocked.Read(ref _rateLimited)).Append('\n');
+
+        return sb.ToString();
+    }
+}

--- a/src/BlocksBeyondTheStars.WorldHost/WorldOrchestrator.cs
+++ b/src/BlocksBeyondTheStars.WorldHost/WorldOrchestrator.cs
@@ -34,6 +34,7 @@ public sealed class WorldOrchestrator
     private readonly HostRegistry _registry;
     private readonly IInstanceLauncher _launcher;
     private readonly Func<WorldRecord, Task<bool>> _healthProbe;
+    private readonly WorldHostMetrics _metrics;
     private readonly ConcurrentDictionary<string, SemaphoreSlim> _wakeLocks = new();
     private static readonly HttpClient Http = new() { Timeout = TimeSpan.FromSeconds(3) };
 
@@ -41,12 +42,14 @@ public sealed class WorldOrchestrator
         WorldHostConfig config,
         HostRegistry registry,
         IInstanceLauncher launcher,
-        Func<WorldRecord, Task<bool>>? healthProbe = null)
+        Func<WorldRecord, Task<bool>>? healthProbe = null,
+        WorldHostMetrics? metrics = null)
     {
         _config = config;
         _registry = registry;
         _launcher = launcher;
         _healthProbe = healthProbe ?? DefaultProbeAsync;
+        _metrics = metrics ?? new WorldHostMetrics();
     }
 
     /// <summary>Default probe: the instance's WS gateway answers /status on the world's (loopback-bound)
@@ -82,6 +85,12 @@ public sealed class WorldOrchestrator
             return (null, "This player name is reserved.");
         }
 
+        // Kid-facing name hygiene applies to in-game identities too, not only account/world names.
+        if (_registry.IsBlockedName(playerName))
+        {
+            return (null, "Please choose a different player name.");
+        }
+
         // Community-rules enforcement happens at the join grant — the choke point every hosted-world
         // entry goes through, regardless of which client asked.
         if (account.IsBanned)
@@ -101,6 +110,9 @@ public sealed class WorldOrchestrator
         {
             return (null, error);
         }
+
+        _metrics.JoinGranted();
+        _registry.TouchWorldActive(world.Id); // real player interest — resets the archive-inactivity clock
 
         long expires = DateTimeOffset.UtcNow.ToUnixTimeSeconds() + JoinTokenTtlSeconds;
         string token = HostedJoinToken.Create(world.JoinSecret, world.Id, account.Id, playerName, expires);
@@ -139,9 +151,17 @@ public sealed class WorldOrchestrator
                 return (world, string.Empty);
             }
 
+            // Archived world: transparently restore its saves first — from the player's side an archived
+            // world is just one that takes a moment longer to wake.
+            if (world.Status == WorldStatus.Archived)
+            {
+                SavePaths.RestoreFromArchive(_config, world.Id);
+                _registry.SetWorldStatus(world.Id, WorldStatus.Stopped, string.Empty);
+            }
+
             // Registry says active but the container is gone (idle shutdown, crash, host reboot) — reconcile,
             // then fall through to a fresh start.
-            if (world.Status != WorldStatus.Stopped)
+            if (world.Status != WorldStatus.Stopped && world.Status != WorldStatus.Archived)
             {
                 _registry.SetWorldStatus(world.Id, WorldStatus.Stopped, string.Empty);
             }
@@ -159,6 +179,7 @@ public sealed class WorldOrchestrator
                 return (null, "The world could not be started — please try again in a moment.");
             }
 
+            _metrics.Woke();
             return await AwaitHealthyAsync(_registry.GetWorld(world.Id)!).ConfigureAwait(false);
         }
         finally
@@ -210,10 +231,40 @@ public sealed class WorldOrchestrator
             if (!_launcher.IsRunning(world.ContainerId))
             {
                 _registry.SetWorldStatus(world.Id, WorldStatus.Stopped, string.Empty);
+                _registry.TouchWorldActive(world.Id); // it WAS just running — inactivity starts now
                 reaped++;
             }
         }
 
+        _metrics.Reaped(reaped);
         return reaped;
+    }
+
+    /// <summary>Archives stopped worlds whose last activity predates the configured window: saves move
+    /// to the archive folder, status flips to archived. Joining later restores them transparently.
+    /// Time is passed in so the sweep is testable; returns the number archived.</summary>
+    public int ArchiveSweep(long nowUnix)
+    {
+        if (_config.ArchiveAfterMonths <= 0)
+        {
+            return 0;
+        }
+
+        long cutoff = nowUnix - (long)_config.ArchiveAfterMonths * 30 * 86400;
+        int archived = 0;
+        foreach (var world in _registry.ListArchiveCandidates(cutoff))
+        {
+            if (_launcher.IsRunning(world.ContainerId))
+            {
+                continue; // belt and braces — never archive under a live container
+            }
+
+            SavePaths.MoveToArchive(_config, world.Id);
+            _registry.SetWorldStatus(world.Id, WorldStatus.Archived, string.Empty);
+            archived++;
+        }
+
+        _metrics.Archived(archived);
+        return archived;
     }
 }

--- a/tests/BlocksBeyondTheStars.Tests/WorldHostPhase3Tests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/WorldHostPhase3Tests.cs
@@ -1,0 +1,239 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using BlocksBeyondTheStars.WorldHost;
+using Xunit;
+
+namespace BlocksBeyondTheStars.Tests;
+
+/// <summary>
+/// Hosted-worlds Phase 3 hardening: rate limiting, blocked-name hygiene, archive-after-inactivity with
+/// transparent restore-on-join, and the Prometheus metrics rendering.
+/// </summary>
+public sealed class WorldHostPhase3Tests : IDisposable
+{
+    private readonly string _root;
+    private readonly List<HostRegistry> _registries = new();
+
+    public WorldHostPhase3Tests()
+    {
+        _root = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "bbts_wh3_" + Guid.NewGuid().ToString("N"));
+        System.IO.Directory.CreateDirectory(_root);
+    }
+
+    private HostRegistry NewRegistry(WorldHostConfig config)
+    {
+        var registry = new HostRegistry(config, System.IO.Path.Combine(_root, Guid.NewGuid().ToString("N") + ".db"));
+        _registries.Add(registry);
+        return registry;
+    }
+
+    private sealed class FakeLauncher : IInstanceLauncher
+    {
+        public int StartCount;
+        public readonly HashSet<string> Running = new(StringComparer.Ordinal);
+
+        public string Start(WorldRecord world)
+        {
+            StartCount++;
+            string id = "container-" + StartCount;
+            Running.Add(id);
+            return id;
+        }
+
+        public void Stop(string containerId) => Running.Remove(containerId);
+
+        public bool IsRunning(string containerId) => containerId != null && Running.Contains(containerId);
+    }
+
+    private static WorldOrchestrator NewOrchestrator(HostRegistry registry, FakeLauncher launcher, WorldHostConfig config, WorldHostMetrics? metrics = null)
+        => new(config, registry, launcher, w => Task.FromResult(launcher.IsRunning(w.ContainerId)), metrics);
+
+    private static (string AccountId, AccountRecord Account) NewAccount(HostRegistry registry, string name = "Owner")
+    {
+        var (ok, error, accountId, session) = registry.CreateAccount(name, "super-secret-1", acceptedTermsVersion: 1);
+        Assert.True(ok, error);
+        return (accountId, registry.ResolveSession(session)!);
+    }
+
+    // ---------------- Rate limiter ----------------
+
+    [Fact]
+    public void RateLimiter_EnforcesTheWindow_AndResets()
+    {
+        long now = 1000;
+        var limiter = new RateLimiter(2, TimeSpan.FromSeconds(60), () => now);
+
+        Assert.True(limiter.TryPass("ip-1"));
+        Assert.True(limiter.TryPass("ip-1"));
+        Assert.False(limiter.TryPass("ip-1"));   // budget spent
+        Assert.True(limiter.TryPass("ip-2"));    // other keys are independent
+
+        now += 61;                                // window rolls over
+        Assert.True(limiter.TryPass("ip-1"));
+    }
+
+    [Fact]
+    public void RateLimiter_NonPositiveLimit_DisablesIt()
+    {
+        var limiter = new RateLimiter(0, TimeSpan.FromSeconds(1), () => 0);
+        for (int i = 0; i < 100; i++)
+        {
+            Assert.True(limiter.TryPass("ip"));
+        }
+    }
+
+    // ---------------- Blocked names (kid-facing hygiene) ----------------
+
+    [Fact]
+    public async Task BlockedWords_AreRejected_ForAccounts_Worlds_AndPlayerNamesAsync()
+    {
+        var config = new WorldHostConfig { WakeTimeoutSeconds = 5 };
+        var registry = NewRegistry(config);
+        var orchestrator = NewOrchestrator(registry, new FakeLauncher(), config);
+
+        // Account names: exact, cased and separator-tricked variants are all caught.
+        Assert.False(registry.CreateAccount("hitler88", "super-secret-1", acceptedTermsVersion: 1).Ok);
+        Assert.False(registry.CreateAccount("H-i-t-l-e-r", "super-secret-1", acceptedTermsVersion: 1).Ok);
+        Assert.True(registry.CreateAccount("Hilda", "super-secret-1", acceptedTermsVersion: 1).Ok); // no false positive
+
+        var (accountId, account) = NewAccount(registry);
+
+        // World display names.
+        Assert.False(registry.CreateWorld(accountId, "xX fuck Xx").Ok);
+        var world = registry.CreateWorld(accountId, "Friendly World").World!;
+
+        // In-game player names at the join grant.
+        Assert.Null((await orchestrator.JoinAsync(world.Id, account, "N_a_z_i")).Grant);
+        Assert.NotNull((await orchestrator.JoinAsync(world.Id, account, "NicePilot")).Grant);
+    }
+
+    [Fact]
+    public void BlockedWords_OperatorExtension_IsHonored()
+    {
+        var config = new WorldHostConfig();
+        config.BlockedNameWords.Add("kackwurst");
+        var registry = NewRegistry(config);
+        Assert.False(registry.CreateAccount("Kack-Wurst", "super-secret-1", acceptedTermsVersion: 1).Ok);
+    }
+
+    // ---------------- Archive after inactivity ----------------
+
+    [Fact]
+    public async Task ArchiveSweep_ArchivesInactiveWorlds_AndJoinRestoresThemTransparentlyAsync()
+    {
+        var config = new WorldHostConfig
+        {
+            WakeTimeoutSeconds = 5,
+            ArchiveAfterMonths = 6,
+            WorldsDir = System.IO.Path.Combine(_root, "worlds"),
+        };
+        var registry = NewRegistry(config);
+        var launcher = new FakeLauncher();
+        var orchestrator = NewOrchestrator(registry, launcher, config);
+        var (accountId, account) = NewAccount(registry);
+        var world = registry.CreateWorld(accountId, "Sleepy World").World!;
+
+        // The world has been played once: saves exist on disk.
+        string dbPath = SavePaths.WorldDbPath(config, world.Id);
+        System.IO.Directory.CreateDirectory(System.IO.Path.GetDirectoryName(dbPath)!);
+        System.IO.File.WriteAllText(dbPath, "save-bytes");
+
+        // Fresh worlds are safe: a sweep "today" archives nothing.
+        Assert.Equal(0, orchestrator.ArchiveSweep(DateTimeOffset.UtcNow.ToUnixTimeSeconds()));
+
+        // Seven months later the world is a candidate and gets archived: saves moved, status flipped.
+        long sevenMonthsLater = DateTimeOffset.UtcNow.ToUnixTimeSeconds() + 7L * 30 * 86400;
+        Assert.Equal(1, orchestrator.ArchiveSweep(sevenMonthsLater));
+        Assert.Equal(WorldStatus.Archived, registry.GetWorld(world.Id)!.Status);
+        Assert.False(System.IO.File.Exists(dbPath));
+        Assert.True(System.IO.File.Exists(
+            System.IO.Path.Combine(SavePaths.ArchivedSavesDir(config, world.Id), world.Id, "world.db")));
+
+        // Joining an archived world restores the saves and wakes it — transparent to the player.
+        var (grant, error) = await orchestrator.JoinAsync(world.Id, account, "Pilot");
+        Assert.NotNull(grant);
+        Assert.Equal(string.Empty, error);
+        Assert.Equal(WorldStatus.Running, registry.GetWorld(world.Id)!.Status);
+        Assert.True(System.IO.File.Exists(dbPath)); // saves are back in the live location
+        Assert.False(System.IO.Directory.Exists(SavePaths.ArchivedSavesDir(config, world.Id)));
+    }
+
+    [Fact]
+    public async Task ArchiveSweep_SparesRecentlyActiveWorldsAsync()
+    {
+        var config = new WorldHostConfig
+        {
+            WakeTimeoutSeconds = 5,
+            ArchiveAfterMonths = 6,
+            WorldsDir = System.IO.Path.Combine(_root, "worlds-active"),
+        };
+        var registry = NewRegistry(config);
+        var launcher = new FakeLauncher();
+        var orchestrator = NewOrchestrator(registry, launcher, config);
+        var (accountId, account) = NewAccount(registry);
+        var world = registry.CreateWorld(accountId, "Busy World").World!;
+
+        // A join stamps activity; the instance then idle-exits and the reaper re-stamps it.
+        Assert.NotNull((await orchestrator.JoinAsync(world.Id, account, "Pilot")).Grant);
+        launcher.Stop(registry.GetWorld(world.Id)!.ContainerId);
+        Assert.Equal(1, orchestrator.Reap());
+
+        // Five months of silence: still spared (threshold is six).
+        long fiveMonthsLater = DateTimeOffset.UtcNow.ToUnixTimeSeconds() + 5L * 30 * 86400;
+        Assert.Equal(0, orchestrator.ArchiveSweep(fiveMonthsLater));
+        Assert.Equal(WorldStatus.Stopped, registry.GetWorld(world.Id)!.Status);
+    }
+
+    [Fact]
+    public void ArchiveSweep_Disabled_WhenMonthsIsZero()
+    {
+        var config = new WorldHostConfig { ArchiveAfterMonths = 0, WorldsDir = System.IO.Path.Combine(_root, "worlds-off") };
+        var registry = NewRegistry(config);
+        var orchestrator = NewOrchestrator(registry, new FakeLauncher(), config);
+        var (accountId, _) = NewAccount(registry);
+        registry.CreateWorld(accountId, "Kept World");
+
+        Assert.Equal(0, orchestrator.ArchiveSweep(DateTimeOffset.UtcNow.ToUnixTimeSeconds() + 100L * 30 * 86400));
+    }
+
+    // ---------------- Metrics ----------------
+
+    [Fact]
+    public void Metrics_RenderCarriesGaugesAndCounters()
+    {
+        var config = new WorldHostConfig();
+        var registry = NewRegistry(config);
+        var (accountId, _) = NewAccount(registry);
+        registry.CreateWorld(accountId, "My World");
+
+        var metrics = new WorldHostMetrics();
+        metrics.JoinGranted();
+        metrics.Archived(2);
+
+        string text = metrics.Render(registry);
+        Assert.Contains("bbs_accounts_total 1", text, StringComparison.Ordinal);
+        Assert.Contains("bbs_worlds{status=\"stopped\"} 1", text, StringComparison.Ordinal);
+        Assert.Contains("bbs_joins_granted_total 1", text, StringComparison.Ordinal);
+        Assert.Contains("bbs_worlds_archived_total 2", text, StringComparison.Ordinal);
+        Assert.Contains("bbs_reports_open 0", text, StringComparison.Ordinal);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            foreach (var r in _registries)
+            {
+                r.Dispose();
+            }
+
+            Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+            if (System.IO.Directory.Exists(_root)) System.IO.Directory.Delete(_root, recursive: true);
+        }
+        catch { }
+    }
+}


### PR DESCRIPTION
Hardening of the WorldHost control plane before public launch. Closes #228.

- **Archive after inactivity** (`BBS_WH_ARCHIVE_MONTHS`, default 6, 0 = off): hourly sweep moves a stopped world''s saves to `_archive/` once `last_active_unix` (stamped on join/wake and by the reaper) ages out; **joining an archived world restores it transparently**. Never destructive.
- **Fixed-window rate limits**: signups 5/h + logins 10/min per client IP (X-Forwarded-For from Caddy now honored), uploads 6/h + reports 10/h per account; HTTP 429 with a friendly message.
- **Blocked-name hygiene** on account names, world names and in-game player names (normalized like the reserved-name check; `BBS_WH_BLOCKED_WORDS` extends the short default list).
- **Prometheus `GET /metrics`** on the loopback bind (gauges: worlds by status, accounts, open reports; counters: joins, wakes, reaps, archives, rate-limited).
- Fleet **version policy** documented in HOSTED_WORLDS.md; multi-host placement stays deferred until one host stops being enough.

## Verification
- 0-warning clean solution rebuild; fast-tier suite green (831 server + 94 client, 8 new `WorldHostPhase3Tests`)
- No client/Assets changes (server-side only) — no Unity build needed
- Developed in an isolated git worktree to avoid touching the concurrently used main checkout

🤖 Generated with [Claude Code](https://claude.com/claude-code)