### PR TITLE
fix(ci): deploy input validation rejected empty (default) tags

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,8 +48,10 @@ jobs:
           WORLDHOST_TAG: ${{ inputs.worldhost_tag }}
           REPORTS_TAG: ${{ inputs.reports_tag }}
         run: |
+          # Empty = keep the currently pinned tag; grep sees no line on empty input, so skip explicitly.
           for t in "$WORLDHOST_TAG" "$REPORTS_TAG"; do
-            if ! printf '%s' "$t" | grep -Eq '^[A-Za-z0-9._-]*$'; then
+            [ -z "$t" ] && continue
+            if ! printf '%s' "$t" | grep -Eq '^[A-Za-z0-9._-]+$'; then
               echo "invalid image tag: $t"; exit 1
             fi
           done


### PR DESCRIPTION
The first "Deploy (VPS)" run failed in **Validate inputs**: `grep -q` never matches on empty stdin (there is no line to match), so the guard rejected exactly the default case — both tag inputs left empty ("keep the currently pinned tag"). Empty values are now skipped explicitly; non-empty tags are still restricted to `[A-Za-z0-9._-]+`.

One-line behavior fix, no server contact happened in the failed run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)