### PR TITLE
fix(worldhost): remove stale world container before re-wake

### DIFF
--- a/src/BlocksBeyondTheStars.WorldHost/InstanceLauncher.cs
+++ b/src/BlocksBeyondTheStars.WorldHost/InstanceLauncher.cs
@@ -47,6 +47,11 @@ public sealed class DockerCliLauncher : IInstanceLauncher
         string savesDir = SavePaths.HostSavesDir(_config, world.Id);
         Directory.CreateDirectory(savesDir);
 
+        // Instances exit on idle but their container OBJECT remains (we run without --rm so logs stay
+        // inspectable while a world sleeps) — remove any stale one first or the re-wake's `docker run
+        // --name bbs-world-<id>` fails with a name conflict. Best effort: "no such container" is fine.
+        Run(new List<string> { "rm", "-f", $"bbs-world-{world.Id}" });
+
         var (exitCode, stdout, stderr) = Run(BuildRunArgs(_config, world, savesDir));
         if (exitCode != 0)
         {


### PR DESCRIPTION
Closes #242.

Surfaced by the first real e2e world-wake on the VPS (after #234): instances exit on idle but their container object remains (we deliberately run without `--rm` so logs stay inspectable while a world sleeps). The next wake's `docker run --name bbs-world-<id>` then fails with a **name conflict** — every world could be woken exactly once.

Fix: best-effort `docker rm -f bbs-world-<id>` before starting ("no such container" is fine). Verified: WorldHost builds clean; the stop→rejoin e2e cycle will be re-run on the VPS after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)