### PR TITLE
feat(worldhost): admin server-health card + public /api/stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,8 +342,9 @@ above), and **hosted worlds** — a Minecraft-Realms-style option where a player
 multiplayer world online (optionally from a singleplayer save) that runs as one dedicated-server
 container per world behind a control plane ("WorldHost"). The desktop client's **"Official Worlds"**
 menu signs in, lists your worlds and joins with one click; a free web portal manages worlds, community
-rules, reports and account deletion. Privacy is deliberately minimal — a chosen name and a password
-hash, **no email, no tracking**. This is a **beta in active development** (the public service isn't live
+rules, reports and account deletion. Operators get an `/admin` dashboard (fleet overview, reports,
+bans, live server health) and a public `GET /api/stats` with aggregate player/world counts. Privacy is
+deliberately minimal — a chosen name and a password hash, **no email, no tracking**. This is a **beta in active development** (the public service isn't live
 yet); the architecture, routing and operations are documented in
 [docs/developer/HOSTED_WORLDS.md](docs/developer/HOSTED_WORLDS.md). The web client never picks servers —
 it is always bound to whoever serves its page.
@@ -374,7 +375,7 @@ the VEGA ship-AI onboarding/advisor companion, world-creation options, and an op
 for dynamic dialogue/mission text. Self-hostable dedicated server. **Native Windows and Linux**
 clients (no Wine/Proton; an experimental macOS build exists), and **opt-in automatic crash reporting**
 so problems get fixed faster.
-Currently **875 xUnit tests pass** (779 server/shared + 96 headless client<->server).
+Currently **988 xUnit tests pass** (887 server/shared + 101 headless client<->server).
 
 See [TODO.md](TODO.md) for the current Done/Open status, the
 [user manual](docs/user/USER_MANUAL.md) for controls/mechanics/commands, and [AGENTS.md](AGENTS.md)

--- a/TODO.md
+++ b/TODO.md
@@ -5500,6 +5500,20 @@ is **pre-approved** (keys in `tools/ai-assets/.env`, run via `uv`).
 
 ---
 
+## ✅ Done (2026-07-05): server observability — admin health card + public stats API (#244, #245)
+Two observability surfaces on WorldHost (details: HOSTED_WORLDS.md).
+- **Server health card on `/admin`**: host load/RAM/disk (from `/proc/meminfo` + `/proc/loadavg` —
+  host-wide inside the container — and `DriveInfo` on the worlds bind mount) plus per-container
+  CPU/memory via `docker stats` (new `IInstanceLauncher.ContainerStats()`); filled asynchronously
+  from `GET /admin/stats.json` (Basic-Auth) so the ~1-2 s docker sample never stalls the page.
+  Green/amber/red thresholds mirror the ops alert levels; degrades to "n/a" without `/proc`/docker.
+- **Public `GET /api/stats`**: worlds created/active + players registered/online as aggregates only
+  (no names/ids). Doubly guarded: TTL cache with single-flight rebuild (`BBS_WH_STATS_CACHE_SECONDS`,
+  30 s — instance `/status` probes never run per-request) + per-IP rate limit
+  (`BBS_WH_STATS_PER_MINUTE`, 30). CORS-open so the marketing website can show live numbers.
+- 11 new tests (`WorldHostStatsTests`): /proc + docker-stats parsers, size units, cache TTL/expiry,
+  single-flight concurrency, stale-serve during rebuild.
+
 ## ✅ Done (2026-07-05): fleet AI texts, per-world resource fences, operator admin UIs
 The LLM backend joins the fleet and the host gets guard rails (details: HOSTED_WORLDS.md).
 - **AI backend containerized** (`Dockerfile.ai`, uv-locked; `ai-image.yml` publishes

--- a/docs/developer/HOSTED_WORLDS.md
+++ b/docs/developer/HOSTED_WORLDS.md
@@ -224,6 +224,27 @@ live player counts via `/status`, stop/wake), the open player-report queue (clos
 reviewed/dismissed, reported names link to account lookup) and ban/unban with reason. The
 bug-report inbox has its own `/admin` (ReportHost) including a filtered JSON bulk export.
 
+**Server health card** (top of `/admin`): host load/RAM/disk plus per-container CPU/memory and the
+fleet aggregates, filled asynchronously from `GET /admin/stats.json` (same Basic-Auth gate) because
+the `docker stats` sample behind it takes ~1-2 s. Host numbers come from `/proc/meminfo` +
+`/proc/loadavg` (host-wide inside a container) and `DriveInfo` resolved against the worlds bind
+mount; on platforms without `/proc` (Windows dev) the fields are null and the card degrades.
+
+## Public stats API
+
+`GET /api/stats` (portal domain, no auth) returns exactly four aggregate numbers for the marketing
+site / client — never names or ids:
+
+```json
+{ "worlds": { "created": 12, "active": 3 }, "players": { "registered": 45, "online": 7 }, "updatedUnix": 1783300000 }
+```
+
+Being public it is doubly guarded: the JSON snapshot is cached with single-flight rebuild
+(`BBS_WH_STATS_CACHE_SECONDS`, default 30 — the per-instance `/status` probes behind `online` never
+run per-request) and requests are rate limited per IP (`BBS_WH_STATS_PER_MINUTE`, default 30).
+Responses carry `Access-Control-Allow-Origin: *` (so the website can fetch it client-side) and a
+matching `Cache-Control`.
+
 ## Registry storage: SQLite now, Postgres when it earns it
 
 The registry is SQLite on purpose: one host, one writer process, a tiny write volume, backup = one

--- a/src/BlocksBeyondTheStars.WorldHost/HostStats.cs
+++ b/src/BlocksBeyondTheStars.WorldHost/HostStats.cs
@@ -1,0 +1,272 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using System.Globalization;
+using System.Text.Json;
+
+namespace BlocksBeyondTheStars.WorldHost;
+
+/// <summary>One row of <c>docker stats</c>: a container's CPU percentage and memory used/limit.</summary>
+public sealed record ContainerStat(string Name, double CpuPercent, long MemUsedBytes, long MemLimitBytes);
+
+/// <summary>Host utilization snapshot. Fields are null where the platform doesn't provide them
+/// (no <c>/proc</c> on Windows dev boxes) — consumers render "n/a" instead of failing.</summary>
+public sealed record HostUtilization(
+    double? Load1, double? Load5, double? Load15, int Cores,
+    long? MemTotalKb, long? MemAvailableKb,
+    long? DiskTotalBytes, long? DiskFreeBytes);
+
+/// <summary>
+/// Host-utilization readings for the admin page. Inside a container <c>/proc/meminfo</c> and
+/// <c>/proc/loadavg</c> report HOST-wide values (procfs is not namespaced for them), and the worlds
+/// bind mount resolves to the host filesystem — so WorldHost can show real host numbers without any
+/// extra agent or privilege. Parsers are pure statics so they are unit-testable with captured samples.
+/// </summary>
+public static class HostStats
+{
+    /// <summary>Reads the full snapshot; every part is best-effort (null on unsupported platforms).</summary>
+    public static HostUtilization Read(string worldsDir)
+    {
+        var load = TryRead("/proc/loadavg") is { } loadText ? ParseLoadavg(loadText) : null;
+        var mem = TryRead("/proc/meminfo") is { } memText ? ParseMeminfo(memText) : null;
+        var disk = DiskFor(worldsDir);
+        return new HostUtilization(
+            load?.Load1, load?.Load5, load?.Load15, Environment.ProcessorCount,
+            mem?.TotalKb, mem?.AvailableKb,
+            disk?.TotalBytes, disk?.FreeBytes);
+    }
+
+    /// <summary>MemTotal/MemAvailable from <c>/proc/meminfo</c> content; null when either is missing.</summary>
+    public static (long TotalKb, long AvailableKb)? ParseMeminfo(string text)
+    {
+        long? total = null, available = null;
+        foreach (var line in text.Split('\n'))
+        {
+            if (line.StartsWith("MemTotal:", StringComparison.Ordinal))
+            {
+                total = ParseMeminfoKb(line);
+            }
+            else if (line.StartsWith("MemAvailable:", StringComparison.Ordinal))
+            {
+                available = ParseMeminfoKb(line);
+            }
+        }
+
+        return total is { } t && available is { } a ? (t, a) : null;
+    }
+
+    private static long? ParseMeminfoKb(string line)
+    {
+        var parts = line.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        return parts.Length >= 2 && long.TryParse(parts[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out long kb) ? kb : null;
+    }
+
+    /// <summary>The three load averages from <c>/proc/loadavg</c> ("0.42 0.30 0.19 1/123 456").</summary>
+    public static (double Load1, double Load5, double Load15)? ParseLoadavg(string text)
+    {
+        var parts = text.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        return parts.Length >= 3
+               && double.TryParse(parts[0], NumberStyles.Float, CultureInfo.InvariantCulture, out double l1)
+               && double.TryParse(parts[1], NumberStyles.Float, CultureInfo.InvariantCulture, out double l5)
+               && double.TryParse(parts[2], NumberStyles.Float, CultureInfo.InvariantCulture, out double l15)
+            ? (l1, l5, l15)
+            : null;
+    }
+
+    /// <summary>Total/free bytes of the filesystem holding <paramref name="dir"/> — resolved via the
+    /// longest matching mount point, because <c>DriveInfo(path)</c> only accepts drive roots. Pointing
+    /// this at the worlds bind mount yields HOST disk numbers from inside the container.</summary>
+    public static (long TotalBytes, long FreeBytes)? DiskFor(string dir)
+    {
+        try
+        {
+            string full = Path.GetFullPath(dir);
+            var comparison = OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+            DriveInfo? best = null;
+            foreach (var drive in DriveInfo.GetDrives())
+            {
+                if (!drive.IsReady)
+                {
+                    continue;
+                }
+
+                string root = drive.RootDirectory.FullName;
+                if (full.StartsWith(root, comparison)
+                    && (best is null || root.Length > best.RootDirectory.FullName.Length))
+                {
+                    best = drive;
+                }
+            }
+
+            return best is null ? null : (best.TotalSize, best.AvailableFreeSpace);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>Parses <c>docker stats --no-stream --format '{{json .}}'</c> output (one JSON object
+    /// per line, e.g. <c>{"Name":"bbs-caddy","CPUPerc":"0.12%","MemUsage":"115.7MiB / 7.696GiB"}</c>).
+    /// Unparseable lines are skipped — a half-broken docker answer degrades to fewer rows, not an error.</summary>
+    public static IReadOnlyList<ContainerStat> ParseDockerStats(string output)
+    {
+        var result = new List<ContainerStat>();
+        foreach (var line in output.Split('\n'))
+        {
+            string trimmed = line.Trim();
+            if (trimmed.Length == 0)
+            {
+                continue;
+            }
+
+            try
+            {
+                using var doc = JsonDocument.Parse(trimmed);
+                var root = doc.RootElement;
+                string name = root.GetProperty("Name").GetString() ?? string.Empty;
+                string cpuText = root.GetProperty("CPUPerc").GetString() ?? string.Empty;
+                string memText = root.GetProperty("MemUsage").GetString() ?? string.Empty;
+
+                if (!double.TryParse(cpuText.TrimEnd('%'), NumberStyles.Float, CultureInfo.InvariantCulture, out double cpu))
+                {
+                    continue;
+                }
+
+                var memParts = memText.Split('/', 2);
+                if (memParts.Length != 2
+                    || ParseSizeToBytes(memParts[0]) is not { } used
+                    || ParseSizeToBytes(memParts[1]) is not { } limit)
+                {
+                    continue;
+                }
+
+                result.Add(new ContainerStat(name, cpu, used, limit));
+            }
+            catch (JsonException)
+            {
+                // not a stats row (warning line, partial write) — skip
+            }
+        }
+
+        return result;
+    }
+
+    // docker (go-units) prints binary units for memory ("MiB") but decimal ones appear in other fields;
+    // accept both. Longest suffixes first so "MiB" wins over "B".
+    private static readonly (string Suffix, long Factor)[] SizeSuffixes =
+    {
+        ("KiB", 1024L), ("MiB", 1024L * 1024), ("GiB", 1024L * 1024 * 1024), ("TiB", 1024L * 1024 * 1024 * 1024),
+        ("kB", 1000L), ("MB", 1000_000L), ("GB", 1000_000_000L), ("TB", 1000_000_000_000L),
+        ("B", 1L),
+    };
+
+    /// <summary>"115.7MiB" → bytes; null when the value has no recognizable size suffix.</summary>
+    public static long? ParseSizeToBytes(string value)
+    {
+        string trimmed = value.Trim();
+        foreach (var (suffix, factor) in SizeSuffixes)
+        {
+            if (trimmed.EndsWith(suffix, StringComparison.Ordinal))
+            {
+                string number = trimmed.Substring(0, trimmed.Length - suffix.Length).Trim();
+                return double.TryParse(number, NumberStyles.Float, CultureInfo.InvariantCulture, out double n)
+                    ? (long)(n * factor)
+                    : null;
+            }
+        }
+
+        return null;
+    }
+
+    private static string? TryRead(string path)
+    {
+        try
+        {
+            return File.Exists(path) ? File.ReadAllText(path) : null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}
+
+/// <summary>
+/// TTL-cached JSON string with single-flight rebuild — the guard that makes a PUBLIC stats endpoint
+/// safe: no matter how many requests arrive, the (comparatively expensive) snapshot builder runs at
+/// most once per TTL window, and concurrent callers during a rebuild get the previous value instantly.
+/// The clock is injectable so tests don't sleep.
+/// </summary>
+public sealed class CachedJson : IDisposable
+{
+    private sealed record Entry(string Json, long BuiltUnix);
+
+    private readonly long _ttlSeconds;
+    private readonly Func<Task<string>> _rebuild;
+    private readonly Func<long> _nowUnix;
+    private readonly SemaphoreSlim _gate = new(1, 1);
+    private volatile Entry? _entry;
+
+    public CachedJson(TimeSpan ttl, Func<Task<string>> rebuild, Func<long>? nowUnix = null)
+    {
+        _ttlSeconds = Math.Max(1, (long)ttl.TotalSeconds);
+        _rebuild = rebuild;
+        _nowUnix = nowUnix ?? (() => DateTimeOffset.UtcNow.ToUnixTimeSeconds());
+    }
+
+    public async Task<string> GetAsync()
+    {
+        var entry = _entry;
+        if (entry != null && !Expired(entry))
+        {
+            return entry.Json;
+        }
+
+        if (await _gate.WaitAsync(0).ConfigureAwait(false))
+        {
+            try
+            {
+                return await RebuildLockedAsync().ConfigureAwait(false);
+            }
+            finally
+            {
+                _gate.Release();
+            }
+        }
+
+        // A rebuild is in flight. Serving the stale snapshot beats queueing up callers …
+        if (entry != null)
+        {
+            return entry.Json;
+        }
+
+        // … but with no snapshot at all (first request storm), wait for the builder.
+        await _gate.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            return await RebuildLockedAsync().ConfigureAwait(false);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    private async Task<string> RebuildLockedAsync()
+    {
+        var entry = _entry;
+        if (entry != null && !Expired(entry))
+        {
+            return entry.Json;
+        }
+
+        string built = await _rebuild().ConfigureAwait(false);
+        _entry = new Entry(built, _nowUnix());
+        return built;
+    }
+
+    private bool Expired(Entry entry) => _nowUnix() - entry.BuiltUnix >= _ttlSeconds;
+
+    public void Dispose() => _gate.Dispose();
+}

--- a/src/BlocksBeyondTheStars.WorldHost/InstanceLauncher.cs
+++ b/src/BlocksBeyondTheStars.WorldHost/InstanceLauncher.cs
@@ -19,6 +19,11 @@ public interface IInstanceLauncher
 
     /// <summary>Whether the container is still running — false once an idle shutdown has exited it.</summary>
     bool IsRunning(string containerId);
+
+    /// <summary>CPU/memory snapshot of every container on the host (admin server-health card). Empty
+    /// when docker is unavailable — the card degrades, nothing fails. NOTE: <c>docker stats</c> samples
+    /// for ~1-2 s, so callers must keep this off the page-render path.</summary>
+    IReadOnlyList<ContainerStat> ContainerStats();
 }
 
 /// <summary>
@@ -140,6 +145,12 @@ public sealed class DockerCliLauncher : IInstanceLauncher
 
         var (exitCode, stdout, _) = Run(new List<string> { "inspect", "--format", "{{.State.Running}}", containerId });
         return exitCode == 0 && stdout.Trim() == "true";
+    }
+
+    public IReadOnlyList<ContainerStat> ContainerStats()
+    {
+        var (exitCode, stdout, _) = Run(new List<string> { "stats", "--no-stream", "--format", "{{json .}}" });
+        return exitCode == 0 ? HostStats.ParseDockerStats(stdout) : Array.Empty<ContainerStat>();
     }
 
     private static (int ExitCode, string Stdout, string Stderr) Run(List<string> args)

--- a/src/BlocksBeyondTheStars.WorldHost/Program.cs
+++ b/src/BlocksBeyondTheStars.WorldHost/Program.cs
@@ -24,6 +24,7 @@ var signupLimit = new RateLimiter(config.SignupPerHourPerIp, TimeSpan.FromHours(
 var loginLimit = new RateLimiter(config.LoginPerMinutePerIp, TimeSpan.FromMinutes(1));
 var uploadLimit = new RateLimiter(config.UploadsPerHourPerAccount, TimeSpan.FromHours(1));
 var reportLimit = new RateLimiter(config.ReportsPerHourPerAccount, TimeSpan.FromHours(1));
+var statsLimit = new RateLimiter(config.StatsPerMinutePerIp, TimeSpan.FromMinutes(1));
 
 var builder = WebApplication.CreateBuilder(args);
 builder.Logging.ClearProviders();
@@ -146,6 +147,49 @@ IResult? GuardAdminUi(HttpContext ctx)
     return Results.Text("Unauthorized.", statusCode: StatusCodes.Status401Unauthorized);
 }
 
+// Extracts joinedPlayers from an instance's /status JSON; null when unreadable — callers show "?"
+// (admin page) or count 0 (aggregates) rather than fail.
+static int? ParseJoinedPlayers(string statusJson)
+{
+    try
+    {
+        using var doc = System.Text.Json.JsonDocument.Parse(statusJson);
+        return doc.RootElement.TryGetProperty("joinedPlayers", out var jp) ? jp.GetInt32() : null;
+    }
+    catch
+    {
+        return null;
+    }
+}
+
+// Sum of players currently on running instances, probed in parallel. Callers are throttled (the
+// admin page and the CACHED public snapshot) — never wire this to an uncached public path.
+async Task<int> CountPlayersOnlineAsync()
+{
+    var running = registry.ListAllWorldsAdmin().Where(e => e.World.Status == WorldStatus.Running);
+    var counts = await Task.WhenAll(running.Select(async e =>
+        await orchestrator.ReadInstanceStatusAsync(e.World) is { } json ? ParseJoinedPlayers(json) ?? 0 : 0));
+    return counts.Sum();
+}
+
+// Public aggregate snapshot (/api/stats): rebuilt at most once per TTL no matter the request rate —
+// the instance probes behind `online` are the expensive part this cache exists to protect.
+using var publicStats = new CachedJson(TimeSpan.FromSeconds(Math.Max(1, config.StatsCacheSeconds)), async () =>
+{
+    var counts = registry.CountForMetrics();
+    long created = counts.WorldsByStatus.Sum(s => s.Count);
+    long active = counts.WorldsByStatus
+        .Where(s => s.Status is WorldStatus.Running or WorldStatus.Starting)
+        .Sum(s => s.Count);
+    int online = await CountPlayersOnlineAsync();
+    return System.Text.Json.JsonSerializer.Serialize(new
+    {
+        worlds = new { created, active },
+        players = new { registered = counts.Accounts, online },
+        updatedUnix = DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+    });
+});
+
 // Gathers everything the admin page shows; live joined counts are probed in parallel for running
 // instances only (3 s HTTP cap keeps a dead instance from stalling the page).
 async Task<IResult> RenderAdminAsync(HttpContext ctx)
@@ -154,24 +198,10 @@ async Task<IResult> RenderAdminAsync(HttpContext ctx)
     var all = registry.ListAllWorldsAdmin();
     var rows = await Task.WhenAll(all.Select(async entry =>
     {
-        int? joined = null;
-        if (entry.World.Status == WorldStatus.Running
-            && await orchestrator.ReadInstanceStatusAsync(entry.World) is { } json)
-        {
-            try
-            {
-                using var doc = System.Text.Json.JsonDocument.Parse(json);
-                if (doc.RootElement.TryGetProperty("joinedPlayers", out var jp))
-                {
-                    joined = jp.GetInt32();
-                }
-            }
-            catch
-            {
-                // unreadable status — show "?" rather than fail the page
-            }
-        }
-
+        int? joined = entry.World.Status == WorldStatus.Running
+            && await orchestrator.ReadInstanceStatusAsync(entry.World) is { } json
+            ? ParseJoinedPlayers(json)
+            : null;
         return new AdminWorldRow(entry.World, entry.OwnerName, joined);
     }));
 
@@ -186,6 +216,30 @@ app.MapGet("/healthz", () => Results.Text("ok\n"));
 // Prometheus scrape (Phase 3). Reachable only on the loopback bind — Caddy deliberately does not
 // route /metrics, so fleet numbers never leak publicly.
 app.MapGet("/metrics", () => Results.Text(metrics.Render(registry), "text/plain; version=0.0.4; charset=utf-8"));
+
+// Public aggregate stats (closes #245): four numbers for the website/client — no names, no ids, so
+// nothing personal leaves the service. Doubly guarded because it is unauthenticated: the cached
+// single-flight snapshot bounds the work, the per-IP limit bounds the traffic. CORS-open on purpose
+// so the marketing site can fetch it client-side.
+app.MapGet("/api/stats", async (HttpContext ctx) =>
+{
+    if (!statsLimit.TryPass(CallerIp(ctx)))
+    {
+        return RateLimited();
+    }
+
+    ctx.Response.Headers.AccessControlAllowOrigin = "*";
+    ctx.Response.Headers.CacheControl = $"public, max-age={Math.Max(1, config.StatsCacheSeconds)}";
+    try
+    {
+        return Results.Text(await publicStats.GetAsync(), "application/json; charset=utf-8");
+    }
+    catch (Exception ex)
+    {
+        log.LogWarning(ex, "Public stats snapshot failed.");
+        return Results.StatusCode(StatusCodes.Status503ServiceUnavailable);
+    }
+});
 
 // ---------------- Portal pages (server-rendered shells; the JS talks to /api with a Bearer session) ----------------
 
@@ -361,6 +415,49 @@ app.MapGet("/admin", async (HttpContext ctx) =>
     }
 
     return await RenderAdminAsync(ctx);
+});
+
+// Server-health JSON behind the admin page's "Server health" card (closes #244). Fetched by the card
+// AFTER the page renders, because `docker stats` samples for ~1-2 s and must not stall the page.
+app.MapGet("/admin/stats.json", async (HttpContext ctx) =>
+{
+    if (GuardAdminUi(ctx) is { } denied)
+    {
+        return denied;
+    }
+
+    var host = HostStats.Read(config.WorldsDir);
+    var containers = await Task.Run(() => launcher.ContainerStats());
+    var counts = registry.CountForMetrics();
+    int online = await CountPlayersOnlineAsync();
+    return Results.Json(new
+    {
+        host = new
+        {
+            load1 = host.Load1,
+            load5 = host.Load5,
+            load15 = host.Load15,
+            cores = host.Cores,
+            memTotalKb = host.MemTotalKb,
+            memAvailableKb = host.MemAvailableKb,
+            diskTotalBytes = host.DiskTotalBytes,
+            diskFreeBytes = host.DiskFreeBytes,
+        },
+        containers = containers.Select(c => new
+        {
+            name = c.Name,
+            cpuPercent = c.CpuPercent,
+            memUsedBytes = c.MemUsedBytes,
+            memLimitBytes = c.MemLimitBytes,
+        }),
+        fleet = new
+        {
+            accounts = counts.Accounts,
+            reportsOpen = counts.OpenReports,
+            playersOnline = online,
+            worlds = counts.WorldsByStatus.Select(s => new { status = s.Status, count = s.Count }),
+        },
+    });
 });
 
 app.MapPost("/admin/reports/{id:long}/close", async (HttpContext ctx, long id) =>

--- a/src/BlocksBeyondTheStars.WorldHost/WorldHostAdminPages.cs
+++ b/src/BlocksBeyondTheStars.WorldHost/WorldHostAdminPages.cs
@@ -46,6 +46,10 @@ public static class WorldHostAdminPages
         sb.Append($"<p class='hint'>{worlds.Count} worlds · <b>{active}</b>/{(config.MaxActiveInstances > 0 ? config.MaxActiveInstances.ToString() : "∞")} instances awake · " +
                   $"{openReports.Count} open report(s) · {banned.Count} banned account(s)</p>");
 
+        // ---- Server health (filled by JS from /admin/stats.json AFTER the page renders — the
+        // docker-stats sample behind it takes ~1-2 s and must not stall the page) ----
+        sb.Append("<div class='card'><h2>Server health</h2><div id='sh' class='hint'>loading…</div></div>");
+
         // ---- Instances ----
         sb.Append("<div class='card'><h2>Instances</h2>");
         if (worlds.Count == 0)
@@ -136,6 +140,46 @@ public static class WorldHostAdminPages
         sb.Append("</div>");
         sb.Append("<p><a href='/'>← Portal</a></p>");
         sb.Append("<style>table{width:100%;border-collapse:collapse} th,td{padding:6px 8px;text-align:left;border-bottom:1px solid var(--line);vertical-align:top} form{margin:0}</style>");
+
+        // Server-health card renderer. Thresholds mirror the ops alerting levels (<70 % green,
+        // <85 % amber, else red). Values interpolated into innerHTML are numbers plus docker container
+        // names, whose charset docker itself restricts — nothing player-controlled reaches this card.
+        sb.Append(@"<script>
+(function () {
+  var el = document.getElementById('sh');
+  function bar(label, frac, text) {
+    var pct = Math.max(0, Math.min(100, Math.round(frac * 100)));
+    var color = pct < 70 ? '#7dff9e' : pct < 85 ? '#ff8c26' : '#e05c5c';
+    return ""<div style='margin:6px 0'>"" + label + "" <span class='sub'>"" + text + ""</span>"" +
+      ""<div style='height:8px;border:1px solid var(--line);border-radius:4px;overflow:hidden'>"" +
+      ""<div style='height:100%;width:"" + pct + ""%;background:"" + color + ""'></div></div></div>"";
+  }
+  fetch('/admin/stats.json').then(function (r) { return r.json(); }).then(function (s) {
+    var h = s.host || {}, html = '';
+    if (h.load1 != null) { html += bar('CPU load', h.cores ? h.load1 / h.cores : 0, h.load1.toFixed(2) + ' (1 min) / ' + h.cores + ' cores'); }
+    if (h.memTotalKb) {
+      var usedKb = h.memTotalKb - (h.memAvailableKb || 0);
+      html += bar('RAM', usedKb / h.memTotalKb, (usedKb / 1048576).toFixed(1) + ' / ' + (h.memTotalKb / 1048576).toFixed(1) + ' GB');
+    }
+    if (h.diskTotalBytes) {
+      var usedB = h.diskTotalBytes - (h.diskFreeBytes || 0);
+      html += bar('Disk (worlds)', usedB / h.diskTotalBytes, (usedB / 1073741824).toFixed(1) + ' / ' + (h.diskTotalBytes / 1073741824).toFixed(1) + ' GB');
+    }
+    if (!html) { html = ""<p class='hint'>No host metrics on this platform.</p>""; }
+    if (s.containers && s.containers.length) {
+      html += ""<table><tr><th>Container</th><th>CPU</th><th>Memory</th></tr>"";
+      s.containers.forEach(function (c) {
+        html += ""<tr><td><code>"" + c.name + ""</code></td><td>"" + c.cpuPercent.toFixed(1) + "" %</td><td>"" +
+          (c.memUsedBytes / 1048576).toFixed(0) + "" / "" + (c.memLimitBytes / 1048576).toFixed(0) + "" MB</td></tr>"";
+      });
+      html += ""</table>"";
+    }
+    html += ""<p class='hint'>"" + s.fleet.playersOnline + "" player(s) online · "" + s.fleet.accounts +
+      "" account(s) · "" + s.fleet.reportsOpen + "" open report(s)</p>"";
+    el.innerHTML = html;
+  }).catch(function () { el.textContent = 'stats unavailable'; });
+})();
+</script>");
 
         return WorldHostPortalPages.Shell("Fleet admin — Blocks Beyond the Stars", sb.ToString());
     }

--- a/src/BlocksBeyondTheStars.WorldHost/WorldHostConfig.cs
+++ b/src/BlocksBeyondTheStars.WorldHost/WorldHostConfig.cs
@@ -114,6 +114,16 @@ public sealed class WorldHostConfig
 
     public int ReportsPerHourPerAccount { get; set; } = 10;
 
+    // --- Public aggregate stats (GET /api/stats): four numbers for the website/client. Public and
+    // unauthenticated, therefore doubly guarded: a cached single-flight snapshot plus a per-IP limit. ---
+
+    /// <summary>Per-IP request limit for /api/stats (BBS_WH_STATS_PER_MINUTE); non-positive disables the limiter.</summary>
+    public int StatsPerMinutePerIp { get; set; } = 30;
+
+    /// <summary>Seconds the /api/stats snapshot is served from cache (BBS_WH_STATS_CACHE_SECONDS) —
+    /// the instance /status probes behind the online-player count never run more often than this.</summary>
+    public int StatsCacheSeconds { get; set; } = 30;
+
     // --- Legal pages (§5 DDG Impressum + DSGVO privacy). Operator-set on purpose: a SELF-HOSTED
     // WorldHost must carry ITS operator's data, never the project authors' — empty values make the
     // pages render a clear "not configured" notice instead of wrong legal information. ---
@@ -217,6 +227,8 @@ public sealed class WorldHostConfig
         if (Env("BBS_WH_LOGINS_PER_MINUTE") is { } liStr && int.TryParse(liStr, out var li)) { c.LoginPerMinutePerIp = li; }
         if (Env("BBS_WH_UPLOADS_PER_HOUR") is { } ulStr && int.TryParse(ulStr, out var ul)) { c.UploadsPerHourPerAccount = ul; }
         if (Env("BBS_WH_REPORTS_PER_HOUR") is { } rpStr && int.TryParse(rpStr, out var rp)) { c.ReportsPerHourPerAccount = rp; }
+        if (Env("BBS_WH_STATS_PER_MINUTE") is { } spStr && int.TryParse(spStr, out var sp)) { c.StatsPerMinutePerIp = sp; }
+        if (Env("BBS_WH_STATS_CACHE_SECONDS") is { } scStr && int.TryParse(scStr, out var sc)) { c.StatsCacheSeconds = sc; }
         if (Env("BBS_WH_LEGAL_NAME") is { } legalName) { c.LegalName = legalName; }
         if (Env("BBS_WH_LEGAL_ADDRESS") is { } legalAddress) { c.LegalAddress = legalAddress; }
         if (Env("BBS_WH_LEGAL_EMAIL") is { } legalEmail) { c.LegalEmail = legalEmail; }

--- a/tests/BlocksBeyondTheStars.Tests/WorldHostPhase3Tests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/WorldHostPhase3Tests.cs
@@ -47,6 +47,8 @@ public sealed class WorldHostPhase3Tests : IDisposable
         public void Stop(string containerId) => Running.Remove(containerId);
 
         public bool IsRunning(string containerId) => containerId != null && Running.Contains(containerId);
+
+        public IReadOnlyList<ContainerStat> ContainerStats() => Array.Empty<ContainerStat>();
     }
 
     private static WorldOrchestrator NewOrchestrator(HostRegistry registry, FakeLauncher launcher, WorldHostConfig config, WorldHostMetrics? metrics = null)

--- a/tests/BlocksBeyondTheStars.Tests/WorldHostStatsTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/WorldHostStatsTests.cs
@@ -1,0 +1,189 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using BlocksBeyondTheStars.WorldHost;
+using Xunit;
+
+namespace BlocksBeyondTheStars.Tests;
+
+/// <summary>
+/// Server-stats observability (issues #244/#245): the /proc and docker-stats parsers behind the admin
+/// "Server health" card, and the TTL/single-flight cache that makes the public /api/stats endpoint safe.
+/// All pure logic — no docker, no /proc, no web host needed.
+/// </summary>
+public sealed class WorldHostStatsTests
+{
+    // ---------------- /proc parsers ----------------
+
+    [Fact]
+    public void ParseMeminfo_ReadsTotalAndAvailable()
+    {
+        const string sample = "MemTotal:        8069984 kB\nMemFree:         6224140 kB\nMemAvailable:    7256064 kB\nBuffers:          123456 kB\n";
+        var parsed = HostStats.ParseMeminfo(sample);
+        Assert.NotNull(parsed);
+        Assert.Equal(8069984, parsed!.Value.TotalKb);
+        Assert.Equal(7256064, parsed.Value.AvailableKb);
+    }
+
+    [Fact]
+    public void ParseMeminfo_NullWhenFieldsMissing()
+    {
+        Assert.Null(HostStats.ParseMeminfo("MemFree: 100 kB\n"));
+        Assert.Null(HostStats.ParseMeminfo(string.Empty));
+    }
+
+    [Fact]
+    public void ParseLoadavg_ReadsThreeAverages()
+    {
+        var parsed = HostStats.ParseLoadavg("0.42 0.30 0.19 1/123 4567\n");
+        Assert.NotNull(parsed);
+        Assert.Equal(0.42, parsed!.Value.Load1, 3);
+        Assert.Equal(0.30, parsed.Value.Load5, 3);
+        Assert.Equal(0.19, parsed.Value.Load15, 3);
+        Assert.Null(HostStats.ParseLoadavg("garbage"));
+    }
+
+    [Fact]
+    public void DiskFor_CurrentDirectory_ReportsPositiveSizes()
+    {
+        var disk = HostStats.DiskFor(Environment.CurrentDirectory);
+        Assert.NotNull(disk);
+        Assert.True(disk!.Value.TotalBytes > 0);
+        Assert.True(disk.Value.FreeBytes >= 0);
+    }
+
+    // ---------------- docker stats parsing ----------------
+
+    [Theory]
+    [InlineData("115.7MiB", 121_320_243L)]
+    [InlineData("7.696GiB", 8_263_517_078L)]
+    [InlineData("512kB", 512_000L)]
+    [InlineData("1.5GB", 1_500_000_000L)]
+    [InlineData("0B", 0L)]
+    public void ParseSizeToBytes_HandlesDockerUnits(string text, long expected)
+    {
+        var bytes = HostStats.ParseSizeToBytes(text);
+        Assert.NotNull(bytes);
+        // double→long conversion may round the last bits; a per-mille tolerance is plenty here.
+        Assert.InRange(bytes!.Value, expected - expected / 1000 - 1, expected + expected / 1000 + 1);
+    }
+
+    [Fact]
+    public void ParseSizeToBytes_NullOnGarbage()
+    {
+        Assert.Null(HostStats.ParseSizeToBytes("many"));
+        Assert.Null(HostStats.ParseSizeToBytes(""));
+    }
+
+    [Fact]
+    public void ParseDockerStats_ParsesRowsAndSkipsGarbage()
+    {
+        const string output =
+            "{\"Name\":\"bbs-caddy\",\"CPUPerc\":\"0.12%\",\"MemUsage\":\"45.2MiB / 7.696GiB\"}\n" +
+            "not json at all\n" +
+            "{\"Name\":\"bbs-worldhost\",\"CPUPerc\":\"1.50%\",\"MemUsage\":\"115.7MiB / 7.696GiB\"}\n";
+
+        var rows = HostStats.ParseDockerStats(output);
+
+        Assert.Equal(2, rows.Count);
+        Assert.Equal("bbs-caddy", rows[0].Name);
+        Assert.Equal(0.12, rows[0].CpuPercent, 3);
+        Assert.Equal("bbs-worldhost", rows[1].Name);
+        Assert.True(rows[1].MemUsedBytes > 100L * 1024 * 1024);
+        Assert.True(rows[1].MemLimitBytes > 7L * 1024 * 1024 * 1024);
+    }
+
+    [Fact]
+    public void ParseDockerStats_EmptyOutput_EmptyList()
+    {
+        Assert.Empty(HostStats.ParseDockerStats(string.Empty));
+    }
+
+    // ---------------- CachedJson (the public-endpoint guard) ----------------
+
+    [Fact]
+    public async Task CachedJson_ServesFromCacheWithinTtl()
+    {
+        long now = 1000;
+        int rebuilds = 0;
+        var cache = new CachedJson(TimeSpan.FromSeconds(30), () =>
+        {
+            rebuilds++;
+            return Task.FromResult($"snapshot-{rebuilds}");
+        }, () => now);
+
+        Assert.Equal("snapshot-1", await cache.GetAsync());
+        now += 29;
+        Assert.Equal("snapshot-1", await cache.GetAsync());
+        Assert.Equal(1, rebuilds);
+    }
+
+    [Fact]
+    public async Task CachedJson_RebuildsAfterTtl()
+    {
+        long now = 1000;
+        int rebuilds = 0;
+        var cache = new CachedJson(TimeSpan.FromSeconds(30), () =>
+        {
+            rebuilds++;
+            return Task.FromResult($"snapshot-{rebuilds}");
+        }, () => now);
+
+        Assert.Equal("snapshot-1", await cache.GetAsync());
+        now += 31;
+        Assert.Equal("snapshot-2", await cache.GetAsync());
+        Assert.Equal(2, rebuilds);
+    }
+
+    [Fact]
+    public async Task CachedJson_ConcurrentFirstRequests_RebuildOnce()
+    {
+        int rebuilds = 0;
+        var release = new TaskCompletionSource();
+        var cache = new CachedJson(TimeSpan.FromSeconds(30), async () =>
+        {
+            Interlocked.Increment(ref rebuilds);
+            await release.Task;
+            return "snapshot";
+        }, () => 1000);
+
+        var calls = Enumerable.Range(0, 8).Select(_ => cache.GetAsync()).ToArray();
+        release.SetResult();
+        var results = await Task.WhenAll(calls);
+
+        Assert.All(results, r => Assert.Equal("snapshot", r));
+        Assert.Equal(1, rebuilds);
+    }
+
+    [Fact]
+    public async Task CachedJson_StaleValueServedWhileRebuildInFlight()
+    {
+        long now = 1000;
+        int rebuilds = 0;
+        var release = new TaskCompletionSource();
+        var cache = new CachedJson(TimeSpan.FromSeconds(30), async () =>
+        {
+            int n = Interlocked.Increment(ref rebuilds);
+            if (n > 1)
+            {
+                await release.Task; // second rebuild hangs — stale readers must not wait on it
+            }
+
+            return $"snapshot-{n}";
+        }, () => now);
+
+        Assert.Equal("snapshot-1", await cache.GetAsync());
+        now += 31;
+        var slowRebuild = cache.GetAsync(); // takes the gate, hangs in the builder
+
+        // While the rebuild is in flight, other callers get the stale snapshot immediately.
+        Assert.Equal("snapshot-1", await cache.GetAsync());
+
+        release.SetResult();
+        Assert.Equal("snapshot-2", await slowRebuild);
+    }
+}

--- a/tests/BlocksBeyondTheStars.Tests/WorldHostStatsTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/WorldHostStatsTests.cs
@@ -106,7 +106,7 @@ public sealed class WorldHostStatsTests
     // ---------------- CachedJson (the public-endpoint guard) ----------------
 
     [Fact]
-    public async Task CachedJson_ServesFromCacheWithinTtl()
+    public async Task CachedJson_ServesFromCacheWithinTtlAsync()
     {
         long now = 1000;
         int rebuilds = 0;
@@ -123,7 +123,7 @@ public sealed class WorldHostStatsTests
     }
 
     [Fact]
-    public async Task CachedJson_RebuildsAfterTtl()
+    public async Task CachedJson_RebuildsAfterTtlAsync()
     {
         long now = 1000;
         int rebuilds = 0;
@@ -140,19 +140,19 @@ public sealed class WorldHostStatsTests
     }
 
     [Fact]
-    public async Task CachedJson_ConcurrentFirstRequests_RebuildOnce()
+    public async Task CachedJson_ConcurrentFirstRequests_RebuildOnceAsync()
     {
         int rebuilds = 0;
-        var release = new TaskCompletionSource();
-        var cache = new CachedJson(TimeSpan.FromSeconds(30), async () =>
+        using var release = new SemaphoreSlim(0);
+        using var cache = new CachedJson(TimeSpan.FromSeconds(30), async () =>
         {
             Interlocked.Increment(ref rebuilds);
-            await release.Task;
+            await release.WaitAsync();
             return "snapshot";
         }, () => 1000);
 
         var calls = Enumerable.Range(0, 8).Select(_ => cache.GetAsync()).ToArray();
-        release.SetResult();
+        release.Release();
         var results = await Task.WhenAll(calls);
 
         Assert.All(results, r => Assert.Equal("snapshot", r));
@@ -160,17 +160,17 @@ public sealed class WorldHostStatsTests
     }
 
     [Fact]
-    public async Task CachedJson_StaleValueServedWhileRebuildInFlight()
+    public async Task CachedJson_StaleValueServedWhileRebuildInFlightAsync()
     {
         long now = 1000;
         int rebuilds = 0;
-        var release = new TaskCompletionSource();
-        var cache = new CachedJson(TimeSpan.FromSeconds(30), async () =>
+        using var release = new SemaphoreSlim(0);
+        using var cache = new CachedJson(TimeSpan.FromSeconds(30), async () =>
         {
             int n = Interlocked.Increment(ref rebuilds);
             if (n > 1)
             {
-                await release.Task; // second rebuild hangs — stale readers must not wait on it
+                await release.WaitAsync(); // second rebuild hangs — stale readers must not wait on it
             }
 
             return $"snapshot-{n}";
@@ -183,7 +183,7 @@ public sealed class WorldHostStatsTests
         // While the rebuild is in flight, other callers get the stale snapshot immediately.
         Assert.Equal("snapshot-1", await cache.GetAsync());
 
-        release.SetResult();
+        release.Release();
         Assert.Equal("snapshot-2", await slowRebuild);
     }
 }

--- a/tests/BlocksBeyondTheStars.Tests/WorldHostTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/WorldHostTests.cs
@@ -60,6 +60,8 @@ public sealed class WorldHostTests : IDisposable
         public void Stop(string containerId) => Running.Remove(containerId);
 
         public bool IsRunning(string containerId) => containerId != null && Running.Contains(containerId);
+
+        public IReadOnlyList<ContainerStat> ContainerStats() => Array.Empty<ContainerStat>();
     }
 
     /// <summary>Orchestrator whose "instance is healthy" probe is simply "its fake container runs".</summary>


### PR DESCRIPTION
## Summary

Two observability surfaces on WorldHost (analysis-first per the saved plan; closes #244, closes #245):

### Server health card on `/admin` (#244)
- Host **load / RAM / disk**: read from `/proc/meminfo` + `/proc/loadavg` (host-wide inside a container) and `DriveInfo` resolved against the **worlds bind mount** (so it reports the HOST disk, not the overlay).
- **Per-container CPU/memory** via new `IInstanceLauncher.ContainerStats()` → `docker stats --no-stream --format '{{json .}}'` on the existing argv-level CLI runner.
- New `GET /admin/stats.json` behind the existing Basic-Auth gate; the card fetches it **after** page render (docker stats samples ~1-2 s). Green/amber/red thresholds mirror the ops alert levels.
- Degrades cleanly: no `/proc` (Windows dev) → nulls, no docker → empty container table.

### Public `GET /api/stats` (#245)
```json
{ "worlds": { "created": 0, "active": 0 }, "players": { "registered": 0, "online": 0 }, "updatedUnix": 1783269385 }
```
- Aggregates only — no names/ids, privacy-neutral.
- **Doubly guarded** (public + unauthenticated): TTL cache with **single-flight rebuild** (`BBS_WH_STATS_CACHE_SECONDS`, 30 s) so the per-instance `/status` probes never run per request, plus per-IP rate limit (`BBS_WH_STATS_PER_MINUTE`, 30).
- `Access-Control-Allow-Origin: *` + `Cache-Control` → the Wix site can show live numbers client-side.

### Docs
HOSTED_WORLDS.md (both endpoints), TODO.md entry, README: one-line mention + test count refreshed (875 → **988**; the old number predated several merged PRs).

## Verification
- `dotnet test`: **887 server/shared** (860 fast + 27 slow) + **101 client** — all pass, 0 warnings on rebuild.
- Live check against a locally running WorldHost: `/api/stats` 200 + CORS/Cache headers; `/admin/stats.json` 200 with Basic Auth, **401 without**; Windows degradation confirmed (host fields null, disk real).

🤖 Generated with [Claude Code](https://claude.com/claude-code)