### PR TITLE
fix(server): honor a stop during initial worldgen — no more exit 137

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ the VEGA ship-AI onboarding/advisor companion, world-creation options, and an op
 for dynamic dialogue/mission text. Self-hostable dedicated server. **Native Windows and Linux**
 clients (no Wine/Proton; an experimental macOS build exists), and **opt-in automatic crash reporting**
 so problems get fixed faster.
-Currently **988 xUnit tests pass** (887 server/shared + 101 headless client<->server).
+Currently **990 xUnit tests pass** (889 server/shared + 101 headless client<->server).
 
 See [TODO.md](TODO.md) for the current Done/Open status, the
 [user manual](docs/user/USER_MANUAL.md) for controls/mechanics/commands, and [AGENTS.md](AGENTS.md)

--- a/TODO.md
+++ b/TODO.md
@@ -5500,6 +5500,20 @@ is **pre-approved** (keys in `tools/ai-assets/.env`, run via `uv`).
 
 ---
 
+## ✅ Done (2026-07-05): clean stop during initial worldgen — no more exit 137 (#243)
+Stopping a freshly created world while it was still generating ended in docker's SIGKILL after the
+60 s grace, risking the initial save. Two-part fix:
+- **SIGINT is honored from the very start**: the CancelKeyPress handler is now registered BEFORE
+  `server.Start()` (which runs the initial worldgen), and `RequestStop()` latches into a new
+  `_stopRequested` flag that `Run()` checks on entry — previously `Run()` re-armed `_running = true`
+  and silently discarded a stop requested during startup. A stop during worldgen now finishes
+  generation, then drains + saves immediately instead of entering the loop.
+- **Stop grace 60 s → 180 s** everywhere (`DockerCliLauncher --stop-timeout`, both compose files'
+  `stop_grace_period`, SELF_HOSTING.md): generation on the 2-CPU fleet fence plus the save must fit
+  inside the grace, otherwise docker still SIGKILLs at the end.
+- 2 new tests (`ServerShutdownTests`): pre-latched stop → Run() returns immediately; stop during a
+  live loop still drains.
+
 ## ✅ Done (2026-07-05): server observability — admin health card + public stats API (#244, #245)
 Two observability surfaces on WorldHost (details: HOSTED_WORLDS.md).
 - **Server health card on `/admin`**: host load/RAM/disk (from `/proc/meminfo` + `/proc/loadavg` —

--- a/docker-compose.tls.yml
+++ b/docker-compose.tls.yml
@@ -22,7 +22,7 @@ services:
       dockerfile: Dockerfile
     image: blocks-beyond-the-stars-server:local
     restart: unless-stopped
-    stop_grace_period: 60s        # give the world time to drain + save on SIGTERM
+    stop_grace_period: 180s       # give the world time to drain + save on SIGTERM — incl. a stop during initial worldgen (#243)
     ports:
       - "31415:31415/udp"          # native UDP clients connect directly; Caddy only fronts the TCP/web/WS
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       dockerfile: Dockerfile
     image: blocks-beyond-the-stars-server:local
     restart: unless-stopped
-    stop_grace_period: 60s        # give the world time to drain + save on SIGTERM
+    stop_grace_period: 180s       # give the world time to drain + save on SIGTERM — incl. a stop during initial worldgen (#243)
     ports:
       - "31415:31415/udp"          # native client (UDP)
       - "31415:31415/tcp"          # browser client over WebSocket (only when BBS_ENABLE_WEBSOCKET=true)

--- a/docs/developer/SELF_HOSTING.md
+++ b/docs/developer/SELF_HOSTING.md
@@ -363,7 +363,8 @@ onto the .NET 8 ASP.NET runtime image and runs them through
 
 `docker stop` sends `SIGTERM`; the entrypoint translates that into the `SIGINT` the server's clean
 drain-and-save path listens for, so the world is always saved on shutdown (give it time with a
-`stop_grace_period`/`--stop-timeout` of ~60 s).
+`stop_grace_period`/`--stop-timeout` of ~180 s — generous enough that even a stop during the initial
+world generation of a brand-new world still ends in a clean save instead of a SIGKILL).
 
 ### Try it locally (Docker Desktop)
 

--- a/src/BlocksBeyondTheStars.GameServer/GameServer.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServer.cs
@@ -164,6 +164,10 @@ public sealed partial class GameServer
     // sub-second remainder lives here between ticks. Only advanced while a player is joined.
     private double _playtimeCarry;
     private volatile bool _running;
+    // Latches a stop request permanently, unlike _running which Run() re-arms on entry. Needed because the
+    // SIGINT handler is registered BEFORE Start() (issue #243): a stop requested while startup worldgen is
+    // still running must survive until Run() begins, which then drains + saves immediately instead of looping.
+    private volatile bool _stopRequested;
     // True while the Run() loop owns the tick thread. Lets Stop() (possibly called from another thread, e.g. a
     // Ctrl-C handler) hand the save off to the run loop instead of saving concurrently with a live Tick().
     private volatile bool _runLoopActive;
@@ -733,7 +737,7 @@ public sealed partial class GameServer
     /// <summary>Blocking loop; runs until <see cref="Stop"/> is called.</summary>
     public void Run()
     {
-        _running = true;
+        _running = !_stopRequested; // a stop requested before the loop started (SIGINT during startup worldgen) skips straight to the drain+save below
         _runLoopActive = true;
         _stopped.Reset();
         double tickSeconds = 1.0 / System.Math.Max(1, _config.TickRate);
@@ -781,8 +785,14 @@ public sealed partial class GameServer
     }
 
     /// <summary>Signals the <see cref="Run"/> loop to stop after the current tick. Safe to call from any
-    /// thread (e.g. a Ctrl-C handler): it does NOT save — the run loop drains + saves on the tick thread.</summary>
-    public void RequestStop() => _running = false;
+    /// thread (e.g. a Ctrl-C handler) and at any time — even BEFORE <see cref="Run"/> starts (a stop during
+    /// startup worldgen is latched and honored on loop entry). It does NOT save — the run loop drains +
+    /// saves on the tick thread.</summary>
+    public void RequestStop()
+    {
+        _stopRequested = true;
+        _running = false;
+    }
 
     public void Stop()
     {

--- a/src/BlocksBeyondTheStars.GameServer/Program.cs
+++ b/src/BlocksBeyondTheStars.GameServer/Program.cs
@@ -128,6 +128,19 @@ TaskScheduler.UnobservedTaskException += (_, e) =>
     }
 };
 
+// Registered BEFORE Start() on purpose (issue #243): Start() runs the initial world generation, which
+// can take a while on a freshly created world — a stop arriving in that window (docker stop → SIGINT)
+// must not hit the runtime's default SIGINT handling (immediate exit, no save). RequestStop() latches
+// the request; Run() notices it on entry and goes straight to the drain + save.
+Console.CancelKeyPress += (_, e) =>
+{
+    // Only REQUEST the stop here (this runs on the SIGINT handler thread). The run loop notices the flag,
+    // drains + saves on the tick thread, then returns from Run() — so the save never races a live Tick().
+    e.Cancel = true;
+    logger.Info("Shutdown requested...");
+    server.RequestStop();
+};
+
 server.Start();
 
 // Automatic crash upload — opt-in. When config supplies an endpoint + key, the server sends queued reports
@@ -163,15 +176,6 @@ else if (pendingCrashes > 0)
     logger.Warn($"{pendingCrashes} unsent crash report(s) in {server.CrashWriter.DirectoryPath}. " +
                 "Attach them to a bug report, or set CrashReportEndpoint + CrashReportApiKey to upload them automatically.");
 }
-
-Console.CancelKeyPress += (_, e) =>
-{
-    // Only REQUEST the stop here (this runs on the SIGINT handler thread). The run loop notices the flag,
-    // drains + saves on the tick thread, then returns from Run() — so the save never races a live Tick().
-    e.Cancel = true;
-    logger.Info("Shutdown requested...");
-    server.RequestStop();
-};
 
 logger.Info("Press Ctrl+C to stop the server.");
 server.Run(); // returns once the shutdown request has been drained + saved on the tick thread

--- a/src/BlocksBeyondTheStars.WorldHost/InstanceLauncher.cs
+++ b/src/BlocksBeyondTheStars.WorldHost/InstanceLauncher.cs
@@ -75,7 +75,7 @@ public sealed class DockerCliLauncher : IInstanceLauncher
             "run", "-d",
             "--name", $"bbs-world-{world.Id}",
             "--restart=no",
-            "--stop-timeout", "60", // match the compose stop_grace_period: drain + save needs time
+            "--stop-timeout", "180", // match the compose stop_grace_period: drain + save needs time — a stop during initial worldgen (#243) must outlast generation on the CPU fence
             "--network", config.DockerNetwork,
             "-p", $"{world.HostPort}:31415/udp",
             "-p", $"127.0.0.1:{world.HostPort}:31415/tcp", // tcp side only for the local /status probe; public wss goes through Caddy

--- a/tests/BlocksBeyondTheStars.Tests/ServerShutdownTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/ServerShutdownTests.cs
@@ -1,0 +1,84 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using BlocksBeyondTheStars.Networking.Transport;
+using BlocksBeyondTheStars.Persistence;
+using BlocksBeyondTheStars.Shared.Configuration;
+using BlocksBeyondTheStars.Shared.Content;
+using Xunit;
+using SvGameServer = BlocksBeyondTheStars.GameServer.GameServer;
+
+namespace BlocksBeyondTheStars.Tests;
+
+/// <summary>
+/// Shutdown-request semantics (issue #243): the SIGINT handler is registered before Start(), so a stop
+/// can be requested while startup worldgen is still running — Run() must honor that pre-latched request
+/// and go straight to the drain + save instead of re-arming the loop and running forever.
+/// </summary>
+public sealed class ServerShutdownTests : IDisposable
+{
+    private readonly string _root;
+    private readonly GameContent _content;
+
+    public ServerShutdownTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "bbts_shutdown_" + Guid.NewGuid().ToString("N"));
+        _content = ContentLoader.LoadFromDirectory(TestPaths.DataDir());
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+        catch
+        {
+            // best-effort temp cleanup
+        }
+    }
+
+    private SvGameServer Started(out SqliteWorldRepository repo)
+    {
+        repo = new SqliteWorldRepository(new SaveGamePaths(_root, "shutdown"));
+        var st = new LoopbackServerTransport(new LoopbackLink());
+        var config = new ServerConfig { WorldName = "shutdown", Seed = 1, AutoSaveIntervalMinutes = 9999, PlaceStarterShip = false };
+        var server = new SvGameServer(config, _content, st, repo);
+        server.Start();
+        return server;
+    }
+
+    [Fact]
+    public async Task RequestStop_BeforeRun_DrainsAndReturnsImmediatelyAsync()
+    {
+        var server = Started(out var repo);
+        using (repo)
+        {
+            // The SIGINT-during-startup case: the stop request lands before Run() begins.
+            server.RequestStop();
+
+            var run = Task.Run(server.Run);
+            var finished = await Task.WhenAny(run, Task.Delay(TimeSpan.FromSeconds(30)));
+
+            Assert.Same(run, finished); // Run() must not re-arm the loop over the latched request
+            await run; // propagate any Run/Shutdown exception into the test
+        }
+    }
+
+    [Fact]
+    public async Task RequestStop_DuringRun_StopsTheLoopAsync()
+    {
+        var server = Started(out var repo);
+        using (repo)
+        {
+            var run = Task.Run(server.Run);
+            await Task.Delay(300); // let the loop tick (if it hasn't started yet, the latched path covers it)
+            server.RequestStop();
+
+            var finished = await Task.WhenAny(run, Task.Delay(TimeSpan.FromSeconds(30)));
+
+            Assert.Same(run, finished);
+            await run;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #243 — stopping a **freshly created** world while its initial world generation was still running ended in docker's SIGKILL (exit 137) after the stop grace, risking the loss of the initial save.

### Root cause (two stacked problems)
1. `Console.CancelKeyPress` was registered **after** `server.Start()` — and `Start()` is where the entire initial worldgen runs. A SIGINT in that window hit the runtime's default handling.
2. Even a stop requested before `Run()` was **silently discarded**: `Run()` re-armed `_running = true` on entry, overwriting the flag `RequestStop()` had just cleared.

### Fix
- The SIGINT handler is registered **before** `Start()`; `RequestStop()` now latches a dedicated `_stopRequested` flag that `Run()` checks on entry (`_running = !_stopRequested`). A stop during worldgen finishes generation and then drains + saves immediately instead of entering the loop.
- Stop grace raised **60 s → 180 s** everywhere it is defined (`DockerCliLauncher --stop-timeout`, both compose `stop_grace_period`s, SELF_HOSTING.md) — generation on the 2-CPU fleet fence **plus** the save must fit inside the grace, and the fleet's wake timeout already assumes up to ~90 s of generation.

### Tests
2 new (`ServerShutdownTests`): a pre-latched stop makes `Run()` return immediately (this hangs forever without the fix), and a stop during a live loop still drains. Full suite green: **889 server/shared + 101 client**; build clean under `-warnaserror`.

### Note for the fleet
World containers get the new 180 s grace only when (re)launched by a WorldHost running this build — existing sleeping containers keep 60 s until their next wake (container is recreated per wake, so this self-heals).

🤖 Generated with [Claude Code](https://claude.com/claude-code)