### PR TITLE
feat(portal): kid-friendly rework — feedback & ideas card, parental notice, discoverable reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ the VEGA ship-AI onboarding/advisor companion, world-creation options, and an op
 for dynamic dialogue/mission text. Self-hostable dedicated server. **Native Windows and Linux**
 clients (no Wine/Proton; an experimental macOS build exists), and **opt-in automatic crash reporting**
 so problems get fixed faster.
-Currently **1048 xUnit tests pass** (935 server/shared + 113 headless client<->server).
+Currently **1056 xUnit tests pass** (943 server/shared + 113 headless client<->server).
 
 See [TODO.md](TODO.md) for the current Done/Open status, the
 [user manual](docs/user/USER_MANUAL.md) for controls/mechanics/commands, and [AGENTS.md](AGENTS.md)

--- a/TODO.md
+++ b/TODO.md
@@ -6,7 +6,7 @@ plans live under [docs/](docs/) (committed); this file is the high-level status.
 keep it current when controls/features change. Last consolidated 2026-06-04.
 
 **Build:** `scripts/build-client.ps1` (Windows) or `scripts/build-client.sh` (Linux) — publishes shared libs + bundled server + Unity player.
-**Test:** `./scripts/run-tests.sh` — currently **935 server + 113 client passing** (2026-07-05). Locale parity (en/de) is enforced by a test.
+**Test:** `./scripts/run-tests.sh` — currently **943 server + 113 client passing** (2026-07-06). Locale parity (en/de) is enforced by a test.
 CI runs two tiers: PRs skip the 31 tests marked `[Trait("Category", "Slow")]` (~6 min gate); pushes to `main` and the release workflow run the full suite.
 **Conventions:** English docs/comments; in-game text bilingual DE+EN; commit to `main` with the
 Claude `Co-Authored-By` trailer; OpenAI texture + ElevenLabs sound generation is blanket-approved
@@ -97,6 +97,25 @@ Per-item detail lives in the dated work log below.
   single-source-of-truth working end-to-end (validated: published the initial Windows zip).
 
 ---
+
+### ★ Kid-friendly worlds portal: feedback & ideas, parental notice, discoverable reporting (#257, 2026-07-06)
+The portal's "Report a player" card was its centerpiece while the better in-game report paths were
+invisible, and there was no way to send game ideas at all. The worlds page now leads with a
+**"Feedback & Ideen" card** — one field, kid-friendly copy — that rides the existing reports pipe as a
+new `feedback` category (`CreateReport` allows an empty reported name for feedback only and requires a
+message instead; own "Feedback & ideas" card on `/admin`, separated from the player-report queue). The
+player-report form moved into a collapsed `<details>` inside it, headed by "the easiest way is in the
+game: `/report <name>` or the report button in the player list"; the scary always-visible **Delete
+account** card is collapsed the same way. New **parental notice** ("🧒 Frag bitte zuerst deine Eltern,
+ob es okay ist, dieses Spiel zu spielen.") on the landing page and as the first community rule; the
+rules' report bullet now names the in-game paths first. Kid-UX polish: create-account card comes before
+sign-in, name rules in plain words instead of `(3-24: A-Z 0-9 - _)`, "write your password down!"
+warning, world-password fields collapsed behind "protect with a password (optional)", beta box in kid
+wording, the join prompt remembers the last player name (`bbs_player_name`), and `say()` scrolls the
+top message line into view. In-game discoverability: `/help` now prints a for-everyone line (`/report`
++ `/bump`) before the admin commands, and joining an official hosted world shows a one-time local chat
+tip pointing at both report paths (new `ui.chat.report_tip` / `ui.chat.help_player` DE+EN). 9 new tests
+(feedback category rules, admin separation, parental notice, collapsed details, prefill, card order).
 
 ### ★ Maintenance announcements + creator-set world passwords (2026-07-05) — issues #249, #250, bug #251
 Two features in one PR (deploy rides the next release anyway). **Maintenance announcements (#249):** new

--- a/client/Assets/BlocksBeyondTheStars/Scripts/ChatUi.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/ChatUi.cs
@@ -21,7 +21,7 @@ namespace BlocksBeyondTheStars.Client
         private Text _log;
         private RectTransform _inputRow;
         private InputField _input;
-        private bool _typing, _subscribed, _built, _hostAnnounced;
+        private bool _typing, _subscribed, _built, _hostAnnounced, _reportTipShown;
         private int _openFrame = -1;
         private const int MaxLog = 40;
 
@@ -49,6 +49,15 @@ namespace BlocksBeyondTheStars.Client
                 _lines.Add($"<color=#80E5D2>{line}</color>");
                 RefreshLog();
                 Game.ShowMessage(line);
+            }
+
+            // Official hosted world: point players at the report paths once — the report button hides
+            // in the alliance tab and /report is invisible otherwise, so kids would never find them.
+            if (!_reportTipShown && !string.IsNullOrEmpty(Game.HostedToken) && !string.IsNullOrEmpty(Game.PortalSession) && Game.Localizer != null)
+            {
+                _reportTipShown = true;
+                _lines.Add($"<color=#80E5D2>{Game.Localizer.Get("ui.chat.report_tip")}</color>");
+                RefreshLog();
             }
 
             // Open the input with Enter (when no other panel is open).
@@ -295,6 +304,7 @@ namespace BlocksBeyondTheStars.Client
             {
                 case "/help":
                 case "/admin":
+                    LocalLine(L("ui.chat.help_player"));
                     LocalLine(L("ui.admin.help"));
                     return true;
 

--- a/data/locales/de.json
+++ b/data/locales/de.json
@@ -162,6 +162,8 @@
   "blueprint.galaxy_radio.desc": "Rüstet das Funkgerät auf galaxieweite Reichweite auf.",
   "ui.chat.hint": "Enter: Chat",
   "ui.chat.send_hint": "Enter zum Senden · Esc zum Abbrechen",
+  "ui.chat.report_tip": "Tipp: Jemand ist gemein? Tippe /report <Name> in den Chat oder nutze den Melden-Knopf in der Spielerliste (Schiff → Allianz).",
+  "ui.chat.help_player": "Für alle: /report <Spieler> [was passiert ist] — Spieler melden (offizielle Welten) · /bump <Notiz> — Fehler an die Entwickler melden",
   "ui.chat.report_usage": "Benutzung: /report <Spieler> [was ist passiert]",
   "ui.chat.report_unavailable": "Spieler melden geht nur auf offiziellen Welten.",
   "ui.chat.report_sent": "Danke — {name} wurde gemeldet. Die Betreiber schauen es sich an.",

--- a/data/locales/en.json
+++ b/data/locales/en.json
@@ -162,6 +162,8 @@
   "blueprint.galaxy_radio.desc": "Upgrades the radio to galaxy-wide range.",
   "ui.chat.hint": "Enter: chat",
   "ui.chat.send_hint": "Enter to send · Esc to cancel",
+  "ui.chat.report_tip": "Tip: someone being mean? Type /report <name> in chat or use the report button in the player list (ship → alliance).",
+  "ui.chat.help_player": "For everyone: /report <player> [what happened] — report a player (official worlds) · /bump <note> — send a bug report to the devs",
   "ui.chat.report_usage": "Usage: /report <player> [what happened]",
   "ui.chat.report_unavailable": "Reporting players works only on official worlds.",
   "ui.chat.report_sent": "Thanks — {name} was reported. The operators will take a look.",

--- a/src/BlocksBeyondTheStars.WorldHost/HostRegistry.cs
+++ b/src/BlocksBeyondTheStars.WorldHost/HostRegistry.cs
@@ -404,24 +404,32 @@ public sealed class HostRegistry : IDisposable
 
     // ---------------- Player reports ----------------
 
-    /// <summary>Files a player report ("Spieler melden"): who (in-game name) misbehaved on which world,
-    /// a category and an optional free-text message. Length-capped server-side; review is manual via the
-    /// operator admin endpoints (an open report never auto-punishes anyone).</summary>
+    /// <summary>Files a player report ("Spieler melden") or a game-feedback entry ("Feedback &amp; Ideen"):
+    /// who (in-game name) misbehaved on which world, a category and an optional free-text message. The
+    /// <c>feedback</c> category carries ideas/suggestions instead of a complaint, so it is the only one
+    /// that allows an empty reported name (and requires a message instead). Length-capped server-side;
+    /// review is manual via the operator admin endpoints (an open report never auto-punishes anyone).</summary>
     public (bool Ok, string Error) CreateReport(string reporterAccountId, string worldId, string reportedName, string category, string message)
     {
-        reportedName = (reportedName ?? string.Empty).Trim();
-        if (reportedName.Length is < 1 or > 24)
-        {
-            return (false, "Reported player name must be 1-24 characters.");
-        }
-
         category = (category ?? string.Empty).Trim().ToLowerInvariant();
-        if (category is not ("chat" or "name" or "griefing" or "other"))
+        if (category is not ("chat" or "name" or "griefing" or "other" or "feedback"))
         {
             return (false, "Unknown report category.");
         }
 
+        reportedName = (reportedName ?? string.Empty).Trim();
+        int minNameLength = category == "feedback" ? 0 : 1;
+        if (reportedName.Length < minNameLength || reportedName.Length > 24)
+        {
+            return (false, "Reported player name must be 1-24 characters.");
+        }
+
         message = (message ?? string.Empty).Trim();
+        if (category == "feedback" && message.Length == 0)
+        {
+            return (false, "Feedback needs a message.");
+        }
+
         if (message.Length > 500)
         {
             message = message.Substring(0, 500);

--- a/src/BlocksBeyondTheStars.WorldHost/WorldHostAdminPages.cs
+++ b/src/BlocksBeyondTheStars.WorldHost/WorldHostAdminPages.cs
@@ -18,6 +18,11 @@ public static class WorldHostAdminPages
 {
     private static string E(string? value) => System.Net.WebUtility.HtmlEncode(value ?? string.Empty);
 
+    /// <summary>The reviewed/dismiss close-form pair every report and feedback row ends with.</summary>
+    private static string CloseButtons(long reportId) =>
+        $"<form method='post' action='/admin/reports/{reportId}/close' style='display:inline'><input type='hidden' name='status' value='reviewed'><button>reviewed</button></form>" +
+        $"<form method='post' action='/admin/reports/{reportId}/close' style='display:inline'><input type='hidden' name='status' value='dismissed'><button>dismiss</button></form>";
+
     private static string Ago(long unix)
     {
         if (unix <= 0)
@@ -40,11 +45,13 @@ public static class WorldHostAdminPages
         string? lookupQuery)
     {
         int active = worlds.Count(w => w.World.Status is WorldStatus.Running or WorldStatus.Starting);
+        var playerReports = openReports.Where(r => r.Category != "feedback").ToList();
+        var feedback = openReports.Where(r => r.Category == "feedback").ToList();
         var sb = new StringBuilder();
 
         sb.Append($"<h1>Fleet <span class='o'>admin</span> <span class='sub'>· {E(config.BaseDomain)}</span></h1>");
         sb.Append($"<p class='hint'>{worlds.Count} worlds · <b>{active}</b>/{(config.MaxActiveInstances > 0 ? config.MaxActiveInstances.ToString() : "∞")} instances awake · " +
-                  $"{openReports.Count} open report(s) · {banned.Count} banned account(s)</p>");
+                  $"{playerReports.Count} open report(s) · {feedback.Count} open feedback · {banned.Count} banned account(s)</p>");
 
         // ---- Server health (filled by JS from /admin/stats.json AFTER the page renders — the
         // docker-stats sample behind it takes ~1-2 s and must not stall the page) ----
@@ -106,22 +113,21 @@ public static class WorldHostAdminPages
 
         sb.Append("</div>");
 
-        // ---- Open player reports ----
+        // ---- Open player reports (game feedback lives in its own card below) ----
         sb.Append("<div class='card'><h2>Open player reports</h2>");
-        if (openReports.Count == 0)
+        if (playerReports.Count == 0)
         {
             sb.Append("<p class='hint'>Nothing to review. 🎉</p>");
         }
         else
         {
             sb.Append("<table><tr><th>#</th><th>Filed</th><th>World</th><th>Reported name</th><th>Category</th><th>Message</th><th></th></tr>");
-            foreach (var r in openReports)
+            foreach (var r in playerReports)
             {
                 sb.Append($"<tr><td>{r.Id}</td><td>{Ago(r.CreatedUnix)}</td><td><code>{E(r.WorldId)}</code></td>" +
                           $"<td><a href='/admin?acct={Uri.EscapeDataString(r.ReportedName)}'>{E(r.ReportedName)}</a></td>" +
                           $"<td>{E(r.Category)}</td><td>{E(r.Message)}</td><td>" +
-                          $"<form method='post' action='/admin/reports/{r.Id}/close' style='display:inline'><input type='hidden' name='status' value='reviewed'><button>reviewed</button></form>" +
-                          $"<form method='post' action='/admin/reports/{r.Id}/close' style='display:inline'><input type='hidden' name='status' value='dismissed'><button>dismiss</button></form>" +
+                          CloseButtons(r.Id) +
                           "</td></tr>");
             }
 
@@ -129,6 +135,27 @@ public static class WorldHostAdminPages
         }
 
         sb.Append("<p class='hint'>The reported name links to the account lookup below (names match only when the player used their account name in-game).</p></div>");
+
+        // ---- Game feedback & ideas (same report table, category 'feedback' — no reported player) ----
+        sb.Append("<div class='card'><h2>Feedback &amp; ideas</h2>");
+        if (feedback.Count == 0)
+        {
+            sb.Append("<p class='hint'>No open feedback.</p>");
+        }
+        else
+        {
+            sb.Append("<table><tr><th>#</th><th>Filed</th><th>Message</th><th></th></tr>");
+            foreach (var r in feedback)
+            {
+                sb.Append($"<tr><td>{r.Id}</td><td>{Ago(r.CreatedUnix)}</td><td>{E(r.Message)}</td><td>" +
+                          CloseButtons(r.Id) +
+                          "</td></tr>");
+            }
+
+            sb.Append("</table>");
+        }
+
+        sb.Append("</div>");
 
         // ---- Ban management ----
         sb.Append("<div class='card'><h2>Accounts &amp; bans</h2>");

--- a/src/BlocksBeyondTheStars.WorldHost/WorldHostPortalPages.cs
+++ b/src/BlocksBeyondTheStars.WorldHost/WorldHostPortalPages.cs
@@ -34,11 +34,26 @@ public static class WorldHostPortalPages
         string body = $@"
 <h1>Blocks Beyond the Stars — <span class='o'>{T("Welten", "Worlds")}</span></h1>
 <p class='sub'>{T("Eigene Multiplayer-Welt erstellen und mit Freunden spielen.", "Create your own multiplayer world and play with friends.")}</p>
+<div class='kids'>🧒 {T(
+        "Frag bitte zuerst deine Eltern, ob es okay ist, dieses Spiel zu spielen.",
+        "Please ask your parents first if it is okay for you to play this game.")}</div>
 <div class='beta'>⚠ <b>Beta:</b> {T(
-        "Gehostete Welten können jederzeit kaputtgehen oder verloren gehen — lade regelmäßig eine Sicherung herunter!",
-        "Hosted worlds can break or disappear at any time — download a backup regularly!")}</div>
+        "Das Spiel wird noch gebaut — Welten können kaputtgehen oder verloren gehen. Lade regelmäßig eine Sicherung herunter!",
+        "The game is still being built — worlds can break or disappear. Download a backup regularly!")}</div>
 <div id='msg'></div>
 <div class='cols'>
+ <div class='card'>
+  <h2>{T("Konto erstellen", "Create account")}</h2>
+  <input id='su-name' placeholder='{T("Erfinde einen Namen (Buchstaben, Zahlen, - und _)", "Invent a name (letters, digits, - and _)")}' maxlength='24'>
+  <input id='su-pass' type='password' placeholder='{T("Passwort (min. 8 Zeichen)", "Password (min. 8 characters)")}'>
+  <p class='hint'>{T(
+        "Keine E-Mail nötig. <b>Schreib dir dein Passwort auf!</b> Wenn du es vergisst, kann es niemand wiederherstellen.",
+        "No email needed. <b>Write your password down!</b> If you forget it, nobody can recover it.")}</p>
+  <label><input type='checkbox' id='su-accept'> {T(
+        "Ich akzeptiere die <a href='/rules?lang=de'>Community-Regeln</a> und den Beta-Hinweis",
+        "I accept the <a href='/rules?lang=en'>community rules</a> and the beta notice")}</label>
+  <button onclick='signup()'>{T("Konto erstellen", "Create account")}</button>
+ </div>
  <div class='card'>
   <h2>{T("Anmelden", "Sign in")}</h2>
   <input id='li-name' placeholder='Name' maxlength='24'>
@@ -51,18 +66,6 @@ public static class WorldHostPortalPages
         "I accept the <a href='/rules?lang=en'>rules</a>")}</label>
     <button onclick='reaccept()'>{T("Weiter", "Continue")}</button>
   </div>
- </div>
- <div class='card'>
-  <h2>{T("Konto erstellen", "Create account")}</h2>
-  <input id='su-name' placeholder='Name (3-24: A-Z 0-9 - _)' maxlength='24'>
-  <input id='su-pass' type='password' placeholder='{T("Passwort (min. 8 Zeichen)", "Password (min. 8 characters)")}'>
-  <p class='hint'>{T(
-        "Keine E-Mail nötig. Merke dir dein Passwort gut — ohne E-Mail gibt es keine Wiederherstellung!",
-        "No email needed. Remember your password — without an email there is no recovery!")}</p>
-  <label><input type='checkbox' id='su-accept'> {T(
-        "Ich akzeptiere die <a href='/rules?lang=de'>Community-Regeln</a> und den Beta-Hinweis",
-        "I accept the <a href='/rules?lang=en'>community rules</a> and the beta notice")}</label>
-  <button onclick='signup()'>{T("Konto erstellen", "Create account")}</button>
  </div>
 </div>" + LandingScript
             .Replace("__TERMS__", config.TermsVersion.ToString())
@@ -125,29 +128,43 @@ function v(id){return document.getElementById(id).value.trim();}
 <div class='card'>
  <h2>{T("Neue Welt", "New world")}</h2>
  <input id='w-name' placeholder='{T("Weltname", "World name")}' maxlength='40'>
- <input id='w-pass' type='password' placeholder='{T("Passwort (optional, min. 4 Zeichen)", "Password (optional, min. 4 characters)")}' maxlength='24' autocomplete='new-password'>
- <input id='w-pass2' type='password' placeholder='{T("Passwort wiederholen", "Repeat password")}' maxlength='24' autocomplete='new-password'>
+ <details>
+  <summary>{T("Mit Passwort schützen (optional)", "Protect with a password (optional)")}</summary>
+  <input id='w-pass' type='password' placeholder='{T("Passwort (min. 4 Zeichen)", "Password (min. 4 characters)")}' maxlength='24' autocomplete='new-password'>
+  <input id='w-pass2' type='password' placeholder='{T("Passwort wiederholen", "Repeat password")}' maxlength='24' autocomplete='new-password'>
+  <p class='hint'>{T("Mit Passwort können nur Spieler beitreten, die es kennen.", "With a password, only players who know it can join.")}</p>
+ </details>
  <button onclick='createWorld()'>{T("Erstellen", "Create")}</button>
- <p class='hint'>{T("Mit Passwort können nur Spieler beitreten, die es kennen.", "With a password, only players who know it can join.")}</p>
 </div>
 <div id='list'></div>
 <div class='card'>
- <h2>{T("Spieler melden", "Report a player")}</h2>
+ <h2>{T("Feedback & Ideen", "Feedback & ideas")}</h2>
  <p class='hint'>{T(
-        "Jemand war gemein oder macht Mist? Sag uns Bescheid — wir schauen es uns an.",
-        "Someone was mean or misbehaving? Tell us — we will look into it.")}</p>
- <input id='r-name' placeholder='{T("Spielername", "Player name")}' maxlength='24'>
- <select id='r-cat'><option value='chat'>Chat</option><option value='name'>Name</option><option value='griefing'>{T("Zerstören (Griefing)", "Griefing")}</option><option value='other'>{T("Anderes", "Other")}</option></select>
- <select id='r-world'><option value=''>{T("Welche Welt? (optional)", "Which world? (optional)")}</option></select>
- <input id='r-msg' placeholder='{T("Was ist passiert?", "What happened?")}' maxlength='500'>
- <button onclick='report()'>{T("Melden", "Report")}</button>
+        "Was wünschst du dir für das Spiel? Was können wir besser machen? Schreib es uns!",
+        "What do you wish for the game? What could we do better? Tell us!")}</p>
+ <input id='f-msg' placeholder='{T("Deine Idee oder dein Wunsch", "Your idea or wish")}' maxlength='500'>
+ <button onclick='sendFeedback()'>{T("Abschicken", "Send")}</button>
+ <details>
+  <summary>{T("Etwas Schlimmes passiert? → Spieler melden", "Something bad happened? → Report a player")}</summary>
+  <p class='hint'>{T(
+        "Am einfachsten geht es direkt im Spiel: Tippe <code>/report &lt;Name&gt;</code> in den Chat oder nutze den Melden-Knopf in der Spielerliste (Schiff → Allianz). Hier geht es auch:",
+        "The easiest way is right in the game: type <code>/report &lt;name&gt;</code> in chat or use the report button in the player list (ship → alliance). It also works here:")}</p>
+  <input id='r-name' placeholder='{T("Spielername", "Player name")}' maxlength='24'>
+  <select id='r-cat'><option value='chat'>Chat</option><option value='name'>Name</option><option value='griefing'>{T("Zerstören (Griefing)", "Griefing")}</option><option value='other'>{T("Anderes", "Other")}</option></select>
+  <select id='r-world'><option value=''>{T("Welche Welt? (optional)", "Which world? (optional)")}</option></select>
+  <input id='r-msg' placeholder='{T("Was ist passiert?", "What happened?")}' maxlength='500'>
+  <button onclick='report()'>{T("Melden", "Report")}</button>
+  <p class='hint'>{T("Wir schauen uns jede Meldung an — niemand wird automatisch bestraft.", "We review every report — nobody is punished automatically.")}</p>
+ </details>
 </div>
 <div class='card'>
- <h2>{T("Konto löschen", "Delete account")}</h2>
- <p class='hint'>{T(
+ <details>
+  <summary>{T("Konto löschen", "Delete account")}</summary>
+  <p class='hint'>{T(
         "Löscht dein Konto endgültig — mitsamt allen deinen Welten und Spielständen. Das kann niemand rückgängig machen!",
         "Permanently deletes your account — including all your worlds and saves. Nobody can undo this!")}</p>
- <button class='danger' onclick='deleteAccount()'>{T("Konto endgültig löschen", "Delete account permanently")}</button>
+  <button class='danger' onclick='deleteAccount()'>{T("Konto endgültig löschen", "Delete account permanently")}</button>
+ </details>
 </div>
 <p><a href='/rules{(lang == "en" ? "?lang=en" : "")}'>{T("Regeln", "Rules")}</a> · <a href='#' onclick=""localStorage.removeItem('bbs_session');location.href='/'"">{T("Abmelden", "Sign out")}</a></p>" + WorldsScript
             .Replace("__L__", System.Text.Json.JsonSerializer.Serialize(new
@@ -168,6 +185,8 @@ function v(id){return document.getElementById(id).value.trim();}
                 uploading = T("Upload läuft…", "Uploading…"),
                 upDone = T("Save übernommen!", "Save imported!"),
                 reported = T("Danke für deine Meldung!", "Thanks for your report!"),
+                feedbackThanks = T("Danke für deine Idee! 🚀", "Thanks for your idea! 🚀"),
+                feedbackEmpty = T("Bitte schreib zuerst deine Idee auf.", "Please write your idea first."),
                 delAcc1 = T("Konto und ALLE Welten endgültig löschen?", "Permanently delete the account and ALL worlds?"),
                 delAcc2 = T("Wirklich sicher? Es gibt kein Zurück!", "Really sure? There is no way back!"),
                 pw = T("Passwort", "Password"),
@@ -202,7 +221,11 @@ const S = localStorage.getItem('bbs_session');
 if(!S) location.href='/';
 const H = {'Authorization':'Bearer '+S, 'Content-Type':'application/json'};
 const L = __L__;
-function say(t){document.getElementById('msg').textContent = t||'';}
+function say(t){
+  const m = document.getElementById('msg'); m.textContent = t||'';
+  // The message line lives at the top — surface it when an action further down reports something.
+  if(t) m.scrollIntoView({behavior:'smooth', block:'nearest'});
+}
 async function api(method, url, body){
   const r = await fetch(url, {method, headers:H, body: body?JSON.stringify(body):undefined});
   if(r.status===401){ location.href='/'; return null; }
@@ -253,13 +276,15 @@ async function removeWorldPassword(id){
   if(await api('POST',`/api/worlds/${id}/password`,{password: ''})){ say(L.pwRemovedDone); load(); }
 }
 async function joinWorld(id, pw){
-  const name = prompt(L.namePrompt); if(!name) return;
+  // Prefill with the last used player name — kids should not have to re-invent it on every join.
+  const name = prompt(L.namePrompt, localStorage.getItem('bbs_player_name')||''); if(!name) return;
   for(;;){
     say(L.waking);
     const r = await fetch(`/api/worlds/${id}/join`, {method:'POST', headers:H, body: JSON.stringify({playerName:name, password: pw||null})});
     if(r.status===401){ location.href='/'; return; }
     let j=null; try{ j=await r.json(); }catch{}
     if(r.ok){
+      localStorage.setItem('bbs_player_name', name);
       // Refresh the list FIRST (the world just woke, its status chip changed) — load() rebuilds every
       // card with an empty grant div, so rendering the grant before awaiting it made Play look like a
       // no-op (#252).
@@ -306,6 +331,13 @@ async function report(){
   const j = await api('POST','/api/reports',{reportedName:v('r-name'), category:document.getElementById('r-cat').value, message:v('r-msg'), worldId:document.getElementById('r-world').value});
   if(j){ say(L.reported); document.getElementById('r-name').value=''; document.getElementById('r-msg').value=''; }
 }
+async function sendFeedback(){
+  const msg = v('f-msg');
+  if(!msg){ say(L.feedbackEmpty); return; }
+  // Game feedback rides the reports pipe with its own category and no reported player.
+  const j = await api('POST','/api/reports',{reportedName:'', category:'feedback', message:msg, worldId:''});
+  if(j){ say(L.feedbackThanks); document.getElementById('f-msg').value=''; }
+}
 async function deleteAccount(){
   if(!confirm(L.delAcc1)) return;
   if(!confirm(L.delAcc2)) return;
@@ -327,12 +359,15 @@ load();
  <p><b>Blocks Beyond the Stars is a family and community project.</b> Kids and grown-ups play here
  together — be kind to each other!</p>
  <ul>
+  <li>🧒 Please ask your parents first if it is okay for you to play this game.</li>
   <li>Be friendly and help other players.</li>
   <li>Build, explore and invent — don't destroy on purpose what others have built.</li>
   <li><b>No hate speech, no bullying, no racism, no insults</b> — not in chat, names or builds. Such
    violations lead to an <b>immediate ban</b>, no warning.</li>
   <li>Never share personal data (real name, address, school …) and don't ask others for theirs.</li>
-  <li>Saw something bad? Use <b>“Report player”</b> — we review every report.</li>
+  <li>Saw something bad? Report it right in the game: type <b><code>/report &lt;name&gt;</code></b> in
+   chat or use the report button in the player list (ship → alliance) — or the form on the worlds
+   page. We review every report.</li>
  </ul>
  <p class='beta'>⚠ <b>Beta notice:</b> the game and its hosted worlds are a beta. Worlds and saves can
  break or disappear at any time. Download a backup of your world regularly if it matters to you!</p>
@@ -342,12 +377,15 @@ load();
  <p><b>Blocks Beyond the Stars ist ein Familien- und Community-Projekt.</b> Hier spielen Kinder und
  Erwachsene zusammen — seid nett zueinander!</p>
  <ul>
+  <li>🧒 Frag bitte zuerst deine Eltern, ob es okay ist, dieses Spiel zu spielen.</li>
   <li>Sei freundlich und hilf anderen Spielern.</li>
   <li>Baue, entdecke und erfinde — zerstöre nicht absichtlich, was andere gebaut haben.</li>
   <li><b>Keine Hetze, kein Mobbing, kein Rassismus, keine Beleidigungen</b> — weder im Chat noch in Namen
    oder Bauwerken. Solche Verstöße führen zum <b>sofortigen Bann</b>, ohne Vorwarnung.</li>
   <li>Gib keine persönlichen Daten weiter (echter Name, Adresse, Schule …) und frage andere nicht danach.</li>
-  <li>Etwas Schlimmes gesehen? Nutze <b>„Spieler melden“</b> — wir schauen uns jede Meldung an.</li>
+  <li>Etwas Schlimmes gesehen? Melde es direkt im Spiel: Tippe <b><code>/report &lt;Name&gt;</code></b>
+   in den Chat oder nutze den Melden-Knopf in der Spielerliste (Schiff → Allianz) — oder das Formular
+   auf der Welten-Seite. Wir schauen uns jede Meldung an.</li>
  </ul>
  <p class='beta'>⚠ <b>Beta-Hinweis:</b> Das Spiel und die gehosteten Welten sind eine Beta. Welten und
  Spielstände können jederzeit kaputtgehen oder verloren gehen. Lade dir regelmäßig eine Sicherung deiner
@@ -431,8 +469,8 @@ load();
 <div class='card'>
  <h2>🇬🇧 English summary</h2>
  <p>This service is deliberately data-minimal: a self-chosen account name, a password hash (never the
- password), your worlds and your reports — <b>no email, no real name, no ads, no tracking, no third-party
- embeds</b>. IPs are held transiently for rate limiting and in routine server logs only. Hosting is in
+ password), your worlds and your reports/feedback — <b>no email, no real name, no ads, no tracking, no
+ third-party embeds</b>. IPs are held transiently for rate limiting and in routine server logs only. Hosting is in
  Germany; nothing is shared or sold. Short in-game NPC texts are generated by an LLM at OVHcloud (EU) —
  only the moment's game context (e.g. your in-world player name, the NPC and the situation) is sent, never
  account data or IPs, and built-in fallback texts take over if it is unavailable. Deleting your account
@@ -458,7 +496,8 @@ load();
   <li><b>Konto:</b> selbst gewählter Kontoname, Passwort-Hash (PBKDF2 — das Passwort selbst wird nie
    gespeichert), Zeitpunkt der Regel-Zustimmung. Keine E-Mail-Adresse, kein Klarname.</li>
   <li><b>Welten &amp; Spielstände:</b> die von dir erstellten oder hochgeladenen Welten (Spieldaten).</li>
-  <li><b>Meldungen:</b> von dir abgesendete „Spieler melden“-Einträge (gemeldeter Name, Kategorie, Text).</li>
+  <li><b>Meldungen &amp; Feedback:</b> von dir abgesendete „Spieler melden“-Einträge (gemeldeter Name,
+   Kategorie, Text) sowie dein Spiel-Feedback („Feedback &amp; Ideen“, nur der Text).</li>
   <li><b>Sitzung:</b> ein zufälliges Sitzungs-Token im localStorage deines Browsers (kein Cookie,
    kein seitenübergreifendes Tracking). Wählst du eine Sprache, merkt sich ein einzelnes Cookie
    (<code>bbs_lang</code>) nur diese Einstellung.</li>
@@ -552,6 +591,8 @@ h1{{font-weight:700;letter-spacing:.5px}} .o{{color:var(--orange)}} a{{color:var
 .cols{{display:flex;gap:16px;flex-wrap:wrap}} .cols .card{{flex:1 1 300px}}
 .card{{background:#0d1526cc;border:1px solid var(--line);border-radius:12px;padding:16px 18px;margin:12px 0}}
 .beta{{background:#3a260a;border:1px solid #7a5218;border-radius:10px;padding:10px 14px;margin:12px 0}}
+.kids{{background:#0d2a38;border:1px solid #2e6f8a;border-radius:10px;padding:10px 14px;margin:12px 0}}
+details{{margin:8px 0}} details summary{{cursor:pointer;color:var(--cyan)}}
 input,select{{display:block;width:100%;margin:8px 0;padding:9px 10px;border-radius:8px;border:1px solid var(--line);
  background:#0a101d;color:#dfe9f7;font:inherit}}
 button{{margin:6px 6px 0 0;padding:9px 16px;border-radius:8px;border:1px solid var(--cyan);background:#12335005;

--- a/tests/BlocksBeyondTheStars.Tests/WorldHostPortalPagesTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/WorldHostPortalPagesTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
 using System;
+using System.Collections.Generic;
 using System.IO;
 using BlocksBeyondTheStars.WorldHost;
 using Xunit;
@@ -104,6 +105,96 @@ public sealed class WorldHostPortalPagesTests
         string de = WorldHostPortalPages.Privacy(Config);
         Assert.True(de.IndexOf("Verantwortlicher", StringComparison.Ordinal)
             < de.IndexOf("English summary", StringComparison.Ordinal));
+    }
+
+    // ---------------- Kid-friendly rework: feedback card + parental notice (#257) ----------------
+
+    [Fact]
+    public void Landing_CarriesTheParentalNotice_InBothLanguages()
+    {
+        Assert.Contains("Frag bitte zuerst deine Eltern", WorldHostPortalPages.Landing(Config));
+        Assert.Contains("Please ask your parents first", WorldHostPortalPages.Landing(Config, "en"));
+    }
+
+    [Fact]
+    public void Rules_OpenWithTheParentalNotice_AndPointToTheInGameReportPaths()
+    {
+        string de = WorldHostPortalPages.Rules(Config);
+        Assert.Contains("Frag bitte zuerst deine Eltern", de);
+        Assert.Contains("/report", de); // reporting is explained via the in-game paths first
+
+        string en = WorldHostPortalPages.Rules(Config, "en");
+        Assert.Contains("Please ask your parents first", en);
+        Assert.Contains("/report", en);
+    }
+
+    [Fact]
+    public void Worlds_OffersFeedback_AndPostsItAsTheFeedbackCategory()
+    {
+        string de = WorldHostPortalPages.Worlds(Config);
+        Assert.Contains("Feedback & Ideen", de);
+        Assert.Contains("category:'feedback'", de); // sendFeedback() rides the reports pipe
+
+        string en = WorldHostPortalPages.Worlds(Config, "en");
+        Assert.Contains("Feedback & ideas", en);
+        Assert.Contains("category:'feedback'", en);
+    }
+
+    [Fact]
+    public void Worlds_DemotesReportAndDeleteAccount_IntoCollapsedDetails()
+    {
+        string html = WorldHostPortalPages.Worlds(Config);
+
+        // The report form and the account-deletion button live inside <details> now — reachable, but
+        // no longer the page's centerpiece (kids first see feedback, not complaint machinery).
+        int reportField = html.IndexOf("id='r-name'", StringComparison.Ordinal);
+        int deleteButton = html.IndexOf("deleteAccount()", StringComparison.Ordinal);
+        Assert.True(reportField >= 0 && deleteButton >= 0);
+        Assert.True(html.LastIndexOf("<details>", reportField, StringComparison.Ordinal) >= 0,
+            "the report form must sit inside a collapsed <details>");
+        Assert.True(html.LastIndexOf("<details>", deleteButton, StringComparison.Ordinal)
+            > html.LastIndexOf("</details>", reportField, StringComparison.Ordinal),
+            "the delete-account button must sit inside its own collapsed <details>");
+    }
+
+    [Fact]
+    public void Worlds_JoinPrompt_RemembersTheLastPlayerName()
+    {
+        string html = WorldHostPortalPages.Worlds(Config);
+        Assert.Contains("localStorage.getItem('bbs_player_name')", html); // prefill on the next join
+        Assert.Contains("localStorage.setItem('bbs_player_name'", html);  // remembered on success
+    }
+
+    [Fact]
+    public void Landing_PutsCreateAccountFirst()
+    {
+        // New (young) visitors should meet "create account" before "sign in".
+        string html = WorldHostPortalPages.Landing(Config);
+        Assert.True(html.IndexOf("id='su-name'", StringComparison.Ordinal)
+            < html.IndexOf("id='li-name'", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void AdminPage_SeparatesFeedbackFromPlayerReports()
+    {
+        var reports = new List<ReportRecord>
+        {
+            new(1, "aabbccddee11", "acct1", "Meanie", "chat", "insults", "open", 0),
+            new(2, "", "acct2", "", "feedback", "please add space whales!", "open", 0),
+        };
+
+        string html = WorldHostAdminPages.Index(
+            Config, Array.Empty<AdminWorldRow>(), reports, Array.Empty<AccountRecord>(), null, null);
+        Assert.Contains("Feedback &amp; ideas", html);
+        Assert.Contains("please add space whales!", html);
+        Assert.Contains("1 open report(s)", html);
+        Assert.Contains("1 open feedback", html);
+
+        // The feedback row must not sit in the player-report table (no reported-name lookup link).
+        int reportsCard = html.IndexOf("Open player reports", StringComparison.Ordinal);
+        int feedbackCard = html.IndexOf("Feedback &amp; ideas", StringComparison.Ordinal);
+        int feedbackRow = html.IndexOf("please add space whales!", StringComparison.Ordinal);
+        Assert.True(reportsCard < feedbackCard && feedbackCard < feedbackRow);
     }
 
     // ---------------- Play button: deep-link + grant rendering order (#252) ----------------

--- a/tests/BlocksBeyondTheStars.Tests/WorldHostTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/WorldHostTests.cs
@@ -426,6 +426,29 @@ public sealed class WorldHostTests : IDisposable
         Assert.Equal("aabbccddee11", report.WorldId);
     }
 
+    [Fact]
+    public void Reports_FeedbackCategoryNeedsNoNameButAMessage()
+    {
+        var registry = NewRegistry();
+        var (accountId, _) = NewAccount(registry);
+
+        // Game feedback ("Feedback & Ideen") is the only category without a reported player — but an
+        // empty idea is worthless, so the message becomes mandatory instead.
+        Assert.False(registry.CreateReport(accountId, "", "", "feedback", "   ").Ok);
+        Assert.True(registry.CreateReport(accountId, "", "", "feedback", "please add space whales!").Ok);
+
+        var open = Assert.Single(registry.ListOpenReports());
+        Assert.Equal("feedback", open.Category);
+        Assert.Equal(string.Empty, open.ReportedName);
+        Assert.Equal("please add space whales!", open.Message);
+
+        // All other categories still require the reported player's name.
+        Assert.False(registry.CreateReport(accountId, "", "", "chat", "some message").Ok);
+
+        registry.CloseReport(open.Id, "reviewed");
+        Assert.Empty(registry.ListOpenReports());
+    }
+
     // ---------------- Save upload validation ----------------
 
     [Fact]


### PR DESCRIPTION
Closes #257

## What
Makes the official hosted-worlds portal friendlier for kids, adds a **Feedback & ideas** channel, and makes the in-game report paths discoverable.

### Portal (worlds page / landing / rules)
- **"Feedback & Ideen · Feedback & ideas" card** — one field, kid-friendly copy, posts to the existing reports pipe as the new `feedback` category. The player-report form moved into a collapsed `<details>` inside it, headed by "the easiest way is in the game: `/report <name>` or the report button in the player list".
- **"Delete account"** collapsed into a `<details>` danger zone (no more always-visible red button).
- **Parental notice** 🧒 on the landing page and as the first community rule: "Please ask your parents first if it is okay for you to play this game." (DE+EN)
- Kid-UX polish: create-account card before sign-in, name rules in plain words instead of `(3-24: A-Z 0-9 - _)`, "write your password down!" warning, world-password fields collapsed behind "protect with a password (optional)", kid wording for the beta box, join prompt prefilled with the last used player name, `say()` scrolls the top message line into view.
- Rules report bullet names the in-game paths first, portal form as fallback.

### Backend
- `HostRegistry.CreateReport` accepts category `feedback` with an empty reported name — the only such category — and requires a message instead. All other categories unchanged.
- `/admin` gets a separate **"Feedback & ideas"** card; the header counts reports and feedback separately.

### In-game
- `/help` now prints a for-everyone line (`/report <player>` + `/bump`) before the admin commands.
- Joining an official hosted world shows a one-time local chat tip pointing at both report paths (new `ui.chat.report_tip` / `ui.chat.help_player`, DE+EN).

## Tests
- 9 new tests (feedback category rules, admin separation, parental notice, collapsed details, name prefill, card order).
- Full suite green: **943 server + 113 client**.
- Local Windows Unity build verified: fresh `Client.dll`, **0 compiler warnings**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)