### PR TITLE
feat(portal): discoverable DE/EN language switcher + CodeQL cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ the VEGA ship-AI onboarding/advisor companion, world-creation options, and an op
 for dynamic dialogue/mission text. Self-hostable dedicated server. **Native Windows and Linux**
 clients (no Wine/Proton; an experimental macOS build exists), and **opt-in automatic crash reporting**
 so problems get fixed faster.
-Currently **1056 xUnit tests pass** (943 server/shared + 113 headless client<->server).
+Currently **1067 xUnit tests pass** (954 server/shared + 113 headless client<->server).
 
 See [TODO.md](TODO.md) for the current Done/Open status, the
 [user manual](docs/user/USER_MANUAL.md) for controls/mechanics/commands, and [AGENTS.md](AGENTS.md)

--- a/TODO.md
+++ b/TODO.md
@@ -6,7 +6,7 @@ plans live under [docs/](docs/) (committed); this file is the high-level status.
 keep it current when controls/features change. Last consolidated 2026-06-04.
 
 **Build:** `scripts/build-client.ps1` (Windows) or `scripts/build-client.sh` (Linux) — publishes shared libs + bundled server + Unity player.
-**Test:** `./scripts/run-tests.sh` — currently **943 server + 113 client passing** (2026-07-06). Locale parity (en/de) is enforced by a test.
+**Test:** `./scripts/run-tests.sh` — currently **954 server + 113 client passing** (2026-07-06). Locale parity (en/de) is enforced by a test.
 CI runs two tiers: PRs skip the 31 tests marked `[Trait("Category", "Slow")]` (~6 min gate); pushes to `main` and the release workflow run the full suite.
 **Conventions:** English docs/comments; in-game text bilingual DE+EN; commit to `main` with the
 Claude `Co-Authored-By` trailer; OpenAI texture + ElevenLabs sound generation is blanket-approved
@@ -97,6 +97,17 @@ Per-item detail lives in the dated work log below.
   single-source-of-truth working end-to-end (validated: published the initial Windows zip).
 
 ---
+
+### ★ Portal language switcher made discoverable: header DE/EN toggle + Accept-Language (2026-07-06)
+The portal's DE/EN switcher existed only as small grey footer links — below the fold on longer pages
+and effectively invisible for the kid/parent audience (even the operator couldn't find it). The shared
+`Shell()` header is now flex space-between and carries a **pill toggle "DE | EN"** (current language
+highlighted, same `?lang=` links; footer links kept). First visits without `?lang=` or the `bbs_lang`
+cookie now honor the browser's **`Accept-Language`** (new testable `LangFromAcceptHeader`: first
+supported primary tag wins, German default) — an English browser gets English immediately instead of
+German-with-a-hidden-switch. Auto-detection sets NO cookie; only an explicit choice persists, so
+`?lang=` semantics are unchanged. 11 new tests (header toggle both languages + above `<main>`,
+Accept-Language parsing incl. q-lists, wildcard, case-insensitivity, unsupported-only headers).
 
 ### ★ Kid-friendly worlds portal: feedback & ideas, parental notice, discoverable reporting (#257, 2026-07-06)
 The portal's "Report a player" card was its centerpiece while the better in-game report paths were

--- a/TODO.md
+++ b/TODO.md
@@ -98,6 +98,14 @@ Per-item detail lives in the dated work log below.
 
 ---
 
+### ★ Code-scanning cleanup: Secure/HttpOnly on the language cookie, LogSafe on the announce log (2026-07-06)
+Closed the two open CodeQL alerts, both in WorldHost `Program.cs`. The `bbs_lang` portal cookie now
+sets `Secure` + `HttpOnly` (`cs/web/cookie-secure-not-set`; safe because the JS never reads it — it
+carries `?lang=` itself, the cookie is the server-side fallback only). The `/admin/announce` form
+handler now logs the world id through the existing `LogSafe()` helper, matching its `/api/admin/announce`
+twin (`cs/log-forging`; practically a false positive — the id is regex-validated 12-hex before use — but
+CodeQL doesn't model the validator, and the twin already did it right). No behavior change, no new tests.
+
 ### ★ Kid-friendly worlds portal: feedback & ideas, parental notice, discoverable reporting (#257, 2026-07-06)
 The portal's "Report a player" card was its centerpiece while the better in-game report paths were
 invisible, and there was no way to send game ideas at all. The worlds page now leads with a

--- a/src/BlocksBeyondTheStars.WorldHost/Program.cs
+++ b/src/BlocksBeyondTheStars.WorldHost/Program.cs
@@ -248,7 +248,9 @@ app.MapGet("/api/stats", async (HttpContext ctx) =>
 // ---------------- Portal pages (server-rendered shells; the JS talks to /api with a Bearer session) ----------------
 
 // Page language: explicit ?lang= wins (and is remembered in a cookie so plain links keep the choice);
-// otherwise the cookie; otherwise German — the portal's primary audience. Only "en"/"de" are honored.
+// otherwise the cookie; otherwise the browser's Accept-Language (first visit — auto-detection sets NO
+// cookie, only an explicit switch persists); otherwise German — the portal's primary audience. Only
+// "en"/"de" are honored.
 string PageLang(HttpContext ctx)
 {
     string? q = ctx.Request.Query["lang"];
@@ -263,7 +265,10 @@ string PageLang(HttpContext ctx)
         return q;
     }
 
-    return WorldHostPortalPages.NormalizeLang(ctx.Request.Cookies["bbs_lang"]);
+    string? cookie = ctx.Request.Cookies["bbs_lang"];
+    return cookie is "en" or "de"
+        ? cookie
+        : WorldHostPortalPages.LangFromAcceptHeader(ctx.Request.Headers.AcceptLanguage);
 }
 
 app.MapGet("/", (HttpContext ctx) => Results.Content(WorldHostPortalPages.Landing(config, PageLang(ctx)), "text/html; charset=utf-8"));

--- a/src/BlocksBeyondTheStars.WorldHost/Program.cs
+++ b/src/BlocksBeyondTheStars.WorldHost/Program.cs
@@ -259,6 +259,9 @@ string PageLang(HttpContext ctx)
             Path = "/",
             MaxAge = TimeSpan.FromDays(365),
             SameSite = SameSiteMode.Lax,
+            // Server-side fallback only (the JS carries ?lang= itself), so it can be locked down fully.
+            Secure = true,
+            HttpOnly = true,
         });
         return q;
     }
@@ -646,7 +649,7 @@ app.MapPost("/admin/announce", async (HttpContext ctx) =>
 
     var (reached, targets) = await orchestrator.AnnounceAsync(kind, message, seconds, worldId);
     log.LogInformation("Admin UI: announce kind {Kind} to {Target} — reached {Reached}/{Targets}.",
-        kind, worldId ?? "fleet", reached, targets);
+        kind, worldId is null ? "fleet" : LogSafe(worldId), reached, targets);
     return Results.Redirect("/admin");
 });
 

--- a/src/BlocksBeyondTheStars.WorldHost/WorldHostPortalPages.cs
+++ b/src/BlocksBeyondTheStars.WorldHost/WorldHostPortalPages.cs
@@ -7,7 +7,8 @@ namespace BlocksBeyondTheStars.WorldHost;
 /// Server-rendered portal shells for the hosted-worlds control plane: landing (sign in / create account
 /// with the required community-rules + beta acceptance), "My Worlds" management, and the rules page.
 /// Pages are fully localized server-side (German default, English via <c>?lang=en</c> — see
-/// <see cref="NormalizeLang"/>); a DE/EN switcher lives in the shared footer. Self-contained like the
+/// <see cref="NormalizeLang"/>); a DE/EN switcher lives in the shared header (pill toggle) and, as
+/// plain links, in the footer. Self-contained like the
 /// per-instance PortalPage (inline CSS + SVG logo, no shipped assets); the pages talk to /api with a
 /// Bearer session from localStorage. Deliberately compact — the polished experience is the game itself.
 /// </summary>
@@ -25,6 +26,36 @@ public static class WorldHostPortalPages
     /// the default for anything unknown — the service's primary audience — and "en" must be an exact,
     /// deliberate choice (URL parameter or the cookie the switcher set).</summary>
     public static string NormalizeLang(string? lang) => lang == "en" ? "en" : "de";
+
+    /// <summary>First-visit language from the browser's <c>Accept-Language</c> header: the first
+    /// supported primary tag wins (browsers list tags in preference order, so full q-value parsing
+    /// would only complicate this), anything else stays German. Only consulted when neither
+    /// <c>?lang=</c> nor the <c>bbs_lang</c> cookie carries an explicit choice — auto-detection never
+    /// persists, so a deliberate switch always outranks it.</summary>
+    public static string LangFromAcceptHeader(string? acceptLanguage)
+    {
+        if (string.IsNullOrWhiteSpace(acceptLanguage))
+        {
+            return "de";
+        }
+
+        foreach (string part in acceptLanguage.Split(','))
+        {
+            string tag = part.Split(';')[0].Trim();
+            string primary = tag.Length >= 3 && tag[2] == '-' ? tag[..2] : tag;
+            if (primary.Equals("de", StringComparison.OrdinalIgnoreCase))
+            {
+                return "de";
+            }
+
+            if (primary.Equals("en", StringComparison.OrdinalIgnoreCase))
+            {
+                return "en";
+            }
+        }
+
+        return "de";
+    }
 
     public static string Landing(WorldHostConfig config, string lang = "de")
     {
@@ -580,7 +611,10 @@ load();
 body{{font-family:'Rajdhani','Segoe UI',system-ui,sans-serif;color:#dfe9f7;margin:0;padding:24px;min-height:100vh;
  background:radial-gradient(1100px 640px at 50% -12%,#15243f 0%,#070a12 58%),#070a12}}
 main{{max-width:860px;margin:0 auto}}
-header{{max-width:860px;margin:0 auto 6px}}
+header{{max-width:860px;margin:0 auto 6px;display:flex;align-items:center;justify-content:space-between;gap:12px;flex-wrap:wrap}}
+.langsw{{display:flex;flex:none;border:1px solid var(--line);border-radius:10px;overflow:hidden;font-weight:600}}
+.langsw a,.langsw .cur{{padding:7px 14px;text-decoration:none}}
+.langsw .cur{{background:#1c4a6e88;color:#eaf6ff}} .langsw a{{color:#9db2cf}} .langsw a:hover{{color:var(--cyan)}}
 .brand{{display:flex;align-items:center;gap:12px;text-decoration:none}}
 .brand .mark{{width:64px;height:48px;flex:none}}
 .brand .word{{font-size:20px;font-weight:700;letter-spacing:.12em;text-transform:uppercase;color:#eaf6ff;
@@ -651,7 +685,10 @@ window.bbsErr = function(j, fallback) {{
 </script>
 </head>
 <body>
-<header><a class='brand' href='/{(lang == "en" ? "?lang=en" : "")}'>{LogoSvg}<span class='word'><b>Blocks</b> Beyond the Stars</span></a></header>
+<header><a class='brand' href='/{(lang == "en" ? "?lang=en" : "")}'>{LogoSvg}<span class='word'><b>Blocks</b> Beyond the Stars</span></a>
+<nav class='langsw' aria-label='Sprache / Language'>{(lang == "en"
+        ? "<a href='?lang=de' lang='de'>DE</a><span class='cur'>EN</span>"
+        : "<span class='cur'>DE</span><a href='?lang=en' lang='en'>EN</a>")}</nav></header>
 <main>{body}</main>
 <footer>
 <a href='/rules{(lang == "en" ? "?lang=en" : "")}'>{T("Regeln", "Rules")}</a> ·

--- a/tests/BlocksBeyondTheStars.Tests/WorldHostPortalPagesTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/WorldHostPortalPagesTests.cs
@@ -96,6 +96,35 @@ public sealed class WorldHostPortalPagesTests
     }
 
     [Fact]
+    public void Shell_ShowsTheLanguageToggle_InTheHeader()
+    {
+        // The footer links alone were effectively invisible (below the fold, small grey text) — the
+        // header pill is the discoverable switcher, rendered before the page body.
+        string de = WorldHostPortalPages.Landing(Config);
+        Assert.Contains("class='langsw'", de);
+        Assert.Contains("<span class='cur'>DE</span><a href='?lang=en'", de);
+        Assert.True(de.IndexOf("class='langsw'", StringComparison.Ordinal)
+            < de.IndexOf("<main>", StringComparison.Ordinal));
+
+        string en = WorldHostPortalPages.Landing(Config, "en");
+        Assert.Contains("<a href='?lang=de' lang='de'>DE</a><span class='cur'>EN</span>", en);
+    }
+
+    [Theory]
+    [InlineData(null, "de")]
+    [InlineData("", "de")]
+    [InlineData("en", "en")]
+    [InlineData("en-US,en;q=0.9", "en")]
+    [InlineData("EN-us", "en")] // header tags are case-insensitive, unlike our own ?lang= values
+    [InlineData("de-DE,de;q=0.9,en;q=0.8", "de")]
+    [InlineData("fr-FR,fr;q=0.9,en;q=0.8", "en")] // first SUPPORTED tag wins, not just the first tag
+    [InlineData("fr-FR,fr", "de")] // nothing supported → German default
+    [InlineData("*", "de")]
+    [InlineData("eng-US", "de")] // only the exact de/en primary tags count
+    public void LangFromAcceptHeader_PicksTheFirstSupportedLanguage(string? header, string expected)
+        => Assert.Equal(expected, WorldHostPortalPages.LangFromAcceptHeader(header));
+
+    [Fact]
     public void Privacy_EnglishPutsTheSummaryFirst_GermanTextStaysAuthoritative()
     {
         string en = WorldHostPortalPages.Privacy(Config, "en");


### PR DESCRIPTION
## What

Two small WorldHost changes in one PR (same code area, `Program.cs` / portal pages):

### 1. Discoverable language switcher (portal UX)

The portal's DE/EN switcher existed only as small grey footer links — below the fold on longer
pages and effectively invisible for the kid/parent audience.

- **Header pill toggle "DE | EN"** in the shared `Shell()` header (current language highlighted,
  same `?lang=` links; footer links kept).
- **`Accept-Language` detection on first visit**: without `?lang=` or the `bbs_lang` cookie, the
  browser's preferred language decides (new testable `LangFromAcceptHeader`; first supported
  primary tag wins, German default). Auto-detection sets NO cookie — only an explicit choice
  persists, so `?lang=` semantics are unchanged.

### 2. Code-scanning cleanup (closes both open CodeQL alerts)

- `bbs_lang` cookie now sets `Secure` + `HttpOnly` (`cs/web/cookie-secure-not-set`) — safe, the
  portal JS never reads it (it carries `?lang=` itself; the cookie is the server-side fallback).
- `/admin/announce` form handler logs the world id through the existing `LogSafe()` helper,
  matching its `/api/admin/announce` twin (`cs/log-forging`).

## Tests

- 11 new tests (header toggle both languages + above `<main>`; Accept-Language parsing incl.
  q-lists, wildcard `*`, case-insensitivity, unsupported-only headers) → suite **954 server +
  113 client green**, 0-warning build.
- Live smoke against a locally running WorldHost: EN browser → EN page + toggle, DE browser → DE,
  `?lang=` wins + sets the cookie, cookie wins over Accept-Language.

Server-side only (WorldHost) — no game/client rebuild needed; live after the next worldhost deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)