### PR TITLE
docs: add project CHANGELOG.md through v0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,279 @@
+# Changelog
+
+All notable changes to **Blocks Beyond the Stars** are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
+(pre-1.0: minor bumps carry features, patch bumps carry fixes and small additions).
+
+Each release below mirrors its [GitHub release notes](https://github.com/marceld23/BlocksBeyondTheStars/releases);
+the richer, screenshot-laden versions live there. `(#123)` references the pull request or issue.
+
+## [Unreleased]
+
+## [0.7.2] — 2026-07-06
+
+Everything below is already on `main` except the client-portal parity work (#271),
+which is in review and expected to land in this release.
+
+### 🖥️ Play without a browser — full client-portal parity
+Everything you could previously only do on the web portal now works inside the game's **Official Worlds** menu; for desktop players the website is optional. (#271, closes #268–#270)
+- **Sign up in-game** with the community rules shown and accepted right there. A new anonymous `GET /api/terms` single-sources the rules text with the `/rules` page (via a new `CommunityRules` class) so they can never drift, and an outdated-terms login opens a **re-accept flow**.
+- **Create a world** (name + optional join password with a repeat check) and a **per-world manage dialog**: set/remove the join password, stop the world, or delete it behind a type-the-name confirmation.
+- **Save backup round-trip without a browser** — download to / upload from `portal_saves/<worldId>-world.db` with an "Open folder" button (world must be stopped; the 50 MB cap surfaces server-side).
+- **Feedback & ideas** form and **GDPR account deletion** (type-the-name confirm; erases the account, its worlds and saves) are both reachable in-game.
+- WebGL is untouched — the browser client still never selects servers.
+
+### 🌱 Algae tank — grow food from water at a base
+- New **algae tank** station block, the game's first food-producing machine (detoxifier station-recipe pattern, base-only). (#265, closes #261)
+- Crafted at the workshop (2 metal panel + 3 glass, no blueprint); turns **1 water → 2 algae rations** (+30 hunger). A new hand recipe (2 ice → 1 water) feeds it.
+- Dedicated bubbling craft cue, new block tile + ration icon, and full bilingual Codex coverage (survival-guide article + auto chapters).
+
+### 🐾 Energy fence & gate — pen in creatures, companions and enemies
+Wild creatures, companions and planet enemies never consult the voxel world for collision, so ordinary walls can't hold them. Two new blocks change that. (#266, closes #263)
+- **`energy_fence`** — a solid emissive pylon that blocks players, NPCs *and* all fauna (workshop: 2 metal panel + 2 cable → 4).
+- **`energy_gate`** — a non-solid membrane players and NPCs walk through but fauna bounce off; a door with no open/close state (workshop: 2 metal panel + 1 energy cell + 1 circuit board → 1).
+- A new fauna fence sweep wires this into creature, companion and enemy movement — so a pen holds your own animals and the fence doubles as base defense. Flying creatures glide over normal-height fences (documented).
+- New atlas tiles for both blocks plus an `energy_fence_hum` loop; DE+EN locales, taming wiki article and manual sections.
+
+### 🗺️ NPC treasure hints
+Settlement NPCs can now point you toward the crashed wreck and hidden caches. (#267, closes #262)
+- On greeting there's a **35% chance to emit a hint** instead of the flavour line: the wreck (while unclaimed) for everyone; the nearest unlooted chest only once your relationship reaches "known".
+- The reveal is **world-global and co-op friendly** — the POI is added to the map and broadcast to all joined players, and persisted in world metadata (no codec change).
+- The spoken line is deterministic and localized DE+EN: an 8-way compass direction + distance, torus-wrap aware. Claimed wrecks and looted chests drop out automatically and are never re-hinted.
+
+### 🪨 Friendlier start planet
+- New games now start on a **hospitable planet** (varied) instead of toxic, plantless rocky; carbon ore was added to varied so the medpack/energy-cell chain still works. Only new worlds are affected — existing saves keep their persisted start type. (#264, closes #260)
+- World generation is hardened: an unknown or unmatched start type no longer crashes world load (it falls back to the first breathable planet with flora).
+- Fixed a latent bug this surfaced: breathable-surface health regen ran before the same-tick death check, so a 0-HP player was nudged to 0.2 HP and **never respawned**. No regen at 0 HP now.
+
+### 🌐 Portal polish & security
+- **Discoverable DE/EN language switcher** — a header "DE | EN" pill (the old switcher was invisible grey footer links), plus `Accept-Language` detection on first visit. Auto-detection sets no cookie; only an explicit choice persists. (#259)
+- Resolved both open CodeQL alerts: the `bbs_lang` cookie now sets `Secure` + `HttpOnly`, and the `/admin/announce` handler logs the world id through the safe helper. (#259)
+
+### 📚 Docs
+- README now links to the game's website. (#264)
+
+## [0.7.1] — 2026-07-06
+
+This release is all about **playing together safely**: world creators can password-protect their worlds, server restarts announce themselves with an in-game countdown, reporting and feedback are easier to find (especially for kids), the portal got a kid-friendly rework, and the Play button finally launches the game right in your browser.
+
+### 🔒 World join passwords
+World creators can lock a hosted world with a password — perfect for "just my friends" worlds. (#255)
+- Set, change or remove the password any time in the portal; new worlds can get one at creation (with a confirm field so no typos lock you out).
+- Joining asks for the password — in the portal and in the game client (masked input). The world owner never needs one.
+- Guess-proof: 10 wrong tries in 15 minutes puts a cooldown on that world, and sleeping worlds aren't even woken for wrong guesses.
+
+### 🔧 Maintenance announcements
+Server restarts no longer come out of nowhere. (#255)
+- In-game countdown banner when a maintenance restart is scheduled, plus an acknowledgeable dialog and a proper "server is restarting" screen instead of a generic disconnect.
+- New commands `//restart <minutes>` and `//cancelrestart` for world admins, a token-gated `/announce` endpoint, and an **Announce card in `/admin`** with a per-world graceful-restart button.
+- Worlds finish the countdown, save, and stop cleanly — no more surprise kicks.
+
+### 🧒 Kid-friendly portal & feedback
+The web portal now reads like the family project it is. (#258)
+- New **"Feedback & ideas" card** on the worlds page — kids and parents can send wishes directly, without filing a "report" against anyone; feedback lands in its own `/admin` queue, separate from player reports.
+- Parental notice on the landing page, and "ask your parents first" is now the first community rule.
+- Kid UX pass: create-account card comes first, the name field speaks plain words, a "write your password down!" warning replaces jargon, and the join prompt remembers your player name.
+- Reporting is discoverable: rules and portal now point at the in-game Report button and `/report` command first.
+
+### 🛡️ Easier reporting in-game
+- New **`/report <name>` chat command** on official worlds — it attaches the last 10 chat lines as evidence. (#248)
+- Every report now records **which world it happened in** — from the button, the command and the portal form. (#248)
+- `/help` now leads with the commands for everyone (`/report`, `/bump`), and official worlds show a one-time chat tip pointing at both report paths (DE+EN). (#258)
+
+### 🌐 Play in the browser, for real
+- The portal **Play button now launches the game directly in your browser** — signed in, world picked, one click, playing — by deep-linking the WebGL client with a short-lived join token. (#256)
+- Fixed the Play button doing nothing for returning players (a permission wipe ate the grant). (#256)
+- The whole portal is now fully bilingual (DE/EN, `?lang=en` or the toggle) and finally shows the game logo and a favicon. (#256)
+
+### 🛠️ Fixes & polish
+- **Stopping a server during initial world generation now works** — previously the stop was ignored and the container was force-killed (exit 137); the generation grace period is also longer now. (#247)
+- Admin server-health card shows the real host core count, so the load bar means what it says.
+- Hardened the admin stop endpoint against log forging (CodeQL): world ids are sanitized before logging.
+
+## [0.7.0] — 2026-07-05
+
+A big visual glow-up with the **organic look overhaul**, plus **gamepad and touch controls**, hosted **Official Worlds** with a web portal, a fleshed-out in-game **Codex**, and a **browser client** that's actually playable end-to-end.
+
+### 🎨 Organic look overhaul
+A full presentation pass — all client-side, no save/world migration needed. (#192)
+- Softer voxel surfaces (per-vertex + cavity AO, beveled convex edges). (#186)
+- GPU-instanced grass tufts and pebbles on open ground. (#187)
+- 3D mesh flora — leaning 3-plane plant rosettes; cacti, crystals and mushrooms are real shapes. (#188)
+- Finer building shapes: panel, post, beam, low ramp, quarter cube. (#189)
+- Fully orientable shapes (all 24 orientations, auto-orient, rebindable rotate key). (#190)
+- Sparse raised plating on exposed ship hull faces. (#191)
+
+### 🎮 Gamepad & touch controls (experimental)
+The whole input epic (#193) shipped — inert on desktop keyboard+mouse.
+- Gamepad/controller support behind a new input-abstraction layer (flight, EVA, menus, building). (#199)
+- Pad rebinding in Settings with device-aware button glyphs. (#206)
+- On-screen touch controls with localized labels (DE+EN). (#204, #206)
+- Text entry on touch in the browser; menus navigable by pad focus-nav. (#206)
+- ⚠️ On-device feel still being playtested (#201–#203).
+
+### 🌍 Hosted Official Worlds (beta)
+Player-created worlds hosted by us, joinable in one click — no port forwarding, no server setup. (#227)
+- "Official Worlds" in the main menu; sleeping worlds wake on demand and idle worlds shut down cleanly.
+- Web portal with privacy-minimal sign-up (name + password, no email), world create/manage, and save upload/download.
+- Kid-friendly bilingual community rules + a beta notice; **DSGVO account self-deletion**. (#233)
+- One-tap in-game **Report** button + portal report form; operators can review and ban, enforced at join.
+- Optional AI backend runs containerized in the fleet (internal-only, OpenAI-compatible) and feeds NPC chatter. (#234)
+- Basic-Auth `/admin` panel: live fleet overview, report queue, ban/unban, server-health card; public aggregate-only `/api/stats`. (#234, #246)
+- Per-world memory/CPU/pids fences + a global cap on awake worlds. (#234)
+- Fixed a stale container blocking every re-wake, found in the first real end-to-end test. (#235)
+- Developer names protected against impersonation + a blocked-name filter. (#230)
+- Worlds untouched for months are archived, not deleted, and restored transparently on join. (#230)
+- Rate limits on signups, logins, save uploads and reports + Prometheus metrics. (#230)
+- Self-hosting unchanged — everything inert by default. Fleet deploys from the repo via an approval-gated SSH workflow. (#229, #231)
+
+### 🐛 Self-owned bug-report inbox
+- New **ReportHost** service: a small Docker container that receives F1 feedback and crash reports (unchanged wire contract), stores them in SQLite with screenshots, and offers a filterable triage UI. (#227)
+- One-click JSON bulk export honoring the current filters. (#234)
+
+### 📖 Codex
+- Every block, item and all 19 worlds now have bilingual (EN/DE) descriptions, plus 14 new guide articles. (#184)
+- Codex is fully navigable again: working chapter links, list descriptions, correct scan names. (#178)
+
+### 🌐 Browser client
+The experimental WebGL path is now genuinely playable.
+- Fixed falling through terrain on landing — chunks and colliders now build synchronously on WebGL. (#205, #207)
+- One-click `/play` flow polished (required name, deep-linking, dark loading template, reliable touch). (#217–#222)
+- WebGL builds no longer drag in the desktop updater (Velopack); dedicated WebGL attach workflow. (#151)
+
+### 🛠️ Fixes & polish
+- You can walk out of your ship again (nozzles moved, doorway cleared, hatch raised to 3 blocks). (#179, #211, #212, #214, #215)
+- Deep water reads see-through — vertical depth, softer reflections and glint. (#213, #216)
+- Helmet lamp switches off when you leave a planet. (#180, #182)
+- Opaque world-options dialog with non-overlapping footer buttons. (#181, #182, #209, #210)
+- All 27 Unity compiler/build warnings resolved — the client builds warning-clean.
+- Game-input hardening on every server: packet-size caps, per-connection rate limiting, validated face data, voice frame-rate cap, control characters stripped from chat/labels. (#233)
+- CI: two-tier test gate — fast PR checks, full suite on main + before release. (#208)
+
+## [0.6.2] — 2026-06-29
+
+Sharpens core gameplay, adds oxygen-tank tiers, seals a station/space exploit, and lays the groundwork for playing in the browser.
+
+### 🎮 Gameplay
+- Shaped blocks now have proper icons in hotbar, crafting and inventory. (#125)
+- Ladders are climbable (forward/Jump up, back/Ctrl down). (#126)
+- Auto-step onto slabs & stairs without jumping. (#127)
+- Tool-gated mining — stone needs a drill (the starter kit grants one); soft blocks stay bare-handed. (#128)
+
+### 🫧 Survival
+- Oxygen Tank tiers I/II/III — worn components giving +50/+100/+200 max oxygen; only your best tank counts, Tank III gated behind titanium. (#133)
+- Easier to climb out of water. (#133)
+
+### 🌐 Browser client (experimental)
+- Hosted WebGL client + optional PostgreSQL backend, servable from the dedicated-server Docker image. Contributed by **[@ProdigyView](https://github.com/ProdigyView) (Devin Dixon)**. (#116, #123)
+- Slimmed browser start menu to name + Play. (#122)
+- ⚠️ Not yet verified end-to-end — ships as experimental.
+
+### 🛠️ Fixes & polish
+- Sealed a station-to-space gap via a bounded flood-fill enclosure check. (#134, #135)
+- Dev builds isolated under a separate pack ID. (#115)
+- German localization fixes — thanks to **[@Maqbool61](https://github.com/Maqbool61) (Maqbool Ahmed)**. (#112)
+
+## [0.6.1] — 2026-06-28
+
+A focused follow-up to v0.6.0: an experimental macOS build, automatic crash reports, and one-click client downloads from your own server.
+
+- 🍎 **Experimental macOS build** (`StandaloneOSX`, portable zip) — unsigned/un-notarized, not yet tested on real hardware; testers wanted ([#87](https://github.com/marceld23/BlocksBeyondTheStars/issues/87)). (#84, #105)
+- 🐧 Native Linux client (new in v0.6.0) gains a one-click download from the server portal. (#83)
+- 🛡️ **Automatic crash reporting** (server + client, opt-in, with a PII scrubber); the server tick is hardened so one bad event can't crash the world. (#103)
+- ⬇️ The dedicated-server portal now hands out Windows, Linux (AppImage) and macOS clients directly. (#107)
+- 👨‍👩‍👦 README, Code of Conduct, in-game Credits and Codex now state the kid-friendly intent. (#109)
+- ⚙️ Faster, cleaner release CI (version resolved once and shared; Docker build decoupled; overlapping runs serialized). (#106)
+
+## [0.6.0] — 2026-06-27
+
+Our biggest update yet: claim your own factory, explore alien ruins — and play natively on **Linux**.
+
+- 🎉 **First community contribution** — native Linux support by **[@corarona](https://github.com/corarona) (Cora de la Mouche)**. (#69)
+- 🏭 **Factories** — rare industrial halls with animated machine bays and a production terminal that turns cheap materials into bulk output.
+- 🏚️ **Ruins** — collapsed settlements you can mine, plus standalone treasure chests with richer loot.
+- 🔑 **SPS access codes** — a rare item that lets you claim a factory as your own editable base, shared with allies.
+- 🐧 **Native Linux client** — real `StandaloneLinux64` build as AppImage + Portable.zip; the Windows-only embedded browser (CEF) was removed so the Codex Wiki and Arcade run without it.
+- 🛠️ Deeper crafting: new **Transmuter** station, the **Refinery** becomes full metallurgy, and the titanium/carbide deadlock is fixed.
+- 🌍 Bigger in-game editors, longer view distance, smoother movement, downhill rivers/lava with waterfalls, brighter worlds, per-world named tree species.
+- 📚 New factory/ruins docs (manual + Codex, EN/DE) and a canonical source-code URL (AGPL).
+
+## [0.5.0] — 2026-06-25
+
+A graphics-quality pass and a licensing/foundation cleanup.
+
+- 🎨 Pro-look graphics quick-wins: in-game post + SMAA + SSAO + emissive glow. (#50)
+- 🎨 Per-biome cinematic mood LUTs (#51), PBR-ish GGX specular + roughness-aware reflections on voxels (#52), and a global Brightness control. (#53)
+- 💧 Soft water reflections + visible sky bodies (#55); clear water you can see into again. (#56)
+- 📜 Relicensed **MIT → AGPL-3.0-or-later** + a Contributor License Agreement. (#59)
+- 🧩 Native in-game Arcade + Wiki — removed UnityWebBrowser/CEF, unblocking Linux/macOS. (#58)
+- ⚡ Runtime-quality pass: client perf, netcode area-of-interest & interpolation, input remapping. (#60)
+- 🚀 Ship cargo hold is now actively usable — manual transfer, capacity, auto-stow. (#62)
+
+## [0.4.2] — 2026-06-23
+
+- 🍽️ **You no longer starve in the first few minutes** — starter food (5 berries + 2 rations), an "eat" onboarding objective, an earlier hunger warning, and clearer food descriptions. (#46)
+- 🔫 **A fighting chance against early hostiles** — a weak ranged starter **scrap pistol**, fixed ranged weapons only firing at point-blank, and a 3D line-of-sight gate so enemies can't hit what they can't see. (#45)
+- 🐧 **Linux/Proton: no more hard 30 fps lock** — VSync is now its own setting with a separate frame-rate cap. (#47)
+- 📝 README intro reworked around the family-and-community project story. (#44)
+
+## [0.4.1] — 2026-06-22
+
+- 🚀 No more creatures trapped in your ship — the ship evicts wild creatures on landing (companions may still follow you aboard); same guard for planet enemies. (#43)
+- 🛡️ You're truly safe once aboard — visible attacks (drone fire, robot claws, creature bites) now stop the moment you board. (#41)
+- 🧭 Cleaner HUD in space — the planet compass and day/night–temperature–gravity panel hide while piloting (compass stays on during EVA). (#39)
+- ⌨️ Feedback is now simply **F1** — the never-clickable bottom-right button is gone. (#42)
+- 🎥 Automated in-game clip recorder (video + frame-synced audio) for marketing clips. (#40)
+- 🐳 Docker Desktop local-test walkthrough in SELF_HOSTING. (#38)
+
+## [0.4.0] — 2026-06-21
+
+- 👥 **Raised the default player cap from 4 to 12** + a 12-player smoke test. (#19, #21)
+- 📻 **Tiered radio reach + live voice chat.** (#30)
+- 🐳 **Optional Docker image for the dedicated server.** (#26)
+- 🧰 UI fix: split the in-game menu top bar into two rows so Close no longer overlaps tabs. (#35)
+- ⚙️ CI hardening: PR build/test gate (warnings-as-errors, docs-only skip), format/lint/CodeQL checks, Actions pinned to SHAs, CodeQL compiles C# in manual build mode, release notes prepend the Docker pull command. (#16–#37)
+
+## [0.3.2] — 2026-06-21
+
+- 🚀 Explosion stays with no landing animation after ship destruction (#10); rear hatch shows a blue energy door in flight, not an open hole. (#11)
+- 🛬 Landing flies the descent to the chosen planet, not the launch body. (#12)
+- 👾 Floating scan-drones fire a ranged laser. (#13)
+- 📸 Per-planet surface screenshots for variety (#8) with terrain-aware capture placement. (#14)
+- 📝 README gains a Project Status section, table of contents and itch.io/releases links. (#6, #15)
+
+## [0.3.1] — 2026-06-20
+
+- 🧹 Release CI strips the Burst `_DoNotShip` folder and mirrors installers to itch.io. (#4)
+
+## [0.3.0] — 2026-06-20
+
+- 🔀 Require a pull-request workflow (repo public, `main` protected). (#1)
+- 🔒 Patched langchain/langsmith/starlette security alerts in the AI backend. (#2)
+- 🧹 Cleared analyzer warnings (nullable, async, dispose). (#3)
+
+## [0.2.0] — 2026-06-20
+
+- Early release. See the [full diff](https://github.com/marceld23/BlocksBeyondTheStars/compare/v0.1.0...v0.2.0).
+
+## [0.1.0] — 2026-06-20
+
+- Initial public release.
+
+[Unreleased]: https://github.com/marceld23/BlocksBeyondTheStars/compare/v0.7.2...HEAD
+[0.7.2]: https://github.com/marceld23/BlocksBeyondTheStars/compare/v0.7.1...v0.7.2
+[0.7.1]: https://github.com/marceld23/BlocksBeyondTheStars/compare/v0.7.0...v0.7.1
+[0.7.0]: https://github.com/marceld23/BlocksBeyondTheStars/compare/v0.6.2...v0.7.0
+[0.6.2]: https://github.com/marceld23/BlocksBeyondTheStars/compare/v0.6.1...v0.6.2
+[0.6.1]: https://github.com/marceld23/BlocksBeyondTheStars/compare/v0.6.0...v0.6.1
+[0.6.0]: https://github.com/marceld23/BlocksBeyondTheStars/compare/v0.5.0...v0.6.0
+[0.5.0]: https://github.com/marceld23/BlocksBeyondTheStars/compare/v0.4.2...v0.5.0
+[0.4.2]: https://github.com/marceld23/BlocksBeyondTheStars/compare/v0.4.1...v0.4.2
+[0.4.1]: https://github.com/marceld23/BlocksBeyondTheStars/compare/v0.4.0...v0.4.1
+[0.4.0]: https://github.com/marceld23/BlocksBeyondTheStars/compare/v0.3.2...v0.4.0
+[0.3.2]: https://github.com/marceld23/BlocksBeyondTheStars/compare/v0.3.1...v0.3.2
+[0.3.1]: https://github.com/marceld23/BlocksBeyondTheStars/compare/v0.3.0...v0.3.1
+[0.3.0]: https://github.com/marceld23/BlocksBeyondTheStars/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/marceld23/BlocksBeyondTheStars/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/marceld23/BlocksBeyondTheStars/releases/tag/v0.1.0


### PR DESCRIPTION
## What

Adds a project-owned `CHANGELOG.md` — until now the changelog lived only in GitHub release notes. Follows [Keep a Changelog](https://keepachangelog.com/) + SemVer, written in the emoji-grouped voice of the existing release notes so it reads consistently.

## Contents

- **v0.7.2** (this release): full client-portal parity (#271), algae tank (#265), energy fence + gate (#266), NPC treasure hints (#267), hospitable start planet + latent 0-HP respawn fix (#264), portal DE/EN language switcher + CodeQL cleanup (#259).
  - Note: #271 is still in review; it's listed as expected-to-land per the release scope.
- **Backfill**: every prior release down to v0.1.0, condensed from the published GitHub release notes (v0.6.0–0.7.1 in detail, older ones thematically), with PR references preserved.
- Compare-link footer for every version.

Docs-only change — no code, no build impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)