### PR TITLE
docs(changelog): finalize v0.7.2 notes (parity merged, +WebGL link & UI polish)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,16 +13,16 @@ the richer, screenshot-laden versions live there. `(#123)` references the pull r
 
 ## [0.7.2] — 2026-07-06
 
-Everything below is already on `main` except the client-portal parity work (#271),
-which is in review and expected to land in this release.
+Play the whole hosted-worlds flow without ever opening a browser, grow your own food, pen in your creatures, get treasure hints from villagers, and start new games somewhere friendlier — plus a round of UI polish.
 
 ### 🖥️ Play without a browser — full client-portal parity
-Everything you could previously only do on the web portal now works inside the game's **Official Worlds** menu; for desktop players the website is optional. (#271, closes #268–#270)
+Everything you could previously only do on the web portal now works inside the game's **Official Worlds** menu; for desktop players the website is optional. (#271, closes #268–#270, #272)
 - **Sign up in-game** with the community rules shown and accepted right there. A new anonymous `GET /api/terms` single-sources the rules text with the `/rules` page (via a new `CommunityRules` class) so they can never drift, and an outdated-terms login opens a **re-accept flow**.
 - **Create a world** (name + optional join password with a repeat check) and a **per-world manage dialog**: set/remove the join password, stop the world, or delete it behind a type-the-name confirmation.
 - **Save backup round-trip without a browser** — download to / upload from `portal_saves/<worldId>-world.db` with an "Open folder" button (world must be stopped; the 50 MB cap surfaces server-side).
 - **Feedback & ideas** form and **GDPR account deletion** (type-the-name confirm; erases the account, its worlds and saves) are both reachable in-game.
-- WebGL is untouched — the browser client still never selects servers.
+- **WebGL round-trip** — the browser client gains a visible "My Worlds / Account" button linking back to the worlds portal on the same origin (#272). It still never selects servers itself, so no portal features are duplicated in WebGL.
+- **UI polish** — modal dialogs are now fully opaque everywhere (forms no longer shine through), the settings list scrolls, overlay notices wrap instead of clipping, the Play/Manage row buttons are wide enough for their labels, signup shows a proper "Password (at least 8 characters)" label, and the rules screen shows a friendly offline message + retry instead of silently dropping "accept" when the terms can't be reached.
 
 ### 🌱 Algae tank — grow food from water at a base
 - New **algae tank** station block, the game's first food-producing machine (detoxifier station-recipe pattern, base-only). (#265, closes #261)


### PR DESCRIPTION
## What

The client-portal parity work (#271) has merged and grew beyond the original scope, so the prepared v0.7.2 changelog was slightly stale. This updates it:

- Drops the "#271 in review / expected to land" caveat — it's on `main`.
- Notes #271 now also **closes #272**.
- Adds two entries for the content that came in with #271:
  - **WebGL round-trip** — the browser client gains a "My Worlds / Account" button linking back to the worlds portal (#272).
  - **UI polish** — opaque modal dialogs everywhere, settings scrollbar, wrapped overlay notices, wider Play/Manage buttons, password label, rules-screen offline retry.
- Replaces the placeholder lead line with a proper release summary.

Docs-only. Feeds the v0.7.2 GitHub release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)