### PR TITLE
docs(changelog): mark Unreleased empty now that v0.7.2 is released

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ the richer, screenshot-laden versions live there. `(#123)` references the pull r
 
 ## [Unreleased]
 
+_Nothing yet — [v0.7.2](#072--2026-07-06) is the latest release._
+
 ## [0.7.2] — 2026-07-06
 
 Play the whole hosted-worlds flow without ever opening a browser, grow your own food, pen in your creatures, get treasure hints from villagers, and start new games somewhere friendlier — plus a round of UI polish.


### PR DESCRIPTION
Small follow-up: v0.7.2 is tagged and live, but the empty `## [Unreleased]` section sat directly above `## [0.7.2]` with nothing between, so it read as if 0.7.2 were still unreleased.

Adds a clear "_Nothing yet — v0.7.2 is the latest release._" placeholder under Unreleased to separate the two. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)