### PR TITLE
Official Worlds + portal UX polish (spinners, aligned layout)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,12 @@ the richer, screenshot-laden versions live there. `(#123)` references the pull r
 
 ## [Unreleased]
 
-_Nothing yet — [v0.7.3](#073--2026-07-07) is the latest release._
+### 🖱️ Official Worlds & portal UX polish
+Follow-up polish to the hosted-worlds flow (portal + in-game *Official Worlds* menu).
+- **Loading spinners** everywhere an action runs in the background — waking/playing, creating, stopping, deleting and uploading a save. The web portal now also gives stopping and deleting a progress state (button disabled + "Stopping…/Deleting…" → "stopped/deleted"); before, those looked like nothing happened until the list refreshed.
+- **Play → clearer name handling in the game client**: if the chosen player name is reserved or not allowed, an in-place prompt lets you pick another name and retries the join, instead of a dead-end error you could only fix from the main menu.
+- **"Play" (portal)** reads a prefilled, remembered player-name field instead of a pop-up prompt; the browser-play button is the clear primary action with the native host/port/token in an expander.
+- **Official Worlds window** widened and laid out as a clean grid: the five action buttons share one uniform row, the per-world Play/Manage buttons line up with the columns above them, and the world **status** ("starting…", "running") gets its own wide column so it never hides behind the buttons.
 
 ## [0.7.3] — 2026-07-07
 

--- a/client/Assets/BlocksBeyondTheStars/Scripts/UiKit.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/UiKit.cs
@@ -29,6 +29,7 @@ namespace BlocksBeyondTheStars.Client
         private static Sprite _panelSprite;
         private static Sprite _buttonSprite;
         private static Sprite _solidSprite;
+        private static Sprite _spinnerSprite;
 
         /// <summary>A plain white sprite (tint via Image.color) — used for fills/bars.</summary>
         public static Sprite SolidSprite
@@ -61,6 +62,7 @@ namespace BlocksBeyondTheStars.Client
 
         public static Sprite PanelSprite => _panelSprite != null ? _panelSprite : _panelSprite = RoundedSprite(18, 3);
         public static Sprite ButtonSprite => _buttonSprite != null ? _buttonSprite : _buttonSprite = RoundedSprite(14, 2);
+        public static Sprite SpinnerSprite => _spinnerSprite != null ? _spinnerSprite : _spinnerSprite = SpinnerRingSprite();
 
         /// <summary>Set from <see cref="ClientSettings.Apply"/>: reduced-effects users keep instant panel snaps.</summary>
         public static bool ReducedMotion;
@@ -675,6 +677,87 @@ namespace BlocksBeyondTheStars.Client
             int b = radius + 2;
             return Sprite.Create(tex, new Rect(0, 0, size, size), new Vector2(0.5f, 0.5f), 100f, 0,
                 SpriteMeshType.FullRect, new Vector4(b, b, b, b));
+        }
+
+        /// <summary>A cyan ring with an alpha gradient around its circumference (a fading tail) — rotated
+        /// by <see cref="SpinnerRotate"/> it reads as a smooth loading spinner.</summary>
+        private static Sprite SpinnerRingSprite()
+        {
+            const int size = 48;
+            float c = (size - 1) / 2f, outer = c, inner = c - 7f;
+            var tex = new Texture2D(size, size, TextureFormat.RGBA32, false)
+            {
+                filterMode = FilterMode.Bilinear,
+                wrapMode = TextureWrapMode.Clamp,
+            };
+            var px = new Color[size * size];
+            for (int y = 0; y < size; y++)
+            {
+                for (int x = 0; x < size; x++)
+                {
+                    float dx = x - c, dy = y - c;
+                    float d = Mathf.Sqrt(dx * dx + dy * dy);
+                    Color col = new Color(0f, 0f, 0f, 0f);
+                    if (d <= outer && d >= inner)
+                    {
+                        // Angle 0..1 around the ring → alpha, so the ring fades to transparent (the tail).
+                        float t = (Mathf.Atan2(dy, dx) + Mathf.PI) / (2f * Mathf.PI);
+                        col = new Color(Cyan.r, Cyan.g, Cyan.b, t);
+                    }
+
+                    px[y * size + x] = col;
+                }
+            }
+
+            tex.SetPixels(px);
+            tex.Apply();
+            return Sprite.Create(tex, new Rect(0, 0, size, size), new Vector2(0.5f, 0.5f), 100f);
+        }
+
+        /// <summary>A small loading spinner. When <paramref name="follow"/> is given, it is visible only while
+        /// that label shows an in-progress message (its text contains "…") — so it auto-appears during
+        /// waking/stopping/deleting and hides on the result, with no per-handler wiring.</summary>
+        public static GameObject AddSpinner(Transform parent, float x, float y, float size, Text follow = null)
+        {
+            var go = new GameObject("Spinner", typeof(RectTransform));
+            go.transform.SetParent(parent, false);
+            Place(go, x, y, size, size);
+            var img = go.AddComponent<Image>();
+            img.sprite = SpinnerSprite;
+            img.raycastTarget = false;
+            var rot = go.AddComponent<SpinnerRotate>();
+            rot.Bind(img, follow);
+            return go;
+        }
+
+        /// <summary>Spins its image and (when bound to a label) shows it only while an action is in progress.</summary>
+        private sealed class SpinnerRotate : MonoBehaviour
+        {
+            private Image _img;
+            private Text _follow;
+
+            public void Bind(Image img, Text follow)
+            {
+                _img = img;
+                _follow = follow;
+                if (_follow != null && _img != null)
+                {
+                    _img.enabled = false; // idle until an in-progress message appears
+                }
+            }
+
+            private void Update()
+            {
+                transform.Rotate(0f, 0f, -220f * Time.unscaledDeltaTime);
+                if (_follow != null && _img != null)
+                {
+                    bool busy = !string.IsNullOrEmpty(_follow.text) && _follow.text.Contains("…");
+                    if (_img.enabled != busy)
+                    {
+                        _img.enabled = busy;
+                    }
+                }
+            }
         }
     }
 }

--- a/client/Assets/BlocksBeyondTheStars/Scripts/UiMainMenu.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/UiMainMenu.cs
@@ -250,33 +250,37 @@ namespace BlocksBeyondTheStars.Client
 
             var odim = UiKit.AddModalDim(root);
             official = odim.gameObject;
-            var odlg = UiKit.AddDialogPanel(official.transform, 610f, 180f, 700f, 720f);
-            UiKit.AddText(odlg, 30f, 24f, 640f, 30f, shell.L("ui.portal.title"), 22, UiKit.Cyan, TextAnchor.MiddleCenter, FontStyle.Bold);
+            // Wide panel (1100) so the world rows have a roomy status column — a "starting…"/"running"
+            // status used to sit behind the Play/Manage buttons on the old 700-wide layout.
+            var odlg = UiKit.AddDialogPanel(official.transform, 410f, 180f, 1100f, 720f);
+            UiKit.AddText(odlg, 30f, 24f, 1040f, 30f, shell.L("ui.portal.title"), 22, UiKit.Cyan, TextAnchor.MiddleCenter, FontStyle.Bold);
 
             // The same notices the portal shows (client parity): the beta warning, the one-line rules
             // summary, and a button opening the full rules page in the browser. The long notices MUST
             // wrap — AddText defaults to overflow, which ran them under the button and off the panel.
-            var betaLine = UiKit.AddText(odlg, 30f, 58f, 640f, 40f, shell.L("ui.portal.beta"), 13,
+            var betaLine = UiKit.AddText(odlg, 30f, 58f, 1040f, 40f, shell.L("ui.portal.beta"), 13,
                 new Color(1f, 0.72f, 0.35f), TextAnchor.UpperLeft);
             betaLine.horizontalOverflow = HorizontalWrapMode.Wrap;
-            var rulesLine = UiKit.AddText(odlg, 30f, 100f, 448f, 44f, shell.L("ui.portal.rules_line"), 13, UiKit.CyanDim, TextAnchor.UpperLeft);
+            var rulesLine = UiKit.AddText(odlg, 30f, 100f, 820f, 44f, shell.L("ui.portal.rules_line"), 13, UiKit.CyanDim, TextAnchor.UpperLeft);
             rulesLine.horizontalOverflow = HorizontalWrapMode.Wrap;
-            // "Regeln ansehen" pulled in from the panel edge and given a wider box so the German label sits
-            // comfortably with clear margins on both sides (was crowding the panel's right border).
-            UiKit.AddButton(odlg, 492f, 98f, 178f, 44f, shell.L("ui.portal.view_rules"),
+            // Right column (x=874, w=195): "Regeln ansehen" here, "Abmelden"/"Konto"/per-world "Verwalten"
+            // below all share this column so the whole right edge lines up.
+            UiKit.AddButton(odlg, 874f, 98f, 195f, 44f, shell.L("ui.portal.view_rules"),
                 () => Application.OpenURL(PortalBase() + "/rules"), "btn_credits");
 
-            var oStatus = UiKit.AddText(odlg, 30f, 592f, 640f, 48f, "", 14,
+            var oStatus = UiKit.AddText(odlg, 66f, 592f, 1004f, 48f, "", 14,
                 new Color(1f, 0.55f, 0.4f), TextAnchor.UpperLeft, FontStyle.Bold);
             oStatus.horizontalOverflow = HorizontalWrapMode.Wrap; // localized errors can be long
-            UiKit.AddButton(odlg, 400f, 648f, 270f, 54f, shell.L("ui.menu.back"), () =>
+            // Spinner shown automatically while a status message is in progress (its text contains "…").
+            UiKit.AddSpinner(odlg, 32f, 590f, 26f, oStatus);
+            UiKit.AddButton(odlg, 415f, 648f, 270f, 54f, shell.L("ui.menu.back"), () =>
             {
                 CloseAllPortalModals(); // leaving the overlay must not park stale dialogs behind it
                 official.SetActive(false);
             }, "btn_exit");
 
             // Content area rebuilt on every state change (signed out ↔ signed in ↔ fresh world list).
-            var oContent = UiKit.AddPanel(odlg, 0f, 150f, 700f, 440f, new Color(0f, 0f, 0f, 0f)).transform;
+            var oContent = UiKit.AddPanel(odlg, 0f, 150f, 1100f, 440f, new Color(0f, 0f, 0f, 0f)).transform;
             var oWorlds = new List<PortalWorldInfo>();
 
             string PortalBase() => string.IsNullOrWhiteSpace(shell.Settings.PortalUrl)
@@ -829,8 +833,9 @@ namespace BlocksBeyondTheStars.Client
                 var mDlg = OpenModalPanel(460f, 150f, 1000f, 780f);
                 UiKit.AddText(mDlg, 30f, 24f, 940f, 30f, world.Name, 22, UiKit.Cyan, TextAnchor.MiddleCenter, FontStyle.Bold);
                 var mStatus = UiKit.AddText(mDlg, 40f, 58f, 920f, 24f, world.Status + (world.HasPassword ? "  [PW]" : ""), 14, UiKit.CyanDim, TextAnchor.MiddleCenter);
-                var mWarn = UiKit.AddText(mDlg, 40f, 596f, 920f, 56f, "", 14, warnCol, TextAnchor.UpperLeft, FontStyle.Bold);
+                var mWarn = UiKit.AddText(mDlg, 76f, 596f, 884f, 56f, "", 14, warnCol, TextAnchor.UpperLeft, FontStyle.Bold);
                 mWarn.horizontalOverflow = HorizontalWrapMode.Wrap;
+                UiKit.AddSpinner(mDlg, 42f, 596f, 26f, mWarn); // spins while a manage action is in progress
 
                 // World join password (owner-only; empty remove keeps the world open).
                 string[] mp1 = { "" };
@@ -1009,6 +1014,47 @@ namespace BlocksBeyondTheStars.Client
                 }, "btn_exit");
             }
 
+            // Error-driven player-name prompt: the world join was refused because the current player name is
+            // reserved/not allowed. Let the player type another name (writing it back to the menu's name field
+            // so CommitName picks it up), then retry the same join.
+            void PromptPlayerName(string worldId, string code)
+            {
+                if (passwordPrompt != null)
+                {
+                    Object.Destroy(passwordPrompt);
+                }
+
+                var dim = UiKit.AddModalDim(official.transform, 0.9f);
+                passwordPrompt = dim.gameObject;
+                var dlg = UiKit.AddDialogPanel(passwordPrompt.transform, 610f, 350f, 700f, 360f);
+                UiKit.AddText(dlg, 30f, 24f, 640f, 30f, shell.L("ui.menu.connect_name"), 20, UiKit.Cyan, TextAnchor.MiddleCenter, FontStyle.Bold);
+                var hint = UiKit.AddText(dlg, 30f, 64f, 640f, 60f,
+                    shell.L(code == "name_reserved" ? "ui.portal.err_name_reserved_hint" : "ui.portal.err_name_blocked_hint"),
+                    14, new Color(1f, 0.55f, 0.4f), TextAnchor.UpperLeft, FontStyle.Bold);
+                hint.horizontalOverflow = HorizontalWrapMode.Wrap;
+
+                string[] nm = { string.Empty };
+                UiKit.AddInput(dlg, 30f, 132f, 640f, 40f, nm[0], v => nm[0] = v);
+                UiKit.AddButton(dlg, 30f, 192f, 320f, 54f, shell.L("ui.portal.play"), () =>
+                {
+                    if (string.IsNullOrWhiteSpace(nm[0]))
+                    {
+                        return;
+                    }
+
+                    natName[0] = nm[0].Trim(); // CommitName (in DoJoinWorld) reads the menu field, not shell.PlayerName
+                    Object.Destroy(passwordPrompt);
+                    passwordPrompt = null;
+                    DoJoinWorld(worldId);
+                }, "btn_join");
+                UiKit.AddButton(dlg, 370f, 192f, 300f, 54f, shell.L("ui.menu.back"), () =>
+                {
+                    Object.Destroy(passwordPrompt);
+                    passwordPrompt = null;
+                    oStatus.text = string.Empty;
+                }, "btn_exit");
+            }
+
             async void DoJoinWorld(string worldId)
             {
                 if (!CommitName())
@@ -1031,6 +1077,15 @@ namespace BlocksBeyondTheStars.Client
                         joinPasswords.Remove(worldId); // a cached one that failed is stale
                         oStatus.text = "";
                         PromptWorldPassword(worldId, wrongBefore: r.Code == "wrong_password");
+                        return;
+                    }
+
+                    // The chosen player name is reserved/not allowed — let the player pick another one right
+                    // here and retry, instead of a dead-end error they can only fix back on the main menu.
+                    if (r.Code == "name_reserved" || r.Code == "name_blocked")
+                    {
+                        oStatus.text = "";
+                        PromptPlayerName(worldId, r.Code);
                         return;
                     }
 
@@ -1057,48 +1112,54 @@ namespace BlocksBeyondTheStars.Client
                 {
                     string[] acc = { shell.Settings.PortalAccountName };
                     string[] pw = { "" };
-                    UiKit.AddText(oContent, 30f, 20f, 640f, 22f, shell.L("ui.portal.account"), 15, UiKit.TextCol, TextAnchor.MiddleLeft);
-                    UiKit.AddInput(oContent, 30f, 46f, 640f, 38f, acc[0], v => acc[0] = v);
-                    UiKit.AddText(oContent, 30f, 100f, 640f, 22f, shell.L("ui.menu.connect_password"), 15, UiKit.TextCol, TextAnchor.MiddleLeft);
-                    var pwInput = UiKit.AddInput(oContent, 30f, 126f, 640f, 38f, pw[0], v => pw[0] = v);
+                    UiKit.AddText(oContent, 30f, 20f, 1040f, 22f, shell.L("ui.portal.account"), 15, UiKit.TextCol, TextAnchor.MiddleLeft);
+                    UiKit.AddInput(oContent, 30f, 46f, 1040f, 38f, acc[0], v => acc[0] = v);
+                    UiKit.AddText(oContent, 30f, 100f, 1040f, 22f, shell.L("ui.menu.connect_password"), 15, UiKit.TextCol, TextAnchor.MiddleLeft);
+                    var pwInput = UiKit.AddInput(oContent, 30f, 126f, 1040f, 38f, pw[0], v => pw[0] = v);
                     pwInput.contentType = InputField.ContentType.Password;
-                    UiKit.AddButton(oContent, 30f, 184f, 300f, 54f, shell.L("ui.portal.login"), () => DoLogin(acc[0].Trim(), pw[0]), "btn_join");
-                    UiKit.AddButton(oContent, 370f, 184f, 300f, 54f, shell.L("ui.portal.signup"), OpenSignup, "btn_credits");
-                    var signupHere = UiKit.AddText(oContent, 30f, 260f, 640f, 44f, shell.L("ui.portal.signup_here"), 14, UiKit.CyanDim, TextAnchor.UpperLeft);
+                    UiKit.AddButton(oContent, 30f, 184f, 320f, 54f, shell.L("ui.portal.login"), () => DoLogin(acc[0].Trim(), pw[0]), "btn_join");
+                    UiKit.AddButton(oContent, 370f, 184f, 320f, 54f, shell.L("ui.portal.signup"), OpenSignup, "btn_credits");
+                    var signupHere = UiKit.AddText(oContent, 30f, 260f, 1040f, 44f, shell.L("ui.portal.signup_here"), 14, UiKit.CyanDim, TextAnchor.UpperLeft);
                     signupHere.horizontalOverflow = HorizontalWrapMode.Wrap;
-                    UiKit.AddText(oContent, 30f, 310f, 640f, 24f, PortalBase(), 15, UiKit.Cyan, TextAnchor.UpperLeft, FontStyle.Bold);
+                    UiKit.AddText(oContent, 30f, 310f, 1040f, 24f, PortalBase(), 15, UiKit.Cyan, TextAnchor.UpperLeft, FontStyle.Bold);
                     return;
                 }
 
-                UiKit.AddText(oContent, 30f, 16f, 420f, 26f,
+                UiKit.AddText(oContent, 30f, 18f, 640f, 26f,
                     shell.L("ui.portal.signed_in") + " " + shell.Settings.PortalAccountName, 16, UiKit.Ok, TextAnchor.MiddleLeft, FontStyle.Bold);
-                UiKit.AddButton(oContent, 460f, 8f, 210f, 42f, shell.L("ui.portal.logout"), SignOut, "btn_exit");
+                UiKit.AddButton(oContent, 874f, 8f, 195f, 44f, shell.L("ui.portal.logout"), SignOut, "btn_exit");
 
-                // Everything the portal's My-Worlds page offers, one row of entry points (#269/#270) + the
-                // public-worlds browser (join others' listed worlds — public-browser feature).
-                UiKit.AddButton(oContent, 30f, 54f, 128f, 42f, shell.L("ui.portal.refresh"), DoRefresh, "btn_settings");
-                UiKit.AddButton(oContent, 166f, 54f, 128f, 42f, shell.L("ui.portal.new_world"), OpenCreateWorld, "btn_join");
-                UiKit.AddButton(oContent, 302f, 54f, 128f, 42f, shell.L("ui.portal.public_browse"), OpenPublicBrowse, "btn_credits");
-                UiKit.AddButton(oContent, 438f, 54f, 110f, 42f, shell.L("ui.portal.feedback"), OpenFeedback, "btn_credits");
-                UiKit.AddButton(oContent, 556f, 54f, 114f, 42f, shell.L("ui.portal.account_btn"), OpenAccount, "btn_settings");
+                // Entry points in one uniform 5-column grid (equal width + gap) so the row lines up cleanly.
+                // Columns are reused below: Play sits in the "Feedback" column (663), Manage in the "Konto"
+                // column (874) — so every button shares a column edge with the row above it.
+                const float colW = 195f;
+                float[] col = { 30f, 241f, 452f, 663f, 874f };
+                UiKit.AddButton(oContent, col[0], 54f, colW, 44f, shell.L("ui.portal.refresh"), DoRefresh, "btn_settings");
+                UiKit.AddButton(oContent, col[1], 54f, colW, 44f, shell.L("ui.portal.new_world"), OpenCreateWorld, "btn_join");
+                UiKit.AddButton(oContent, col[2], 54f, colW, 44f, shell.L("ui.portal.public_browse"), OpenPublicBrowse, "btn_credits");
+                UiKit.AddButton(oContent, col[3], 54f, colW, 44f, shell.L("ui.portal.feedback"), OpenFeedback, "btn_credits");
+                UiKit.AddButton(oContent, col[4], 54f, colW, 44f, shell.L("ui.portal.account_btn"), OpenAccount, "btn_settings");
 
                 if (oWorlds.Count == 0)
                 {
-                    var noWorlds = UiKit.AddText(oContent, 30f, 120f, 640f, 48f, shell.L("ui.portal.no_worlds"), 15, UiKit.TextCol, TextAnchor.UpperLeft);
+                    var noWorlds = UiKit.AddText(oContent, 30f, 116f, 1040f, 48f, shell.L("ui.portal.no_worlds"), 15, UiKit.TextCol, TextAnchor.UpperLeft);
                     noWorlds.horizontalOverflow = HorizontalWrapMode.Wrap;
                     return;
                 }
 
-                float ry = 116f;
+                float ry = 112f;
                 foreach (var world in oWorlds)
                 {
                     var w = world; // capture per row (Play joins, Manage opens the owner dialog)
-                    UiKit.AddText(oContent, 30f, ry + 10f, 280f, 26f, w.Name, 17, UiKit.TextCol, TextAnchor.MiddleLeft, FontStyle.Bold);
-                    UiKit.AddText(oContent, 314f, ry + 10f, 100f, 26f, w.Status + (w.HasPassword ? " [PW]" : "") + (w.IsPublic ? " [PUB]" : ""), 13, UiKit.CyanDim, TextAnchor.MiddleLeft);
-                    UiKit.AddButton(oContent, 418f, ry, 118f, 46f, shell.L("ui.portal.play"), () => DoJoinWorld(w.Id), "btn_join");
-                    UiKit.AddButton(oContent, 542f, ry, 128f, 46f, shell.L("ui.portal.manage"), () => OpenManage(w));
+                    UiKit.AddText(oContent, 30f, ry + 10f, 380f, 26f, w.Name, 17, UiKit.TextCol, TextAnchor.MiddleLeft, FontStyle.Bold);
+                    // Status gets its own wide column (420..640) so "starting…" / "running [PW] [PUB]" never
+                    // hides behind the buttons; Play/Manage align with the Feedback/Konto columns above.
+                    var st = UiKit.AddText(oContent, 420f, ry + 10f, 220f, 26f, w.Status + (w.HasPassword ? " [PW]" : "") + (w.IsPublic ? " [PUB]" : ""), 13, UiKit.CyanDim, TextAnchor.MiddleLeft);
+                    st.horizontalOverflow = HorizontalWrapMode.Wrap;
+                    UiKit.AddButton(oContent, col[3], ry, colW, 44f, shell.L("ui.portal.play"), () => DoJoinWorld(w.Id), "btn_join");
+                    UiKit.AddButton(oContent, col[4], ry, colW, 44f, shell.L("ui.portal.manage"), () => OpenManage(w));
                     ry += 56f;
-                    if (ry > 330f) { break; } // quota keeps this short; guard against overflow anyway
+                    if (ry > 384f) { break; } // quota keeps this short; guard against overflow anyway
                 }
             }
 

--- a/data/locales/de.json
+++ b/data/locales/de.json
@@ -866,6 +866,8 @@
   "ui.portal.err_save_file_missing": "Keine Sicherungs-Datei gefunden — lade zuerst eine herunter oder lege sie in den Sicherungs-Ordner.",
   "ui.portal.err_name_reserved": "Dieser Name ist reserviert.",
   "ui.portal.err_name_blocked": "Bitte wähle einen anderen Namen.",
+  "ui.portal.err_name_reserved_hint": "Dieser Spielername ist reserviert. Bitte wähle einen anderen Namen zum Beitreten:",
+  "ui.portal.err_name_blocked_hint": "Dieser Spielername ist nicht erlaubt. Bitte wähle einen anderen Namen zum Beitreten:",
   "ui.portal.err_player_name_invalid": "Spielername: 1-24 druckbare Zeichen.",
   "ui.portal.err_world_not_found": "Welt nicht gefunden.",
   "ui.portal.err_world_start_failed": "Die Welt konnte nicht gestartet werden — bitte gleich nochmal versuchen.",

--- a/data/locales/en.json
+++ b/data/locales/en.json
@@ -865,6 +865,8 @@
   "ui.portal.err_save_file_missing": "No backup file found — download one first or put it into the backup folder.",
   "ui.portal.err_name_reserved": "This name is reserved.",
   "ui.portal.err_name_blocked": "Please choose a different name.",
+  "ui.portal.err_name_reserved_hint": "That player name is reserved. Please choose a different name to join with:",
+  "ui.portal.err_name_blocked_hint": "That player name isn't allowed. Please choose a different name to join with:",
   "ui.portal.err_player_name_invalid": "Player name must be 1-24 printable characters.",
   "ui.portal.err_world_not_found": "World not found.",
   "ui.portal.err_world_start_failed": "The world could not be started — please try again in a moment.",

--- a/src/BlocksBeyondTheStars.WorldHost/WorldHostPortalPages.cs
+++ b/src/BlocksBeyondTheStars.WorldHost/WorldHostPortalPages.cs
@@ -230,6 +230,10 @@ function v(id){return document.getElementById(id).value.trim();}
                 noWorlds = T("Noch keine Welt — erstelle deine erste!", "No world yet — create your first!"),
                 creating = T("Welt wird erstellt…", "Creating world…"),
                 created = T("Welt erstellt! 🚀", "World created! 🚀"),
+                stopping = T("Welt wird gestoppt…", "Stopping the world…"),
+                stopDone = T("Welt gestoppt.", "World stopped."),
+                deleting = T("Welt wird gelöscht…", "Deleting the world…"),
+                delDone = T("Welt gelöscht.", "World deleted."),
                 makePublic = T("Öffentlich listen", "List publicly"),
                 makePrivate = T("Privat machen", "Make private"),
                 publicOn = T("Welt ist jetzt öffentlich sichtbar. 🌍", "World is now public. 🌍"),
@@ -284,6 +288,14 @@ function say(t){
   // The message line lives at the top — surface it when an action further down reports something.
   if(t) m.scrollIntoView({behavior:'smooth', block:'nearest'});
 }
+// Like say(), but with an animated spinner in front — for actions that run in the background (waking,
+// creating, stopping, deleting, uploading) so a slow action never looks like nothing happened. A later
+// say() (success or error) sets textContent, which clears the spinner.
+function busy(t){
+  const m = document.getElementById('msg');
+  m.innerHTML = '<span class=""spin""></span>' + esc(t||'');
+  m.scrollIntoView({behavior:'smooth', block:'nearest'});
+}
 async function api(method, url, body){
   const r = await fetch(url, {method, headers:H, body: body?JSON.stringify(body):undefined});
   if(r.status===401){ location.href='/'; return null; }
@@ -298,10 +310,10 @@ async function load(){
     const d = document.createElement('div'); d.className='card world';
     d.innerHTML = `<h2>${esc(w.name)} ${w.hasPassword?`<span title='${L.pwProtected}'>🔒</span> `:''}${w.isPublic?`<span title='${L.publicBadge}'>🌍</span> `:''}<span class='st ${w.status}'>${L.st[w.status]||w.status}</span></h2>
       <button onclick=""joinWorld('${w.id}')"">${L.play}</button>
-      <button onclick=""stopWorld('${w.id}')"">${L.stop}</button>
+      <button onclick=""stopWorld('${w.id}', this)"">${L.stop}</button>
       <button onclick=""dlSave('${w.id}')"">${L.dlSave}</button>
       <label class='up'>${L.upSave}<input type='file' style='display:none' onchange=""upSave('${w.id}', this.files[0])""></label>
-      <button class='danger' onclick=""delWorld('${w.id}', '${esc(w.name)}')"">${L.del}</button>
+      <button class='danger' onclick=""delWorld('${w.id}', '${esc(w.name)}', this)"">${L.del}</button>
       <details><summary>${L.pw} ${w.hasPassword?'🔒':L.pwOff}</summary>
         <input id='p1-${w.id}' type='password' placeholder='${L.pwNew}' maxlength='24' autocomplete='new-password'>
         <input id='p2-${w.id}' type='password' placeholder='${L.pwRepeat}' maxlength='24' autocomplete='new-password'>
@@ -344,7 +356,7 @@ async function createWorld(){
   if(pw !== pw2){ say(L.pwMismatch); return; }
   // Disable the button + show progress so the create → re-fetch round-trip never looks like a frozen
   // no-op (the new world used to appear only after a manual refresh, #creating-feedback).
-  const btn = document.getElementById('w-create'); btn.disabled = true; say(L.creating);
+  const btn = document.getElementById('w-create'); btn.disabled = true; busy(L.creating);
   const j = await api('POST','/api/worlds',{name: document.getElementById('w-name').value.trim(), password: pw||null});
   if(j){ for(const f of ['w-name','w-pass','w-pass2']) document.getElementById(f).value=''; await load(); say(L.created); }
   btn.disabled = false;
@@ -369,7 +381,7 @@ async function joinWorld(id, pw, grantId){
   if(!name){ say(L.needName); pn.focus(); pn.scrollIntoView({behavior:'smooth', block:'center'}); return; }
   localStorage.setItem('bbs_player_name', name);
   for(;;){
-    say(L.waking);
+    busy(L.waking);
     const r = await fetch(`/api/worlds/${id}/join`, {method:'POST', headers:H, body: JSON.stringify({playerName:name, password: pw||null})});
     if(r.status===401){ location.href='/'; return; }
     let j=null; try{ j=await r.json(); }catch{}
@@ -404,10 +416,18 @@ async function joinWorld(id, pw, grantId){
     return;
   }
 }
-async function stopWorld(id){ if(await api('POST',`/api/worlds/${id}/stop`)) load(); }
-async function delWorld(id,name){
+async function stopWorld(id, btn){
+  // Show progress + disable the button: stopping runs a docker stop in the background, so without this
+  // the click looked like a no-op until the list refreshed (world-lifecycle UX).
+  if(btn) btn.disabled = true; busy(L.stopping);
+  if(await api('POST',`/api/worlds/${id}/stop`)){ await load(); say(L.stopDone); }
+  else if(btn) btn.disabled = false;
+}
+async function delWorld(id, name, btn){
   if(!confirm(L.delConfirm.replace('%s', name))) return;
-  if(await api('DELETE',`/api/worlds/${id}`)!==null) load();
+  if(btn) btn.disabled = true; busy(L.deleting);
+  if(await api('DELETE',`/api/worlds/${id}`)!==null){ await load(); say(L.delDone); }
+  else if(btn) btn.disabled = false;
 }
 async function dlSave(id){
   const r = await fetch(`/api/worlds/${id}/save`, {headers:{'Authorization':'Bearer '+S}});
@@ -417,7 +437,7 @@ async function dlSave(id){
 }
 async function upSave(id, file){
   if(!file) return;
-  say(L.uploading);
+  busy(L.uploading);
   const r = await fetch(`/api/worlds/${id}/save`, {method:'POST', headers:{'Authorization':'Bearer '+S}, body: file});
   let j=null; try{ j=await r.json(); }catch{}
   say(r.ok ? L.upDone : bbsErr(j, L.err));
@@ -673,6 +693,8 @@ a.playnow:hover{{filter:brightness(1.08)}}
 .st.running{{color:#7dff9e;border-color:#2e7d44}} .st.stopped{{color:#9db2cf}} .st.starting{{color:var(--orange);border-color:#7a5218}}
 code{{background:#0a101d;border:1px solid var(--line);border-radius:6px;padding:1px 6px;word-break:break-all}}
 #msg{{margin:10px 0;color:var(--orange);min-height:1.2em;font-weight:600}}
+.spin{{display:inline-block;width:14px;height:14px;margin-right:8px;vertical-align:-2px;border:2px solid var(--line);border-top-color:var(--orange);border-radius:50%;animation:spin .7s linear infinite}}
+@keyframes spin{{to{{transform:rotate(360deg)}}}}
 ul{{line-height:1.6}}
 footer{{max-width:860px;margin:28px auto 0;padding-top:12px;border-top:1px solid var(--line);
  color:#9db2cf;font-size:.9rem;text-align:center}}


### PR DESCRIPTION
Follow-up UX polish to the hosted-worlds flow (game client *Official Worlds* menu + web portal), on top of v0.7.3.

## Changes
- **Loading spinners** for every background action — waking/playing, creating, stopping, deleting, uploading. New reusable `UiKit.AddSpinner` (auto-shows while a status label's text contains `…`); portal gets a CSS spinner via a `busy()` helper.
- **Portal stop/delete feedback** — button disabled + "Stopping…/Deleting…" → "stopped/deleted". Previously looked like nothing happened until the list refreshed (the reported issue).
- **Reserved/blocked player name** on Play → in-place name prompt that retries the join, instead of a dead-end error.
- **Portal Play** reads a prefilled/persisted name field (no pop-up prompt); browser-play button is the primary action, native host/port/token in a `<details>`.
- **Official Worlds window widened (700→1100)** and laid out as a uniform grid: five equal action buttons in one row, per-world Play/Manage aligned with the columns above, and a **wide dedicated status column** so "starting…"/"running [PW] [PUB]" never hides behind the buttons.
- DE/EN locale hints for the name prompt.

Recorded under **[Unreleased]** in CHANGELOG.

## Verification
Local Windows client build ✓ (layout + spinner verified in-game); WorldHost builds ✓. Portal spinner needs a WorldHost redeploy to show live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)