### PR TITLE
Merge own + public worlds into one Official Worlds window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Follow-up polish to the hosted-worlds flow (portal + in-game *Official Worlds* m
 - **Play → clearer name handling in the game client**: if the chosen player name is reserved or not allowed, an in-place prompt lets you pick another name and retries the join, instead of a dead-end error you could only fix from the main menu.
 - **"Play" (portal)** reads a prefilled, remembered player-name field instead of a pop-up prompt; the browser-play button is the clear primary action with the native host/port/token in an expander.
 - **Official Worlds window** widened and laid out as a clean grid: the five action buttons share one uniform row, the per-world Play/Manage buttons line up with the columns above them, and the world **status** ("starting…", "running") gets its own wide column so it never hides behind the buttons.
+- **One window for both world lists (game client)**: public worlds no longer open a second window. The *Official Worlds* screen now shows your own worlds and the public ones in a single scrollable view, split into clearly labelled **"My worlds"** and **"Public worlds"** sections (own worlds are filtered out of the public list).
 
 ## [0.7.3] — 2026-07-07
 

--- a/client/Assets/BlocksBeyondTheStars/Scripts/UiMainMenu.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/UiMainMenu.cs
@@ -281,7 +281,8 @@ namespace BlocksBeyondTheStars.Client
 
             // Content area rebuilt on every state change (signed out ↔ signed in ↔ fresh world list).
             var oContent = UiKit.AddPanel(odlg, 0f, 150f, 1100f, 440f, new Color(0f, 0f, 0f, 0f)).transform;
-            var oWorlds = new List<PortalWorldInfo>();
+            var oWorlds = new List<PortalWorldInfo>();  // the signed-in account's own worlds
+            var oPublic = new List<PortalWorldInfo>();  // public worlds shared by OTHERS (own ones filtered out)
 
             string PortalBase() => string.IsNullOrWhiteSpace(shell.Settings.PortalUrl)
                 ? PortalClient.DefaultPortalUrl
@@ -327,9 +328,27 @@ namespace BlocksBeyondTheStars.Client
                     return;
                 }
 
+                // Also pull the public worlds so both lists show in one window. A failure here is non-fatal:
+                // the public section just stays empty rather than blocking the player's own worlds.
+                var pub = await Task.Run(() => portal.ListPublicWorlds(session));
+                if (official == null) { return; }
+
                 oStatus.text = "";
                 oWorlds.Clear();
                 oWorlds.AddRange(r.Worlds);
+                oPublic.Clear();
+                if (pub.Ok)
+                {
+                    // Hide worlds the player already owns (they appear in "My worlds" above).
+                    foreach (var p in pub.Worlds)
+                    {
+                        if (!oWorlds.Exists(o => o.Id == p.Id))
+                        {
+                            oPublic.Add(p);
+                        }
+                    }
+                }
+
                 RebuildPortal();
             }
 
@@ -653,56 +672,6 @@ namespace BlocksBeyondTheStars.Client
                 warn.color = UiKit.Ok;
                 warn.text = shell.L(makePublic ? "ui.portal.public_on" : "ui.portal.public_off");
                 DoRefresh(); // the list's [PUB] marker + the manage toggle must follow on reopen
-            }
-
-            async void DoRefreshPublic(Transform list, Text status)
-            {
-                var portal = new PortalClient(PortalBase());
-                string session = shell.Settings.PortalSessionToken;
-                var r = await Task.Run(() => portal.ListPublicWorlds(session));
-                if (official == null || list == null) { return; }
-                if (!r.Ok)
-                {
-                    if (r.Code == "unauthorized" || r.Error == "unauthorized") { CloseModal(); SignOut(); return; }
-                    status.text = PortalErr(r.Code, r.Error);
-                    return;
-                }
-
-                for (int i = list.childCount - 1; i >= 0; i--)
-                {
-                    Object.Destroy(list.GetChild(i).gameObject);
-                }
-
-                if (r.Worlds.Count == 0)
-                {
-                    status.text = shell.L("ui.portal.no_public");
-                    return;
-                }
-
-                status.text = "";
-                float ry = 0f;
-                foreach (var world in r.Worlds)
-                {
-                    var w = world; // capture per row for the Play lambda
-                    UiKit.AddText(list, 10f, ry + 10f, 400f, 26f, w.Name + "  [PW]", 17, UiKit.TextCol, TextAnchor.MiddleLeft, FontStyle.Bold);
-                    UiKit.AddText(list, 420f, ry + 10f, 130f, 26f, w.Status, 13, UiKit.CyanDim, TextAnchor.MiddleLeft);
-                    UiKit.AddButton(list, 560f, ry, 160f, 46f, shell.L("ui.portal.play"), () => DoJoinWorld(w.Id), "btn_join");
-                    ry += 56f;
-                    if (ry > 470f) { break; } // dialog list area caps the visible rows
-                }
-            }
-
-            void OpenPublicBrowse()
-            {
-                var pDlg = OpenModalPanel(560f, 180f, 800f, 720f);
-                UiKit.AddText(pDlg, 30f, 24f, 740f, 30f, shell.L("ui.portal.public_browse_title"), 22, UiKit.Cyan, TextAnchor.MiddleCenter, FontStyle.Bold);
-                var pIntro = UiKit.AddText(pDlg, 40f, 62f, 720f, 44f, shell.L("ui.portal.public_intro"), 13, UiKit.CyanDim, TextAnchor.UpperLeft);
-                pIntro.horizontalOverflow = HorizontalWrapMode.Wrap;
-                var pStatus = UiKit.AddText(pDlg, 40f, 112f, 720f, 24f, shell.L("ui.portal.working"), 14, warnCol, TextAnchor.UpperLeft, FontStyle.Bold);
-                pStatus.horizontalOverflow = HorizontalWrapMode.Wrap;
-                var pList = UiKit.AddPanel(pDlg, 30f, 144f, 740f, 476f, new Color(0f, 0f, 0f, 0f)).transform;
-                UiKit.AddButton(pDlg, 250f, 640f, 300f, 54f, shell.L("ui.menu.back"), CloseModal, "btn_exit");
-                DoRefreshPublic(pList, pStatus);
             }
 
             async void DoStopWorld(string worldId, Text warn, Text statusLabel)
@@ -1129,38 +1098,91 @@ namespace BlocksBeyondTheStars.Client
                     shell.L("ui.portal.signed_in") + " " + shell.Settings.PortalAccountName, 16, UiKit.Ok, TextAnchor.MiddleLeft, FontStyle.Bold);
                 UiKit.AddButton(oContent, 874f, 8f, 195f, 44f, shell.L("ui.portal.logout"), SignOut, "btn_exit");
 
-                // Entry points in one uniform 5-column grid (equal width + gap) so the row lines up cleanly.
-                // Columns are reused below: Play sits in the "Feedback" column (663), Manage in the "Konto"
-                // column (874) — so every button shares a column edge with the row above it.
+                // Entry points in a uniform column grid (equal width + gap). Columns are reused by the world
+                // rows below: Play sits in the "Feedback" column (663), Manage in the "Konto" column (874),
+                // so every button shares a column edge with the row above it. Public worlds are no longer a
+                // separate window — they live in the same scroll area below (see "Öffentliche Welten" section).
                 const float colW = 195f;
                 float[] col = { 30f, 241f, 452f, 663f, 874f };
                 UiKit.AddButton(oContent, col[0], 54f, colW, 44f, shell.L("ui.portal.refresh"), DoRefresh, "btn_settings");
                 UiKit.AddButton(oContent, col[1], 54f, colW, 44f, shell.L("ui.portal.new_world"), OpenCreateWorld, "btn_join");
-                UiKit.AddButton(oContent, col[2], 54f, colW, 44f, shell.L("ui.portal.public_browse"), OpenPublicBrowse, "btn_credits");
                 UiKit.AddButton(oContent, col[3], 54f, colW, 44f, shell.L("ui.portal.feedback"), OpenFeedback, "btn_credits");
                 UiKit.AddButton(oContent, col[4], 54f, colW, 44f, shell.L("ui.portal.account_btn"), OpenAccount, "btn_settings");
 
-                if (oWorlds.Count == 0)
+                // Both lists live in ONE scrollable area with section headers + a divider — no second window,
+                // and a clear visual split between the player's own worlds and the public ones.
+                var scrollGo = new GameObject("WorldsScroll", typeof(RectTransform));
+                scrollGo.transform.SetParent(oContent, false);
+                UiKit.Place(scrollGo, 0f, 108f, 1076f, 322f);
+                var scroll = scrollGo.AddComponent<ScrollRect>();
+                scroll.horizontal = false;
+                scroll.vertical = true;
+                scroll.movementType = ScrollRect.MovementType.Clamped;
+                scroll.scrollSensitivity = 28f;
+                scrollGo.AddComponent<RectMask2D>();
+                var hit = scrollGo.AddComponent<Image>();
+                hit.color = new Color(0f, 0f, 0f, 0.001f); // catches wheel/drag over empty areas
+
+                var listGo = new GameObject("Content", typeof(RectTransform));
+                listGo.transform.SetParent(scrollGo.transform, false);
+                var list = listGo.GetComponent<RectTransform>();
+                list.anchorMin = new Vector2(0f, 1f);
+                list.anchorMax = new Vector2(1f, 1f);
+                list.pivot = new Vector2(0.5f, 1f);
+                list.anchoredPosition = Vector2.zero;
+                scroll.viewport = (RectTransform)scrollGo.transform;
+                scroll.content = list;
+
+                float ry = 0f;
+
+                void WorldRow(PortalWorldInfo world, bool owned)
                 {
-                    var noWorlds = UiKit.AddText(oContent, 30f, 116f, 1040f, 48f, shell.L("ui.portal.no_worlds"), 15, UiKit.TextCol, TextAnchor.UpperLeft);
-                    noWorlds.horizontalOverflow = HorizontalWrapMode.Wrap;
-                    return;
+                    var w = world; // capture per row (Play joins; Manage is owner-only)
+                    UiKit.AddText(list, 30f, ry + 8f, 380f, 26f, w.Name, 17, UiKit.TextCol, TextAnchor.MiddleLeft, FontStyle.Bold);
+                    string status = owned
+                        ? w.Status + (w.HasPassword ? " [PW]" : "") + (w.IsPublic ? " [PUB]" : "")
+                        : w.Status + " [PW]"; // public worlds are always password-gated
+                    var st = UiKit.AddText(list, 420f, ry + 8f, 220f, 26f, status, 13, UiKit.CyanDim, TextAnchor.MiddleLeft);
+                    st.horizontalOverflow = HorizontalWrapMode.Wrap;
+                    UiKit.AddButton(list, col[3], ry, colW, 44f, shell.L("ui.portal.play"), () => DoJoinWorld(w.Id), "btn_join");
+                    if (owned)
+                    {
+                        UiKit.AddButton(list, col[4], ry, colW, 44f, shell.L("ui.portal.manage"), () => OpenManage(w));
+                    }
+
+                    ry += 52f;
                 }
 
-                float ry = 112f;
-                foreach (var world in oWorlds)
+                void SectionHeader(string label)
                 {
-                    var w = world; // capture per row (Play joins, Manage opens the owner dialog)
-                    UiKit.AddText(oContent, 30f, ry + 10f, 380f, 26f, w.Name, 17, UiKit.TextCol, TextAnchor.MiddleLeft, FontStyle.Bold);
-                    // Status gets its own wide column (420..640) so "starting…" / "running [PW] [PUB]" never
-                    // hides behind the buttons; Play/Manage align with the Feedback/Konto columns above.
-                    var st = UiKit.AddText(oContent, 420f, ry + 10f, 220f, 26f, w.Status + (w.HasPassword ? " [PW]" : "") + (w.IsPublic ? " [PUB]" : ""), 13, UiKit.CyanDim, TextAnchor.MiddleLeft);
-                    st.horizontalOverflow = HorizontalWrapMode.Wrap;
-                    UiKit.AddButton(oContent, col[3], ry, colW, 44f, shell.L("ui.portal.play"), () => DoJoinWorld(w.Id), "btn_join");
-                    UiKit.AddButton(oContent, col[4], ry, colW, 44f, shell.L("ui.portal.manage"), () => OpenManage(w));
-                    ry += 56f;
-                    if (ry > 384f) { break; } // quota keeps this short; guard against overflow anyway
+                    UiKit.AddText(list, 30f, ry, 600f, 26f, label, 16, UiKit.Cyan, TextAnchor.MiddleLeft, FontStyle.Bold);
+                    ry += 34f;
                 }
+
+                void EmptyHint(string label)
+                {
+                    var t = UiKit.AddText(list, 30f, ry, 1000f, 40f, label, 14, UiKit.CyanDim, TextAnchor.UpperLeft);
+                    t.horizontalOverflow = HorizontalWrapMode.Wrap;
+                    ry += 40f;
+                }
+
+                // Section 1 — the player's own worlds.
+                SectionHeader(shell.L("ui.portal.my_worlds"));
+                if (oWorlds.Count == 0) { EmptyHint(shell.L("ui.portal.no_worlds")); }
+                else { foreach (var world in oWorlds) { WorldRow(world, owned: true); } }
+
+                // Divider between the two sections.
+                ry += 12f;
+                UiKit.AddImage(list, 30f, ry, 1016f, 2f, UiKit.SolidSprite, new Color(UiKit.Cyan.r, UiKit.Cyan.g, UiKit.Cyan.b, 0.28f));
+                ry += 18f;
+
+                // Section 2 — public worlds shared by other players.
+                SectionHeader(shell.L("ui.portal.public_browse_title"));
+                if (oPublic.Count == 0) { EmptyHint(shell.L("ui.portal.no_public")); }
+                else { foreach (var world in oPublic) { WorldRow(world, owned: false); } }
+
+                list.sizeDelta = new Vector2(0f, Mathf.Max(322f, ry + 8f));
+                UiKit.AddVerticalScrollbar(oContent, scroll, 1080f, 108f, 14f, 322f);
             }
 
             RebuildPortal();

--- a/data/locales/de.json
+++ b/data/locales/de.json
@@ -830,6 +830,7 @@
   "ui.portal.account_deleted": "Dein Konto wurde gelöscht.",
   "ui.portal.no_worlds": "Noch keine Welten — erstelle deine erste Welt mit 'Neue Welt'!",
   "ui.portal.public_browse": "Öffentliche Welten",
+  "ui.portal.my_worlds": "Meine Welten",
   "ui.portal.public_browse_title": "ÖFFENTLICHE WELTEN",
   "ui.portal.public_intro": "Von anderen Spielern geteilte Welten. Zum Beitreten brauchst du das Passwort des Erstellers.",
   "ui.portal.no_public": "Gerade keine öffentlichen Welten. Sei die/der Erste — teile eine deiner Welten!",

--- a/data/locales/en.json
+++ b/data/locales/en.json
@@ -829,6 +829,7 @@
   "ui.portal.account_deleted": "Your account was deleted.",
   "ui.portal.no_worlds": "No worlds yet — create your first world with 'New world'!",
   "ui.portal.public_browse": "Public worlds",
+  "ui.portal.my_worlds": "My worlds",
   "ui.portal.public_browse_title": "PUBLIC WORLDS",
   "ui.portal.public_intro": "Worlds shared by other players. You need the creator's password to join.",
   "ui.portal.no_public": "No public worlds right now. Be the first — list one of yours!",


### PR DESCRIPTION
Removes the confusing second window: the *Official Worlds* screen (game client) now shows the player's own worlds **and** the public ones in a single scrollable view, split into clearly labelled **My worlds** / **Public worlds** sections with a divider.

- `DoRefresh` loads both lists in one go; the public list filters out worlds the player already owns (no duplicates).
- Removed the separate *Öffentliche Welten* button + `OpenPublicBrowse` dialog + `DoRefreshPublic`.
- Buttons keep the aligned column grid; status keeps its own wide column.
- New `ui.portal.my_worlds` locale (DE/EN).

Recorded under **[Unreleased]**. Local Windows client build ✓ (verified in-game).

🤖 Generated with [Claude Code](https://claude.com/claude-code)