### PR TITLE
fix: move the guaranteed start data cube off the landing pad

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ A round of new-player and comfort fixes from a hands-on playtest by **Severin**.
 ### 🧭 New-player guidance
 - **The oxygen mechanic is finally visible** — on a breathable world the vitals bar now reads **"Oxygen (breathable)"** so you understand why it never drains here, and a one-time advisor line explains that space, water and toxic worlds will empty your suit tank. (#294)
 - **Finding iron** — the starter mission and the mining tutorial now tell you iron sits just a few blocks underground, so "where's the iron?" has an answer. Ores in general — and iron in particular — are also a bit more common now. (#295)
+- **The first minutes stay yours** — the guaranteed starter data cube no longer glows right beside your ship; it now sits a short walk off the landing pad (~20 blocks), so new players aren't pulled into a minigame before they've even looked around. (#296)
 
 ### 🙌 Credits
 - **Severin** is credited as a playtester (README + in-game credits) for the feedback behind all of the above. (#297)

--- a/TODO.md
+++ b/TODO.md
@@ -6,7 +6,7 @@ plans live under [docs/](docs/) (committed); this file is the high-level status.
 keep it current when controls/features change. Last consolidated 2026-06-04.
 
 **Build:** `scripts/build-client.ps1` (Windows) or `scripts/build-client.sh` (Linux) — publishes shared libs + bundled server + Unity player.
-**Test:** `./scripts/run-tests.sh` — currently **988 server + 118 client passing** (2026-07-07). Locale parity (en/de) is enforced by a test.
+**Test:** `./scripts/run-tests.sh` — currently **989 server + 118 client passing** (2026-07-08). Locale parity (en/de) is enforced by a test.
 CI runs two tiers: PRs skip the 31 tests marked `[Trait("Category", "Slow")]` (~6 min gate); pushes to `main` and the release workflow run the full suite.
 **Conventions:** English docs/comments; in-game text bilingual DE+EN; commit to `main` with the
 Claude `Co-Authored-By` trailer; OpenAI texture + ElevenLabs sound generation is blanket-approved
@@ -108,7 +108,9 @@ chest-deep (`PlayerController.FeetInWater`, #293). Oxygen is **more discoverable
 rates (Normal tank ~285 s, #294). **Iron/ore onboarding**: the starter mission + mine tutorial say iron sits
 a few blocks down, and ores (esp. iron) are a bit more common (per-world richness + iron rarity, #295).
 Severin credited as a playtester (README + in-game credits, #297). No new tests; suite stays 988+118 green,
-local Unity build verified.
+local Unity build verified. Follow-up: the guaranteed start data cube moved off the landing pad (+6/+6 →
++14/+14, ≈20 blocks from the spawn) so it no longer hijacks a new player's first minutes into the minigame
+(#296, +1 placement test → 989).
 
 ### ★ Client-portal parity: signup, create & manage worlds, saves, feedback and account deletion in-game (#268-#270, 2026-07-06)
 The desktop client could only sign in, list and join hosted worlds — creating an account or a world

--- a/src/BlocksBeyondTheStars.GameServer/GameServerDataCubes.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerDataCubes.cs
@@ -95,13 +95,15 @@ public sealed partial class GameServer
             });
         }
 
-        // Singleplayer/admin convenience: drop one guaranteed cube right beside the start world's landing pad,
-        // once per session (so the first world a solo player lands on always has a minigame within reach).
+        // Singleplayer/admin convenience: drop one guaranteed cube near the start world's landing pad, once
+        // per session (so the first world a solo player lands on always has a minigame within reach). It sits
+        // a short walk OFF the pad (+14/+14 ≈ 20 blocks; the pad radius is 8) — at the old +6/+6 it glowed
+        // right beside the ship and hijacked a new player's first minutes into the minigame (#296).
         if (_config.GuaranteeStartDataCube && !_startCubePlaced && _landingPads.Count > 0)
         {
             _startCubePlaced = true;
-            int gx = WorldConstants.WrapX(_landingPads[0].CenterX + 6, _world.Circumference);
-            int gz = _landingPads[0].CenterZ + 6;
+            int gx = WorldConstants.WrapX(_landingPads[0].CenterX + 14, _world.Circumference);
+            int gz = _landingPads[0].CenterZ + 14;
             int gy = _generator.SurfaceHeight(planet, gx, gz);
             _dataCubes.Add(new ServerDataCube
             {

--- a/tests/BlocksBeyondTheStars.Tests/StartDataCubeTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/StartDataCubeTests.cs
@@ -1,0 +1,74 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using System;
+using System.Linq;
+using BlocksBeyondTheStars.Networking.Transport;
+using BlocksBeyondTheStars.Persistence;
+using BlocksBeyondTheStars.Shared.Configuration;
+using BlocksBeyondTheStars.Shared.Content;
+using Xunit;
+using SvGameServer = BlocksBeyondTheStars.GameServer.GameServer;
+
+namespace BlocksBeyondTheStars.Tests;
+
+/// <summary>
+/// The guaranteed start data cube (singleplayer convenience, <see cref="ServerConfig.GuaranteeStartDataCube"/>)
+/// must sit a short walk OFF the landing pad — near enough to discover, far enough that it doesn't hijack a
+/// new player's first minutes into the minigame right beside the ship (#296, Severin playtest).
+/// </summary>
+public sealed class StartDataCubeTests : IDisposable
+{
+    private readonly string _root;
+    private readonly GameContent _content;
+
+    public StartDataCubeTests()
+    {
+        _root = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "bbts_cube_" + Guid.NewGuid().ToString("N"));
+        _content = ContentLoader.LoadFromDirectory(TestPaths.DataDir());
+    }
+
+    public void Dispose()
+    {
+        try { System.IO.Directory.Delete(_root, recursive: true); } catch { /* best effort */ }
+    }
+
+    [Fact]
+    public void GuaranteedStartCube_SitsOffThePad_ButWithinDiscoveryRange()
+    {
+        var repo = new SqliteWorldRepository(new SaveGamePaths(_root, "cube"));
+        var st = new LoopbackServerTransport(new LoopbackLink());
+        var config = new ServerConfig
+        {
+            WorldName = "cube",
+            Seed = 7,
+            AutoSaveIntervalMinutes = 9999,
+            PlaceStarterShip = false,
+            GuaranteeStartDataCube = true,
+        };
+        var server = new SvGameServer(config, _content, st, repo);
+        server.Start();
+        using (repo)
+        {
+            server.AddLocalPlayer("Pilot"); // loads the home body → stamps pads + data cubes
+
+            Assert.True(server.LandingPadCount > 0, "the home body must have landing pads");
+            var pad0 = server.LandingPadCenters[0];
+            Assert.NotEmpty(server.DataCubeSnapshots); // the guarantee must hold even when the world rolls 0 random cubes
+
+            // The guaranteed cube is the one closest to pad 0 (scattered cubes spawn 60+ blocks out).
+            int circumference = server.World.Circumference;
+            double nearest = server.DataCubeSnapshots.Min(c =>
+            {
+                double dx = Math.Abs(c.Pos.X - pad0.X);
+                dx = Math.Min(dx, circumference - dx); // X wraps around the planet
+                double dz = c.Pos.Z - pad0.Z;
+                return Math.Sqrt(dx * dx + dz * dz);
+            });
+
+            // Off the pad (radius 8) with margin — not glowing right beside the ship — but still a short,
+            // discoverable walk from the spawn.
+            Assert.InRange(nearest, 12.0, 40.0);
+        }
+    }
+}


### PR DESCRIPTION
Closes #296 — the last open item from **Severin's** playtest feedback.

## Problem
In singleplayer a guaranteed data cube spawned at landing-pad centre **+6/+6** — inside the pad radius (8), hovering and glowing with an "E: Extract fragment" prompt right beside the ship. A new player circling their ship almost inevitably stumbled into it and opened a minigame before doing anything else.

## Fix
The cube now spawns at **+14/+14** (~20 blocks from the spawn): clearly off the pad and out of the first-minutes bubble, but still a short, discoverable walk away. One-constant change in `GameServerDataCubes.StampDataCubes` with the reasoning documented in the comment.

## Tests
New `StartDataCubeTests.GuaranteedStartCube_SitsOffThePad_ButWithinDiscoveryRange` — asserts the nearest cube to pad 0 lies in the (12, 40] band, wrap-aware in X. Full suite green: **989 server + 118 client**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)