### PR TITLE
docs: add SignPath code signing policy and update security notices

### DIFF
--- a/CODE_SIGNING.md
+++ b/CODE_SIGNING.md
@@ -1,0 +1,47 @@
+# Code Signing Policy
+
+Windows release binaries of **Blocks Beyond the Stars** are digitally signed using a free code
+signing certificate provided by the [**SignPath Foundation**](https://signpath.org), with a
+certificate issued in the name of the SignPath Foundation.
+
+## Official repository
+
+The only official source of Blocks Beyond the Stars is:
+
+<https://github.com/marceld23/BlocksBeyondTheStars>
+
+Signed builds are published exclusively on this project's
+[GitHub Releases](https://github.com/marceld23/BlocksBeyondTheStars/releases) and mirrored to the
+official [itch.io page](https://jumavegames.itch.io/blocks-beyond-the-stars). Binaries obtained from
+anywhere else are not covered by this policy and should not be trusted.
+
+## What is signed, and how
+
+- Only the **Windows installer artifacts** are signed: the per-user installer (`*Setup.exe`), the
+  machine-wide MSI (`*.msi`), and the portable ZIP (`*Portable.zip`).
+- Signing happens **only** inside the automated GitHub Actions release workflow
+  ([`.github/workflows/release.yml`](.github/workflows/release.yml)), which builds exclusively from
+  source in the public repository above. No locally or manually produced binary is ever signed.
+- A signed release is produced only from a version tag (`vX.Y.Z`) pushed by a project maintainer;
+  the same tag is the single source of truth for the version baked into the build.
+- The Linux and (experimental) macOS builds are **not** covered by this certificate. The macOS
+  build is unsigned and un-notarized by design — see the README security notices.
+
+## Who may authorize a release
+
+Releases are authorized and tagged by the project maintainer(s):
+
+- **Marcel Dütscher** ([@marceld23](https://github.com/marceld23))
+
+Maintainer GitHub accounts have two-factor authentication (2FA) enabled.
+
+## Privacy
+
+Code signing is performed by the SignPath service on the build artifacts described above; it does
+not process end-user data. See the [SignPath Foundation privacy policy](https://signpath.org/privacy)
+and this project's [privacy policy](https://www.blocksbeyondthestars.com/en/datenschutz).
+
+## Acknowledgement
+
+Free code signing on Windows is provided by [SignPath.org](https://signpath.org), certificate by the
+[SignPath Foundation](https://signpath.org). Thank you for supporting open-source software. 🙏

--- a/README.md
+++ b/README.md
@@ -185,14 +185,18 @@ NAS or a VPS (including via Docker) can host a world that players join.
 
 ## Windows security notice
 
-This Windows build is **currently not digitally signed**. Because of that, Windows 11 /
-Microsoft Defender SmartScreen may show a warning such as *"Windows protected your PC"* the
-first time you start the game.
+Windows release builds are digitally **code-signed** using a free code-signing certificate provided
+by the [**SignPath Foundation**](https://signpath.org) — see our
+[Code Signing Policy](CODE_SIGNING.md). Only the installers built by this repository's automated
+GitHub Actions release workflow are signed.
 
-If you downloaded the game from this GitHub page (or from the
-[official releases](https://github.com/marceld23/BlocksBeyondTheStars/releases)) and trust the
-source, you can choose **"More info"** and then **"Run anyway"** to start it. If you do not trust
-the download source, do not run the game.
+> **During onboarding:** while our SignPath certificate is being provisioned, some releases may still
+> be unsigned. Until signing is fully live, Windows 11 / Microsoft Defender SmartScreen may show a
+> warning such as *"Windows protected your PC"* the first time you start the game. If you downloaded
+> the game from this GitHub page (or from the
+> [official releases](https://github.com/marceld23/BlocksBeyondTheStars/releases)) and trust the
+> source, you can choose **"More info"** and then **"Run anyway"** to start it. If you do not trust
+> the download source, do not run the game.
 
 Blocks Beyond the Stars uses a local/server-based multiplayer architecture. On first launch,
 **Windows Defender Firewall** may ask for permission more than once — for example for the game
@@ -412,6 +416,10 @@ network, the AGPL requires you to offer them its source code.
 
 Third-party libraries and bundled assets keep their own (permissive) licenses — see
 [NOTICES.md](NOTICES.md).
+
+**Windows code signing** is generously provided free of charge by the
+[SignPath Foundation](https://signpath.org) through their open-source program — thank you! How
+releases are signed is documented in our [Code Signing Policy](CODE_SIGNING.md).
 
 **Our promise to the community:** we guarantee the GitHub version always stays free,
 AGPL-licensed and current. We (the founders) may additionally license the code commercially

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -30,6 +30,12 @@ Things we especially care about:
 The optional AI backend (`ai-backend/`) talks to third-party LLM providers; please report
 anything that could leak credentials or player data.
 
+## Code signing
+
+Windows release binaries are digitally signed via the **SignPath Foundation**. How signing works —
+the official repository, which artifacts are signed, and who may authorize a release — is documented
+in **[CODE_SIGNING.md](CODE_SIGNING.md)**.
+
 ## Supported versions
 
 This is a single actively-developed line of work — security fixes land on `main` and in the


### PR DESCRIPTION
Prepares the [SignPath Foundation](https://signpath.org) free open-source **code signing** application so Windows release binaries can be digitally signed.

## Changes
- **`CODE_SIGNING.md`** (new) — the required code signing policy: official repository, which artifacts are signed and how (only `Setup.exe`/`.msi`/`Portable.zip` from the GitHub Actions release workflow), who may authorize a release (@marceld23, 2FA enabled), privacy note, and SignPath acknowledgement.
- **`README.md`** — "Windows security notice" now names SignPath and links the policy, with a transitional onboarding note while the certificate is being provisioned; adds a SignPath acknowledgement in the License section.
- **`SECURITY.md`** — cross-links the code signing policy.

Docs only — no code or asset changes.

## Follow-up (after SignPath approval + CI signing integration)
- Remove the transitional "during onboarding … still be unsigned" note from the README.
- Wire the SignPath signing step into `.github/workflows/release.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)