### PR TITLE
ci: stop release builds from writing dead tag-scoped caches

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -90,4 +90,7 @@ jobs:
           push: ${{ inputs.push }}
           tags: ${{ steps.img.outputs.tags }}
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # Only non-tag runs export the layer cache: this workflow is workflow_call'ed by release.yml
+          # on tag refs, and tag-scoped caches are unreadable by every other ref — they only crowded
+          # main's caches out of the 10 GB budget. Tag runs still import via cache-from.
+          cache-to: ${{ startsWith(github.ref, 'refs/tags/') && ' ' || 'type=gha,mode=max' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,8 +181,11 @@ jobs:
         shell: pwsh
         run: ./scripts/publish-local-server.ps1 -Runtime win-x64
 
-      - name: Cache Unity Library
-        uses: actions/cache@v5
+      # Restore-only: release runs on tag refs, and a tag-scoped cache can never be restored by any
+      # other ref (not even the next release tag) — writing them only evicted the useful main-scoped
+      # caches from the repo's 10 GB budget. Tag runs still restore main's caches via restore-keys.
+      - name: Restore Unity Library cache
+        uses: actions/cache/restore@v5
         with:
           path: client/Library
           key: Library-${{ hashFiles('client/Assets/**', 'client/Packages/**', 'client/ProjectSettings/**') }}
@@ -285,8 +288,11 @@ jobs:
       - name: Publish bundled local server (linux-x64)
         run: ./scripts/publish-local-server.sh linux-x64
 
-      - name: Cache Unity Library
-        uses: actions/cache@v5
+      # Restore-only: release runs on tag refs, and a tag-scoped cache can never be restored by any
+      # other ref (not even the next release tag) — writing them only evicted the useful main-scoped
+      # caches from the repo's 10 GB budget. Tag runs still restore main's caches via restore-keys.
+      - name: Restore Unity Library cache
+        uses: actions/cache/restore@v5
         with:
           path: client/Library
           key: Library-Linux-${{ hashFiles('client/Assets/**', 'client/Packages/**', 'client/ProjectSettings/**') }}
@@ -393,8 +399,11 @@ jobs:
       - name: Publish bundled local server (osx-x64)
         run: ./scripts/publish-local-server.sh osx-x64
 
-      - name: Cache Unity Library
-        uses: actions/cache@v5
+      # Restore-only: release runs on tag refs, and a tag-scoped cache can never be restored by any
+      # other ref (not even the next release tag) — writing them only evicted the useful main-scoped
+      # caches from the repo's 10 GB budget. Tag runs still restore main's caches via restore-keys.
+      - name: Restore Unity Library cache
+        uses: actions/cache/restore@v5
         with:
           path: client/Library
           key: Library-macOS-${{ hashFiles('client/Assets/**', 'client/Packages/**', 'client/ProjectSettings/**') }}
@@ -482,8 +491,11 @@ jobs:
       - name: Sync shared libs + content (bash)
         run: ./scripts/sync-client-libs.sh
 
-      - name: Cache Unity Library
-        uses: actions/cache@v5
+      # Restore-only: release runs on tag refs, and a tag-scoped cache can never be restored by any
+      # other ref (not even the next release tag) — writing them only evicted the useful main-scoped
+      # caches from the repo's 10 GB budget. Tag runs still restore main's caches via restore-keys.
+      - name: Restore Unity Library cache
+        uses: actions/cache/restore@v5
         with:
           path: client/Library
           key: Library-WebGL-${{ hashFiles('client/Assets/**', 'client/Packages/**', 'client/ProjectSettings/**') }}

--- a/TODO.md
+++ b/TODO.md
@@ -5609,6 +5609,20 @@ is **pre-approved** (keys in `tools/ai-assets/.env`, run via `uv`).
 
 ---
 
+## ✅ Done (2026-07-10): stop release builds from writing dead tag-scoped Actions caches
+The 10 GB Actions cache budget was 99% full; ~7.7 GB were caches scoped to release tags (four Unity
+Library caches up to 2 GB each + ~60 buildkit blobs). A tag-scoped cache can never be restored by any
+other ref — not even the next release tag — so they sped up nothing and LRU-evicted the useful
+main-scoped caches (the actual cause behind slow Unity CI builds, see unity-build-speedup analysis).
+- **release.yml**: the four "Cache Unity Library" steps (Windows/Linux/macOS/WebGL) switched from
+  `actions/cache` to `actions/cache/restore` — tag runs still restore main's caches via restore-keys
+  but no longer write tag-scoped copies.
+- **docker.yml** (workflow_call'ed by release.yml on tags): `cache-to: type=gha` now only exports on
+  non-tag refs; `cache-from` stays, so tagged image builds still import main's layer cache.
+- Unchanged by design: `webgl-only.yml` / `macos-build.yml` (dispatch-only, run on main — they are the
+  useful main-cache writers) and the three image workflows (main-push only).
+- One-off cleanup already done 2026-07-10: 64 tag caches deleted, 7.7 GB freed (2.23 GB main caches kept).
+
 ## ✅ Done (2026-07-10): hosted-worlds onboarding clarity — explain the model to first-timers
 Analysis found the Realms-style model (no open servers; create your own world, password-gate it, list it
 publicly for friends) was enforced everywhere but explained nowhere a first-time user actually looks.


### PR DESCRIPTION
## Problem

The repo''s 10 GB Actions cache budget was 99% full (9.93 GB). ~7.7 GB of it were caches scoped to release tags (v0.7.3/v0.7.4): four Unity Library caches (Windows 2.0 GB, WebGL 1.7 GB, Linux 1.5 GB, macOS 1.1 GB) plus ~60 buildkit blobs.

**A tag-scoped cache can never be restored by any other ref — not even the next release tag** (Actions cache scope = same ref or default branch). So these caches sped up nothing, while LRU eviction pushed the useful *main*-scoped caches out of the budget — the root cause identified in the Unity-build-speedup analysis.

## Changes

- **release.yml** (runs on tag refs): the four "Cache Unity Library" steps (Windows / Linux / macOS / WebGL) switch from `actions/cache@v5` to `actions/cache/restore@v5`. Tag runs still *restore* main''s caches via `restore-keys`, they just stop *writing* dead tag-scoped copies. No step consumed a `cache-hit` output, so restore-only is a drop-in.
- **docker.yml** (workflow_call''ed by release.yml on tags): `cache-to: type=gha,mode=max` now only exports on non-tag refs (whitespace value on tags → build-push-action treats it as unset); `cache-from: type=gha` stays, so tagged image builds still import main''s layer cache.
- **Unchanged by design**: `webgl-only.yml` / `macos-build.yml` (workflow_dispatch-only → run on main and are the useful main-cache writers) and the three image workflows (main-push only).

## One-off cleanup (already done)

All 64 tag-scoped caches were deleted manually today: **7.7 GB freed**, the 24 main-scoped caches (2.23 GB) kept.

## Verification

- Workflow-only change (no runtime code); `actionlint` runs in CI.
- After the next release tag: `gh cache list` should show no new `refs/tags/*` entries, and the release jobs should still log a Library cache restore from the `Library-*` main keys where one exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)