### PR TITLE
docs(changelog): add v0.7.5 (Official Worlds onboarding + SignPath signing)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,26 @@ the richer, screenshot-laden versions live there. `(#123)` references the pull r
 
 ## [Unreleased]
 
-_Nothing yet — [v0.7.4](#074--2026-07-08) is the latest release._
+_Nothing yet — [v0.7.5](#075--2026-07-10) is the latest release._
+
+## [0.7.5] — 2026-07-10
+
+A small onboarding-and-trust release: newcomers now get the hosted-worlds model explained where they actually look, and Windows builds are moving to free, verified code signing. (#301, #302)
+
+### 🌐 "Official Worlds," explained for first-timers
+The game has **no open public servers** — everyone creates their own world, sets a join password, and lists it publicly so friends can find it. That rule was enforced everywhere but never spelled out for someone opening the menu for the first time. Now it is. (#301)
+- **The signed-out Official Worlds screen** opens with a one-line explainer of how online play works: create your own world → set a join password → list it publicly → friends join with the password.
+- **The public worlds list** now shows the note that was written for it but never displayed — these are worlds shared by other players, and you need the creator's password to join.
+- **Creating a world** shows a friends hint right in the dialog: set a join password now, then list the world publicly under *Manage* so friends can find and join it.
+- **The web portal landing page** gains a *"So funktioniert's / How it works"* card with the three steps and the no-open-servers rule, instead of just a one-line tagline before you log in.
+- **The README and user manual** now state the model and the friends-join path up front.
+
+### 🔒 Windows code signing (SignPath)
+- Windows installers are moving to **free, verified code signing** through the [SignPath Foundation](https://signpath.org)'s open-source program, so Microsoft Defender SmartScreen stops flagging them as coming from an "unknown publisher." A new **CODE_SIGNING.md** documents exactly what is signed, from where, and by whom; the README security notice and SECURITY.md link to it. (#302)
+- **During onboarding:** while the certificate is still being provisioned, some builds may remain unsigned and SmartScreen may still warn — the notice explains the one-time *More info → Run anyway* step until signing is fully live.
+
+### 📓 Devblog
+- We keep a **development blog** ([blocksbeyondthestars.com/blog](https://www.blocksbeyondthestars.com/en/blog)) with the story behind the game — it now has its own link in the README header row.
 
 ## [0.7.4] — 2026-07-08
 


### PR DESCRIPTION
Adds the CHANGELOG entry for **v0.7.5** ahead of tagging the release.

Scope since v0.7.4:
- **#301** — explain the hosted-worlds (Official Worlds) model to first-time users (client overlay, portal landing card, README + user manual).
- **#302** — SignPath free Windows code-signing policy + security-notice rewrite.
- Devblog link in README header row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)