### PR TITLE
chore(devblog): add v0.7.5 release post publish date

### DIFF
--- a/tools/devblog/publish_devblog.py
+++ b/tools/devblog/publish_devblog.py
@@ -92,6 +92,7 @@ PUBLISH_DATES = [
     "2026-06-24T19:05:00Z",  # 33 Arcade: 20 Minispiele
     "2026-06-29T17:20:00Z",  # 34 Musik, Sounds und Texturen
     "2026-07-10T17:05:00Z",  # 35 Story-Teaser: Das VEGA-Protokoll (today, after school post)
+    "2026-07-10T21:30:00Z",  # 36 Version 0.7.5 — Official Worlds onboarding + code signing (release day)
 ]
 EN_EXTRA_MINUTES = 5
 


### PR DESCRIPTION
Adds the backdated publish timestamp for the **Version 0.7.5** devblog post (published live in DE+EN). Article bodies + post state remain local (gitignored), matching the existing devblog workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)