### PR TITLE
fix(singleplayer): bundled host ignores stale config/server.json (start world stuck on 'rocky')

### DIFF
--- a/client/Assets/BlocksBeyondTheStars/Scripts/LocalServerLauncher.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/LocalServerLauncher.cs
@@ -176,6 +176,11 @@ namespace BlocksBeyondTheStars.Client
             // Solo/host convenience: guarantee a data cube next to the start landing pad (only this bundled
             // launcher sets it; dedicated/shared servers use the normal random scatter).
             const string startCubeArg = " --guarantee-start-cube true";
+            // Ignore any config/server.json next to the bundled exe: use pure code defaults + the CLI
+            // overrides here. The server writes that file on first run, and the read-only bundle folder is
+            // reused across rebuilds — a leftover (e.g. an old "StartPlanet: rocky") would otherwise be read
+            // verbatim and override current defaults, so a fresh build could still spawn the old start world.
+            const string noConfigArg = " --no-config true";
             // "Creative" world options (only set when the player picked them at creation; the server bakes them
             // into the save on first launch, so they persist regardless of later launches).
             string creativeArgs =
@@ -198,7 +203,7 @@ namespace BlocksBeyondTheStars.Client
             {
                 FileName = exe,
                 Arguments = $"--port {Port} --name \"{serverName}\" --world \"{worldName}\" " +
-                            $"--max-players {Mathf.Max(1, maxPlayers)} --saves \"{saves}\" --data \"{data}\" --usercontent \"{userContent}\"" + viewArg + seedArg + spaceArgs + voiceArg + startCubeArg + creativeArgs + optionArgs + hostArgs,
+                            $"--max-players {Mathf.Max(1, maxPlayers)} --saves \"{saves}\" --data \"{data}\" --usercontent \"{userContent}\"" + viewArg + seedArg + spaceArgs + voiceArg + startCubeArg + noConfigArg + creativeArgs + optionArgs + hostArgs,
                 WorkingDirectory = Path.GetDirectoryName(exe),
                 UseShellExecute = false,
                 CreateNoWindow = true,

--- a/scripts/build-client.ps1
+++ b/scripts/build-client.ps1
@@ -79,6 +79,18 @@ if ($compileFail -or -not $succeeded) {
     Write-Error "Build FAILED ($why). See $log"
 }
 
+# Strip any runtime-generated config from the bundled singleplayer server in the build output. The server
+# writes config/server.json next to itself on first run, and this output folder is reused across rebuilds,
+# so a copy left from an earlier playtest (or an old branch) would ship with the build and be read verbatim,
+# overriding current code defaults (e.g. an old "StartPlanet: rocky" pinning the start world). The bundled
+# host also passes --no-config so it ignores such a file at runtime; this keeps the shipped bytes clean too
+# (publish-client-installer.ps1 packs this folder). Safe: the server regenerates config on demand.
+$bundledConfig = Join-Path $project "$Out/BlocksBeyondTheStars_Data/StreamingAssets/server/config"
+if (Test-Path $bundledConfig) {
+    Remove-Item $bundledConfig -Recurse -Force
+    Write-Host "Stripped stale bundled-server config -> $bundledConfig" -ForegroundColor DarkGray
+}
+
 # Front the player with the loading-splash launcher (it shows an instant "Loading…" splash to cover the black
 # pre-engine startup gap, then starts the player and hands off when its window appears). Built self-contained
 # single-file (compressed) so it needs no .NET runtime on the player's machine, then dropped next to the player

--- a/src/BlocksBeyondTheStars.GameServer/Program.cs
+++ b/src/BlocksBeyondTheStars.GameServer/Program.cs
@@ -13,7 +13,11 @@ using BlocksBeyondTheStars.Shared.Content;
 string installDir = AppContext.BaseDirectory;
 string configPath = Path.Combine(installDir, "config", "server.json");
 
-var config = ServerConfig.Load(configPath);
+// Normally reads (and first-run auto-creates) config/server.json. With --no-config — which the bundled
+// singleplayer host passes — it uses pure code defaults and touches no file, so a stale server.json left
+// in the read-only, reused-across-rebuilds bundle folder can never override current defaults (e.g. the
+// start planet). See ServerConfig.LoadForStartup.
+var config = ServerConfig.LoadForStartup(args, configPath);
 
 // Configuration precedence: server.json < BBS_* environment variables < command line. The env layer
 // is the container channel (Docker/Compose), the CLI is what the in-game singleplayer host passes.

--- a/src/BlocksBeyondTheStars.Shared/Configuration/ServerConfig.cs
+++ b/src/BlocksBeyondTheStars.Shared/Configuration/ServerConfig.cs
@@ -221,6 +221,22 @@ public sealed class ServerConfig
         Converters = { new JsonStringEnumConverter() },
     };
 
+    /// <summary>
+    /// Resolves the startup config. Normally this is <see cref="Load"/> (which reads — and on first run
+    /// auto-creates — <c>config/server.json</c> next to the exe, the documented dedicated-server flow).
+    /// When <c>--no-config</c> is present it returns pure in-memory defaults instead and touches no file.
+    ///
+    /// The bundled singleplayer host passes <c>--no-config</c> (see <c>LocalServerLauncher</c>): its server
+    /// exe lives in the read-only, reused-across-rebuilds bundle folder, where a leftover <c>server.json</c>
+    /// from an earlier run/playtest would otherwise be read verbatim and override newer code defaults such
+    /// as the start planet — the exact reason a freshly-built client could still spawn the old "rocky" start
+    /// world. The host relies purely on code defaults plus its explicit CLI overrides, so it is immune to a
+    /// stale bundled config on every install path (local build, installer, portable, Velopack update).
+    /// Dedicated servers omit the flag and keep the auto-generated, editable <c>config/server.json</c>.
+    /// </summary>
+    public static ServerConfig LoadForStartup(string[]? args, string path)
+        => (args is not null && Array.IndexOf(args, "--no-config") >= 0) ? new ServerConfig() : Load(path);
+
     public static ServerConfig Load(string path)
     {
         if (!File.Exists(path))
@@ -292,6 +308,11 @@ public sealed class ServerConfig
                 case "usercontent":
                 case "user-content":
                     UserContentDir = value; applied.Add("usercontent");
+                    break;
+                case "no-config":
+                    // Handled earlier: ServerConfig.LoadForStartup reads --no-config straight from the raw
+                    // args (before Load) to skip the config file entirely. Recognized here only so its value
+                    // token is consumed and can't shadow a following flag; nothing to apply to this config.
                     break;
                 case "database":
                 case "database-provider":

--- a/tests/BlocksBeyondTheStars.Tests/ServerConfigTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/ServerConfigTests.cs
@@ -231,6 +231,72 @@ public sealed class ServerConfigTests
         });
     }
 
+    // --- Startup config resolution (--no-config): the bundled singleplayer host must ignore any stale
+    // config/server.json next to its exe so it always starts from current code defaults (e.g. StartPlanet). ---
+
+    [Fact]
+    public void LoadForStartup_WithNoConfigFlag_IgnoresExistingFileAndUsesDefaults()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "bbts_noconfig_" + Guid.NewGuid().ToString("N"), "server.json");
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        // A stale file pinning the OLD start planet — exactly the situation that made a fresh build spawn "rocky".
+        new ServerConfig { StartPlanet = "rocky" }.Save(path);
+        var fileBefore = File.ReadAllText(path);
+
+        try
+        {
+            var config = ServerConfig.LoadForStartup(new[] { "--no-config", "true" }, path);
+
+            Assert.Equal("varied", config.StartPlanet); // code default, NOT the file's "rocky"
+            Assert.Equal(fileBefore, File.ReadAllText(path)); // the file is neither read into effect nor rewritten
+        }
+        finally
+        {
+            Directory.Delete(Path.GetDirectoryName(path)!, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void LoadForStartup_WithNoConfigFlag_DoesNotCreateAFileWhenMissing()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "bbts_noconfig_" + Guid.NewGuid().ToString("N"), "server.json");
+
+        var config = ServerConfig.LoadForStartup(new[] { "--no-config", "true" }, path);
+
+        Assert.Equal("varied", config.StartPlanet);
+        Assert.False(File.Exists(path)); // unlike Load(), --no-config never writes a default file
+    }
+
+    [Fact]
+    public void LoadForStartup_WithoutFlag_ReadsTheConfigFile()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "bbts_cfg_" + Guid.NewGuid().ToString("N"), "server.json");
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        new ServerConfig { StartPlanet = "ice" }.Save(path);
+
+        try
+        {
+            var config = ServerConfig.LoadForStartup(new[] { "--port", "31550" }, path); // no --no-config
+            Assert.Equal("ice", config.StartPlanet); // the dedicated-server flow still honours the file
+        }
+        finally
+        {
+            Directory.Delete(Path.GetDirectoryName(path)!, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ApplyCommandLine_NoConfigFlagConsumesItsValueWithoutShadowingTheNextFlag()
+    {
+        // --no-config is a valued flag (" --no-config true") so it must not swallow the following --port.
+        var config = new ServerConfig();
+        var applied = config.ApplyCommandLine(new[] { "--no-config", "true", "--port", "31550" });
+
+        Assert.Equal(31550, config.GameplayPort);
+        Assert.Contains("port", applied);
+        Assert.DoesNotContain("no-config", applied); // recognized no-op, nothing applied to the config
+    }
+
     /// <summary>Sets the given environment variables for the duration of <paramref name="body"/>, then restores them.</summary>
     private static void WithEnvironment(Dictionary<string, string?> vars, Action body)
     {


### PR DESCRIPTION
@
## Problem

A freshly-built client kept spawning the old **rocky** start world in Singleplayer even though the bundled server exe was current (varied start planet shipped in #264).

Root cause: the bundled server writes a default `config/server.json` next to its exe on first run (`ServerConfig.Load`) and reads it verbatim afterwards. The bundle folder is read-only and **reused across rebuilds**, so a leftover file from an earlier playtest (here: `StartPlanet: rocky`, dated weeks before #264) overrode the current code default. The exe was byte-identical to the freshly-published one — only the stale config differed. Deleting it made the same exe log `planet varied`.

`LocalServerLauncher` does not pass `--start-planet`, so the config value wins.

## Fix

- **Root fix** — `ServerConfig.LoadForStartup(args, path)`: normal `Load` (dedicated servers keep their auto-generated, editable `config/server.json` — unchanged, see SELF_HOSTING.md), but pure in-memory defaults when `--no-config` is passed. `LocalServerLauncher` now passes `--no-config`, so the singleplayer host uses code defaults + its explicit CLI overrides and can never be pinned by a stale bundled config — on **any** install path (local build, installer, portable, Velopack update).
- **Build hygiene** — `build-client.ps1` strips the shipped `server/config` from the build output, so locally-built installers (`publish-client-installer.ps1` packs `Build/Windows`) never ship a stale config either.

## Releases

Already safe: each release job builds in a clean CI workspace and never runs the server, so the packaged server is config-less and a fresh install writes a `varied` config on first run; Velopack updates extract each version cleanly. This PR hardens local builds and the portable-zip-overwrite edge case.

## Tests

New `ServerConfigTests`: `--no-config` ignores an existing rocky file, never creates one when missing, still honours the file without the flag, and consumes its value without shadowing the next flag. GameServer builds clean with `-warnaserror`.

Verified end-to-end: the **same** server exe with a planted `rocky` config → `varied` with `--no-config`, `rocky` without.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@