### PR TITLE
build: upgrade server-side stack from .NET 8 to .NET 10 LTS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@
 # release — is still covered by all tests. See the Test step below for details.
 #
 # We target the test projects directly (not the whole .sln) on purpose: the .sln also contains the
-# WinForms launcher (net8.0-windows), which cannot build on the Linux runner. Building the test
+# WinForms launcher (net10.0-windows), which cannot build on the Linux runner. Building the test
 # projects pulls in exactly their dependencies (server/shared/client.core) and nothing Windows-only.
 #
 # Warnings ARE enforced here: the build runs with -warnaserror so any analyzer/compiler warning fails
@@ -62,7 +62,7 @@ jobs:
       - name: Set up .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '10.0.x'
 
       - name: Restore
         run: |
@@ -113,7 +113,7 @@ jobs:
       - name: Set up .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '10.0.x'
 
       - name: dotnet format --verify-no-changes
         run: dotnet format BlocksBeyondTheStars.CI.slnf --verify-no-changes

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -71,7 +71,7 @@ jobs:
         if: matrix.language == 'csharp'
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '10.0.x'
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4

--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '10.0.x'
 
       - name: Sync shared libs + content (bash)
         run: ./scripts/sync-client-libs.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,7 +129,7 @@ jobs:
       - name: Set up .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '10.0.x'
 
       - name: Restore + build test projects
         run: |
@@ -161,7 +161,7 @@ jobs:
       - name: Set up .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '10.0.x'
 
       # StreamingAssets/ (data + web + bundled server) and Plugins/ (shared libs) are gitignored
       # generated content, so they must be produced before the Unity build. pwsh ships on the runner.
@@ -277,7 +277,7 @@ jobs:
       - name: Set up .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '10.0.x'
 
       - name: Sync shared libs + content (bash)
         run: ./scripts/sync-client-libs.sh
@@ -358,7 +358,7 @@ jobs:
       - name: Re-install .NET (disk-cleanup removed it)
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '10.0.x'
 
       - name: Build Linux console launcher
         run: |
@@ -388,7 +388,7 @@ jobs:
       - name: Set up .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '10.0.x'
 
       - name: Sync shared libs + content (bash)
         run: ./scripts/sync-client-libs.sh
@@ -483,7 +483,7 @@ jobs:
       - name: Set up .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '10.0.x'
 
       # Shared libs + content only: the WebGL build strips the bundled native-server StreamingAssets, so no
       # publish-local-server / Velopack steps. sync-client-libs makes data/ present so the build writes the
@@ -574,7 +574,7 @@ jobs:
       - name: Set up .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '10.0.x'
 
       - name: Install Velopack CLI (pinned)
         run: |
@@ -745,7 +745,7 @@ jobs:
       - name: Set up .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '10.0.x'
 
       # Self-contained single-file launcher (same flags as scripts/build-client.ps1) so it needs no
       # .NET runtime on the player's machine. -p:Version stamps it with the same release version.

--- a/.github/workflows/webgl-only.yml
+++ b/.github/workflows/webgl-only.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Set up .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '10.0.x'
 
       # Shared libs + content only (no publish-local-server / Velopack): the browser build strips the
       # bundled native server and has no auto-updater. sync-client-libs makes data/ present so the build

--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,9 @@ backups/
 # Local planning / requirement specs (kept out of the repo by request)
 plans/
 
+# Local media production (book manuscript, raw/edited videos, editing assets; kept local by request)
+/media/
+
 # Generated Unity client content (reproduce via scripts/sync-client-libs.ps1).
 # Ignore synced plugin payloads, but keep hand-written WebGL browser plugins versioned.
 client/Assets/Plugins/*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,12 +24,12 @@ LAN/self-hosting and anti-cheat correct by construction.
 ## Tech stack (decided)
 
 - **Client:** Unity 6 LTS (6000.4.x), C#. Lives in `client/` (open in the Unity Editor). Builds for Windows (WinForms launcher) and Linux (console launcher).
-- **Server:** .NET 8, standalone console host. **No Unity runtime on the server.**
+- **Server:** .NET 10, standalone console host. **No Unity runtime on the server.**
 - **Admin/API:** ASP.NET Core 8 (Minimal API).
 - **DB:** SQLite by default (portable); PostgreSQL later.
 - **Realtime networking:** LiteNetLib (UDP). MessagePack for wire serialization.
 - **Shared/WorldGeneration target `netstandard2.1`** so the *same* code runs in both
-  Unity and the .NET server. Everything else targets `net8.0`.
+  Unity and the .NET server. Everything else targets `net10.0`.
 
 ## Repository layout
 
@@ -42,8 +42,8 @@ src/BlocksBeyondTheStars.GameServer/      authoritative tick loop + console host
 src/BlocksBeyondTheStars.Api/             admin web UI + API
 src/BlocksBeyondTheStars.Tools/           backup/export/debug CLI
 src/BlocksBeyondTheStars.Client.Core/     Unity-free client logic (NetworkClient, ClientWorld), netstandard2.1
-src/BlocksBeyondTheStars.Launcher/        Windows-only WinForms loading-splash launcher (net8.0-windows)
-src/BlocksBeyondTheStars.Launcher.Console/Cross-platform console launcher for Linux (net8.0, SkiaSharp splash)
+src/BlocksBeyondTheStars.Launcher/        Windows-only WinForms loading-splash launcher (net10.0-windows)
+src/BlocksBeyondTheStars.Launcher.Console/Cross-platform console launcher for Linux (net10.0, SkiaSharp splash)
 tests/BlocksBeyondTheStars.Tests/         xUnit tests (server/shared)
 tests/BlocksBeyondTheStars.Client.Tests/  headless client<->server integration (real NetworkClient vs real GameServer)
 client/                         Unity project (incl. Assets/Tests EditMode/PlayMode suites)

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 # the huge Unity client/, bin/obj and .git out of the build).
 
 # ---- build ----
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
 COPY . .
 
@@ -19,7 +19,7 @@ RUN dotnet publish src/BlocksBeyondTheStars.GameServer/BlocksBeyondTheStars.Game
  && cp -r data /app/data
 
 # ---- runtime ----
-FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime
 
 # tini = a proper PID 1 (reaps zombies + forwards signals to the entrypoint). curl = best-effort download
 # of the client downloads from GitHub Releases so the portal's /download (Windows Setup.exe),

--- a/Dockerfile.reports
+++ b/Dockerfile.reports
@@ -9,13 +9,13 @@
 #   docker build -f Dockerfile.reports -t blocks-beyond-the-stars-reports:local .
 
 # ---- build ----
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
 COPY . .
 RUN dotnet publish src/BlocksBeyondTheStars.ReportHost/BlocksBeyondTheStars.ReportHost.csproj -c Release -o /app
 
 # ---- runtime ----
-FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime
 RUN apt-get update \
  && apt-get install -y --no-install-recommends curl ca-certificates \
  && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile.worldhost
+++ b/Dockerfile.worldhost
@@ -9,22 +9,24 @@
 #   docker build -f Dockerfile.worldhost -t blocks-beyond-the-stars-worldhost:local .
 
 # ---- build ----
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
 COPY . .
 RUN dotnet publish src/BlocksBeyondTheStars.WorldHost/BlocksBeyondTheStars.WorldHost.csproj -c Release -o /app
 
 # ---- runtime ----
-FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime
 
 # WorldHost shells out to the docker CLI (DockerCliLauncher) against the HOST's daemon through the
 # mounted /var/run/docker.sock — so it needs the CLI only, never a daemon of its own.
+# The Docker apt repo is derived from /etc/os-release because the base image distro changes across
+# .NET versions (8.0 = Debian bookworm, 10.0 = Ubuntu noble).
 RUN apt-get update \
  && apt-get install -y --no-install-recommends curl ca-certificates gnupg \
  && install -m 0755 -d /etc/apt/keyrings \
- && curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc \
  && . /etc/os-release \
- && echo "deb [signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian ${VERSION_CODENAME} stable" > /etc/apt/sources.list.d/docker.list \
+ && curl -fsSL "https://download.docker.com/linux/${ID}/gpg" -o /etc/apt/keyrings/docker.asc \
+ && echo "deb [signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/${ID} ${VERSION_CODENAME} stable" > /etc/apt/sources.list.d/docker.list \
  && apt-get update \
  && apt-get install -y --no-install-recommends docker-ce-cli \
  && rm -rf /var/lib/apt/lists/*

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Blocks Beyond the Stars is not a traditional indie game—it is an exploration o
 *   **Music & Sound Effects:** Synthesized using AI audio tools.
 *   **Dynamic Storytelling:** Powered by an optional integrated Python LLM backend (FastAPI + LangChain) for real-time NPC/ship-AI dialogue.
 
-**We'd love your help making this game better!** We made this repository Open Source not just to share our AI workflow, but to build it together with you. Whether you're a developer who wants to dig into the Unity 6 / .NET 8 client/server architecture, an artist, a writer, or simply a player with ideas and bug reports — there's a place for you here. Big features, small fixes, balancing tweaks, fresh ideas: all are welcome. Have a look at **[CONTRIBUTING.md](CONTRIBUTING.md)** to get started, or just press **F1** in-game to send feedback. Let's make it great together. 🚀 And if you're not the coding type — no problem at all: a single ⭐ is the easiest way to cheer Justus on and help us grow.
+**We'd love your help making this game better!** We made this repository Open Source not just to share our AI workflow, but to build it together with you. Whether you're a developer who wants to dig into the Unity 6 / .NET 10 client/server architecture, an artist, a writer, or simply a player with ideas and bug reports — there's a place for you here. Big features, small fixes, balancing tweaks, fresh ideas: all are welcome. Have a look at **[CONTRIBUTING.md](CONTRIBUTING.md)** to get started, or just press **F1** in-game to send feedback. Let's make it great together. 🚀 And if you're not the coding type — no problem at all: a single ⭐ is the easiest way to cheer Justus on and help us grow.
 
 ## 🪐 What is it? (The Short Pitch)
 
@@ -181,7 +181,7 @@ NAS or a VPS (including via Docker) can host a world that players join.
   locally. See [SELF_HOSTING.md §10](docs/developer/SELF_HOSTING.md#10-running-in-docker).
 - Lightweight: **no GPU**, modest CPU/RAM. On low-power ARM64 boards prefer an SSD over a
   microSD/eMMC for the world database.
-- From source you only need the **.NET 8 SDK** (see [Build, test, run](#build-test-run)).
+- From source you only need the **.NET 10 SDK** (see [Build, test, run](#build-test-run)).
 
 ## Windows security notice
 
@@ -239,7 +239,7 @@ oxygen, damage, blueprints or travel.
 | Area | Choice |
 |---|---|
 | Client | Unity 6 LTS (6000.4.x), URP + C# (Windows, Linux, experimental macOS) — see [`client/`](client/) |
-| Server | .NET 8, standalone console host (no Unity runtime) |
+| Server | .NET 10, standalone console host (no Unity runtime) |
 | Admin UI | ASP.NET Core 8 minimal API + HTML dashboard |
 | Database | SQLite (default, portable); optional PostgreSQL for hosted realms |
 | Realtime net | LiteNetLib UDP + MessagePack for native clients; WebSocket + JSON envelope for WebGL |
@@ -256,8 +256,8 @@ src/BlocksBeyondTheStars.GameServer/      authoritative tick loop + console host
 src/BlocksBeyondTheStars.Api/             admin web UI + API
 src/BlocksBeyondTheStars.Tools/           validate/info/backup CLI
 src/BlocksBeyondTheStars.Client.Core/     Unity-free client logic (NetworkClient, ClientWorld), netstandard2.1
-src/BlocksBeyondTheStars.Launcher/        Windows-only WinForms loading-splash launcher (net8.0-windows)
-src/BlocksBeyondTheStars.Launcher.Console/Cross-platform console launcher for Linux (net8.0, SkiaSharp splash)
+src/BlocksBeyondTheStars.Launcher/        Windows-only WinForms loading-splash launcher (net10.0-windows)
+src/BlocksBeyondTheStars.Launcher.Console/Cross-platform console launcher for Linux (net10.0, SkiaSharp splash)
 tests/BlocksBeyondTheStars.Tests/         xUnit tests (server/shared)
 tests/BlocksBeyondTheStars.Client.Tests/  headless client<->server integration tests
 client/                         Unity project (scripts + scaffold + Assets/Tests; open in the Unity Editor)
@@ -272,7 +272,7 @@ scripts/                        build-client.ps1 (Windows) + build-client.sh (Li
 
 ## Build, test, run
 
-Requires the **.NET 8 SDK**.
+Requires the **.NET 10 SDK**.
 
 ```powershell
 dotnet build BlocksBeyondTheStars.CI.slnf  # build everything (Linux: use .slnf to skip WinForms launcher)

--- a/TODO.md
+++ b/TODO.md
@@ -98,6 +98,21 @@ Per-item detail lives in the dated work log below.
 
 ---
 
+### ★ Server-side stack upgraded from .NET 8 to .NET 10 LTS (#309, closes #308, 2026-07-12)
+.NET 8 LTS support ends Nov 2026, so all ten `net8.0` projects (server, hosts, launchers, tests) now target
+`net10.0` — the Unity boundary is untouched (`Shared`/`Networking`/`WorldGeneration`/`Client.Core` stay
+`netstandard2.1`, `System.Text.Json` stays 8.0.5 in Shared). Packages: Microsoft.Data.Sqlite 10.0.9,
+Npgsql 10.0.3, Test.Sdk 18.7.0, coverlet 10.0.1, **plus a direct `SQLitePCLRaw.bundle_e_sqlite3` 3.0.3
+override** — the transitive 2.1.11 native sqlite has a known high-severity CVE (GHSA-2m69-gcr7-jv3q) that
+the .NET 10 SDK's transitive audit turns into NU1903 errors under `-warnaserror`. Code fixes the new SDK
+demanded: 8 `object` lock fields → `System.Threading.Lock` (MA0158) and `KnownNetworks` → `KnownIPNetworks`
+(ASPDEPR005, Api + WorldHost). CI workflows on `dotnet-version: 10.0.x`, Docker images on `sdk/aspnet:10.0`;
+**gotcha:** the 10.0 base image is Ubuntu noble (8.0 was Debian bookworm), so `Dockerfile.worldhost` now
+derives the Docker-CLI apt repo from `/etc/os-release` instead of hardcoding `linux/debian`. No action for
+players (bundled server + launchers are self-contained) or the VPS (pulls rebuilt images); local dev needs
+the .NET 10 SDK. Verified: solution `-warnaserror` clean, 993+118 tests green, all three images build, the
+dedicated-server container and the self-contained singleplayer publish both boot and generate a world.
+
 ### ★ Singleplayer start world no longer pinned by a stale bundled server config (#307, 2026-07-11)
 A freshly-built client could still spawn the pre-#264 **rocky** start world: the bundled server auto-writes
 `config/server.json` next to its exe on first run and reads it verbatim afterwards, and the reused build

--- a/TODO.md
+++ b/TODO.md
@@ -12,7 +12,7 @@ CI runs two tiers: PRs skip the 31 tests marked `[Trait("Category", "Slow")]` (~
 Claude `Co-Authored-By` trailer; OpenAI texture + ElevenLabs sound generation is blanket-approved
 (no per-batch gate).
 
-Architecture: Unity 6 (URP since 2026-06-10) client + authoritative .NET 8 server, everything built in
+Architecture: Unity 6 (URP since 2026-06-10) client + authoritative .NET 10 server, everything built in
 code (no scene authoring). One shared world; MessagePack networking for native clients plus a WebGL JSON
 envelope at the WebSocket edge; deterministic seed world-gen; SQLite default persistence with opt-in PostgreSQL.
 
@@ -876,7 +876,7 @@ New [.github/workflows/ci.yml](.github/workflows/ci.yml) runs on every `pull_req
 from the tag-only `release.yml`). On `ubuntu-latest`, **no Unity / no license**: restores, builds and tests the
 two headless suites directly — `tests/BlocksBeyondTheStars.Tests` (Dotnet) + `tests/BlocksBeyondTheStars.Client.Tests`
 (ClientCore) — the same default set as `run-tests.ps1`.
-- **Targets the test projects, not the `.sln`** — the solution's WinForms launcher (`net8.0-windows`) can't build on Linux.
+- **Targets the test projects, not the `.sln`** — the solution's WinForms launcher (`net10.0-windows`) can't build on Linux.
 - **Warnings fail the PR** via `-warnaserror` (local build keeps `TreatWarningsAsErrors=false`; tree is currently 0-warning). `.trx` results uploaded as an artifact.
 - **Docs-only PRs skip the build but stay green** — a `changes` job (`dorny/paths-filter`) gates the `build-test` job; on a docs-only PR (`**/*.md`, `docs/**`, licences, issue/PR templates) `build-test` is skipped and a skipped *required* job counts as a pass, so it never blocks. `data/**` counts as code (it feeds tests). This makes the check **safe to mark required** (unlike a plain `paths-ignore` skip, which would stall a required check).
 - **Unity tiers (`UnityEdit`/`UnityPlay`) stay local** (need the Editor) — run `./scripts/run-tests.ps1 -Suites All` before client-affecting changes.
@@ -949,7 +949,7 @@ Unity-free client logic (`NetworkClient`, `ClientWorld`) was extracted into a ne
 `src/BlocksBeyondTheStars.Client.Core/` so the *same* code runs in the Unity player and in headless tests; the
 Unity layer keeps `UnityEngine.Vector3` call-sites working via `NetworkClientUnityExtensions` (the Core
 `NetworkClient` speaks Shared's `Vector3f`).
-- **Tier 1 — `tests/BlocksBeyondTheStars.Client.Tests/`** (xUnit, net8.0): the real `NetworkClient` drives the
+- **Tier 1 — `tests/BlocksBeyondTheStars.Client.Tests/`** (xUnit, net10.0): the real `NetworkClient` drives the
   real in-process `GameServer` over a `LoopbackLink` (no Unity, no sockets) via `ClientServerHarness` — join,
   chunk streaming, mine→block-change+inventory, craft success, craft-rejected. **5 tests green.**
 - **Tier 1.5 — `client/Assets/Tests/EditMode/`**: in-Editor unit tests — `ClientWorld` round-trips (Unity-safe

--- a/client/README.md
+++ b/client/README.md
@@ -29,7 +29,7 @@ This places `BlocksBeyondTheStars.Shared.dll`, `BlocksBeyondTheStars.WorldGenera
 ### Singleplayer hosting (optional but recommended)
 
 "Singleplayer" launches the bundled dedicated server as a child process bound to loopback
-(Option A — `GameServer`/`Persistence` are net8.0 + native SQLite and can't run inside Unity).
+(Option A — `GameServer`/`Persistence` are net10.0 + native SQLite and can't run inside Unity).
 Publish the server into the client once:
 
 ```powershell

--- a/docs/developer/ARCHITECTURE.md
+++ b/docs/developer/ARCHITECTURE.md
@@ -12,7 +12,7 @@ runtimes** that share code:
 
 - **The Unity 6 client (`client/`) is presentation and input.** It renders the voxel world,
   the ship, space, the UI and audio, and turns the player's actions into *intents*.
-- **The .NET 8 server (`src/`) is the truth of the game world.** It owns the world, players,
+- **The .NET 10 server (`src/`) is the truth of the game world.** It owns the world, players,
   ships, inventory, crafting, combat, travel and persistence. It validates every intent and
   replies with authoritative *state*. No Unity runtime ever runs on the server.
 
@@ -25,20 +25,20 @@ construction.
 
 The .NET solution `BlocksBeyondTheStars.sln` holds eight projects under `src/` plus the
 xUnit test project. Two projects target **`netstandard2.1`** so the *same compiled code* runs
-both inside Unity and on the server; everything else targets **`net8.0`** (the Launcher
-`net8.0-windows`).
+both inside Unity and on the server; everything else targets **`net10.0`** (the Launcher
+`net10.0-windows`).
 
 | Project | Target | Role |
 |---|---|---|
 | `BlocksBeyondTheStars.Shared` | `netstandard2.1` | Data models, data-driven definitions, geometry, localization, protocol DTOs, game rules, story engine. Depends on nothing in the solution. |
 | `BlocksBeyondTheStars.WorldGeneration` | `netstandard2.1` | Seed-deterministic chunk/galaxy/flora/settlement/creature generation. |
 | `BlocksBeyondTheStars.Networking` | `netstandard2.1` | Transport abstraction + concrete transports, message classes, `NetCodec` registry. Refs LiteNetLib + MessagePack; WebGL uses a JSON envelope at the WebSocket edge. |
-| `BlocksBeyondTheStars.Persistence` | `net8.0` | `IWorldRepository` + SQLite/PostgreSQL implementations, savegame paths/snapshots. Refs Microsoft.Data.Sqlite + Npgsql. |
-| `BlocksBeyondTheStars.GameServer` | `net8.0` (Exe) | Authoritative tick loop + console host. |
-| `BlocksBeyondTheStars.Api` | `net8.0` (Web) | ASP.NET Core minimal-API admin/portal/distribution. |
-| `BlocksBeyondTheStars.Tools` | `net8.0` (Exe) | Backup/export/debug CLI. |
-| `BlocksBeyondTheStars.Launcher` | `net8.0-windows` | WinForms + Velopack instant-splash launcher that starts the Unity exe. |
-| `tests/BlocksBeyondTheStars.Tests` | `net8.0` | xUnit tests across all server-side projects. |
+| `BlocksBeyondTheStars.Persistence` | `net10.0` | `IWorldRepository` + SQLite/PostgreSQL implementations, savegame paths/snapshots. Refs Microsoft.Data.Sqlite + Npgsql. |
+| `BlocksBeyondTheStars.GameServer` | `net10.0` (Exe) | Authoritative tick loop + console host. |
+| `BlocksBeyondTheStars.Api` | `net10.0` (Web) | ASP.NET Core minimal-API admin/portal/distribution. |
+| `BlocksBeyondTheStars.Tools` | `net10.0` (Exe) | Backup/export/debug CLI. |
+| `BlocksBeyondTheStars.Launcher` | `net10.0-windows` | WinForms + Velopack instant-splash launcher that starts the Unity exe. |
+| `tests/BlocksBeyondTheStars.Tests` | `net10.0` | xUnit tests across all server-side projects. |
 
 **Dependency direction (no cycles)** — verified from the `.csproj` `ProjectReference`s:
 

--- a/docs/developer/CLIENT_COMPLETION.md
+++ b/docs/developer/CLIENT_COMPLETION.md
@@ -25,7 +25,7 @@ server, unlock cursor).
 
 **Singleplayer hosting = Option A (bundle the server, child process).** `BlocksBeyondTheStars.Shared` /
 `WorldGeneration` / `Networking` are netstandard2.1 and load in Unity directly, but `GameServer` +
-`Persistence` are net8.0 with native SQLite, so they cannot run in the Mono runtime. Instead the
+`Persistence` are net10.0 with native SQLite, so they cannot run in the Mono runtime. Instead the
 published `GameServer` exe is bundled under `StreamingAssets/server/` (`scripts/publish-local-server.ps1`)
 and `LocalServerLauncher` starts it bound to `127.0.0.1` on a free port, then the normal `NetworkClient`
 connects; it is stopped on quit. This uses the real server unchanged, identical to multiplayer.

--- a/docs/developer/CLIENT_TESTING.md
+++ b/docs/developer/CLIENT_TESTING.md
@@ -42,7 +42,7 @@ only reachable from the Unity tiers (1.5 / 2).
 
 ## Tier 1 — headless client ↔ server (`ClientCore`)
 
-`tests/BlocksBeyondTheStars.Client.Tests/` (net8.0, xUnit). It references `Client.Core` **and** the real
+`tests/BlocksBeyondTheStars.Client.Tests/` (net10.0, xUnit). It references `Client.Core` **and** the real
 `GameServer`, and wires them through one `LoopbackLink` — no Unity, no sockets, same authoritative logic as
 the shipping game.
 

--- a/docs/developer/DEVELOPER.md
+++ b/docs/developer/DEVELOPER.md
@@ -66,7 +66,7 @@ tests/BlocksBeyondTheStars.Client.Tests # ClientCore — real NetworkClient ↔ 
 These are the same two suites `run-tests.ps1` / `run-tests.sh` run by default. Two deliberate choices:
 
 - **It targets the test projects directly, not `BlocksBeyondTheStars.sln`.** The solution also contains the
-  WinForms launcher (`net8.0-windows`), which cannot build on the Linux runner; building the test projects
+  WinForms launcher (`net10.0-windows`), which cannot build on the Linux runner; building the test projects
   pulls in exactly their dependencies (server/shared/`Client.Core`/`Launcher.Console`) and nothing Windows-only.
 - **Warnings fail the PR.** The build step runs with **`-warnaserror`**, so any compiler or analyzer warning
   breaks the check — even though the local build keeps `TreatWarningsAsErrors=false`

--- a/docs/developer/LINUX_PORT.md
+++ b/docs/developer/LINUX_PORT.md
@@ -38,7 +38,7 @@ embedding for both targets.
 **Problem:** Windows has a WinForms loading-splash launcher (`src/BlocksBeyondTheStars.Launcher/`) — it
 shows a graphical splash, runs Velopack hooks, then launches the Unity player. WinForms doesn't run on Linux.
 
-**Solution:** A new `src/BlocksBeyondTheStars.Launcher.Console/` project (net8.0, cross-platform) replaces it
+**Solution:** A new `src/BlocksBeyondTheStars.Launcher.Console/` project (net10.0, cross-platform) replaces it
 on Linux:
 
 - **Program.cs:** runs Velopack lifecycle hooks, prints "Loading..." to the terminal, starts the Unity
@@ -67,8 +67,8 @@ The `release.yml` workflow gained two new jobs alongside the existing Windows jo
 - **package-linux:** packages the Linux player with Velopack (`vpk`) into an AppImage + portable zip,
   published to the GitHub Release
 
-The `BlocksBeyondTheStars.CI.slnf` solution filter now includes `Launcher.Console` (it targets plain net8.0
-and builds on Linux, unlike the WinForms launcher which is net8.0-windows).
+The `BlocksBeyondTheStars.CI.slnf` solution filter now includes `Launcher.Console` (it targets plain net10.0
+and builds on Linux, unlike the WinForms launcher which is net10.0-windows).
 
 **Execute-bit fix:** GitHub's `upload-/download-artifact` strips the Unix execute bit, so after the player
 artifact round-trips into `package-linux` the bundled local server (and the player binary) lose `+x`.
@@ -84,7 +84,7 @@ See [DEVELOPER.md](DEVELOPER.md) (§ Building the Linux client) for the full gui
 Quick start:
 
 ```bash
-# Prerequisites: Unity 6000.4.x Linux Editor + .NET 8 SDK
+# Prerequisites: Unity 6000.4.x Linux Editor + .NET 10 SDK
 
 # One-command full build:
 ./scripts/build-client.sh --unity-path /path/to/Unity

--- a/docs/developer/MACOS_BUILD.md
+++ b/docs/developer/MACOS_BUILD.md
@@ -82,7 +82,7 @@ the bundle).
 ## How to build locally
 
 ```bash
-# Prerequisites: Unity 6000.4.x with the Mac-Mono build module + .NET 8 SDK
+# Prerequisites: Unity 6000.4.x with the Mac-Mono build module + .NET 10 SDK
 ./scripts/sync-client-libs.sh
 ./scripts/sync-velopack-libs.sh
 ./scripts/publish-local-server.sh osx-x64

--- a/docs/developer/SELF_HOSTING.md
+++ b/docs/developer/SELF_HOSTING.md
@@ -13,7 +13,7 @@ Download or build a package for your platform:
 | Linux x64 | `blocks-beyond-the-stars-server-linux-x64.zip` |
 | Linux ARM64 | `blocks-beyond-the-stars-server-linux-arm64.zip` |
 
-Build them yourself from a checkout with the .NET 8 SDK:
+Build them yourself from a checkout with the .NET 10 SDK:
 
 ```powershell
 ./scripts/publish-server.ps1                 # Windows
@@ -138,7 +138,7 @@ loopback bind and shows a warning in the status. Live operations on a *running* 
 
 From a source checkout the same UI runs with
 `dotnet run --project src/BlocksBeyondTheStars.Api`. Note that it then resolves
-`config/server.json` relative to its **own build folder** (`bin/Debug/net8.0/`), not the
+`config/server.json` relative to its **own build folder** (`bin/Debug/net10.0/`), not the
 game server's — for a shared config run both executables from one published install
 directory.
 
@@ -351,7 +351,7 @@ or a VPS. The **game client stays Windows-only** — the container hosts the ser
 installer out via `/download`.
 
 **One image, asymmetric processes.** [`Dockerfile`](../../Dockerfile) publishes the headless projects
-onto the .NET 8 ASP.NET runtime image and runs them through
+onto the .NET 10 ASP.NET runtime image and runs them through
 [`docker/entrypoint.sh`](../../docker/entrypoint.sh) under `tini` (PID 1). The split is deliberate:
 
 - the **game server** is the critical foreground process — it receives the shutdown signal and saves

--- a/docs/developer/adr/0001-authoritative-dotnet-server.md
+++ b/docs/developer/adr/0001-authoritative-dotnet-server.md
@@ -3,6 +3,9 @@
 - **Status:** Accepted
 - **Date:** 2026-05-30
 - **Context source:** `technische_anforderungen.md`
+- **Amendment (2026-07-12):** all `net8.0` projects retargeted to `net10.0` (LTS; .NET 8
+  support ends Nov 2026). The decision itself is unchanged; ".NET 8" below reflects the
+  version at the time of writing. Shared libraries stay `netstandard2.1`.
 
 ## Context
 

--- a/docs/developer/adr/0005-bundled-singleplayer-child-process-server.md
+++ b/docs/developer/adr/0005-bundled-singleplayer-child-process-server.md
@@ -3,6 +3,8 @@
 - **Status:** Accepted
 - **Date:** 2026-06-19
 - **Context source:** `CLIENT_COMPLETION.md`, `ARCHITECTURE.md`
+- **Amendment (2026-07-12):** server projects retargeted `net8.0` → `net10.0` (see ADR 0001
+  amendment). The Mono-boundary reasoning below is unchanged — it applies to any modern .NET.
 
 ## Context
 

--- a/src/BlocksBeyondTheStars.Api/BlocksBeyondTheStars.Api.csproj
+++ b/src/BlocksBeyondTheStars.Api/BlocksBeyondTheStars.Api.csproj
@@ -6,7 +6,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/src/BlocksBeyondTheStars.Api/Program.cs
+++ b/src/BlocksBeyondTheStars.Api/Program.cs
@@ -27,7 +27,7 @@ builder.WebHost.UseUrls($"http://{startupConfig.AdminBindAddress}:{startupConfig
 builder.Services.Configure<ForwardedHeadersOptions>(options =>
 {
     options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto | ForwardedHeaders.XForwardedHost;
-    options.KnownNetworks.Clear();
+    options.KnownIPNetworks.Clear();
     options.KnownProxies.Clear();
 });
 

--- a/src/BlocksBeyondTheStars.GameServer/BlocksBeyondTheStars.GameServer.csproj
+++ b/src/BlocksBeyondTheStars.GameServer/BlocksBeyondTheStars.GameServer.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
     <ProjectReference Include="..\BlocksBeyondTheStars.Shared\BlocksBeyondTheStars.Shared.csproj" />
@@ -9,7 +9,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/BlocksBeyondTheStars.GameServer/GameServerMaintenance.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerMaintenance.cs
@@ -25,7 +25,7 @@ public sealed partial class GameServer
     /// leaves the transport before it shuts down.</summary>
     private const double MaintenanceStopFlushSeconds = 2.0;
 
-    private readonly object _maintenanceGate = new();
+    private readonly Lock _maintenanceGate = new();
     private MaintenanceNotice? _maintenancePending;
 
     private double _maintenanceRemaining = -1; // < 0 = no countdown active

--- a/src/BlocksBeyondTheStars.GameServer/IGameLogger.cs
+++ b/src/BlocksBeyondTheStars.GameServer/IGameLogger.cs
@@ -16,7 +16,7 @@ public interface IGameLogger
     Justification = "Process-lifetime logger; the optional log file uses AutoFlush and its handle is released when the host process exits. Making it IDisposable would force a dispose obligation on every long-lived call site without benefit.")]
 public sealed class ConsoleGameLogger : IGameLogger
 {
-    private readonly object _gate = new();
+    private readonly Lock _gate = new();
     private readonly TextWriter? _file;
 
     public ConsoleGameLogger(string? logFilePath = null)

--- a/src/BlocksBeyondTheStars.Launcher.Console/BlocksBeyondTheStars.Launcher.Console.csproj
+++ b/src/BlocksBeyondTheStars.Launcher.Console/BlocksBeyondTheStars.Launcher.Console.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AssemblyName>BlocksBeyondTheStars.Launcher.Console</AssemblyName>

--- a/src/BlocksBeyondTheStars.Launcher/BlocksBeyondTheStars.Launcher.csproj
+++ b/src/BlocksBeyondTheStars.Launcher/BlocksBeyondTheStars.Launcher.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/src/BlocksBeyondTheStars.Persistence/BlocksBeyondTheStars.Persistence.csproj
+++ b/src/BlocksBeyondTheStars.Persistence/BlocksBeyondTheStars.Persistence.csproj
@@ -1,16 +1,18 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
     <ProjectReference Include="..\BlocksBeyondTheStars.Shared\BlocksBeyondTheStars.Shared.csproj" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.10" />
-    <PackageReference Include="Npgsql" Version="8.0.6" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.9" />
+    <!-- Override the transitive SQLitePCLRaw 2.1.11 bundle: its native e_sqlite3 has a known CVE (GHSA-2m69-gcr7-jv3q, NU1903). -->
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
+    <PackageReference Include="Npgsql" Version="10.0.3" />
   </ItemGroup>
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/BlocksBeyondTheStars.Persistence/CrashReportWriter.cs
+++ b/src/BlocksBeyondTheStars.Persistence/CrashReportWriter.cs
@@ -37,7 +37,7 @@ public sealed class CrashReportWriter
     private readonly string _directory;
     private readonly string _worldName;
     private readonly string _version;
-    private readonly object _gate = new();
+    private readonly Lock _gate = new();
     private int _seq;
 
     /// <param name="directory">Folder reports are written to (created on demand). Empty disables writing.</param>

--- a/src/BlocksBeyondTheStars.Persistence/PostgreSqlWorldRepository.cs
+++ b/src/BlocksBeyondTheStars.Persistence/PostgreSqlWorldRepository.cs
@@ -20,7 +20,7 @@ public sealed class PostgreSqlWorldRepository : IWorldRepository
     private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = false };
 
     private readonly SaveGamePaths _paths;
-    private readonly object _gate = new();
+    private readonly Lock _gate = new();
     private NpgsqlConnection? _connection;
     private readonly string _connectionString;
     private readonly string _schemaName;

--- a/src/BlocksBeyondTheStars.Persistence/SqliteWorldRepository.cs
+++ b/src/BlocksBeyondTheStars.Persistence/SqliteWorldRepository.cs
@@ -20,7 +20,7 @@ public sealed class SqliteWorldRepository : IWorldRepository
     private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = false };
 
     private readonly SaveGamePaths _paths;
-    private readonly object _gate = new();
+    private readonly Lock _gate = new();
     private SqliteConnection? _connection;
     // True while a RunInTransaction batch is open (manual BEGIN/COMMIT via raw SQL — all the per-row write
     // commands then run inside it at the SQLite level without each needing a SqliteTransaction object).

--- a/src/BlocksBeyondTheStars.ReportHost/BlocksBeyondTheStars.ReportHost.csproj
+++ b/src/BlocksBeyondTheStars.ReportHost/BlocksBeyondTheStars.ReportHost.csproj
@@ -1,11 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.10" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.9" />
+    <!-- Override the transitive SQLitePCLRaw 2.1.11 bundle: its native e_sqlite3 has a known CVE (GHSA-2m69-gcr7-jv3q, NU1903). -->
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
   </ItemGroup>
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/src/BlocksBeyondTheStars.ReportHost/IngestRateLimiter.cs
+++ b/src/BlocksBeyondTheStars.ReportHost/IngestRateLimiter.cs
@@ -10,7 +10,7 @@ namespace BlocksBeyondTheStars.ReportHost;
 /// </summary>
 public sealed class IngestRateLimiter
 {
-    private readonly object _gate = new();
+    private readonly Lock _gate = new();
     private readonly Dictionary<string, (long WindowMinute, int Count)> _counters = new(StringComparer.Ordinal);
     private readonly int _perMinute;
 

--- a/src/BlocksBeyondTheStars.ReportHost/ReportStore.cs
+++ b/src/BlocksBeyondTheStars.ReportHost/ReportStore.cs
@@ -45,7 +45,7 @@ public static class BugReportStatus
 /// </summary>
 public sealed class ReportStore : IDisposable
 {
-    private readonly object _gate = new();
+    private readonly Lock _gate = new();
     private readonly SqliteConnection _db;
     private readonly string _screenshotsDir;
 

--- a/src/BlocksBeyondTheStars.Tools/BlocksBeyondTheStars.Tools.csproj
+++ b/src/BlocksBeyondTheStars.Tools/BlocksBeyondTheStars.Tools.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
     <ProjectReference Include="..\BlocksBeyondTheStars.Shared\BlocksBeyondTheStars.Shared.csproj" />
@@ -8,7 +8,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/BlocksBeyondTheStars.WorldHost/BlocksBeyondTheStars.WorldHost.csproj
+++ b/src/BlocksBeyondTheStars.WorldHost/BlocksBeyondTheStars.WorldHost.csproj
@@ -5,11 +5,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.10" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.9" />
+    <!-- Override the transitive SQLitePCLRaw 2.1.11 bundle: its native e_sqlite3 has a known CVE (GHSA-2m69-gcr7-jv3q, NU1903). -->
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
   </ItemGroup>
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/src/BlocksBeyondTheStars.WorldHost/HostRegistry.cs
+++ b/src/BlocksBeyondTheStars.WorldHost/HostRegistry.cs
@@ -78,7 +78,7 @@ public sealed class HostRegistry : IDisposable
 
     private static readonly Regex WorldIdRx = new("^[a-f0-9]{12}$", RegexOptions.Compiled, TimeSpan.FromSeconds(1));
 
-    private readonly object _gate = new();
+    private readonly Lock _gate = new();
     private readonly SqliteConnection _db;
     private readonly WorldHostConfig _config;
 

--- a/src/BlocksBeyondTheStars.WorldHost/Program.cs
+++ b/src/BlocksBeyondTheStars.WorldHost/Program.cs
@@ -36,7 +36,7 @@ builder.WebHost.UseUrls($"http://{config.BindAddress}:{config.Port}");
 builder.Services.Configure<ForwardedHeadersOptions>(options =>
 {
     options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
-    options.KnownNetworks.Clear();
+    options.KnownIPNetworks.Clear();
     options.KnownProxies.Clear();
 });
 

--- a/tests/BlocksBeyondTheStars.Client.Tests/BlocksBeyondTheStars.Client.Tests.csproj
+++ b/tests/BlocksBeyondTheStars.Client.Tests/BlocksBeyondTheStars.Client.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <!--
     Headless client↔server integration tests: they drive the REAL Unity-free NetworkClient
@@ -8,7 +8,7 @@
     See docs/developer/CLIENT_TESTING.md.
   -->
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -17,8 +17,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="coverlet.collector" Version="10.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="xunit" Version="2.5.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
   </ItemGroup>

--- a/tests/BlocksBeyondTheStars.Tests/BlocksBeyondTheStars.Tests.csproj
+++ b/tests/BlocksBeyondTheStars.Tests/BlocksBeyondTheStars.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="Npgsql" Version="8.0.6" />
+    <PackageReference Include="coverlet.collector" Version="10.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="Npgsql" Version="10.0.3" />
     <PackageReference Include="xunit" Version="2.5.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
   </ItemGroup>


### PR DESCRIPTION
Closes #308.

## Why

.NET 8 LTS support ends **November 2026**; .NET 10 is the current LTS (supported until Nov 2028). The .NET 10 SDK's transitive NuGet audit also surfaced a known high-severity CVE in the SQLite native bundle we were shipping (GHSA-2m69-gcr7-jv3q) — fixed here via a direct `SQLitePCLRaw.bundle_e_sqlite3` 3.0.3 override.

## What changed

- **Retarget `net8.0` → `net10.0`** for all 10 server-side/launcher/test projects; the WinForms Launcher goes `net8.0-windows` → `net10.0-windows`. The Unity boundary is untouched: `Shared`, `Networking`, `WorldGeneration`, `Client.Core` stay `netstandard2.1`, and `System.Text.Json` stays pinned at 8.0.5 in Shared.
- **Packages:** Microsoft.Data.Sqlite → 10.0.9, Npgsql → 10.0.3, Microsoft.NET.Test.Sdk → 18.7.0, coverlet.collector → 10.0.1, plus the SQLitePCLRaw 3.0.3 override (NU1903).
- **Code (required by `-warnaserror` on the new SDK):** 8 `object` lock fields → `System.Threading.Lock` (MA0158); `ForwardedHeadersOptions.KnownNetworks` → `KnownIPNetworks` in Api + WorldHost (ASPDEPR005).
- **CI/CD:** `dotnet-version: 10.0.x` in all five workflows; Docker base images → `sdk:10.0`/`aspnet:10.0`.
- **Dockerfile.worldhost gotcha:** the 10.0 base image is **Ubuntu noble**, not Debian — the hardcoded `download.docker.com/linux/debian` apt repo 404'd. The repo is now derived from `/etc/os-release`.
- **Docs** updated to .NET 10; ADR 0001/0005 get amendment notes (bodies stay historical).

## No action needed for

- **Players** — bundled singleplayer server and both launchers are self-contained (runtime included).
- **VPS** — it only pulls the rebuilt images.
- Local dev needs the .NET 10 SDK.

## Verification

- Full solution builds with `-warnaserror` — 0 warnings
- Server suite **993/993**, client-core suite **118/118** green on net10
- All three Docker images build; the dedicated-server container boots on the new Ubuntu-based runtime and generates a world on SQLite
- Self-contained single-file singleplayer publish (win-x64) boots and generates a world — validates the new SQLitePCLRaw 3.0.3 native bundle end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)