### PR TITLE
chore(devblog): add v0.7.6 release post publish date

### DIFF
--- a/tools/devblog/publish_devblog.py
+++ b/tools/devblog/publish_devblog.py
@@ -94,6 +94,7 @@ PUBLISH_DATES = [
     "2026-07-10T17:05:00Z",  # 35 Story-Teaser: Das VEGA-Protokoll (today, after school post)
     "2026-07-10T22:00:00Z",  # 36 Baumhaus-Prinzip (right after the v0.7.5 news; file order!)
     "2026-07-10T21:30:00Z",  # 37 Version 0.7.5 news (already live; sits after the export section in the md)
+    "2026-07-12T20:30:00Z",  # 38 Version 0.7.6 news (already live; posted right after the v0.7.6 release)
 ]
 EN_EXTRA_MINUTES = 5
 


### PR DESCRIPTION
Records the publish date of the v0.7.6 release post (DE 2026-07-12 20:30 UTC, EN +5 min) in the PUBLISH_DATES table, matching the convention of the v0.7.5 and Baumhaus entries. Both posts are live on the blog (DE + EN, linked via translationId).

🤖 Generated with [Claude Code](https://claude.com/claude-code)