### PR TITLE
fix: eight bugs from the 2026-07 code audit

### DIFF
--- a/client/Assets/BlocksBeyondTheStars/Scripts/GameBootstrap.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/GameBootstrap.cs
@@ -1384,9 +1384,9 @@ namespace BlocksBeyondTheStars.Client
             for (int i = 0; i < _unloadScratch.Count; i++)
             {
                 var coord = _unloadScratch[i];
-                if (_chunkObjects.TryGetValue(coord, out var view) && view?.Go != null)
+                if (_chunkObjects.TryGetValue(coord, out var view))
                 {
-                    Destroy(view.Go);
+                    DestroyChunkView(view); // frees the chunk's meshes too, not just the GameObject
                 }
 
                 _chunkObjects.Remove(coord);
@@ -1462,6 +1462,33 @@ namespace BlocksBeyondTheStars.Client
         }
 
         /// <summary>The active world changed (travel): drop all chunks/meshes so the new planet streams in.</summary>
+        /// <summary>Destroys a chunk's GameObject AND its procedurally-built render + collision meshes. Unity
+        /// does NOT free a MeshFilter/MeshCollider's sharedMesh when the GameObject is destroyed, so without
+        /// this every unloaded chunk (far-chunk eviction, world reset) orphans two per-chunk meshes — native
+        /// memory that is never reclaimed and grows across a long session.</summary>
+        private void DestroyChunkView(ChunkView view)
+        {
+            if (view == null)
+            {
+                return;
+            }
+
+            if (view.Filter != null && view.Filter.sharedMesh != null)
+            {
+                Destroy(view.Filter.sharedMesh);
+            }
+
+            if (view.Collider != null && view.Collider.sharedMesh != null)
+            {
+                Destroy(view.Collider.sharedMesh);
+            }
+
+            if (view.Go != null)
+            {
+                Destroy(view.Go);
+            }
+        }
+
         private void OnWorldReset(BlocksBeyondTheStars.Networking.Messages.WorldReset m)
         {
             LocationName = string.IsNullOrEmpty(m.SystemName) ? m.PlanetName : $"{m.SystemName} · {m.PlanetName}";
@@ -1480,8 +1507,9 @@ namespace BlocksBeyondTheStars.Client
                     // the *old* world this frame, "find ground", release early, and drop the player into the
                     // void before the new world's floor chunk has streamed in (the station-boarding fall).
                     view.Go.SetActive(false);
-                    Destroy(view.Go);
                 }
+
+                DestroyChunkView(view); // frees the chunk's render + collision meshes, not just the GameObject
             }
 
             _chunkObjects.Clear();
@@ -1846,9 +1874,11 @@ namespace BlocksBeyondTheStars.Client
             var mcol = view!.Collider;
             if (collider == null)
             {
-                if (mcol != null)
+                if (mcol != null && mcol.sharedMesh != null)
                 {
+                    var stale = mcol.sharedMesh; // chunk became all-fluid/air — free the outgoing collision mesh
                     mcol.sharedMesh = null;
+                    Destroy(stale);
                 }
             }
             else
@@ -1859,7 +1889,12 @@ namespace BlocksBeyondTheStars.Client
                 // frame, so the spawn ground-check raycast finds footing and the player never falls through.
                 if (mcol != null)
                 {
+                    var oldWebgl = mcol.sharedMesh; // freshly cooked each remesh — free the previous one (leak otherwise)
                     mcol.sharedMesh = collider;
+                    if (oldWebgl != null && oldWebgl != collider)
+                    {
+                        Destroy(oldWebgl);
+                    }
                 }
 #else
                 var meshId = collider.GetEntityId();
@@ -1898,7 +1933,13 @@ namespace BlocksBeyondTheStars.Client
                     var mc = view.Collider;
                     if (mc != null)
                     {
+                        var old = mc.sharedMesh; // collider meshes are always freshly cooked (never reused) —
                         mc.sharedMesh = baked.Collider; // cook cached by BakeMesh → cheap assign, no main-thread stall
+                        if (old != null && old != baked.Collider)
+                        {
+                            Destroy(old); // …so the outgoing one is orphaned unless we free it (leak on every remesh)
+                        }
+
                         assigned = true;
                     }
                 }

--- a/client/Assets/BlocksBeyondTheStars/Scripts/LandedShipView.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/LandedShipView.cs
@@ -108,7 +108,13 @@ namespace BlocksBeyondTheStars.Client
             {
                 if (_roots[id] != null)
                 {
-                    Destroy(_roots[id]);
+                    var root = _roots[id];
+                    for (int i = root.transform.childCount - 1; i >= 0; i--)
+                    {
+                        DestroyShipChunk(root.transform.GetChild(i).gameObject); // free the ship's chunk meshes
+                    }
+
+                    Destroy(root);
                 }
 
                 _roots.Remove(id);
@@ -129,6 +135,31 @@ namespace BlocksBeyondTheStars.Client
             }
         }
 
+        /// <summary>Destroys a ship-chunk GameObject AND the fresh render + collision meshes ChunkMesher.Build
+        /// allocated for it — Unity does not free a MeshFilter/MeshCollider's sharedMesh with the GameObject, so
+        /// each ship re-mesh or removal would otherwise leak two meshes per chunk.</summary>
+        private void DestroyShipChunk(GameObject go)
+        {
+            if (go == null)
+            {
+                return;
+            }
+
+            var mf = go.GetComponent<MeshFilter>();
+            if (mf != null && mf.sharedMesh != null)
+            {
+                Destroy(mf.sharedMesh);
+            }
+
+            var mc = go.GetComponent<MeshCollider>();
+            if (mc != null && mc.sharedMesh != null)
+            {
+                Destroy(mc.sharedMesh);
+            }
+
+            Destroy(go);
+        }
+
         /// <summary>Meshes one parked ship under its root: the same ChunkMesher + block atlas the world and
         /// flight view use, with the owner's hull colour painted into the mesh (item 32) and a MeshCollider
         /// per voxel chunk so walking, standing inside and the settle-freeze ground probe all work.</summary>
@@ -136,7 +167,7 @@ namespace BlocksBeyondTheStars.Client
         {
             for (int i = root.transform.childCount - 1; i >= 0; i--)
             {
-                Destroy(root.transform.GetChild(i).gameObject);
+                DestroyShipChunk(root.transform.GetChild(i).gameObject); // free the child's fresh meshes too
             }
 
             if (m.Cells.Count == 0 || Game.ChunkMaterial == null || Game.Atlas == null || Game.Content == null)

--- a/client/Assets/BlocksBeyondTheStars/Scripts/SpaceView.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/SpaceView.cs
@@ -2952,7 +2952,7 @@ namespace BlocksBeyondTheStars.Client
         {
             for (int i = parent.childCount - 1; i >= 0; i--)
             {
-                Destroy(parent.GetChild(i).gameObject);
+                DestroyVoxChunk(parent.GetChild(i).gameObject); // free the child's fresh meshes, not just the GameObject
             }
 
             if (cells == null || cells.Count == 0)
@@ -3009,6 +3009,31 @@ namespace BlocksBeyondTheStars.Client
                 go.AddComponent<MeshRenderer>().sharedMaterials = mats;
                 go.AddComponent<MeshCollider>().sharedMesh = collider; // S2/S3: hull/ore collision (suit + future)
             }
+        }
+
+        /// <summary>Destroys a vox-chunk GameObject AND the fresh render + collision meshes ChunkMesher.Build
+        /// allocated for it. Unity does not free a MeshFilter/MeshCollider's sharedMesh with the GameObject, so
+        /// without this every ship/asteroid re-mesh (each edit, each hull repaint) leaks two meshes per chunk.</summary>
+        private void DestroyVoxChunk(GameObject go)
+        {
+            if (go == null)
+            {
+                return;
+            }
+
+            var mf = go.GetComponent<MeshFilter>();
+            if (mf != null && mf.sharedMesh != null)
+            {
+                Destroy(mf.sharedMesh);
+            }
+
+            var mc = go.GetComponent<MeshCollider>();
+            if (mc != null && mc.sharedMesh != null)
+            {
+                Destroy(mc.sharedMesh);
+            }
+
+            Destroy(go);
         }
 
         /// <summary>Builds a cell dict + its centre from a structure design message (shared by ship + asteroid).</summary>

--- a/src/BlocksBeyondTheStars.GameServer/GameServer.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServer.cs
@@ -216,6 +216,10 @@ public sealed partial class GameServer
     public void Start()
     {
         _repo.Initialize();
+        // Record the current block-id palette and remap any save written under a different block set BEFORE
+        // world load. Block ids are assigned by key sort order, so adding a block shifts them; without this a
+        // content update would silently decode every stored edit to the wrong block.
+        _repo.EnsureBlockPalette(_content.BlockPalette());
 
         var launchRules = _config.Rules.Clone();
         _meta = _repo.LoadMetadata() ?? CreateInitialMetadata();
@@ -912,6 +916,7 @@ public sealed partial class GameServer
         Guard("SweepExpiredLandedTraders", SweepExpiredLandedTraders); // P3: free pads of traders whose dwell ended on bodies nobody is on
         Guard("TickGreetings", TickGreetings); // push any LLM NPC greetings finished off-thread (item 15)
         Guard("TickMissionTexts", TickMissionTexts); // push mission-list refreshes when L3 board texts arrive
+        Guard("TickAiMissions", TickAiMissions); // publish /ai_mission generations finished off-thread
         Guard("TickVegaBanter", TickVegaBanter); // push VEGA's LLM banter lines finished off-thread
 
         Guard("AccumulatePlaytime", deltaSeconds, AccumulatePlaytime);
@@ -1630,6 +1635,10 @@ public sealed partial class GameServer
             BroadcastToWorld(new PlayerLeft { PlayerId = session.State.PlayerId }); // remove their avatar in-world
             if (!string.IsNullOrEmpty(loc) && loc != _meta.ActiveLocationId && !OccupiedLocations().Contains(loc))
             {
+                // Move the cursor off the world we're about to drop, back to the (always-resident) default
+                // body. Without this the Unload would target the world the disconnect just made Active and
+                // silently no-op, leaking that world (and leaving the empty server ticking the orphan).
+                SetActiveWorld(_meta.ActiveLocationId);
                 _worlds.Unload(loc); // last player left this body — drop it from memory (edits persisted)
             }
         }
@@ -2173,6 +2182,17 @@ public sealed partial class GameServer
         EnsureSafeSpawn(session); // self-heal a position persisted mid-fall (don't load them into the void)
         ApplyCreativeGrants(session); // singleplayer "Creative" world: unlock-all / all-ships / starter kit
         return session;
+    }
+
+    /// <summary>Test seam: simulates a player's connection dropping, running the same disconnect handling a
+    /// real transport close would (session cleanup, save, world unload) — so tests can assert that behaviour
+    /// without a live socket. No-op if the player isn't joined.</summary>
+    public void DisconnectLocalPlayerForTest(string playerId)
+    {
+        if (FindSessionByPlayerId(playerId) is { } session)
+        {
+            OnClientDisconnected(session.ConnectionId);
+        }
     }
 
     /// <summary>Runs the authoritative mine validator for a player until the block breaks (used by local
@@ -3098,9 +3118,11 @@ public sealed partial class GameServer
         // Admin content tooling (not a cheat): AI mission generation.
         if (string.Equals(cmd.Command, "ai_mission", StringComparison.OrdinalIgnoreCase))
         {
-            var (ok, message) = TryGenerateAiMission(cmd.StringArg ?? string.Empty);
-            Send(session, new ServerMessage { Text = message });
-            CheatLog(p, ok ? $"generated an AI mission" : $"AI mission request: {message}");
+            // Generation runs off the tick thread (the LLM call blocks up to the backend timeout); the
+            // published/rejected result is pushed to the admin later by TickAiMissions. Acknowledge now.
+            string ack = RequestAiMission(session, cmd.StringArg ?? string.Empty);
+            Send(session, new ServerMessage { Text = ack });
+            CheatLog(p, "requested an AI mission");
             return;
         }
 
@@ -3156,7 +3178,10 @@ public sealed partial class GameServer
 
                     var target = FindSessionByName(cmd.TargetPlayer) ?? session;
                     int amount = System.Math.Max(1, cmd.IntArg);
-                    new MaterialPool(_content, target.State, _ship).Add(cmd.StringArg!, amount);
+                    // Resolve the TARGET's own ship, not the admin's cursor ship (`_ship`): a give to an
+                    // aboard-ship target must spill into that player's cargo, not the admin's.
+                    var targetShip = target.Ships.TryGetValue(target.ActiveShipId, out var ts) ? ts : _noShip;
+                    new MaterialPool(_content, target.State, targetShip).Add(cmd.StringArg!, amount);
                     SendInventory(target);
                     CheatLog(p, $"gave {amount} {cmd.StringArg} to {target.State.Name}");
                     break;

--- a/src/BlocksBeyondTheStars.GameServer/GameServerAi.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerAi.cs
@@ -1,7 +1,9 @@
 // Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using BlocksBeyondTheStars.Networking.Messages;
 using BlocksBeyondTheStars.Shared.Configuration;
 using BlocksBeyondTheStars.Shared.Missions;
 
@@ -12,21 +14,32 @@ namespace BlocksBeyondTheStars.GameServer;
 /// AI proposes a <see cref="MissionPlan"/>; the server validates and clamps it, then
 /// publishes (Auto) or drafts (Suggest) it. Everything keeps working with AI Off or the
 /// backend unreachable — failures fall back to "no mission".
+///
+/// The LLM call blocks up to the backend HTTP timeout, so at runtime generation runs OFF the
+/// game thread (same pattern as NPC greetings / board mission texts): <see cref="RequestAiMission"/>
+/// kicks it on a task and <see cref="TickAiMissions"/> validates + publishes the result on the tick.
+/// Doing it inline on the tick thread would freeze the single-threaded server for every player until
+/// the backend responds.
 /// </summary>
 public sealed partial class GameServer
 {
+    /// <summary>Finished generations awaiting validation + publish on the tick thread.</summary>
+    private readonly ConcurrentQueue<(int ConnectionId, MissionPlan? Plan)> _aiMissionOutbox = new();
+
+    /// <summary>Per-admin single-flight guard (keyed by connection): one pending generation at a time.</summary>
+    private readonly ConcurrentDictionary<int, byte> _aiMissionInFlight = new();
+
     /// <summary>
     /// Requests an AI mission for the given context. Returns whether a mission was created
-    /// and a human-readable status message. Never throws.
+    /// and a human-readable status message. Never throws. SYNCHRONOUS — this blocks on the LLM
+    /// call, so it is a test/util seam only; the runtime path is <see cref="RequestAiMission"/>,
+    /// which generates off the tick thread.
     /// </summary>
     public (bool Ok, string Message) TryGenerateAiMission(string context)
     {
-        switch (_config.AiLevel)
+        if (AiMissionGate() is { } gate)
         {
-            case AiLevel.Off:
-                return (false, "AI is disabled on this server.");
-            case AiLevel.TextOnly:
-                return (false, "AI level is text-only; full mission generation is disabled.");
+            return gate;
         }
 
         MissionPlan? plan;
@@ -36,16 +49,84 @@ public sealed partial class GameServer
         }
         catch
         {
-            plan = null; // defensive: providers should not throw, but never crash the tick
+            plan = null; // defensive: providers should not throw, but never crash the caller
         }
 
+        return PublishAiMission(plan);
+    }
+
+    /// <summary>Runtime entrypoint for the <c>/ai_mission</c> admin command. Generates OFF the tick thread
+    /// (the LLM call blocks up to the HTTP timeout — inline it would freeze the whole server) and enqueues
+    /// the plan for <see cref="TickAiMissions"/> to validate + publish. Returns the acknowledgement to show
+    /// the admin immediately; the published/rejected result is delivered when the drain runs.</summary>
+    private string RequestAiMission(PlayerSession admin, string context)
+    {
+        if (AiMissionGate() is { } gate)
+        {
+            return gate.Message;
+        }
+
+        int connId = admin.ConnectionId;
+        if (!_aiMissionInFlight.TryAdd(connId, 1))
+        {
+            return "An AI mission is already being generated — please wait.";
+        }
+
+        string enriched = EnrichMissionContext(context);
+        _ = System.Threading.Tasks.Task.Run(() =>
+        {
+            MissionPlan? plan;
+            try
+            {
+                plan = _ai.Generate(enriched);
+            }
+            catch
+            {
+                plan = null;
+            }
+
+            _aiMissionOutbox.Enqueue((connId, plan));
+        });
+
+        return "Generating an AI mission…";
+    }
+
+    /// <summary>Drains finished AI mission generations: validates, publishes/drafts, and reports the result
+    /// to the requesting admin — all on the tick thread (no cross-thread state access). Called per tick.</summary>
+    private void TickAiMissions()
+    {
+        while (_aiMissionOutbox.TryDequeue(out var pending))
+        {
+            _aiMissionInFlight.TryRemove(pending.ConnectionId, out _);
+            var (ok, message) = PublishAiMission(pending.Plan);
+            if (_sessions.TryGetValue(pending.ConnectionId, out var session) && session.Joined)
+            {
+                Send(session, new ServerMessage { Text = message });
+                CheatLog(session.State, ok ? "generated an AI mission" : $"AI mission request: {message}");
+            }
+        }
+    }
+
+    /// <summary>The AI-level gate shared by the sync + async entrypoints: a message when mission generation
+    /// isn't available at this level, or null when it is.</summary>
+    private (bool Ok, string Message)? AiMissionGate() => _config.AiLevel switch
+    {
+        AiLevel.Off => (false, "AI is disabled on this server."),
+        AiLevel.TextOnly => (false, "AI level is text-only; full mission generation is disabled."),
+        _ => null,
+    };
+
+    /// <summary>Validates an AI-proposed plan and publishes (Auto) or drafts (Suggest) it. Runs on the tick
+    /// thread (or the sync test seam). A null plan (backend unavailable) falls back to "no mission".</summary>
+    private (bool Ok, string Message) PublishAiMission(MissionPlan? plan)
+    {
         if (plan is null)
         {
             _log.Warn("AI backend returned no mission (unavailable or disabled) — falling back to none.");
             return (false, "AI backend unavailable — no mission generated (fallback).");
         }
 
-        var id = "ai_" + Guid.NewGuid().ToString("N");
+        var id = "ai_" + System.Guid.NewGuid().ToString("N");
         var def = MissionPlanConverter.ToDefinition(plan, id, MissionSource.Admin);
 
         var problems = MissionValidator.Validate(def, _content);

--- a/src/BlocksBeyondTheStars.GameServer/GameServerEnemies.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerEnemies.cs
@@ -147,7 +147,8 @@ public sealed partial class GameServer
     private const float EnemyWanderSpeed = 1.1f;
     private const double EnemySightGiveUpSeconds = 6.0; // out of sight this long → give up the hunt and resume roaming
 
-    private double _enemySyncTimer;
+    // Per-world (routes through the active world) — a shared field would starve enemy syncs on all but one world.
+    private double _enemySyncTimer { get => _worlds.Active.SinceEnemySync; set => _worlds.Active.SinceEnemySync = value; }
     private readonly Dictionary<string, (double Heading, double Until)> _enemyWander = new();
     private readonly Dictionary<string, double> _enemySightSeenAt = new(); // enemy id → uptime it last had line-of-sight to its prey
 

--- a/src/BlocksBeyondTheStars.GameServer/GameServerPresence.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerPresence.cs
@@ -17,7 +17,8 @@ public sealed partial class GameServer
 {
     private const double PresenceInterval = 0.1; // ~10 Hz
 
-    private double _sincePresence;
+    // Per-world (routes through the active world) — see LoadedWorld.SincePresence for why a shared field starves worlds.
+    private double _sincePresence { get => _worlds.Active.SincePresence; set => _worlds.Active.SincePresence = value; }
 
     private void HandleSetAppearance(PlayerSession session, SetAppearanceIntent intent)
     {

--- a/src/BlocksBeyondTheStars.GameServer/GameServerSpawnSafety.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerSpawnSafety.cs
@@ -20,7 +20,8 @@ public sealed partial class GameServer
     private const int VoidProbeDepth = 24;   // …with no solid block within this many blocks below them
     private const double VoidRescueInterval = 1.0; // how often the runtime void check runs (seconds)
 
-    private double _sinceVoidCheck;
+    // Per-world (routes through the active world) — a shared field would starve the void rescue on all but one world.
+    private double _sinceVoidCheck { get => _worlds.Active.SinceVoidCheck; set => _worlds.Active.SinceVoidCheck = value; }
 
     /// <summary>True if there's a solid block within <paramref name="depth"/> blocks below the position —
     /// something to stand on (terrain, a cave floor, the ship's deck). Reads generate the column as needed.</summary>

--- a/src/BlocksBeyondTheStars.GameServer/GameServerTrade.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerTrade.cs
@@ -118,7 +118,11 @@ public sealed partial class GameServer
         }
 
         var offer = items.Where(i => i.Count > 0).Select(i => new ItemAmount(i.Item, i.Count)).ToList();
-        var pool = new MaterialPool(_content, s.State, _ship);
+        // Validate against the offering player's OWN ship cargo, not the ship cursor (`_ship`). In normal
+        // message dispatch the cursor already is this player, but keying off their own session removes the
+        // cursor dependency so the check is correct regardless of who the server is currently serving.
+        var ownShip = s.Ships.TryGetValue(s.ActiveShipId, out var sh) ? sh : _noShip;
+        var pool = new MaterialPool(_content, s.State, ownShip);
         if (!pool.Has(offer))
         {
             Reject(s, "trade", "You don't have those items to offer.");
@@ -206,8 +210,14 @@ public sealed partial class GameServer
             return;
         }
 
-        var poolA = new MaterialPool(_content, sa.State, _ship);
-        var poolB = new MaterialPool(_content, sb.State, _ship);
+        // Each side's pool must wrap that side's OWN ship cargo — not the ship cursor (`_ship`), which
+        // points at whoever's message triggered the commit (the confirmer). Using `_ship` for both would
+        // make a partner-aboard trade read/remove items from the confirmer's hold: item dupe/loss. Same
+        // pattern the mission payout uses (GameServerMissions.RewardMissionPoster).
+        var shipA = sa.Ships.TryGetValue(sa.ActiveShipId, out var psa) ? psa : _noShip;
+        var shipB = sb.Ships.TryGetValue(sb.ActiveShipId, out var psb) ? psb : _noShip;
+        var poolA = new MaterialPool(_content, sa.State, shipA);
+        var poolB = new MaterialPool(_content, sb.State, shipB);
 
         // Re-validate both sides still hold their offers (they could have used items meanwhile).
         if (!poolA.Has(session.OfferA) || !poolB.Has(session.OfferB))

--- a/src/BlocksBeyondTheStars.GameServer/WorldManager.cs
+++ b/src/BlocksBeyondTheStars.GameServer/WorldManager.cs
@@ -137,6 +137,12 @@ internal sealed class LoadedWorld
     public double EnemySpawnTimer { get; set; }
     public double SinceFluid { get; set; }
     public double SinceFire { get; set; }
+    // These three run once per occupied world each tick, so their accumulate-and-reset throttles MUST be
+    // per-world — a single shared field lets whichever world is iterated first reset it before the others
+    // reach their interval, starving every world but one of presence/enemy syncs and the void rescue.
+    public double SincePresence { get; set; }
+    public double SinceEnemySync { get; set; }
+    public double SinceVoidCheck { get; set; }
     public double NpcBroadcastTimer { get; set; }
     public int NextNpcId { get; set; } = 1;
     public int NextDoorId { get; set; } = 1;
@@ -282,12 +288,40 @@ internal sealed class WorldManager
     }
 
     /// <summary>Drops a resident world from memory (its chunk edits are already persisted by the repo).
-    /// No-op if it isn't loaded or is still the active cursor.</summary>
-    public void Unload(string locationId)
+    /// No-op if it isn't loaded. If it is the active cursor, the cursor is first repointed to another
+    /// resident world so the world under the cursor is never dropped; if it is the ONLY resident world it
+    /// is kept (there must always be an active world). Returns whether the world was dropped.</summary>
+    public bool Unload(string locationId)
     {
-        if (_loaded.TryGetValue(locationId, out var w) && !ReferenceEquals(w, Active))
+        if (!_loaded.TryGetValue(locationId, out var w))
         {
-            _loaded.Remove(locationId);
+            return false;
         }
+
+        if (ReferenceEquals(w, Active))
+        {
+            // Never drop the world under the cursor (that silently no-ops and leaks it). Repoint to any
+            // other resident world first; if this is the only one, keep it — callers guarantee they never
+            // unload the default/occupied world, so this branch only guards against a stuck cursor.
+            LoadedWorld? other = null;
+            foreach (var kv in _loaded)
+            {
+                if (!ReferenceEquals(kv.Value, w))
+                {
+                    other = kv.Value;
+                    break;
+                }
+            }
+
+            if (other is null)
+            {
+                return false;
+            }
+
+            Active = other;
+        }
+
+        _loaded.Remove(locationId);
+        return true;
     }
 }

--- a/src/BlocksBeyondTheStars.Persistence/BlockPaletteMigration.cs
+++ b/src/BlocksBeyondTheStars.Persistence/BlockPaletteMigration.cs
@@ -1,0 +1,77 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+namespace BlocksBeyondTheStars.Persistence;
+
+/// <summary>
+/// Backend-agnostic helpers for the block-id palette migration shared by the SQLite and PostgreSQL
+/// repositories. Numeric block ids are assigned by key sort order, so adding a block whose key sorts before
+/// existing ones shifts every later id. Persisting the palette (numeric id → key) lets a save rebuild a
+/// remap (old id → new id) by matching KEYS, then translate its stored ids to the current assignment.
+/// </summary>
+internal static class BlockPaletteMigration
+{
+    /// <summary>Builds old-id → new-id for every stored id whose current id (matched by key) differs. A stored
+    /// key that no longer exists in content maps to air (0) — its cells decode to "removed" rather than
+    /// mis-decoding to whatever block now holds the old id. Ids that don't change are omitted.</summary>
+    public static Dictionary<ushort, ushort> BuildRemap(
+        IReadOnlyDictionary<ushort, string> stored,
+        IReadOnlyDictionary<ushort, string> current)
+    {
+        var currentByKey = new Dictionary<string, ushort>(current.Count);
+        foreach (var kv in current)
+        {
+            currentByKey[kv.Value] = kv.Key;
+        }
+
+        var remap = new Dictionary<ushort, ushort>();
+        foreach (var kv in stored)
+        {
+            ushort oldId = kv.Key;
+            ushort newId = currentByKey.TryGetValue(kv.Value, out var id) ? id : (ushort)0;
+            if (newId != oldId)
+            {
+                remap[oldId] = newId;
+            }
+        }
+
+        return remap;
+    }
+
+    /// <summary>Remaps the block id inside a space-structure cell string ("x:y:z:block" cells joined by ';').
+    /// The block is the LAST colon-separated field, so negative coordinates are handled correctly. Returns the
+    /// original string unchanged when nothing needed remapping (so callers can skip a no-op DB write).</summary>
+    public static string RemapCellString(string blocks, IReadOnlyDictionary<ushort, ushort> remap)
+    {
+        if (string.IsNullOrEmpty(blocks) || remap.Count == 0)
+        {
+            return blocks;
+        }
+
+        var cells = blocks.Split(';');
+        bool changed = false;
+        for (int i = 0; i < cells.Length; i++)
+        {
+            string cell = cells[i];
+            if (cell.Length == 0)
+            {
+                continue;
+            }
+
+            int lastColon = cell.LastIndexOf(':');
+            if (lastColon < 0)
+            {
+                continue;
+            }
+
+            if (ushort.TryParse(cell.AsSpan(lastColon + 1), out ushort b)
+                && remap.TryGetValue(b, out ushort nb) && nb != b)
+            {
+                cells[i] = string.Concat(cell.AsSpan(0, lastColon + 1), nb.ToString());
+                changed = true;
+            }
+        }
+
+        return changed ? string.Join(";", cells) : blocks;
+    }
+}

--- a/src/BlocksBeyondTheStars.Persistence/IWorldRepository.cs
+++ b/src/BlocksBeyondTheStars.Persistence/IWorldRepository.cs
@@ -163,6 +163,14 @@ public interface IWorldRepository : IDisposable
     /// <summary>Opens/creates the database and ensures the schema exists.</summary>
     void Initialize();
 
+    /// <summary>Records the current block-id palette (numeric id → block key) and, if a stored palette from an
+    /// earlier content set is present and differs, remaps every persisted numeric block id (block edits,
+    /// structure edits, flora regrowth, stored space structures) to the current assignment BEFORE any world
+    /// loads. Call once at startup after <see cref="Initialize"/>. This is what stops a content update that
+    /// inserts a block — which shifts the sort-order-assigned ids — from silently decoding every existing
+    /// save's edits to the wrong blocks. A block key no longer in content maps to air (0).</summary>
+    void EnsureBlockPalette(IReadOnlyDictionary<ushort, string> currentPalette);
+
     WorldMetadata? LoadMetadata();
     void SaveMetadata(WorldMetadata metadata);
 

--- a/src/BlocksBeyondTheStars.Persistence/PostgreSqlWorldRepository.cs
+++ b/src/BlocksBeyondTheStars.Persistence/PostgreSqlWorldRepository.cs
@@ -90,7 +90,8 @@ public sealed class PostgreSqlWorldRepository : IWorldRepository
                 block INTEGER NOT NULL, PRIMARY KEY (structure, x, y, z));
             CREATE TABLE IF NOT EXISTS flora_regrow (
                 planet TEXT NOT NULL, x INTEGER NOT NULL, y INTEGER NOT NULL, z INTEGER NOT NULL,
-                block INTEGER NOT NULL, timer DOUBLE PRECISION NOT NULL, PRIMARY KEY (planet, x, y, z));");
+                block INTEGER NOT NULL, timer DOUBLE PRECISION NOT NULL, PRIMARY KEY (planet, x, y, z));
+            CREATE TABLE IF NOT EXISTS block_palette (numeric_id INTEGER PRIMARY KEY, key TEXT NOT NULL);");
         // (Landing pads are deterministic + live-occupancy now — no per-player landing_zone table; item 38.)
 
         // Migrate older saves to carry per-voxel colour modifiers (dyed blocks / coloured lights). The
@@ -101,6 +102,142 @@ public sealed class PostgreSqlWorldRepository : IWorldRepository
         // Migrate older saves to carry the per-voxel shape descriptor (non-cube building forms). Same pattern:
         // harmlessly ignored on a fresh DB where the CREATE already added the column.
         TryExecute("ALTER TABLE block_edit ADD COLUMN IF NOT EXISTS shape INTEGER NOT NULL DEFAULT 0;");
+    }
+
+    // --- Block-id palette (content-shift migration) ---
+
+    public void EnsureBlockPalette(IReadOnlyDictionary<ushort, string> currentPalette)
+    {
+        Dictionary<ushort, string> stored;
+        lock (_gate)
+        {
+            Execute("CREATE TABLE IF NOT EXISTS block_palette (numeric_id INTEGER PRIMARY KEY, key TEXT NOT NULL);");
+            stored = ReadBlockPalette();
+        }
+
+        if (stored.Count == 0)
+        {
+            // Fresh save, or the first load after this feature shipped: no recorded mapping to remap FROM, so
+            // adopt the current assignment as the baseline. From here on, any content change that shifts ids is
+            // detected and remapped on the next load.
+            WriteBlockPalette(currentPalette);
+            return;
+        }
+
+        var remap = BlockPaletteMigration.BuildRemap(stored, currentPalette);
+        if (remap.Count == 0)
+        {
+            WriteBlockPalette(currentPalette);
+            return;
+        }
+
+        // Atomic: remap every persisted id AND rewrite the palette in one transaction.
+        RunInTransaction(() =>
+        {
+            RemapBlockColumn("block_edit", remap);
+            RemapBlockColumn("structure_edit", remap);
+            RemapBlockColumn("flora_regrow", remap);
+            RemapSpaceStructureBlocks(remap);
+            WriteBlockPaletteLocked(currentPalette);
+        });
+    }
+
+    private Dictionary<ushort, string> ReadBlockPalette()
+    {
+        var result = new Dictionary<ushort, string>();
+        using var cmd = Connection.CreateCommand();
+        cmd.CommandText = "SELECT numeric_id, key FROM block_palette;";
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read())
+        {
+            result[(ushort)reader.GetInt32(0)] = reader.GetString(1);
+        }
+
+        return result;
+    }
+
+    private void WriteBlockPalette(IReadOnlyDictionary<ushort, string> palette)
+        => RunInTransaction(() => WriteBlockPaletteLocked(palette));
+
+    private void WriteBlockPaletteLocked(IReadOnlyDictionary<ushort, string> palette)
+    {
+        Execute("DELETE FROM block_palette;");
+        foreach (var kv in palette)
+        {
+            using var cmd = Connection.CreateCommand();
+            cmd.CommandText = "INSERT INTO block_palette (numeric_id, key) VALUES (@id, @k);";
+            cmd.Parameters.AddWithValue("@id", (int)kv.Key);
+            cmd.Parameters.AddWithValue("@k", kv.Value);
+            cmd.ExecuteNonQuery();
+        }
+    }
+
+    /// <summary>Remaps the <c>block</c> column of a table via a single CASE over the ORIGINAL value, so every
+    /// row is translated atomically. Only changed ids appear; all values are server-side ushorts, so inlining
+    /// them is injection-safe.</summary>
+    private void RemapBlockColumn(string table, IReadOnlyDictionary<ushort, ushort> remap)
+    {
+        if (remap.Count == 0)
+        {
+            return;
+        }
+
+        var sb = new System.Text.StringBuilder();
+        sb.Append("UPDATE ").Append(table).Append(" SET block = CASE block");
+        foreach (var kv in remap)
+        {
+            sb.Append(" WHEN ").Append(kv.Key).Append(" THEN ").Append(kv.Value);
+        }
+
+        sb.Append(" ELSE block END WHERE block IN (");
+        bool first = true;
+        foreach (var kv in remap)
+        {
+            if (!first)
+            {
+                sb.Append(',');
+            }
+
+            sb.Append(kv.Key);
+            first = false;
+        }
+
+        sb.Append(");");
+        Execute(sb.ToString());
+    }
+
+    private void RemapSpaceStructureBlocks(IReadOnlyDictionary<ushort, ushort> remap)
+    {
+        if (remap.Count == 0)
+        {
+            return;
+        }
+
+        var rows = new List<(string Id, string Blocks)>();
+        using (var read = Connection.CreateCommand())
+        {
+            read.CommandText = "SELECT id, blocks FROM space_structure;";
+            using var reader = read.ExecuteReader();
+            while (reader.Read())
+            {
+                rows.Add((reader.GetString(0), reader.GetString(1)));
+            }
+        }
+
+        foreach (var (id, blocks) in rows)
+        {
+            string remapped = BlockPaletteMigration.RemapCellString(blocks, remap);
+            if (remapped == blocks)
+            {
+                continue;
+            }
+
+            using var upd = Connection.CreateCommand();
+            upd.CommandText = "UPDATE space_structure SET blocks = @b WHERE id = @id;";
+            upd.Parameters.AddWithValue("@b", remapped);
+            upd.Parameters.AddWithValue("@id", id);
+            upd.ExecuteNonQuery();
+        }
     }
 
     // --- Metadata ---

--- a/src/BlocksBeyondTheStars.Persistence/SqliteWorldRepository.cs
+++ b/src/BlocksBeyondTheStars.Persistence/SqliteWorldRepository.cs
@@ -92,7 +92,8 @@ public sealed class SqliteWorldRepository : IWorldRepository
                 block INTEGER NOT NULL, PRIMARY KEY (structure, x, y, z));
             CREATE TABLE IF NOT EXISTS flora_regrow (
                 planet TEXT NOT NULL, x INTEGER NOT NULL, y INTEGER NOT NULL, z INTEGER NOT NULL,
-                block INTEGER NOT NULL, timer REAL NOT NULL, PRIMARY KEY (planet, x, y, z));");
+                block INTEGER NOT NULL, timer REAL NOT NULL, PRIMARY KEY (planet, x, y, z));
+            CREATE TABLE IF NOT EXISTS block_palette (numeric_id INTEGER PRIMARY KEY, key TEXT NOT NULL);");
         // (Landing pads are deterministic + live-occupancy now — no per-player landing_zone table; item 38.)
 
         // Migrate older saves to carry per-voxel colour modifiers (dyed blocks / coloured lights). The
@@ -103,6 +104,144 @@ public sealed class SqliteWorldRepository : IWorldRepository
         // Migrate older saves to carry the per-voxel shape descriptor (non-cube building forms). Same pattern:
         // harmlessly ignored on a fresh DB where the CREATE already added the column.
         TryExecute("ALTER TABLE block_edit ADD COLUMN shape INTEGER NOT NULL DEFAULT 0;");
+    }
+
+    // --- Block-id palette (content-shift migration) ---
+
+    public void EnsureBlockPalette(IReadOnlyDictionary<ushort, string> currentPalette)
+    {
+        Dictionary<ushort, string> stored;
+        lock (_gate)
+        {
+            Execute("CREATE TABLE IF NOT EXISTS block_palette (numeric_id INTEGER PRIMARY KEY, key TEXT NOT NULL);");
+            stored = ReadBlockPalette();
+        }
+
+        if (stored.Count == 0)
+        {
+            // Fresh save, or the first load after this feature shipped: no recorded mapping to remap FROM, so
+            // adopt the current assignment as the baseline. From here on, any content change that shifts ids is
+            // detected and remapped on the next load.
+            WriteBlockPalette(currentPalette);
+            return;
+        }
+
+        var remap = BlockPaletteMigration.BuildRemap(stored, currentPalette);
+        if (remap.Count == 0)
+        {
+            // Ids unchanged (e.g. new blocks only appended after every stored key): just refresh the record.
+            WriteBlockPalette(currentPalette);
+            return;
+        }
+
+        // Atomic: remap every persisted id AND rewrite the palette in one transaction, so a crash mid-migration
+        // never leaves half-remapped data paired with the new palette.
+        RunInTransaction(() =>
+        {
+            RemapBlockColumn("block_edit", remap);
+            RemapBlockColumn("structure_edit", remap);
+            RemapBlockColumn("flora_regrow", remap);
+            RemapSpaceStructureBlocks(remap);
+            WriteBlockPaletteLocked(currentPalette);
+        });
+    }
+
+    private Dictionary<ushort, string> ReadBlockPalette()
+    {
+        var result = new Dictionary<ushort, string>();
+        using var cmd = Connection.CreateCommand();
+        cmd.CommandText = "SELECT numeric_id, key FROM block_palette;";
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read())
+        {
+            result[(ushort)reader.GetInt32(0)] = reader.GetString(1);
+        }
+
+        return result;
+    }
+
+    private void WriteBlockPalette(IReadOnlyDictionary<ushort, string> palette)
+        => RunInTransaction(() => WriteBlockPaletteLocked(palette));
+
+    private void WriteBlockPaletteLocked(IReadOnlyDictionary<ushort, string> palette)
+    {
+        Execute("DELETE FROM block_palette;");
+        foreach (var kv in palette)
+        {
+            using var cmd = Connection.CreateCommand();
+            cmd.CommandText = "INSERT INTO block_palette (numeric_id, key) VALUES ($id, $k);";
+            cmd.Parameters.AddWithValue("$id", (int)kv.Key);
+            cmd.Parameters.AddWithValue("$k", kv.Value);
+            cmd.ExecuteNonQuery();
+        }
+    }
+
+    /// <summary>Remaps the <c>block</c> column of a table via a single CASE over the ORIGINAL value, so every
+    /// row is translated atomically (a row remapped to N is never re-caught by a later WHEN N). Only ids that
+    /// actually change appear; all values are server-side ushorts, so inlining them is injection-safe.</summary>
+    private void RemapBlockColumn(string table, IReadOnlyDictionary<ushort, ushort> remap)
+    {
+        if (remap.Count == 0)
+        {
+            return;
+        }
+
+        var sb = new System.Text.StringBuilder();
+        sb.Append("UPDATE ").Append(table).Append(" SET block = CASE block");
+        foreach (var kv in remap)
+        {
+            sb.Append(" WHEN ").Append(kv.Key).Append(" THEN ").Append(kv.Value);
+        }
+
+        sb.Append(" ELSE block END WHERE block IN (");
+        bool first = true;
+        foreach (var kv in remap)
+        {
+            if (!first)
+            {
+                sb.Append(',');
+            }
+
+            sb.Append(kv.Key);
+            first = false;
+        }
+
+        sb.Append(");");
+        Execute(sb.ToString());
+    }
+
+    private void RemapSpaceStructureBlocks(IReadOnlyDictionary<ushort, ushort> remap)
+    {
+        if (remap.Count == 0)
+        {
+            return;
+        }
+
+        var rows = new List<(string Id, string Blocks)>();
+        using (var read = Connection.CreateCommand())
+        {
+            read.CommandText = "SELECT id, blocks FROM space_structure;";
+            using var reader = read.ExecuteReader();
+            while (reader.Read())
+            {
+                rows.Add((reader.GetString(0), reader.GetString(1)));
+            }
+        }
+
+        foreach (var (id, blocks) in rows)
+        {
+            string remapped = BlockPaletteMigration.RemapCellString(blocks, remap);
+            if (remapped == blocks)
+            {
+                continue;
+            }
+
+            using var upd = Connection.CreateCommand();
+            upd.CommandText = "UPDATE space_structure SET blocks = $b WHERE id = $id;";
+            upd.Parameters.AddWithValue("$b", remapped);
+            upd.Parameters.AddWithValue("$id", id);
+            upd.ExecuteNonQuery();
+        }
     }
 
     // --- Metadata ---

--- a/src/BlocksBeyondTheStars.Shared/Content/GameContent.cs
+++ b/src/BlocksBeyondTheStars.Shared/Content/GameContent.cs
@@ -310,6 +310,21 @@ public sealed class GameContent
     public BlockDefinition? BlockById(BlockId id)
         => id.Value < _blocksById.Length ? _blocksById[id.Value] : null;
 
+    /// <summary>The current block-id palette: numeric id → block key, for every loaded block (incl. air = 0).
+    /// Numeric ids are assigned by key sort order (<see cref="AssignBlockIds"/>), so they shift whenever a
+    /// block is added whose key sorts before existing ones. Persisting this lets a save remap its stored
+    /// edits to the current ids on load instead of silently decoding them to the wrong blocks.</summary>
+    public IReadOnlyDictionary<ushort, string> BlockPalette()
+    {
+        var palette = new Dictionary<ushort, string>(_blocks.Count);
+        foreach (var b in _blocks.Values)
+        {
+            palette[b.NumericId.Value] = b.Key;
+        }
+
+        return palette;
+    }
+
     // Item keys may carry a colour modifier (e.g. "mud#t3f6fb0" for dyed mud). Definition lookups
     // strip it back to the base key — a dyed item shares its base item's definition (max stack,
     // placed block, name, …); the colour lives only in the key + the per-voxel modifier store.

--- a/src/BlocksBeyondTheStars.WorldGeneration/WorldGenerator.cs
+++ b/src/BlocksBeyondTheStars.WorldGeneration/WorldGenerator.cs
@@ -1739,7 +1739,12 @@ public sealed class WorldGenerator
         }
     }
 
-    private bool _floraResolved;
+    // The planet key the resolved flora state below belongs to (null = not yet resolved). Flora is a
+    // PER-PLANET subset (FloraGenerator.GenerateRoster XORs the planet key into the seed), and this one
+    // generator instance serves every body in the save — so the state must be re-resolved whenever the
+    // requested planet changes, or the first-visited planet's flora would contaminate all others (and the
+    // baseline would depend on visit order instead of the seed).
+    private string? _floraResolvedFor;
     private bool _kelpActive, _lilyActive; // whether the seabed kelp / surface lily archetypes grow on this world
     private bool _coralActive, _seagrassActive; // the other two seabed archetypes (coral reefs / seagrass)
     // surface block id -> the pool of (this world's active) flora that may grow on it.
@@ -1753,12 +1758,14 @@ public sealed class WorldGenerator
     /// surface or the seas ever go bare).</summary>
     private void ResolveFlora(PlanetType planet)
     {
-        if (_floraResolved)
+        if (_floraResolvedFor == planet.Key)
         {
             return;
         }
 
-        _floraResolved = true;
+        _floraResolvedFor = planet.Key;
+        _floraBySurface.Clear(); // re-resolving for a different planet: drop the previous planet's pools
+        _floraTagByBlock.Clear();
 
         var active = new System.Collections.Generic.HashSet<string>();
         foreach (var fs in FloraGenerator.GenerateRoster(planet, _worldSeed))

--- a/tests/BlocksBeyondTheStars.Tests/FloraVarietyTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/FloraVarietyTests.cs
@@ -160,6 +160,32 @@ public sealed class FloraVarietyTests
 
     [Fact]
     [Trait("Category", "Slow")]
+    public void Worldgen_FloraIsPerPlanet_NotContaminatedByFirstWorldVisited()
+    {
+        var jungle = _content.GetPlanet("jungle")!;
+        var alpine = _content.GetPlanet("highland")!;
+        var floraIds = FloraIds();
+
+        HashSet<ushort> JungleFlora(WorldGenerator gen)
+            => CountArea(gen, jungle, chunksXZ: 4).Keys.Where(floraIds.Contains).ToHashSet();
+
+        // Jungle generated with a fresh generator — the correct, seed-only baseline.
+        var baseline = JungleFlora(new WorldGenerator(2026, _content));
+
+        // The same jungle, but this generator first produced a DIFFERENT planet (alpine). Flora is a per-planet
+        // subset, so resolving it once for the first-visited planet would make the jungle grow alpine's plants.
+        var contaminated = new WorldGenerator(2026, _content);
+        CountArea(contaminated, alpine, chunksXZ: 2); // visit alpine first
+        var afterAlpine = JungleFlora(contaminated);
+
+        Assert.NotEmpty(baseline);
+        Assert.True(baseline.SetEquals(afterAlpine),
+            $"jungle flora changed after visiting alpine first — baseline={string.Join(",", baseline.OrderBy(x => x))}, "
+            + $"after={string.Join(",", afterAlpine.OrderBy(x => x))}");
+    }
+
+    [Fact]
+    [Trait("Category", "Slow")]
     public void Worldgen_ConiferWorld_GrowsPines_NotBroadleafCrowns()
     {
         var planet = _content.GetPlanet("highland")!; // alpine theme → conifers only

--- a/tests/BlocksBeyondTheStars.Tests/PersistenceTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/PersistenceTests.cs
@@ -156,6 +156,68 @@ public sealed class PersistenceTests : IDisposable
         Assert.Equal(7, verify.LoadMetadata()!.Seed);
     }
 
+    [Fact]
+    public void BlockPalette_RemapsStoredIdsWhenContentShifts()
+    {
+        // Baseline content: steel_wall=5, torch=6, gone_block=7.
+        var paletteA = new Dictionary<ushort, string> { [5] = "steel_wall", [6] = "torch", [7] = "gone_block" };
+        // A new block (algae) sorts first and takes id 5, shifting steel_wall→6 and torch→7; gone_block removed.
+        var paletteB = new Dictionary<ushort, string> { [5] = "algae", [6] = "steel_wall", [7] = "torch" };
+
+        using (var repo = NewRepo())
+        {
+            repo.SetBlock("rocky", new Vector3i(1, 2, 3), 5);  // steel_wall
+            repo.SetBlock("rocky", new Vector3i(2, 2, 3), 6);  // torch
+            repo.SetBlock("rocky", new Vector3i(3, 2, 3), 7);  // gone_block → air after migration
+            repo.SetStructureBlock("ship:p1", new Vector3i(0, 0, 0), 5);
+            repo.SaveFloraRegrow("rocky", new Vector3i(4, 2, 3), 6, 12.0);
+            repo.SaveSpaceStructure(new StoredSpaceStructure
+            {
+                Id = "st1",
+                OwnerId = "p1",
+                Name = "Base",
+                Location = "sys0-p1",
+                Blocks = "0:0:0:5;1:0:0:6;-2:3:0:7",
+            });
+            repo.EnsureBlockPalette(paletteA); // record the baseline palette
+        }
+
+        using (var repo = NewRepo())
+        {
+            repo.EnsureBlockPalette(paletteB); // content shifted → remap every stored id
+        }
+
+        using var reopened = NewRepo();
+        var edits = reopened.LoadChunkEdits("rocky", new ChunkCoord(0, 0, 0));
+        ushort BlockAt(int x) => edits.First(e => e.WorldPosition.X == x).Block;
+        Assert.Equal((ushort)6, BlockAt(1)); // steel_wall 5 → 6 (no cascade into torch's remap)
+        Assert.Equal((ushort)7, BlockAt(2)); // torch 6 → 7
+        Assert.Equal((ushort)0, BlockAt(3)); // gone_block 7 → air (key no longer in content)
+
+        Assert.Equal((ushort)6, reopened.LoadStructureEdits("ship:p1").Single().Block);
+        Assert.Equal((ushort)7, reopened.ListFloraRegrow("rocky").Single().Block);
+        Assert.Equal("0:0:0:6;1:0:0:7;-2:3:0:0", reopened.ListSpaceStructures().Single().Blocks);
+    }
+
+    [Fact]
+    public void BlockPalette_LeavesIdsUntouchedWhenUnchanged()
+    {
+        var palette = new Dictionary<ushort, string> { [5] = "steel_wall", [6] = "torch" };
+        using (var repo = NewRepo())
+        {
+            repo.SetBlock("rocky", new Vector3i(1, 2, 3), 5);
+            repo.EnsureBlockPalette(palette);
+        }
+
+        using (var repo = NewRepo())
+        {
+            repo.EnsureBlockPalette(palette); // identical palette → no remap
+        }
+
+        using var reopened = NewRepo();
+        Assert.Equal((ushort)5, reopened.LoadChunkEdits("rocky", new ChunkCoord(0, 0, 0)).Single().Block);
+    }
+
     public void Dispose()
     {
         try

--- a/tests/BlocksBeyondTheStars.Tests/TradeTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/TradeTests.cs
@@ -248,6 +248,38 @@ public sealed class TradeTests : IDisposable
         }
     }
 
+    [Fact]
+    public void Trade_UsesEachPartnersOwnShipCargo_WhenAboard()
+    {
+        var server = Started(out var repo);
+        using (repo)
+        {
+            // Alice joins first (cursor → Alice): stock HER ship's cargo with the item she'll offer.
+            var alice = server.AddLocalPlayer("Alice");
+            server.Ship.Cargo.Add("iron_ore", 10, 99); // server.Ship is the cursor's ship = Alice's here
+            alice.State.AboardShip = true;
+            alice.State.Position = new Vector3f(0, 64, 0);
+
+            // Bob joins last (cursor → Bob): stock HIS ship's cargo with the item he'll offer.
+            var bob = server.AddLocalPlayer("Bob");
+            server.Ship.Cargo.Add("carbon", 5, 99); // now Bob's ship
+            bob.State.AboardShip = true;
+            bob.State.Position = new Vector3f(1, 64, 0); // within trade range
+
+            OpenTrade(server);
+            server.SetTradeOffer("Alice", new[] { new ItemAmount("iron_ore", 4) }); // from Alice's ship cargo
+            server.SetTradeOffer("Bob", new[] { new ItemAmount("carbon", 2) });      // from Bob's ship cargo
+            server.ConfirmTrade("Alice");
+            server.ConfirmTrade("Bob"); // both ready → commit
+
+            // With the bug (both pools resolved through the confirmer's ship cursor), one side's offer can't be
+            // found in the wrong hold and the whole trade rejects. Fixed: each pool draws from its own cargo.
+            Assert.Null(server.ActiveTrade("Alice"));           // committed
+            Assert.Equal(2, alice.State.Inventory.CountOf("carbon"));   // Alice received Bob's carbon
+            Assert.Equal(4, bob.State.Inventory.CountOf("iron_ore"));   // Bob received Alice's iron_ore
+        }
+    }
+
     public void Dispose()
     {
         try

--- a/tests/BlocksBeyondTheStars.Tests/TravelTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/TravelTests.cs
@@ -191,6 +191,34 @@ public sealed class TravelTests : IDisposable
     }
 
     [Fact]
+    public void LastPlayerLeavingABody_UnloadsItsWorld_AndReturnsCursorToDefault()
+    {
+        var server = Started(out var repo);
+        using (repo)
+        {
+            server.AddLocalPlayer("Alice");
+            server.AddLocalPlayer("Bob");
+            var alice = server.Sessions.Values.First(s => s.State.PlayerId == "Alice");
+            string origin = alice.CurrentLocationId;
+            alice.Ships[alice.ActiveShipId].Modules.Add("jump_generator");
+
+            var dest = OtherPlanet(server);
+            server.Travel("Alice", dest.Id);
+            Assert.True(server.ResidentWorldCount >= 2);
+            Assert.NotNull(server.WorldAt(dest.Id));
+
+            // Alice is the only player on the destination body. Her disconnect must drop that world from memory
+            // (previously a no-op: the handler made it the Active cursor first, so Unload refused to drop it)
+            // and leave the cursor on the always-resident default body, not stranded on the emptied world.
+            server.DisconnectLocalPlayerForTest("Alice");
+
+            Assert.Null(server.WorldAt(dest.Id));                   // destination world unloaded
+            Assert.NotNull(server.WorldAt(origin));                 // Bob's world stays resident
+            Assert.Equal(server.Metadata.ActiveLocationId, server.ActiveLocationId); // cursor back on default
+        }
+    }
+
+    [Fact]
     public void FlyAndLand_OnSameSystemBody_LandsThere_NoJumpNeeded()
     {
         var server = Started(out var repo, jumpDrive: false); // system-scale flight needs no jump drive


### PR DESCRIPTION
Read-only audit of the server + Unity client, then fixes for every confirmed finding. Each was verified against the code before fixing; the risky ones carry new regression tests.

## Server / persistence
- **Trade & `give_item` cargo** — draw each player's items from their **own** ship cargo instead of the ship cursor (`_ship`), so an aboard-ship partner's offer is validated and swapped against the right hold (mirrors the mission-payout pattern). Also hardens `SetTradeOffer` off the cursor.
- **World unload on disconnect** (Closes #313) — move the cursor off the departing player's body before unloading so the world actually drops from memory, and harden `WorldManager.Unload` so it can never silently no-op on the Active world again.
- **`/ai_mission` tick freeze** (Closes #314) — generate off the tick thread and publish on a `TickAiMissions` drain, so a slow AI backend can't freeze the single-threaded server.
- **Per-world throttles** (Closes #315) — move the presence / enemy-sync / void-rescue timers into `LoadedWorld` so each occupied world keeps its own cadence in multi-world play.
- **Per-planet flora** (Closes #317) — resolve the active flora subset per planet (keyed on `planet.Key`) instead of once for the first-visited planet; restores per-planet variety and seed-only determinism.
- **Block-id palette** (Closes #318) — persist the numeric-id → key palette and remap every stored block id (block/structure edits, flora regrowth, space structures) when the content set shifts, so adding a block no longer decodes existing saves to the wrong blocks. SQLite + PostgreSQL, atomic.

## Client (Unity)
- **Mesh leaks** (Closes #316) — free procedurally-built meshes Unity doesn't release with their GameObject: destroy the outgoing collision mesh on every chunk re-mesh, and free render+collision meshes on chunk unload, world reset, and ship/asteroid re-mesh (shared `DestroyChunkView` / `DestroyVoxChunk` / `DestroyShipChunk`).

## Verification
- Full test suite **1116 passing** (998 server + 118 client), including **5 new regression tests** (block-palette remap, per-partner trade cargo, per-planet flora determinism, world unload on disconnect).
- Clean **Release** rebuild — 0 warnings, 0 errors.
- Local Unity player build for the client-script changes: in progress at PR-open (mesh-lifecycle edits using APIs already present in those files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
