### PR TITLE
docs(changelog): add v0.7.7 (audit stability fixes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,31 @@ the richer, screenshot-laden versions live there. `(#123)` references the pull r
 
 ## [Unreleased]
 
-_Nothing yet — [v0.7.6](#076--2026-07-12) is the latest release._
+_Nothing yet — [v0.7.7](#077--2026-07-14) is the latest release._
+
+## [0.7.7] — 2026-07-14
+
+A pure stability release: a full code audit of the game server and the Unity client turned up eight bugs — all fixed here, the risky ones with new regression tests. Highlights: your saves are now safe across future content updates, multi-world hosting got fairer and lighter, and long play sessions stop growing in memory. (#319)
+
+### 💾 Saves are now safe across content updates
+- Saved worlds stored every block as a numeric id derived from the sorted content list — adding a new block in a later update could shift those ids and silently decode your existing builds into the *wrong* blocks. Worlds now persist an id→block palette and remap all stored ids (block & structure edits, regrown flora, space structures) when the content set changes — atomically, on SQLite and PostgreSQL alike. (#318)
+
+### 🛰️ Multi-world hosting: fairer, lighter, harder to freeze
+- Presence updates, enemy sync and void-rescue checks each ran on a **single shared timer** for the whole server — with several occupied worlds, one world could starve all the others of those updates. Each occupied world now keeps its own cadence. (#315)
+- A world now really unloads (and frees its memory) when its last player disconnects — before, the unload could silently do nothing and the world stayed resident. (#313)
+- `/ai_mission` called the AI backend synchronously on the tick thread, so a slow LLM response froze the entire server for everyone. Mission generation now runs off-thread and the result is applied on a later tick. (#314)
+
+### 🪐 Planets: flora variety restored
+- The set of plants for a planet was resolved once — for the first planet visited after server start — and then reused everywhere, so every world grew that first planet's flora. Each planet now resolves its own subset, deterministic from the seed again. (#317)
+
+### 🧠 Client: mesh memory leaks plugged
+- Unity never frees procedurally-built meshes on its own — chunk re-meshing, chunk unload, world reset and ship/asteroid re-meshing each leaked their outgoing render/collision meshes. All of these now destroy the replaced meshes, so long sessions no longer creep up in memory. (#316)
+
+### 🤝 Trading: the right cargo on both sides
+- Player-to-player trades (and the admin `give_item` command) now validate and swap each partner's items against that player's **own** ship cargo instead of the last ship the server happened to look at — an offer made while aboard someone else's ship no longer resolves against the wrong hold. (#319)
+
+### ✅ Verification
+- The full suite is now **1116 tests** (998 server + 118 client), including 5 new regression tests: block-palette remap, per-partner trade cargo, per-planet flora determinism, and world unload on disconnect. (#319)
 
 ## [0.7.6] — 2026-07-12
 

--- a/TODO.md
+++ b/TODO.md
@@ -6,7 +6,7 @@ plans live under [docs/](docs/) (committed); this file is the high-level status.
 keep it current when controls/features change. Last consolidated 2026-06-04.
 
 **Build:** `scripts/build-client.ps1` (Windows) or `scripts/build-client.sh` (Linux) — publishes shared libs + bundled server + Unity player.
-**Test:** `./scripts/run-tests.sh` — currently **989 server + 118 client passing** (2026-07-08). Locale parity (en/de) is enforced by a test.
+**Test:** `./scripts/run-tests.sh` — currently **998 server + 118 client passing** (2026-07-14). Locale parity (en/de) is enforced by a test.
 CI runs two tiers: PRs skip the 31 tests marked `[Trait("Category", "Slow")]` (~6 min gate); pushes to `main` and the release workflow run the full suite.
 **Conventions:** English docs/comments; in-game text bilingual DE+EN; commit to `main` with the
 Claude `Co-Authored-By` trailer; OpenAI texture + ElevenLabs sound generation is blanket-approved


### PR DESCRIPTION
Adds the **0.7.7** CHANGELOG section (mirrors the upcoming GitHub release notes for the eight 2026-07 audit fixes from #319) and refreshes the TODO.md test count to 998 + 118.

Doc-only; merged ahead of the `v0.7.7` tag so the tag points at a commit that already contains its own changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)