### PR TITLE
chore(devblog): add v0.7.7 release post publish date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,8 +31,9 @@ A pure stability release: a full code audit of the game server and the Unity cli
 ### 🧠 Client: mesh memory leaks plugged
 - Unity never frees procedurally-built meshes on its own — chunk re-meshing, chunk unload, world reset and ship/asteroid re-meshing each leaked their outgoing render/collision meshes. All of these now destroy the replaced meshes, so long sessions no longer creep up in memory. (#316)
 
-### 🤝 Trading: the right cargo on both sides
+### 🤝 Trading: the right cargo on both sides (security fix)
 - Player-to-player trades (and the admin `give_item` command) now validate and swap each partner's items against that player's **own** ship cargo instead of the last ship the server happened to look at — an offer made while aboard someone else's ship no longer resolves against the wrong hold. (#319)
+- **Security note** *(disclosed only after the official fleet was patched)*: the wrong-cargo lookup was player-reproducible and could be abused to **duplicate items** in multiplayer trades. The official hosted worlds already run v0.7.7 — if you host your own server, please update / pull the rebuilt Docker image promptly.
 
 ### ✅ Verification
 - The full suite is now **1116 tests** (998 server + 118 client), including 5 new regression tests: block-palette remap, per-partner trade cargo, per-planet flora determinism, and world unload on disconnect. (#319)

--- a/tools/devblog/publish_devblog.py
+++ b/tools/devblog/publish_devblog.py
@@ -95,6 +95,7 @@ PUBLISH_DATES = [
     "2026-07-10T22:00:00Z",  # 36 Baumhaus-Prinzip (right after the v0.7.5 news; file order!)
     "2026-07-10T21:30:00Z",  # 37 Version 0.7.5 news (already live; sits after the export section in the md)
     "2026-07-12T20:30:00Z",  # 38 Version 0.7.6 news (already live; posted right after the v0.7.6 release)
+    "2026-07-14T03:57:00Z",  # 39 Version 0.7.7 news (already live; posted right after the v0.7.7 release)
 ]
 EN_EXTRA_MINUTES = 5
 


### PR DESCRIPTION
Adds the dated `PUBLISH_DATES` entry for the v0.7.7 release post (live since 2026-07-14 03:57 UTC, DE + EN), following the per-release convention.

Also updates the 0.7.7 CHANGELOG trading section with the security note: the fix closed a player-reproducible **item-duplication exploit** in multiplayer trades. Disclosure was deliberately held back until the official fleet was redeployed on v0.7.7 — which happened earlier today — matching the neutral wording used in #319 while servers were still unpatched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)