### PR TITLE
fix(build): sync GameServer/Persistence netstandard flavors in the bash lib sync too

### DIFF
--- a/scripts/sync-client-libs.sh
+++ b/scripts/sync-client-libs.sh
@@ -15,21 +15,32 @@ STREAMING="$REPO/client/Assets/StreamingAssets/data"
 mkdir -p "$PLUGINS"
 mkdir -p "$STREAMING"
 
+# "project[:framework]" — the last two are multi-target; Unity consumes their netstandard2.1
+# library flavor (the in-browser singleplayer server + managed persistence). Keep in sync with
+# scripts/sync-client-libs.ps1.
 PROJECTS=(
     "src/BlocksBeyondTheStars.Shared"
     "src/BlocksBeyondTheStars.WorldGeneration"
     "src/BlocksBeyondTheStars.Networking"
     "src/BlocksBeyondTheStars.Client.Core"
+    "src/BlocksBeyondTheStars.Persistence:netstandard2.1"
+    "src/BlocksBeyondTheStars.GameServer:netstandard2.1"
 )
 
 TEMP="$(mktemp -d)"
 trap 'rm -rf "$TEMP"' EXIT
 
-for p in "${PROJECTS[@]}"; do
-    echo "==> Publishing $p ..."
+for entry in "${PROJECTS[@]}"; do
+    p="${entry%%:*}"
+    fw="${entry#*:}"
+    fwargs=()
+    if [ "$fw" != "$entry" ]; then
+        fwargs=(-f "$fw")
+    fi
+    echo "==> Publishing $p ${fwargs[*]:-} ..."
     name="$(basename "$p")"
     out="$TEMP/$name"
-    dotnet publish "$REPO/$p" -c Release -o "$out" >/dev/null
+    dotnet publish "$REPO/$p" -c Release "${fwargs[@]}" -o "$out" >/dev/null
     find "$out" -name '*.dll' -exec cp -f {} "$PLUGINS/" \;
 done
 


### PR DESCRIPTION
The v0.8.0 release run failed on the Linux-runner Unity builds (Linux/WebGL/macOS): #326 updated only `sync-client-libs.ps1`, so the bash variant CI uses never shipped the new netstandard2.1 GameServer/Persistence DLLs into Plugins — CS0234 in `BrowserLocalServer.cs`. This mirrors the ps1 (`-f netstandard2.1` for both multi-target projects). Verified locally: the script publishes all six libraries and the DLLs land in Plugins. (The dedicated-server-image failure in the same run was an unrelated transient apt-mirror timeout on the arm64 leg.)

The v0.8.0 tag + release will be recreated on top of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)