### PR TITLE
fix(webgl-menu): no server picking on glitch.fun — Play retries the arcade

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -5679,6 +5679,21 @@ index.html at root for Glitch's deploy engine, optional CLI deploy). Docs: HOSTE
 Known v0.7.8 limitation: in-game `/report` is portal-session-bound and silently unavailable for
 arcade guests (documented). The public Baumhaus amendment ships as a devblog follow-up with launch.
 
+## ✅ Done (2026-07-15): glitch.fun store page filled + `tools/glitch-media` uploader
+
+The glitch.fun store page for the title is now fully populated via a new API tool,
+[tools/glitch-media/upload_media.py](tools/glitch-media/upload_media.py) (uv script; login via
+git-ignored `.env`, JWT lives at `token.access_token` in the login response): main image
+(`start_screen.png`), banner (`space_flight.png`), gallery = full EN trailer + the 13 EN press
+screenshots (`docs/screenshots/en`), gameplay instructions (`instructions.md`), genres
+(Adventure, Sandbox, Survival, OpenWorld, Voxel — replaced the lone wrong "MMO") and all
+deep-dive fields (`deep_dive.json`: tagline, mechanics, narrative, style, multiplayer, DLC,
+system requirements, key features). `critical_reception`/`age_rating`/`release_date`/`pricing`
+deliberately left empty. The 12 pre-existing gallery items (a WRONG game's video+screenshot,
+outdated low-res DE-UI shots, old DE trailer) were removed after a full local backup
+(`media/glitch-store-backup-2026-07-15/`, git-ignored). Flags: `--list/--main-image/--banner/`
+`--media/--defaults/--attach/--remove/--instructions-file/--genres/--update-json/--dry-run`.
+
 ## ✅ Done (2026-07-10): stop release builds from writing dead tag-scoped Actions caches
 The 10 GB Actions cache budget was 99% full; ~7.7 GB were caches scoped to release tags (four Unity
 Library caches up to 2 GB each + ~60 buildkit blobs). A tag-scoped cache can never be restored by any

--- a/client/Assets/BlocksBeyondTheStars/Scripts/AppShell.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/AppShell.cs
@@ -171,6 +171,15 @@ namespace BlocksBeyondTheStars.Client
         private bool _autoSingleplayerWhenReady;
 
 #if UNITY_WEBGL && !UNITY_EDITOR
+        /// <summary>Menu retry for the glitch.fun arcade: the auto-join runs on page load, but when it
+        /// fails (gateway hiccup, full worlds) the menu's Play button re-requests a session instead of
+        /// dialing the meaningless default host — on Glitch the player never picks a server.</summary>
+        public void RetryArcadeJoin()
+        {
+            MenuNotice = "";
+            StartCoroutine(RequestArcadeJoin());
+        }
+
         private IEnumerator RequestArcadeJoin()
         {
             yield return GlitchIntegration.RequestArcadeSession((session, error) =>

--- a/client/Assets/BlocksBeyondTheStars/Scripts/UiMainMenu.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/UiMainMenu.cs
@@ -72,6 +72,12 @@ namespace BlocksBeyondTheStars.Client
             var webWarn = UiKit.AddText(root, bx, by + 80f, bw, 22f, "", 14,
                 new Color(1f, 0.55f, 0.4f), TextAnchor.MiddleLeft, FontStyle.Bold);
             float wby = by + 112f;
+
+            // glitch.fun context (install_id in the URL): the player NEVER picks a server here — the
+            // arcade auto-join runs on page load, so the menu only appears when it failed. Play then
+            // re-requests an arcade session instead of dialing the meaningless default host (which
+            // built an empty, serverless world rig), and the manual server picker stays hidden.
+            bool onGlitch = GlitchIntegration.ArcadeInstallId.Length > 0 && GlitchIntegration.PortalUrl.Length > 0;
             UiKit.AddButton(root, bx, wby, bw, bh, shell.L("ui.menu.play"), () =>
             {
                 if (string.IsNullOrWhiteSpace(webName[0]))
@@ -83,7 +89,14 @@ namespace BlocksBeyondTheStars.Client
                 shell.PlayerName = webName[0].Trim();
                 shell.Settings.PlayerName = shell.PlayerName; // remember the identity across sessions
                 shell.Settings.Save();
-                shell.StartJoin();
+                if (onGlitch)
+                {
+                    shell.RetryArcadeJoin();
+                }
+                else
+                {
+                    shell.StartJoin();
+                }
             }, "btn_join");
 
             // In-browser singleplayer: the REAL authoritative server runs in-process (LoopbackTransport,
@@ -105,10 +118,10 @@ namespace BlocksBeyondTheStars.Client
             }, "btn_singleplayer");
 
             // The manual server picker only helps when /play was opened WITHOUT a deep-linked server —
-            // players arriving through the portal already have host/port preconfigured, so the extra
-            // choice is just noise for them (#221).
+            // players arriving through the portal already have host/port preconfigured, and on
+            // glitch.fun there is nothing to pick at all (#221).
             float wextra = 0f;
-            if (!GlitchIntegration.TryGetConfiguredServer(out _, out _, out _))
+            if (!onGlitch && !GlitchIntegration.TryGetConfiguredServer(out _, out _, out _))
             {
                 UiKit.AddButton(root, bx, wby + gap * 2f, bw, bh, shell.L("ui.menu.connect_manual"), () =>
                 {


### PR DESCRIPTION
On glitch.fun the menu only appears when the arcade auto-join failed. Play then dialed the meaningless default host and built an empty, serverless world rig (the "empty world" from the first live test); the manual "Connect to a server…" dialog was also offered. In the Glitch context (install_id present + baked portal origin) Play now re-requests an arcade session and the manual picker stays hidden — on Glitch the player never picks a server.

Closes #331

🤖 Generated with [Claude Code](https://claude.com/claude-code)