### PR TITLE
fix(glitch): create/resume the install before validating (required call order)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,12 @@ _Nothing yet — [v0.8.1](#081--2026-07-15) is the latest release._
 
 A small launch-day patch for the glitch.fun edition, straight from the first live test. (#332)
 
+### 🕹️ glitch.fun: arcade joins actually work now
+- The arcade session gateway validated a visitor's install **before** registering it with Glitch — but Glitch's contract requires create-then-validate, so every fresh browser session was rejected with "could not be verified" and nobody could enter the arcade worlds. The gateway now follows the required call order (create/resume first, then validate), with a regression test pinning the sequence. (#334)
+- Fleet side (no download needed): the arcade gateway env passthrough was fixed in deployment, so the gateway is actually switched on. (#330)
+
 ### 🕹️ glitch.fun: the menu never offers server picking anymore
 - On glitch.fun the arcade join runs automatically when the page loads, so the menu only ever appears when that join failed. That menu still offered the generic browser actions: **Play** dialed a meaningless default host and dropped the player into an empty, serverless void, and **"Connect to a server…"** suggested picking a server — which on Glitch is never the player's job. In the Glitch context, Play now simply retries the arcade join and the manual picker is gone. (#331)
-- Fleet side (no download needed): the arcade gateway env passthrough was fixed in deployment, so the shared arcade worlds actually accept players. (#330)
 
 ## [0.8.0] — 2026-07-15
 

--- a/src/BlocksBeyondTheStars.WorldHost/GlitchGateway.cs
+++ b/src/BlocksBeyondTheStars.WorldHost/GlitchGateway.cs
@@ -608,6 +608,27 @@ public sealed class GlitchGateway
 
         try
         {
+            // Glitch's REQUIRED call order: create/resume the install FIRST (POST /installs — the
+            // same idempotent route the heartbeat uses), THEN validate. Validating an install the
+            // platform has never seen answers 403 — which is exactly what a fresh browser session
+            // is until this call.
+            using (var create = new HttpRequestMessage(HttpMethod.Post, InstallsUrl()))
+            {
+                create.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", _config.GlitchTitleToken);
+                create.Content = new StringContent(
+                    System.Text.Json.JsonSerializer.Serialize(new Dictionary<string, string>
+                    {
+                        ["user_install_id"] = installId,
+                        ["platform"] = "web",
+                    }),
+                    Encoding.UTF8, "application/json");
+                using var createResponse = await _glitchApi.SendAsync(create).ConfigureAwait(false);
+                if (!createResponse.IsSuccessStatusCode)
+                {
+                    return (false, string.Empty);
+                }
+            }
+
             using var request = new HttpRequestMessage(HttpMethod.Post, $"{InstallsUrl()}/{Uri.EscapeDataString(installId)}/validate");
             request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", _config.GlitchTitleToken);
             request.Content = new StringContent("{}", Encoding.UTF8, "application/json");

--- a/tests/BlocksBeyondTheStars.Tests/GlitchGatewayTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/GlitchGatewayTests.cs
@@ -162,6 +162,23 @@ public sealed class GlitchGatewayTests : IDisposable
     }
 
     [Fact]
+    public async Task Session_CreatesTheInstallBeforeValidating_GlitchRequiredCallOrderAsync()
+    {
+        // Glitch's documented call order: create/resume the install FIRST, then validate — validating
+        // an install the platform has never seen answers 403 (the launch-day arcade join failure).
+        var (gateway, _, api, _) = NewGateway();
+
+        var result = await gateway.SessionAsync(Install);
+
+        Assert.True(result.Ok, result.Error);
+        int createIndex = api.Requests.FindIndex(r => r.Url.EndsWith("/installs", StringComparison.Ordinal));
+        int validateIndex = api.Requests.FindIndex(r => r.Url.EndsWith("/validate", StringComparison.Ordinal));
+        Assert.True(createIndex >= 0, "the install create/resume call must happen");
+        Assert.True(validateIndex > createIndex, "create/resume must precede validate");
+        Assert.Contains("\"user_install_id\":\"" + Install + "\"", api.Requests[createIndex].Body, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task Session_StableIdentity_SameInstallGetsTheSameNameEveryVisitAsync()
     {
         var (gateway, _, _, _) = NewGateway();


### PR DESCRIPTION
First live arcade test failed for every fresh visitor: the session gateway validated the install before registering it, but Glitch's contract requires **create → validate** — validating an unknown install answers 403. Verified from the fleet host that the runtime token + endpoint are fine (known dev-test installs validate `valid:true`); only the order was wrong. The gateway now posts the idempotent create/resume first; a regression test pins the sequence, and the pending v0.8.1 changelog entry now covers it.

Closes #334

🤖 Generated with [Claude Code](https://claude.com/claude-code)