### PR TITLE
feat(glitch): keep the arcade pool awake + allow the S3 content-bucket origin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ A small launch-day patch for the glitch.fun edition, straight from the first liv
 
 ### 🕹️ glitch.fun: arcade joins actually work now
 - The arcade session gateway validated a visitor's install **before** registering it with Glitch — but Glitch's contract requires create-then-validate, so every fresh browser session was rejected with "could not be verified" and nobody could enter the arcade worlds. The gateway now follows the required call order (create/resume first, then validate), with a regression test pinning the sequence. (#334)
+- **CORS knew the wrong address:** Glitch serves the actual game files from its S3 content bucket, not from `play.glitch.fun` — so the browser refused to even send the arcade requests. The bucket origin is now part of the default allowlist. (#336)
+- **The arcade never sleeps:** the pool worlds now run permanently — woken at startup, never idle-exiting, re-woken automatically if one crashes — so a store visitor lands in a running world instead of waiting out a cold world generation. (`BBS_WH_GLITCH_KEEP_AWAKE=false` opts tight hosts out.) (#336)
 - Fleet side (no download needed): the arcade gateway env passthrough was fixed in deployment, so the gateway is actually switched on. (#330)
 
 ### 🕹️ glitch.fun: the menu never offers server picking anymore

--- a/deploy/worldhost/.env.example
+++ b/deploy/worldhost/.env.example
@@ -53,11 +53,16 @@ BBS_WH_GLITCH_TITLE_ID=80f5dc18-dc0f-45de-9a57-8599e08669ed
 BBS_WH_GLITCH_TITLE_TOKEN=
 BBS_WH_GLITCH_WORLDS=2
 BBS_WH_GLITCH_MAX_PLAYERS=8
-# Comma-separated origins allowed to call /api/glitch/* cross-origin (the Glitch-hosted build).
-# Default: https://play.glitch.fun, https://glitch.fun, https://www.glitch.fun
+# Comma-separated origins allowed to call /api/glitch/* cross-origin. NOTE: Glitch serves the game
+# from its S3 content bucket — that bucket IS the page origin the browser sends. Default:
+# https://play.glitch.fun, https://glitch.fun, https://www.glitch.fun,
+# https://glitch-game-content.s3.amazonaws.com
 #BBS_WH_GLITCH_ALLOWED_ORIGINS=
 # Cloud-save relay writes per install per hour (browser singleplayer autosaves; default 40).
 #BBS_WH_GLITCH_SAVES_PER_HOUR=40
+# Keep the arcade pool awake permanently (default true): worlds wake at startup, never idle-exit,
+# and the reaper re-wakes crashes — store visitors never wait out a cold worldgen.
+#BBS_WH_GLITCH_KEEP_AWAKE=true
 
 # Legal pages (§5 DDG Impressum + DSGVO Datenschutz). REQUIRED before a public launch — with these
 # empty the pages render a "not configured" notice instead of wrong data. A self-hosted operator MUST

--- a/src/BlocksBeyondTheStars.WorldHost/GlitchGateway.cs
+++ b/src/BlocksBeyondTheStars.WorldHost/GlitchGateway.cs
@@ -516,6 +516,35 @@ public sealed class GlitchGateway
         }
     }
 
+    /// <summary>Keep-awake pass (GlitchKeepAwake): creates the pool if needed and wakes every arcade
+    /// world that is not running, so a store visitor never waits out a cold worldgen. Called once at
+    /// WorldHost startup and again from the reaper loop (which also re-wakes a crashed instance —
+    /// the containers run with idle shutdown off, so a healthy one never stops by itself). Returns
+    /// the number of worlds woken.</summary>
+    public async Task<int> WakePoolAsync()
+    {
+        if (!Enabled || !_config.GlitchKeepAwake)
+        {
+            return 0;
+        }
+
+        EnsurePool();
+        int woken = 0;
+        foreach (var world in _registry.ListWorldsByChannel(WorldChannel.Glitch))
+        {
+            if (world.Status != WorldStatus.Running)
+            {
+                var (running, _) = await _orchestrator.EnsureRunningAsync(world.Id).ConfigureAwait(false);
+                if (running is not null)
+                {
+                    woken++;
+                }
+            }
+        }
+
+        return woken;
+    }
+
     /// <summary>Picks the arcade world for the next guest: a running world with player headroom first
     /// (probed live), then a sleeping one to wake on demand. Racy by design — the instance's own
     /// BBS_MAX_PLAYERS cap is the hard fence; a lost race answers "Server is full" client-side.</summary>

--- a/src/BlocksBeyondTheStars.WorldHost/InstanceLauncher.cs
+++ b/src/BlocksBeyondTheStars.WorldHost/InstanceLauncher.cs
@@ -84,7 +84,9 @@ public sealed class DockerCliLauncher : IInstanceLauncher
             "-e", $"BBS_SERVER_NAME={world.DisplayName}",
             // glitch.fun arcade worlds get their own (smaller) player cap; applied on container start.
             "-e", $"BBS_MAX_PLAYERS={(world.Channel == WorldChannel.Glitch ? config.GlitchMaxPlayers : config.MaxPlayersPerWorld)}",
-            "-e", $"BBS_IDLE_SHUTDOWN_MINUTES={config.IdleShutdownMinutes}",
+            // Kept-awake arcade worlds never self-exit (0 = idle shutdown off) — a store visitor
+            // should land in a running world, not wait out a cold worldgen.
+            "-e", $"BBS_IDLE_SHUTDOWN_MINUTES={(world.Channel == WorldChannel.Glitch && config.GlitchKeepAwake ? 0 : config.IdleShutdownMinutes)}",
             "-e", $"BBS_JOIN_TOKEN_SECRET={world.JoinSecret}",
             "-e", $"BBS_WORLD_OWNER={world.OwnerAccountId}",
             "-e", "BBS_ENABLE_WEBSOCKET=true",

--- a/src/BlocksBeyondTheStars.WorldHost/Program.cs
+++ b/src/BlocksBeyondTheStars.WorldHost/Program.cs
@@ -1122,6 +1122,24 @@ app.MapGet("/api/worlds/{id}/save", (HttpContext ctx, string id) =>
 
 // Reconcile registry vs Docker every 30 s: instances that exited themselves (idle shutdown — the normal
 // sleep path) get marked stopped so the next join wakes them and world lists stay truthful.
+// Keep-awake arcade worlds: wake the pool once at startup (fire-and-forget — worldgen on a fresh
+// pool can take a minute per world) so the first glitch.fun visitor lands in a RUNNING world.
+if (config.GlitchKeepAwake && glitch.Enabled)
+{
+    _ = Task.Run(async () =>
+    {
+        try
+        {
+            int woken = await glitch.WakePoolAsync();
+            log.LogInformation("glitch.fun keep-awake: {Count} arcade world(s) woken at startup.", woken);
+        }
+        catch (Exception ex)
+        {
+            log.LogWarning(ex, "glitch.fun keep-awake startup pass failed (the reaper retries).");
+        }
+    });
+}
+
 var reaper = Task.Run(async () =>
 {
     using var timer = new PeriodicTimer(TimeSpan.FromSeconds(30));
@@ -1134,6 +1152,14 @@ var reaper = Task.Run(async () =>
             if (reaped > 0)
             {
                 log.LogInformation("Reaper: {Count} idle-stopped world(s) marked stopped.", reaped);
+            }
+
+            // Keep-awake arcade worlds: re-wake anything the reaper just found dead (crash/OOM/host
+            // reboot) — with idle shutdown off these should never stop on their own.
+            int rewoken = await glitch.WakePoolAsync();
+            if (rewoken > 0)
+            {
+                log.LogInformation("glitch.fun keep-awake: {Count} arcade world(s) re-woken.", rewoken);
             }
 
             // Archive sweep once an hour (120 × 30 s): long-inactive stopped worlds move to the archive.

--- a/src/BlocksBeyondTheStars.WorldHost/WorldHostConfig.cs
+++ b/src/BlocksBeyondTheStars.WorldHost/WorldHostConfig.cs
@@ -220,11 +220,20 @@ public sealed class WorldHostConfig
     public int GlitchMaxPlayers { get; set; } = 8;
 
     /// <summary>Origins allowed to call the /api/glitch endpoints cross-origin
-    /// (BBS_WH_GLITCH_ALLOWED_ORIGINS, comma-separated) — the Glitch-hosted WebGL build's origins.</summary>
+    /// (BBS_WH_GLITCH_ALLOWED_ORIGINS, comma-separated). Note the S3 origin: Glitch serves the
+    /// actual game files from its content bucket, so THAT is the page origin the browser sends —
+    /// not play.glitch.fun (launch-day lesson: every preflight failed without it).</summary>
     public List<string> GlitchAllowedOrigins { get; set; } = new()
     {
         "https://play.glitch.fun", "https://glitch.fun", "https://www.glitch.fun",
+        "https://glitch-game-content.s3.amazonaws.com",
     };
+
+    /// <summary>Keep the arcade pool awake permanently (BBS_WH_GLITCH_KEEP_AWAKE, default true):
+    /// pool worlds never idle-exit and are woken at WorldHost startup + re-woken by the reaper, so
+    /// a store visitor never waits out a cold worldgen. Costs GlitchWorldCount × InstanceMemory of
+    /// standing RAM; disable for tight hosts.</summary>
+    public bool GlitchKeepAwake { get; set; } = true;
 
     /// <summary>Glitch platform API base (BBS_WH_GLITCH_API_URL) — overridable so tests can point the
     /// gateway at a fake.</summary>
@@ -315,6 +324,7 @@ public sealed class WorldHostConfig
         if (Env("BBS_WH_GLITCH_API_URL") is { } gApi) { c.GlitchApiBaseUrl = gApi; }
         if (Env("BBS_WH_GLITCH_SESSIONS_PER_MINUTE") is { } gspStr && int.TryParse(gspStr, out var gsp)) { c.GlitchSessionsPerMinutePerIp = gsp; }
         if (Env("BBS_WH_GLITCH_SAVES_PER_HOUR") is { } gsvStr && int.TryParse(gsvStr, out var gsv)) { c.GlitchSavesPerHourPerInstall = gsv; }
+        if (Env("BBS_WH_GLITCH_KEEP_AWAKE") is { } gkaStr && bool.TryParse(gkaStr, out var gka)) { c.GlitchKeepAwake = gka; }
 
         return c;
     }

--- a/tests/BlocksBeyondTheStars.Tests/GlitchGatewayTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/GlitchGatewayTests.cs
@@ -508,10 +508,11 @@ public sealed class GlitchGatewayTests : IDisposable
     }
 
     [Fact]
-    public void BuildRunArgs_GlitchWorldsGetTheArcadePlayerCap()
+    public void BuildRunArgs_GlitchWorldsGetTheArcadePlayerCap_AndKeepAwakeDisablesIdleExit()
     {
         var config = NewConfig();
         config.MaxPlayersPerWorld = 12;
+        config.IdleShutdownMinutes = 20;
         var registry = NewRegistry(config);
         var arcade = registry.CreateGlitchWorld("Glitch Arcade 1").World!;
         var (_, _, accountId, _) = registry.CreateAccount("Owner", "super-secret-1", acceptedTermsVersion: 1);
@@ -522,6 +523,37 @@ public sealed class GlitchGatewayTests : IDisposable
 
         Assert.Contains("BBS_MAX_PLAYERS=2", arcadeArgs);
         Assert.Contains("BBS_MAX_PLAYERS=12", portalArgs);
+        Assert.Contains("BBS_IDLE_SHUTDOWN_MINUTES=0", arcadeArgs);  // kept awake: never self-exits
+        Assert.Contains("BBS_IDLE_SHUTDOWN_MINUTES=20", portalArgs); // portal worlds keep sleeping
+
+        // Tight hosts can opt out — arcade worlds then idle-exit like everyone else.
+        config.GlitchKeepAwake = false;
+        Assert.Contains("BBS_IDLE_SHUTDOWN_MINUTES=20", DockerCliLauncher.BuildRunArgs(config, arcade, "saves"));
+    }
+
+    [Fact]
+    public async Task WakePool_CreatesAndWakesEveryArcadeWorld_AndIsIdempotentAsync()
+    {
+        var config = NewConfig();
+        var registry = NewRegistry(config);
+        var launcher = new FakeLauncher();
+        var orchestrator = new WorldOrchestrator(config, registry, launcher,
+            w => Task.FromResult(launcher.IsRunning(w.ContainerId)));
+        var gateway = new GlitchGateway(config, registry, orchestrator, new FakeGlitchApi(),
+            statusReader: _ => Task.FromResult<string?>(null));
+
+        Assert.Equal(2, await gateway.WakePoolAsync()); // fresh pool: both created + woken
+        Assert.Equal(2, launcher.StartCount);
+        Assert.All(registry.ListWorldsByChannel(WorldChannel.Glitch), w => Assert.Equal(WorldStatus.Running, w.Status));
+
+        Assert.Equal(0, await gateway.WakePoolAsync()); // already running: nothing to do
+        Assert.Equal(2, launcher.StartCount);
+
+        // Keep-awake off → the pass is a no-op even with stopped worlds.
+        config.GlitchKeepAwake = false;
+        launcher.Running.Clear();
+        orchestrator.Reap();
+        Assert.Equal(0, await gateway.WakePoolAsync());
     }
 
     public void Dispose()


### PR DESCRIPTION
Launch findings from the first real arcade sessions (see #336): the game's true page origin is Glitch's S3 content bucket (every preflight failed without it — the hotfix is already live on the fleet via the env override; this PR bakes it into the default), and the arcade pool now stays awake permanently (idle shutdown off, woken at startup, reaper re-wakes crashes) so first joins are instant instead of ~90 s of cold worldgen. `BBS_WH_GLITCH_KEEP_AWAKE=false` opts out. 33 gateway tests green incl. new keep-awake + run-args cases.

Closes #336

🤖 Generated with [Claude Code](https://claude.com/claude-code)