### PR TITLE
docs(strategy): documented strategy — vision, mission, roadmap

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,13 @@ Thanks for your interest! **Blocks Beyond the Stars** is a family project that w
 opening up to the community — and we would love your help. There are three ways to join
 in, from "no setup at all" to "write some code".
 
-Everyone is welcome here. Please be kind — see our short
+Everyone is welcome here — players who tell us what's confusing, hobby and professional
+programmers, and experts from every craft (graphics, music, game design, UX, translation …).
+Feedback-only contributions count fully; if you want to know what you'd be joining, the project's
+[vision](docs/strategy/vision.md), [mission](docs/strategy/mission.md) and
+[roadmap](docs/strategy/roadmap.md) are short reads.
+
+Please be kind — see our short
 [Code of Conduct](CODE_OF_CONDUCT.md) (it's basically "be nice to one another").
 
 > Repository: <https://github.com/marceld23/BlocksBeyondTheStars>

--- a/README.md
+++ b/README.md
@@ -135,7 +135,8 @@ Community contributions we're grateful for:
 
 Want to see your name here? See **[CONTRIBUTING.md](CONTRIBUTING.md)**.
 
-> **Status & docs:** [TODO.md](TODO.md) is the single Done/Open status doc; player operation is in
+> **Status & docs:** the project strategy (vision · mission · roadmap) lives in
+> [docs/strategy/](docs/strategy/vision.md); [TODO.md](TODO.md) is the single Done/Open status doc; player operation is in
 > [docs/user/USER_MANUAL.md](docs/user/USER_MANUAL.md); building and verifying builds is in
 > [docs/developer/DEVELOPER.md](docs/developer/DEVELOPER.md); the system overview is in
 > [docs/developer/ARCHITECTURE.md](docs/developer/ARCHITECTURE.md) and every developer doc is indexed in

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,8 @@
 # Blocks Beyond the Stars — Project Status
 
 The single source of truth for **what is built** and **what is still open**. Design notes and deep
-plans live under [docs/](docs/) (committed); this file is the high-level status. Player-facing operation
+plans live under [docs/](docs/) (committed); the long-range direction is the strategy trio in
+[docs/strategy/](docs/strategy/vision.md) (vision · mission · roadmap); this file is the high-level status. Player-facing operation
 (controls, mechanics, editors, commands) is documented in [docs/user/USER_MANUAL.md](docs/user/USER_MANUAL.md) —
 keep it current when controls/features change. Last consolidated 2026-06-04.
 

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -2,7 +2,8 @@
 
 Engineering and design documentation for **Blocks Beyond the Stars**. Player-facing operation lives in
 [../user/USER_MANUAL.md](../user/USER_MANUAL.md); the live Done/Open status is [../../TODO.md](../../TODO.md);
-the hard contributor rules are in [../../AGENTS.md](../../AGENTS.md).
+the hard contributor rules are in [../../AGENTS.md](../../AGENTS.md); the project strategy
+(vision · mission · roadmap) is in [../strategy/](../strategy/vision.md).
 
 These are *how it works* / *why it is built this way* references — not pre-implementation checklists (status
 belongs in TODO.md). Each doc states its own status near the top. Last reorganised 2026-06-19.

--- a/docs/strategy/mission.md
+++ b/docs/strategy/mission.md
@@ -1,0 +1,72 @@
+# Mission — Blocks Beyond the Stars
+
+> The strategy trio: [vision.md](vision.md) (where we want to be), **mission.md** (what we do and
+> how we decide), [roadmap.md](roadmap.md) (the concrete path).
+
+## Mission statement
+
+**We build and operate a free, open-source, kid-friendly voxel space game — and we make its
+existing mechanics bug-free and satisfying before we make them bigger.** We keep it fast enough to
+run in a browser tab and on a Raspberry Pi, we keep it safe enough for children to play online, and
+we carry it to the places players actually are: glitch.fun, itch.io, our own portal — and, as a
+long-held wish rather than a business plan, **Xbox and Steam**.
+
+## What we do (in priority order)
+
+1. **Fix before feature.** A shipped mechanic that half-works (a station that ignores `E`, a
+   recipe chain that ends in an unused item, a HUD that leaks into space flight) outranks any new
+   content. Every release should shrink the "known broken/odd" list.
+2. **Deepen what exists.** More items, materials and crafting recipes are welcome **when they
+   connect to existing loops** — a new ore needs a chain (mine → refine → craft → use), not just an
+   atlas tile. Content is data-driven by design; we exploit that for cheap, well-connected additions.
+3. **Operate the live game.** glitch.fun arcade, the hosted fleet and the portal are production:
+   launch bugs get patched in days, moderation levers exist before problems do, and every release
+   reaches all channels from one tagged pipeline.
+4. **Widen where it runs.** Browser and desktop today; documented Raspberry-Pi self-hosting next;
+   Steam and Xbox as deliberate, researched milestones — because having our game there would be
+   wonderful, not profitable.
+
+## Operating principles
+
+### Kid-friendly is a hard constraint
+- No horror, no gore, no gambling patterns, no punishing loss mechanics; bilingual DE+EN.
+- Online safety scales with reach: password-gated private worlds on our portal (the "Baumhaus
+  rule"), install-scoped guests on glitch.fun, moderation tooling grows **before** audience does.
+- Ratings and store policies for kids (IARC/PEGI, console cert) are treated as design inputs, not
+  paperwork at the end.
+
+### Performance is a budget, not a wish
+- Reference targets: a WebGL tab on a school laptop, and a **Raspberry Pi (ARM64, 4–8 GB) hosting a
+  family world** — the server already publishes `linux-arm64`; we keep it that way and measure,
+  not guess (per-world RAM, tick headroom, SD-card write load).
+- New server features must state their tick/memory cost; new client features must survive the
+  WebGL "Lite" profile.
+
+### Quality has a routine
+- Authoritative server + full test suite (1100+ tests) stay green; regressions get a test.
+- Changes to the client get a local Unity build check; releases go through the tagged CI pipeline
+  (installers, Docker multi-arch, itch.io, WebGL `/play`, glitch.fun) — never hand-rolled.
+- Real playtests (the standing playtest issues, and our own kids) are part of "done".
+
+### Open by default
+- Source, content data, docs and honest devblogs stay public; community contributions (languages,
+  designs, playtests, expert feedback) are actively invited and credited.
+- English for docs and code; the game itself speaks German and English.
+
+## Who this is for
+
+- **Kids and families** who want a safe, curious space sandbox — solo in a browser or together on
+  a home LAN.
+- **The two of us** — this is a father-son project; joy of building it is a first-class goal,
+  which is exactly why *our game on the Xbox* matters despite earning nothing.
+- **Tinkerers and contributors** who want a readable, open, data-driven game they can run on their
+  own hardware and extend with a JSON file.
+
+## What we say no to
+
+- Monetization of any kind, and features whose main value is monetization-shaped (battle passes,
+  timers, FOMO).
+- Big-bang rewrites and speculative engines; we evolve the shipped architecture.
+- New mechanics while their neighbors are broken — depth follows solidity.
+- Reach without moderation: we do not open doors (public listings, open registration, bigger
+  arcade pools) faster than our safety tooling grows.

--- a/docs/strategy/roadmap.md
+++ b/docs/strategy/roadmap.md
@@ -1,0 +1,196 @@
+# Roadmap — Blocks Beyond the Stars
+
+> The strategy trio: [vision.md](vision.md) (where we want to be), [mission.md](mission.md) (what
+> we do and how we decide), **roadmap.md** (the concrete path). Day-to-day status lives in
+> [TODO.md](../../TODO.md); this file orders the *horizons* and gets revisited when one completes.
+>
+> Written 2026-07-15 against v0.8.1, based on a code-verified analysis of the crafting/content
+> systems, the server's ARM64/Raspberry-Pi readiness, the glitch.fun integration, and external
+> research on Steam/Xbox publishing. Horizons are ordered by the mission's rule: **fix → deepen →
+> operate → widen**. Version numbers are intents, not promises.
+
+## Where we stand (2026-07-15)
+
+- **Live:** v0.8.1 on all channels — Windows/Linux/macOS installers, itch.io, own portal + hosted
+  fleet, WebGL `/play`, and the freshly launched **glitch.fun edition** (arcade worlds, in-browser
+  singleplayer, cloud saves, auto-publish on tag). Suite: 1127 tests.
+- **Content:** fully data-driven — 142 blocks, 167 items, 180 recipes, 57 blueprints, 8 crafting
+  stations, a real blueprint tech-tree and ore→ingot→alloy→component chains. Content validation
+  rejects dangling references at startup; savegames survive content additions via the id→palette
+  remap shipped in v0.7.7.
+- **Server:** .NET 10, authoritative, 15 Hz tick; `linux-arm64` self-contained publish and
+  multi-arch Docker already exist; a bare `GameServer` runs standalone for LAN without any portal.
+- **Known soft spots:** a fresh glitch.fun launch bug (#334), a handful of half-working mechanics
+  (ship console station, UFO-kill on old saves, HUD leaks), shallow demand for many late-game
+  materials, and no measured performance numbers for small hardware.
+
+---
+
+## Horizon 0 — Stabilize the glitch.fun launch (days; v0.8.x patches)
+
+*The arcade is our widest door and it is currently jammed. Everything here is small and urgent.*
+
+- **Merge + deploy the #334 fix** (branch `fix/glitch-install-call-order` exists, unmerged):
+  the session gateway validates installs before creating them, so **every fresh visitor gets 403**
+  — the arcade is effectively closed to the public until this ships and the WorldHost is
+  redeployed.
+- **Live launch smoke test** on play.glitch.fun after the fix: fresh-install auto-join, pointer
+  lock inside Glitch's iframe, touch controls on a tablet, cloud-save round-trip with a logged-in
+  account. (No iframe `allow`/pointer-lock handling exists in code — verify it's actually fine.)
+- **Fix the store-page copy inconsistency:** `tools/glitch-media/instructions.md` tells players to
+  use `/report`, which arcade guests *cannot* do (needs a portal session). Reword to the real
+  recourse until guest reporting exists.
+- **Release-pipeline check:** confirm `release.yml` passes `linux/amd64,linux/arm64` to
+  `docker.yml` (its `platforms` default is amd64-only) so tagged server images really are
+  multi-arch.
+- Publish the planned Baumhaus/arcade devblog post once the arcade demonstrably works.
+
+**Done when:** a stranger on glitch.fun can click Play and be in an arcade world, on desktop and
+tablet, and the fix is verified from a clean browser profile.
+
+## Horizon 1 — Bug-free core mechanics (weeks; v0.9)
+
+*Mission rule #1: no new depth while shipped mechanics half-work. Close the known list, then keep
+it closed via playtests.*
+
+**Fix the "does nothing / does wrong" list (all previously analyzed):**
+- Ship **console station**: `E` is a no-op + missing locale key; decide and implement what engines
+  and other decorative ship devices actually do (analysis: ship-device-blocks-function).
+- **UFO-kill bug**: `ShipWeapons=Off` on old saves makes UFOs unkillable.
+- **Spaceflight HUD leak**: compass + time panel showing during space flight.
+- **Helmet lamp** stays on entering space; world-options modal transparency.
+- **Dark worlds**: lava=night / jungle=rain brightness floor (5-point plan exists).
+- **Loading-screen gap** (star flash) and remaining WebGL pop-in complaints as capacity allows.
+
+**Then verify with people, not just tests:**
+- Drive the standing playtest issues to closure: lighting #88, smoothness #89, audio #90, UI
+  readability #91, first-session clarity #92, creatures #93, flora sprout #94; platform tests
+  Linux #86, macOS #87, gamepad #201, touch #202, WebGL #203.
+- Harvest the expert-feedback issues (#276 menu/settings UX, #277 crafting & ship menu UX,
+  #278 URP graphics advice) into concrete follow-ups; Codex review #185.
+- Keep the audit muscle: repeat the v0.7.7-style full audit once per minor version.
+
+**Done when:** the "known broken/odd" list in TODO.md is empty, and a new-player playtest (#92)
+passes without an adult explaining anything.
+
+## Horizon 2 — Deeper crafting, more materials & items (v0.10+)
+
+*Only after Horizon 1. The content pipeline is pure JSON — additions are cheap — but the mission
+requires every addition to connect to a loop: mine → refine → craft → **use**.*
+
+**Close the existing dead ends first (they are cheap wins):**
+- **`reactor_fuel` has zero consumers** — the entire uranium/lead chain ends in an unused item.
+  Give it a real sink: e.g. a ship reactor upgrade, a base power system, or factory speed-ups.
+- **Thin-demand metals**: aluminium, tin, nickel, cobalt, platinum, lead, zinc, tungsten ingots are
+  each used in only ~2 recipes; lithium, neodymium, light_alloy, biofuel, magnet in exactly 1.
+  Target: every ore family has ≥3 meaningful uses across at least two stations.
+- **Decorative blocks players can't get**: lights, strip lights, panels, machine blocks are
+  worldgen-only (no drops, no recipes). Make the nice-looking blocks craftable — base-building is
+  a kid-favorite loop and this is pure data work.
+
+**Then add depth, kid-friendly by design:**
+- **New tiered content** that exploits the existing tool-tier (1–3) and blueprint gates: more
+  suit/gadget/vehicle-adjacent items, deeper food & farming (algae tank and seeds exist; recipes
+  are shallow), more consumables with gentle effects. No durability/tool-breaking — depth through
+  discovery, not maintenance chores (mission: no punishing mechanics).
+- **A material rarity/tier tag** if needed for UI sorting and balance visibility (today tiering is
+  implicit via `minToolTier` + chain depth; rarity exists only on planets/structures).
+- **More recipes for existing stations** before any new station: detoxifier (1 recipe) and
+  algae tank (1 recipe) are nearly empty; factories offer only 10 recipes.
+
+**Engineering guardrails for content growth (verify before the big batch):**
+- Block atlas: 16×16 = 256 slots, effective ceiling ≈ 239 blocks before procedural variants are
+  dropped — plan a larger atlas (or per-block texture fields) before crossing ~200 blocks.
+- Plain blocks/items are data-only; blocks with special rendering (transparency, cutout, scatter)
+  need `ChunkMesher`/`BlockTextureAtlas` code — batch those deliberately.
+- Every item/block ships DE+EN locale keys (parity is test-enforced) and, where relevant, a Codex
+  entry; content batches end with a save/load round-trip test on an existing world.
+
+**Done when:** zero defined-but-useless items in the content data, every station has a reason to
+be visited, and a returning player always has an affordable *next* blueprint.
+
+## Horizon 3 — Runs on a Raspberry Pi (parallel track, promote after H1)
+
+*The server is closer than expected: `linux-arm64` self-contained builds and ARM64-ready deps
+already ship. What's missing is measurement, tuning and a documented family-hosting story.*
+
+- **Measure before tuning:** capture real per-world RAM/CPU on ARM64 (or the VPS as proxy) — the
+  only number today is the 768 MB/2-CPU *policy fence*, not a measured working set. Add a tiny
+  perf log (tick overrun counter already implied by `ChunkStreamPerTick` docs).
+- **A "small hardware" server profile:** documented preset lowering `ChunkStreamPerTick` (16→~4),
+  `TickRate` (15→10), `ViewDistanceChunks`, `MaxPlayers` (target: 4–6 players, 1–2 worlds on a Pi
+  4/5 with 4–8 GB). Consider `DOTNET_GCHeapHardLimit` guidance for fenceless bare-metal runs.
+- **Take worldgen off the tick thread** (the one structural risk for weak hardware): fresh chunks
+  are generated synchronously in-tick, up to 16/tick during exploration — the main stutter/overrun
+  source on a Pi. This also helps the VPS fleet and browser singleplayer.
+- **Storage guidance:** keep and sharpen the existing "SSD over microSD" warning (WAL autosave
+  write amplification); document autosave/backup interval tuning for SD-card setups.
+- **Ship it as a story, not just a zip:** a SELF_HOSTING.md "Raspberry Pi family server" section
+  with a tested step-by-step (bare `dotnet` + systemd unit — no Docker/portal needed for LAN),
+  verified on real hardware once. This is also a lovely devblog.
+
+**Done when:** a stock Pi hosts a 4-player family world through an evening session with no tick
+overruns, following only the docs.
+
+## Horizon 4 — Steam & Xbox (the heart goals; sequenced, researched 2026-07)
+
+*Not for revenue — because our own game on the shelf is the point. Order follows realism.*
+
+**4a. Gamepad-first UX (prerequisite for everything console, start during H1):**
+Full controller support is the single investment that serves Steam, Steam Deck *and* Xbox — and
+issue #201 (Xbox pad on Windows) already tracks its verification. Target: complete a session —
+menus, crafting, building, flying, chat via on-screen keyboard — without touching a mouse.
+
+**4b. Steam (realistic first store; weeks of calendar time, ~$100):**
+- Individuals in Germany can onboard as sole proprietor — no company needed; free games are fine;
+  connecting to our own dedicated servers is explicitly supported; open source is fine (AGPL note:
+  skip linking the Steamworks SDK initially — upload via SteamPipe works without it).
+- Calendar mechanics: tax interview (days), $100 app fee → 30-day minimum to release, "coming
+  soon" page ≥2 weeks. Work items: store assets, Steam build depots (Windows + native Linux —
+  the Linux build doubles as the Steam Deck path), controller polish for a Deck-friendly review.
+- Honest constraint: Steam accounts are 13+ (COPPA) — Steam is the "families and older kids"
+  channel; the browser/glitch.fun channel remains the youngest players' door.
+- **Decision point for the user:** German side (hobby vs. Gewerbe for a zero-revenue release) —
+  clarify once before paying the fee.
+
+**4c. Xbox Dev Mode (~$19, days — the family win):**
+Retail-Xbox **Dev Mode** still lets us deploy our own UWP build to our own console. Unity 6 still
+has the UWP target (IL2CPP-only). This puts Blocks Beyond the Stars on the living-room Xbox for
+us — no store, no certification, this year. Known ports of work: IL2CPP AOT quirks (the
+MessagePack→JSON lesson from WebGL will recur) and running the singleplayer server in-process
+(the glitch.fun loopback architecture is exactly the reusable piece).
+
+**4d. ID@Xbox (the real store shelf; months, only after Steam):**
+- The Xbox Creators Program is effectively closed for new console games (and never allowed online
+  multiplayer anyway) — **ID@Xbox is the only retail path.** It is free (application, cert, two
+  dev kits) but curated: concept approval, NDA, likely a registered business (a simple Gewerbe
+  should suffice; unverified for pure private persons), full certification.
+- Technical scope beyond 4a/4c: Xbox network sign-in + parental-control/privilege checks, MPSD
+  session state, chat permission handling, UGC reporting, cross-network-play approval (Xbox
+  players in the same worlds as PC/web is exactly our model and is approvable), cert-grade
+  network-failure handling. NDA means Xbox-specific integration code lives outside the public
+  repo.
+- Treat as its own project with a go/no-go **after** Steam ships and Dev Mode proves the port.
+
+## Ongoing tracks (never "done", grow with reach)
+
+- **Kid safety & moderation:** guest reporting for arcade/browser players (today `/report` needs a
+  portal session); name/chat moderation stages from the existing analysis; PEGI/IARC self-rating
+  (needed for Xbox anyway — do it once, reuse everywhere); moderation capacity gates any arcade
+  pool growth.
+- **Community & localization:** keep the invite issues alive (#95–#100 designs/languages/docs),
+  credit contributors, honest devblogs per release.
+- **Operations:** VPS fleet health (Netdata alerts live), rate-limit follow-ups, CI cache fix,
+  UptimeRobot; one tagged pipeline feeds all channels — keep it that way as channels grow.
+
+## Explicitly not on this roadmap
+
+- Monetization in any form; paid platform features.
+- New big mechanics (weather systems, new vehicle classes, story arcs) while Horizon 1 is open.
+- Public/open registration or unmoderated world listings — the Baumhaus rule stands.
+- PlayStation/Switch — one console dream at a time.
+
+## Review cadence
+
+Revisit this file when a horizon completes or at least every two months; keep per-release status
+in TODO.md and per-decision records in `docs/developer/adr/`.

--- a/docs/strategy/vision.md
+++ b/docs/strategy/vision.md
@@ -38,12 +38,26 @@ and community stay safe by design.
 - **On the platforms we grew up with** — the game on **Xbox** (and Steam) is a heart goal: not for
   revenue, but because seeing our own game on the console shelf is the point of making it.
 
-### An open project people can join
+### Carried by a community, not just by us
 
-The source stays open, the content stays data-driven (JSON in `data/`), and contributing a new
-item, recipe, language, ship design or playtest report is something a motivated teenager can do.
-Community issues ("design a village", "add a language", playtests) are real invitations, and the
-devblog tells the story honestly — including the failures.
+The game grows a community that supports it from every side — and there is a real seat at the
+table for each of them:
+
+- **People who play and make us better.** Players — kids, parents, friends — who report what's
+  confusing, what's too dark, what's boring, and what they'd love next. Playtesting is a
+  first-class contribution: the standing playtest issues, the in-game report flow and the devblog
+  comment threads are how the game actually improves.
+- **People who build on GitHub.** From the one-line locale fix to a whole platform port (the
+  Linux client was our first community contribution) — the source stays open, the content stays
+  data-driven (JSON in `data/`), and adding an item, recipe, language or ship design is something
+  a motivated teenager can do. Hobby programmers are as welcome as professionals.
+- **Experts from every craft.** Graphic artists, musicians, sound designers, game designers,
+  UX reviewers, translators, engine specialists — the "expertise wanted" issues invite exactly
+  this: feedback-only contributions count fully, no code required.
+
+Every contribution is credited (in-game and in the repo), invitations stay concrete and honest
+("design a village", "review our crafting UX", "is the audio balanced?"), and the devblog tells
+the story openly — including the failures — so people know what they are joining.
 
 ## What we are deliberately NOT
 
@@ -59,6 +73,8 @@ devblog tells the story honestly — including the failures.
 ## How we know we are getting closer
 
 - Playtesters (especially kids) finish their first session without help and want to come back.
+- Contributions arrive from beyond the two of us — code and non-code alike (playtest reports,
+  art, music, translations, design feedback) — and repeat contributors stick around.
 - Zero known "does nothing" mechanics in a release; the open-bug list trends short and young.
 - A stock Raspberry Pi hosts a family world for 4+ players at stable tick rate.
 - The game is live and healthy on glitch.fun, itch.io and our portal from one release pipeline —

--- a/docs/strategy/vision.md
+++ b/docs/strategy/vision.md
@@ -1,0 +1,65 @@
+# Vision — Blocks Beyond the Stars
+
+> The strategy trio: **vision.md** (where we want to be), [mission.md](mission.md) (what we do and
+> how we decide), [roadmap.md](roadmap.md) (the concrete path). Status tracking stays in
+> [TODO.md](../../TODO.md); this document changes rarely.
+
+## The one-sentence vision
+
+**A voxel space adventure that any kid can safely play anywhere — in a browser tab, on the family
+PC, on a Raspberry Pi under the desk, and one day on the living-room console — built in the open by
+a father and son who love making it.**
+
+## What the world looks like when we get there
+
+### A finished-feeling game, not a tech demo
+
+The core loop — *explore planets, mine materials, craft better gear, build bases and ships, fly to
+the next star* — works without rough edges. Every station, device and item in the game **does
+something**; there are no decorative dead ends, no recipes into nowhere, no "this button does
+nothing yet". A new player always knows what to do next, and a returning player always has a next
+goal on the tech tree.
+
+### Deep enough to stay, gentle enough for kids
+
+Crafting and progression have real depth — tiered tools, metallurgy chains, factories, blueprints —
+but the game never punishes: no fear-driven mechanics, no harsh loss on death, no reading-age walls
+(bilingual DE/EN, symbols over text). Depth comes from *more to discover and combine*, not from
+grind or pressure. "Kid-friendly" is a design pillar, not a marketing label: content, chat, names
+and community stay safe by design.
+
+### Playable anywhere, hostable by anyone
+
+- **One click in the browser** — the glitch.fun arcade and our own portal make the first minute
+  free of installers, accounts and passwords.
+- **At home on anything** — the dedicated server runs on small hardware, explicitly including a
+  Raspberry Pi for a family or classroom LAN world. Self-hosting is a documented first-class path,
+  not an afterthought.
+- **On the platforms we grew up with** — the game on **Xbox** (and Steam) is a heart goal: not for
+  revenue, but because seeing our own game on the console shelf is the point of making it.
+
+### An open project people can join
+
+The source stays open, the content stays data-driven (JSON in `data/`), and contributing a new
+item, recipe, language, ship design or playtest report is something a motivated teenager can do.
+Community issues ("design a village", "add a language", playtests) are real invitations, and the
+devblog tells the story honestly — including the failures.
+
+## What we are deliberately NOT
+
+- **Not a commercial product.** Free, no monetization, no ads, no dark patterns. Platform releases
+  (glitch.fun, itch.io, Steam, Xbox) are distribution and pride, not revenue.
+- **Not a Minecraft clone race.** We don't chase feature parity with the giants; we keep the scope
+  a two-person hobby team can polish to a high standard.
+- **Not a hardware-hungry showcase.** Every feature must survive the question: *does it still run
+  in a browser tab and on a Pi?* Performance is a feature, not an optimization phase.
+- **Not an unmoderated public playground.** Multiplayer stays password/word-of-mouth on our portal
+  and platform-account-scoped on glitch.fun; we grow moderation before we grow reach.
+
+## How we know we are getting closer
+
+- Playtesters (especially kids) finish their first session without help and want to come back.
+- Zero known "does nothing" mechanics in a release; the open-bug list trends short and young.
+- A stock Raspberry Pi hosts a family world for 4+ players at stable tick rate.
+- The game is live and healthy on glitch.fun, itch.io and our portal from one release pipeline —
+  and eventually installable on Steam and Xbox.


### PR DESCRIPTION
## What

Adds the documented project strategy as a trio under `docs/strategy/`:

- **vision.md** — where we want to be: a finished-feeling, kid-friendly voxel space adventure playable anywhere (browser tab, family PC, Raspberry Pi, one day Xbox/Steam), carried by a community of players, GitHub contributors and experts from every craft.
- **mission.md** — what we do and how we decide: fix before feature, deepen only what connects to existing loops, operate the live channels (glitch.fun/fleet/portal), widen where it runs; kid-friendly and performance as hard constraints; no monetization ever.
- **roadmap.md** — the concrete path in five horizons: H0 stabilize the glitch.fun launch (#334), H1 bug-free core mechanics, H2 deeper crafting/materials/items (close the `reactor_fuel` dead end, thin-metal demand, craftable deco blocks), H3 Raspberry-Pi family hosting, H4 Steam → Xbox Dev Mode → ID@Xbox; plus ongoing safety/community/ops tracks.

The trio is cross-linked from README, CONTRIBUTING, TODO.md and the developer-docs index.

## Why

We want a written, agreed direction: a well-working game first (bug-free existing mechanics, then more items/materials/crafting), kid-friendly AND performant (server should eventually run on a Raspberry Pi), operated on glitch.fun — and the heart goal of seeing the game on Xbox (and Steam), not for revenue.

Grounded in a code-verified analysis (2026-07-15) of the content/crafting data, the server's ARM64 readiness, the glitch.fun integration, and external research on Steam/Xbox publishing paths.

## Notes

- Docs only — no code or data changes.
- Roadmap facts of note: the #334 fix branch exists but is unmerged (arcade rejects fresh installs until it ships); `docker.yml`'s `platforms` default is amd64-only (release must pass arm64 explicitly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)