### PR TITLE
feat(glitch): mode chooser — no auto-join, pick arcade or singleplayer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,9 @@ A small launch-day patch for the glitch.fun edition, straight from the first liv
 - **The arcade never sleeps:** the pool worlds now run permanently — woken at startup, never idle-exiting, re-woken automatically if one crashes — so a store visitor lands in a running world instead of waiting out a cold world generation. (`BBS_WH_GLITCH_KEEP_AWAKE=false` opts tight hosts out.) (#336)
 - Fleet side (no download needed): the arcade gateway env passthrough was fixed in deployment, so the gateway is actually switched on. (#330)
 
-### 🕹️ glitch.fun: the menu never offers server picking anymore
-- On glitch.fun the arcade join runs automatically when the page loads, so the menu only ever appears when that join failed. That menu still offered the generic browser actions: **Play** dialed a meaningless default host and dropped the player into an empty, serverless void, and **"Connect to a server…"** suggested picking a server — which on Glitch is never the player's job. In the Glitch context, Play now simply retries the arcade join and the manual picker is gone. (#331)
+### 🕹️ glitch.fun: pick your mode — arcade or singleplayer
+- The page used to jump straight into the shared arcade world, so nobody ever learned that a full **browser singleplayer** exists. glitch.fun now lands on the menu with two clear choices: **Play Online (Arcade)** and **Singleplayer** — still one click to play, but a chosen one. (#340)
+- That menu also stops offering the generic browser actions that made no sense on Glitch: **Play** used to dial a meaningless default host and drop the player into an empty, serverless void, and **"Connect to a server…"** suggested picking a server — never the player's job on Glitch. The arcade button requests a session properly and the manual picker is gone. (#331)
 
 ## [0.8.0] — 2026-07-15
 

--- a/client/Assets/BlocksBeyondTheStars/Scripts/AppShell.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/AppShell.cs
@@ -159,12 +159,11 @@ namespace BlocksBeyondTheStars.Client
                 // ?singleplayer=1 deep-link: straight into the in-browser world once content is ready.
                 _autoSingleplayerWhenReady = true;
             }
-            else if (GlitchIntegration.ArcadeSessionRequested)
-            {
-                // glitch.fun arcade: Glitch injects only an install_id — the join grant (world, name,
-                // token) comes from our portal's session gateway, then rides the same auto-join path.
-                StartCoroutine(RequestArcadeJoin());
-            }
+
+            // glitch.fun deliberately does NOT auto-join anymore: the menu offers the choice between
+            // the shared arcade worlds and the in-browser singleplayer — jumping straight into
+            // multiplayer hid that singleplayer exists (first live feedback). The menu's arcade
+            // button calls RetryArcadeJoin(); still one click, but a chosen one.
 #endif
         }
 

--- a/client/Assets/BlocksBeyondTheStars/Scripts/UiMainMenu.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/UiMainMenu.cs
@@ -78,7 +78,7 @@ namespace BlocksBeyondTheStars.Client
             // re-requests an arcade session instead of dialing the meaningless default host (which
             // built an empty, serverless world rig), and the manual server picker stays hidden.
             bool onGlitch = GlitchIntegration.ArcadeInstallId.Length > 0 && GlitchIntegration.PortalUrl.Length > 0;
-            UiKit.AddButton(root, bx, wby, bw, bh, shell.L("ui.menu.play"), () =>
+            UiKit.AddButton(root, bx, wby, bw, bh, shell.L(onGlitch ? "ui.menu.arcade" : "ui.menu.play"), () =>
             {
                 if (string.IsNullOrWhiteSpace(webName[0]))
                 {

--- a/data/locales/de.json
+++ b/data/locales/de.json
@@ -1010,6 +1010,7 @@
   "ui.menu.connect_manual": "Mit Server verbinden…",
   "ui.webgl.gameplay_blocked": "Browser-Builds koennen der Online-Welt beitreten, aber auf diesem Geraet keine lokale Welt starten.",
   "ui.webgl.need_name": "Bitte gib einen Namen ein, bevor du spielst.",
+  "ui.menu.arcade": "Online spielen (Arcade)",
   "ui.glitch.arcade_failed": "Die Arcade-Welt konnte gerade nicht betreten werden - bitte versuch es gleich noch einmal.",
   "ui.glitch.access_revoked": "Dein Arcade-Zugang wurde gesperrt.",
   "ui.sp.browser_failed": "Die Welt konnte in diesem Browser nicht gestartet werden - bitte lade die Seite neu und versuch es noch einmal.",

--- a/data/locales/en.json
+++ b/data/locales/en.json
@@ -1009,6 +1009,7 @@
   "ui.menu.connect_manual": "Connect to a server…",
   "ui.webgl.gameplay_blocked": "Browser builds can join the online realm, but cannot start a local world on this device.",
   "ui.webgl.need_name": "Please enter a name before you play.",
+  "ui.menu.arcade": "Play Online (Arcade)",
   "ui.glitch.arcade_failed": "Could not join the arcade world right now - please try again in a moment.",
   "ui.glitch.access_revoked": "Your arcade access has been revoked.",
   "ui.sp.browser_failed": "The world could not be started in this browser - please reload the page and try again.",


### PR DESCRIPTION
Auto-joining the arcade hid the browser singleplayer entirely (first live feedback). glitch.fun now lands on the menu with two clear choices — **Play Online (Arcade)** and **Singleplayer** — one click either way. Deep links unchanged; changelog folded into the pending v0.8.1 entry.

Closes #340

🤖 Generated with [Claude Code](https://claude.com/claude-code)