### PR TITLE
feat(feedback): F1 player feedback in the browser + cutover to the VPS ReportHost

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -205,22 +205,23 @@ jobs:
 
       - name: Inject player-feedback API key
         # Writes the git-ignored BugReportBuildSecrets.Generated.cs so the player can POST feedback to the
-        # website. Guarded: without the secret the build still works (feedback just stays disabled). The key
+        # report inbox (ReportHost on the VPS — docs/developer/REPORT_HOST.md; the secret = its write key).
+        # Guarded: without the secret the build still works (feedback just stays disabled). The key
         # is only a spam gate, not a real secret; GitHub masks it in logs.
         env:
-          WIX_BUGREPORT_API_KEY: ${{ secrets.WIX_BUGREPORT_API_KEY }}
+          BBS_BUGREPORT_API_KEY: ${{ secrets.BBS_BUGREPORT_API_KEY }}
         run: |
-          if [ -z "$WIX_BUGREPORT_API_KEY" ]; then
-            echo "WIX_BUGREPORT_API_KEY not set — player feedback will be disabled in this build."
+          if [ -z "$BBS_BUGREPORT_API_KEY" ]; then
+            echo "BBS_BUGREPORT_API_KEY not set — player feedback will be disabled in this build."
             exit 0
           fi
           {
-            echo '// CI-generated from the WIX_BUGREPORT_API_KEY secret — not committed.'
+            echo '// CI-generated from the BBS_BUGREPORT_API_KEY secret — not committed.'
             echo 'namespace BlocksBeyondTheStars.Build'
             echo '{'
             echo '    public static partial class BugReportBuildSecrets'
             echo '    {'
-            echo "        static partial void ApplyApiKey(ref string key) => key = \"$WIX_BUGREPORT_API_KEY\";"
+            echo "        static partial void ApplyApiKey(ref string key) => key = \"$BBS_BUGREPORT_API_KEY\";"
             echo '    }'
             echo '}'
           } > client/Assets/BlocksBeyondTheStars/Scripts/BugReportBuildSecrets.Generated.cs
@@ -309,19 +310,19 @@ jobs:
 
       - name: Inject player-feedback API key
         env:
-          WIX_BUGREPORT_API_KEY: ${{ secrets.WIX_BUGREPORT_API_KEY }}
+          BBS_BUGREPORT_API_KEY: ${{ secrets.BBS_BUGREPORT_API_KEY }}
         run: |
-          if [ -z "$WIX_BUGREPORT_API_KEY" ]; then
-            echo "WIX_BUGREPORT_API_KEY not set — player feedback will be disabled in this build."
+          if [ -z "$BBS_BUGREPORT_API_KEY" ]; then
+            echo "BBS_BUGREPORT_API_KEY not set — player feedback will be disabled in this build."
             exit 0
           fi
           {
-            echo '// CI-generated from the WIX_BUGREPORT_API_KEY secret — not committed.'
+            echo '// CI-generated from the BBS_BUGREPORT_API_KEY secret — not committed.'
             echo 'namespace BlocksBeyondTheStars.Build'
             echo '{'
             echo '    public static partial class BugReportBuildSecrets'
             echo '    {'
-            echo "        static partial void ApplyApiKey(ref string key) => key = \"$WIX_BUGREPORT_API_KEY\";"
+            echo "        static partial void ApplyApiKey(ref string key) => key = \"$BBS_BUGREPORT_API_KEY\";"
             echo '    }'
             echo '}'
           } > client/Assets/BlocksBeyondTheStars/Scripts/BugReportBuildSecrets.Generated.cs
@@ -420,19 +421,19 @@ jobs:
 
       - name: Inject player-feedback API key
         env:
-          WIX_BUGREPORT_API_KEY: ${{ secrets.WIX_BUGREPORT_API_KEY }}
+          BBS_BUGREPORT_API_KEY: ${{ secrets.BBS_BUGREPORT_API_KEY }}
         run: |
-          if [ -z "$WIX_BUGREPORT_API_KEY" ]; then
-            echo "WIX_BUGREPORT_API_KEY not set — player feedback will be disabled in this build."
+          if [ -z "$BBS_BUGREPORT_API_KEY" ]; then
+            echo "BBS_BUGREPORT_API_KEY not set — player feedback will be disabled in this build."
             exit 0
           fi
           {
-            echo '// CI-generated from the WIX_BUGREPORT_API_KEY secret — not committed.'
+            echo '// CI-generated from the BBS_BUGREPORT_API_KEY secret — not committed.'
             echo 'namespace BlocksBeyondTheStars.Build'
             echo '{'
             echo '    public static partial class BugReportBuildSecrets'
             echo '    {'
-            echo "        static partial void ApplyApiKey(ref string key) => key = \"$WIX_BUGREPORT_API_KEY\";"
+            echo "        static partial void ApplyApiKey(ref string key) => key = \"$BBS_BUGREPORT_API_KEY\";"
             echo '    }'
             echo '}'
           } > client/Assets/BlocksBeyondTheStars/Scripts/BugReportBuildSecrets.Generated.cs
@@ -512,19 +513,19 @@ jobs:
 
       - name: Inject player-feedback API key
         env:
-          WIX_BUGREPORT_API_KEY: ${{ secrets.WIX_BUGREPORT_API_KEY }}
+          BBS_BUGREPORT_API_KEY: ${{ secrets.BBS_BUGREPORT_API_KEY }}
         run: |
-          if [ -z "$WIX_BUGREPORT_API_KEY" ]; then
-            echo "WIX_BUGREPORT_API_KEY not set — player feedback will be disabled in this build."
+          if [ -z "$BBS_BUGREPORT_API_KEY" ]; then
+            echo "BBS_BUGREPORT_API_KEY not set — player feedback will be disabled in this build."
             exit 0
           fi
           {
-            echo '// CI-generated from the WIX_BUGREPORT_API_KEY secret — not committed.'
+            echo '// CI-generated from the BBS_BUGREPORT_API_KEY secret — not committed.'
             echo 'namespace BlocksBeyondTheStars.Build'
             echo '{'
             echo '    public static partial class BugReportBuildSecrets'
             echo '    {'
-            echo "        static partial void ApplyApiKey(ref string key) => key = \"$WIX_BUGREPORT_API_KEY\";"
+            echo "        static partial void ApplyApiKey(ref string key) => key = \"$BBS_BUGREPORT_API_KEY\";"
             echo '    }'
             echo '}'
           } > client/Assets/BlocksBeyondTheStars/Scripts/BugReportBuildSecrets.Generated.cs

--- a/.github/workflows/webgl-only.yml
+++ b/.github/workflows/webgl-only.yml
@@ -73,19 +73,19 @@ jobs:
 
       - name: Inject player-feedback API key
         env:
-          WIX_BUGREPORT_API_KEY: ${{ secrets.WIX_BUGREPORT_API_KEY }}
+          BBS_BUGREPORT_API_KEY: ${{ secrets.BBS_BUGREPORT_API_KEY }}
         run: |
-          if [ -z "$WIX_BUGREPORT_API_KEY" ]; then
-            echo "WIX_BUGREPORT_API_KEY not set — player feedback will be disabled in this build."
+          if [ -z "$BBS_BUGREPORT_API_KEY" ]; then
+            echo "BBS_BUGREPORT_API_KEY not set — player feedback will be disabled in this build."
             exit 0
           fi
           {
-            echo '// CI-generated from the WIX_BUGREPORT_API_KEY secret — not committed.'
+            echo '// CI-generated from the BBS_BUGREPORT_API_KEY secret — not committed.'
             echo 'namespace BlocksBeyondTheStars.Build'
             echo '{'
             echo '    public static partial class BugReportBuildSecrets'
             echo '    {'
-            echo "        static partial void ApplyApiKey(ref string key) => key = \"$WIX_BUGREPORT_API_KEY\";"
+            echo "        static partial void ApplyApiKey(ref string key) => key = \"$BBS_BUGREPORT_API_KEY\";"
             echo '    }'
             echo '}'
           } > client/Assets/BlocksBeyondTheStars/Scripts/BugReportBuildSecrets.Generated.cs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,13 @@ _Nothing yet — [v0.8.1](#081--2026-07-15) is the latest release._
 
 ## [0.8.1] — 2026-07-15
 
-A small launch-day patch for the glitch.fun edition, straight from the first live test. (#332)
+The glitch.fun edition's launch-day round: the first live tests turned up several arcade rough edges (all fixed here), and in-game feedback now works in the browser and flows to our own inbox.
+
+### 📮 In-game feedback (F1): works in the browser, lands in our own inbox
+- **The F1 feedback key now works in the WebGL player.** Browsers have neither the HTTP client nor the threads the old uploader used, so the browser build could never actually send feedback — it now posts through the proper browser path. (#342)
+- **F1 works during space flight too** — it was silently blocked in the flight view; the dialog also restores your cursor cleanly on close (matters for the landing-pad picker). (#342)
+- **Feedback never gets lost:** a failed send is spooled locally and retried on your next launches (a handful of times, then quietly parked — never deleted), with a clear "saved, will retry" note. (#342)
+- Under the hood, player feedback and crash reports now go to **our own report service** (`reports.blocksbeyondthestars.de`) instead of the old third-party endpoint. Already-installed builds keep using the old one for now. (#342)
 
 ### 🕹️ glitch.fun: arcade joins actually work now
 - The arcade session gateway validated a visitor's install **before** registering it with Glitch — but Glitch's contract requires create-then-validate, so every fresh browser session was rejected with "could not be verified" and nobody could enter the arcade worlds. The gateway now follows the required call order (create/resume first, then validate), with a regression test pinning the sequence. (#334)

--- a/TODO.md
+++ b/TODO.md
@@ -99,6 +99,27 @@ Per-item detail lives in the dated work log below.
 
 ---
 
+### ★ F1 feedback: VPS ReportHost cutover, works in space flight + WebGL, offline spool (2026-07-15, local branch feat/feedback-vps-cutover)
+The F1 player feedback now goes to **our own inbox**: `FeedbackUploader.DefaultEndpoint` (and the server's
+`CrashReportEndpoint` default) point at `https://reports.blocksbeyondthestars.de/api/bugreport` (ReportHost,
+[docs/developer/REPORT_HOST.md](docs/developer/REPORT_HOST.md)) instead of the legacy Wix function; the CI secret
+was renamed `WIX_BUGREPORT_API_KEY` → **`BBS_BUGREPORT_API_KEY`** (its value must be the deployed ReportHost's
+`BBS_REPORTS_WRITE_KEY`). And "F1 always works, wherever technically possible":
+- **Space flight**: `canLaunch` no longer excludes `SpaceViewActive` (cruise hint advertises F1, DE+EN); the
+  dialog restores the pre-open cursor state on close (landing-pad chooser safe).
+- **WebGL**: the upload is serialized once on the main thread and posted via `UnityWebRequest` on a coroutine
+  (WASM has no HttpClient/threads — the browser build could never deliver F1 feedback before); the ReportHost
+  answers the CORS preflight on `/api/bugreport`.
+- **Offline spool**: a failed upload is queued in `persistentDataPath/feedback` and retried on later session
+  starts with **bounded attempts** ([FeedbackSpool.cs](src/BlocksBeyondTheStars.Client.Core/Feedback/FeedbackSpool.cs),
+  `MaxAttempts=5`, exhausted reports parked in `givenup/`, accepted in `sent/`); new key `ui.feedback.queued`
+  (DE+EN); [FeedbackSpoolTests.cs](tests/BlocksBeyondTheStars.Client.Tests/FeedbackSpoolTests.cs).
+- **Open (ops, before the release ships)**: Cloudflare A record `reports.blocksbeyondthestars.de` → VPS
+  (DNS-only, no proxy — cert is HTTP-01 via the shared Caddy); `/opt/bbs/reports/.env` (write/read keys, admin
+  creds) + `deploy.yml service=reports`; create the `BBS_BUGREPORT_API_KEY` Environment secret (without it,
+  release builds ship with feedback disabled); keep the legacy Wix endpoint alive for pre-cutover builds.
+  **NEEDS Unity build check** (client/Assets changed) + a WebGL smoke test of the F1 dialog.
+
 ### ★ Server-side stack upgraded from .NET 8 to .NET 10 LTS (#309, closes #308, 2026-07-12)
 .NET 8 LTS support ends Nov 2026, so all ten `net8.0` projects (server, hosts, launchers, tests) now target
 `net10.0` — the Unity boundary is untouched (`Shared`/`Networking`/`WorldGeneration`/`Client.Core` stay

--- a/client/Assets/BlocksBeyondTheStars/Scripts/FeedbackUi.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/FeedbackUi.cs
@@ -9,6 +9,10 @@ using BlocksBeyondTheStars.Build;
 using BlocksBeyondTheStars.Client.Feedback;
 using UnityEngine;
 using UnityEngine.UI;
+#if UNITY_WEBGL && !UNITY_EDITOR
+using System.Text;
+using UnityEngine.Networking;
+#endif
 
 namespace BlocksBeyondTheStars.Client
 {
@@ -21,8 +25,9 @@ namespace BlocksBeyondTheStars.Client
     /// On send we grab a full-frame screenshot WITH the HUD but WITHOUT this dialog (captured at the moment the
     /// dialog opens, while the live HUD is still on screen), gather a small client-side diagnostic snapshot,
     /// and fire BOTH paths:
-    ///   • a client-direct HTTPS POST to the website API (<see cref="FeedbackUploader"/>) — reaches the devs on
-    ///     any server, even someone else's dedicated server;
+    ///   • a client-direct HTTPS POST to the report inbox (<see cref="FeedbackUploader"/>; UnityWebRequest on
+    ///     WebGL, where HttpClient/threads don't exist) — reaches the devs on any server, even someone else's
+    ///     dedicated server;
     ///   • the existing <c>/bump</c> message (<see cref="NetworkClient.SendBumpReport"/>) so the server also
     ///     writes its rich local snapshot (inventory/position/surroundings) when on an own/singleplayer server.
     ///
@@ -233,10 +238,18 @@ namespace BlocksBeyondTheStars.Client
             string serverNote = string.IsNullOrEmpty(title) ? desc : title + " — " + desc;
             Game?.Network?.SendBumpReport("[feedback] " + serverNote, jpg ?? Array.Empty<byte>());
 
-            // Path B — client-direct upload to the website API, off the game thread.
+            // Path B — client-direct upload to the report inbox. The body is serialized ONCE here on the
+            // main thread; only the POST leaves the game loop.
             if (_uploader != null && _uploader.IsConfigured)
             {
-                _uploadTask = Task.Run(() => _uploader.Upload(report, jpg));
+                string json = FeedbackUploader.Serialize(report, jpg);
+#if UNITY_WEBGL && !UNITY_EDITOR
+                // WASM has neither sockets nor threads — HttpClient/Task.Run can't run in the browser, so
+                // the WebGL player posts the identical body via UnityWebRequest on a coroutine.
+                StartCoroutine(PostJsonWebGl(json, OnUploadFinished));
+#else
+                _uploadTask = Task.Run(() => _uploader.UploadRawJson(json));
+#endif
             }
             else
             {
@@ -294,6 +307,39 @@ namespace BlocksBeyondTheStars.Client
             };
             return report;
         }
+
+        // --- WebGL transport ---------------------------------------------------------------------------------
+
+#if UNITY_WEBGL && !UNITY_EDITOR
+        /// <summary>Browser upload: posts an already-serialized report body via <see cref="UnityWebRequest"/>
+        /// (the WebGL stand-in for <see cref="FeedbackUploader.UploadRawJson"/> — same endpoint, header and
+        /// never-throws contract). Runs on the main thread as a coroutine; WebGL requests are async under the
+        /// hood, so nothing blocks. Calls <paramref name="done"/> with the outcome.</summary>
+        private IEnumerator PostJsonWebGl(string json, Action<FeedbackUploadResult> done)
+        {
+            using (var req = new UnityWebRequest(FeedbackUploader.DefaultEndpoint, UnityWebRequest.kHttpVerbPOST))
+            {
+                req.uploadHandler = new UploadHandlerRaw(Encoding.UTF8.GetBytes(json)) { contentType = "application/json" };
+                req.downloadHandler = new DownloadHandlerBuffer();
+                req.SetRequestHeader(FeedbackUploader.ApiKeyHeader, BugReportBuildSecrets.ApiKey);
+                req.timeout = 15; // mirrors the HttpClient timeout
+
+                yield return req.SendWebRequest();
+
+                var result = new FeedbackUploadResult
+                {
+                    StatusCode = (int)req.responseCode,
+                    Ok = req.result == UnityWebRequest.Result.Success,
+                };
+                if (!result.Ok)
+                {
+                    result.Error = result.StatusCode > 0 ? "http_" + result.StatusCode : (req.error ?? "network");
+                }
+
+                done?.Invoke(result);
+            }
+        }
+#endif
 
         // --- Screenshot ------------------------------------------------------------------------------------
 

--- a/client/Assets/BlocksBeyondTheStars/Scripts/FeedbackUi.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/FeedbackUi.cs
@@ -15,7 +15,8 @@ namespace BlocksBeyondTheStars.Client
     /// <summary>
     /// Player feedback ("Spieler Feedback"): the F1 hotkey opens a modal dialog where any player can send a bug
     /// report OR a feature wish — one form, no type distinction: a title, a description, an optional e-mail and a
-    /// short note that game data + a screenshot are attached. (F1 is advertised in the on-foot HUD controls hint.)
+    /// short note that game data + a screenshot are attached. (F1 is advertised in the on-foot HUD controls hint
+    /// and in the space-flight cruise hint; it works in both modes.)
     ///
     /// On send we grab a full-frame screenshot WITH the HUD but WITHOUT this dialog (captured at the moment the
     /// dialog opens, while the live HUD is still on screen), gather a small client-side diagnostic snapshot,
@@ -46,6 +47,7 @@ namespace BlocksBeyondTheStars.Client
 
         private bool _open;
         private bool _sending;
+        private bool _cursorWasLocked = true; // cursor state before the dialog opened, restored on close
         private byte[] _shotJpg;                 // screenshot captured when the dialog opened
         private Task<FeedbackUploadResult> _uploadTask;
 
@@ -65,9 +67,9 @@ namespace BlocksBeyondTheStars.Client
                 return;
             }
 
-            // F1 opens feedback only during normal on-foot play (not in menus, flight, chat or the death prompt)
-            // — matching when the HUD (and its controls hint) is up.
-            bool canLaunch = !Game.MenuOpen && !Game.ChatTyping && !Game.AwaitingRespawnConfirm && !Game.SpaceViewActive;
+            // F1 opens feedback during normal play — on foot AND in space flight (both HUDs advertise it);
+            // not while a menu/chat modal or the death prompt already owns the screen.
+            bool canLaunch = !Game.MenuOpen && !Game.ChatTyping && !Game.AwaitingRespawnConfirm;
 
             if (!_open && canLaunch && Input.GetKeyDown(KeyCode.F1))
             {
@@ -117,7 +119,10 @@ namespace BlocksBeyondTheStars.Client
             ResetFields();
             _dialog.SetActive(true);
 
-            // Modal: free the cursor + pause on-foot control (mirrors GameMenu / BeamPadUi).
+            // Modal: free the cursor + pause player/flight control (mirrors GameMenu / BeamPadUi; SpaceView
+            // holds position while MenuOpen). Remember the cursor state so closing restores it — in flight
+            // sub-screens like the landing-pad chooser the cursor was already free, not locked.
+            _cursorWasLocked = Cursor.lockState == CursorLockMode.Locked;
             Game.MenuOpen = true;
             Cursor.lockState = CursorLockMode.None;
             Cursor.visible = true;
@@ -134,8 +139,8 @@ namespace BlocksBeyondTheStars.Client
             if (Game != null)
             {
                 Game.MenuOpen = false;
-                Cursor.lockState = CursorLockMode.Locked;
-                Cursor.visible = false;
+                Cursor.lockState = _cursorWasLocked ? CursorLockMode.Locked : CursorLockMode.None;
+                Cursor.visible = !_cursorWasLocked;
             }
         }
 

--- a/client/Assets/BlocksBeyondTheStars/Scripts/FeedbackUi.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/FeedbackUi.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.IO;
 using System.Threading.Tasks;
 using BlocksBeyondTheStars.Build;
 using BlocksBeyondTheStars.Client.Feedback;
@@ -41,7 +42,9 @@ namespace BlocksBeyondTheStars.Client
         private const float W = 1920f, H = 1080f;
 
         private FeedbackUploader _uploader;
+        private FeedbackSpool _spool;
         private string _sessionId = string.Empty;
+        private string _pendingJson; // the in-flight dialog send's body, spooled if the upload fails
 
         // Dialog (built lazily on first open).
         private Canvas _dialogCanvas;
@@ -63,6 +66,12 @@ namespace BlocksBeyondTheStars.Client
             // A random id groups several reports from one sitting (varies per session; no Unity-restricted Date use).
             _sessionId = Guid.NewGuid().ToString("N");
             _uploader = new FeedbackUploader(FeedbackUploader.DefaultEndpoint, BugReportBuildSecrets.ApiKey);
+            _spool = new FeedbackSpool(Path.Combine(Application.persistentDataPath, "feedback"));
+
+            if (_uploader.IsConfigured)
+            {
+                FlushSpool(); // deliver what an earlier session couldn't (bounded attempts, see FeedbackSpool)
+            }
         }
 
         private void Update()
@@ -243,6 +252,7 @@ namespace BlocksBeyondTheStars.Client
             if (_uploader != null && _uploader.IsConfigured)
             {
                 string json = FeedbackUploader.Serialize(report, jpg);
+                _pendingJson = json;
 #if UNITY_WEBGL && !UNITY_EDITOR
                 // WASM has neither sockets nor threads — HttpClient/Task.Run can't run in the browser, so
                 // the WebGL player posts the identical body via UnityWebRequest on a coroutine.
@@ -264,11 +274,22 @@ namespace BlocksBeyondTheStars.Client
         private void OnUploadFinished(FeedbackUploadResult result)
         {
             _sending = false;
+            string body = _pendingJson;
+            _pendingJson = null;
+
             if (result != null && result.Ok)
             {
                 if (_status != null) { _status.text = L("ui.feedback.sent"); _status.color = UiKit.Ok; }
                 Game?.ShowMessage(L("ui.feedback.sent"));
                 Invoke(nameof(Close), 1.2f);
+            }
+            else if (_spool != null && !string.IsNullOrEmpty(body) && _spool.Write(body) != null)
+            {
+                // Offline / inbox down: the report is queued on disk and retried on later sessions with
+                // bounded attempts — nothing to re-type, so tell the player and close.
+                if (_status != null) { _status.text = L("ui.feedback.queued"); _status.color = UiKit.Ok; }
+                Game?.ShowMessage(L("ui.feedback.queued"));
+                Invoke(nameof(Close), 1.6f);
             }
             else
             {
@@ -307,6 +328,78 @@ namespace BlocksBeyondTheStars.Client
             };
             return report;
         }
+
+        // --- Spool retry -------------------------------------------------------------------------------------
+
+        /// <summary>Retries reports queued by earlier sessions whose upload failed. Each report gets a
+        /// bounded number of attempts (<see cref="FeedbackSpool.MaxAttempts"/>); on the first failure the
+        /// rest wait for the next session — the inbox is likely down or we're offline.</summary>
+        private void FlushSpool()
+        {
+#if UNITY_WEBGL && !UNITY_EDITOR
+            StartCoroutine(FlushSpoolWebGl());
+#else
+            var spool = _spool;
+            var uploader = _uploader;
+            _ = Task.Run(() =>
+            {
+                try
+                {
+                    foreach (var path in spool.ListPending())
+                    {
+                        string json = spool.Read(path);
+                        if (string.IsNullOrEmpty(json))
+                        {
+                            continue;
+                        }
+
+                        var result = uploader.UploadRawJson(json);
+                        if (result != null && result.Ok)
+                        {
+                            spool.MarkSent(path);
+                        }
+                        else
+                        {
+                            spool.RegisterFailedAttempt(path);
+                            break;
+                        }
+                    }
+                }
+                catch
+                {
+                    // best-effort startup catch-up — never disturb the game
+                }
+            });
+#endif
+        }
+
+#if UNITY_WEBGL && !UNITY_EDITOR
+        /// <summary>WebGL flavor of <see cref="FlushSpool"/>: one UnityWebRequest at a time on a coroutine
+        /// (persistentDataPath is IndexedDB-backed in the browser, so the queue survives page reloads).</summary>
+        private IEnumerator FlushSpoolWebGl()
+        {
+            foreach (var path in _spool.ListPending())
+            {
+                string json = _spool.Read(path);
+                if (string.IsNullOrEmpty(json))
+                {
+                    continue;
+                }
+
+                FeedbackUploadResult result = null;
+                yield return PostJsonWebGl(json, r => result = r);
+                if (result != null && result.Ok)
+                {
+                    _spool.MarkSent(path);
+                }
+                else
+                {
+                    _spool.RegisterFailedAttempt(path);
+                    yield break;
+                }
+            }
+        }
+#endif
 
         // --- WebGL transport ---------------------------------------------------------------------------------
 

--- a/data/locales/de.json
+++ b/data/locales/de.json
@@ -755,6 +755,7 @@
   "ui.feedback.sent": "Danke! Dein Feedback wurde gesendet.",
   "ui.feedback.sent_local": "Danke! Dein Feedback wurde lokal gespeichert.",
   "ui.feedback.failed": "Senden fehlgeschlagen. Bitte versuche es später erneut.",
+  "ui.feedback.queued": "Gerade keine Verbindung — dein Feedback ist gespeichert und wird später automatisch gesendet.",
   "ui.menu.singleplayer": "Einzelspieler / Lokale Welt",
   "ui.save.title": "WELT WÄHLEN",
   "ui.save.subtitle": "Eine gespeicherte Welt fortsetzen oder eine neue zum Testen starten.",

--- a/data/locales/de.json
+++ b/data/locales/de.json
@@ -1149,7 +1149,7 @@
   "ui.tab.space": "Weltraum",
   "ui.space.enter": "In den Weltraum starten",
   "ui.space.leave": "Zur Oberfläche zurück",
-  "ui.space.controls": "WASD/Maus fliegen · 1–9 System · LMB nutzen · V Ansicht · E landen/andocken · L zurück · F ins Schiff",
+  "ui.space.controls": "WASD/Maus fliegen · 1–9 System · LMB nutzen · V Ansicht · E landen/andocken · L zurück · F ins Schiff · F1 Feedback",
   "ui.space.controls_pad": "Linker Stick fliegen · Rechter Stick steuern · RB feuern · (X) landen/andocken · (Y) Ansicht",
   "ui.space.sys_laser": "Laser",
   "ui.space.sys_tractor": "Traktor",

--- a/data/locales/en.json
+++ b/data/locales/en.json
@@ -754,6 +754,7 @@
   "ui.feedback.sent": "Thanks! Your feedback was sent.",
   "ui.feedback.sent_local": "Thanks! Your feedback was saved locally.",
   "ui.feedback.failed": "Sending failed. Please try again later.",
+  "ui.feedback.queued": "No connection right now — your feedback is saved and will be sent automatically later.",
   "ui.menu.singleplayer": "Singleplayer / Local World",
   "ui.save.title": "SELECT WORLD",
   "ui.save.subtitle": "Resume a saved world or start a new one to test.",

--- a/data/locales/en.json
+++ b/data/locales/en.json
@@ -1148,7 +1148,7 @@
   "ui.tab.space": "Space",
   "ui.space.enter": "Launch into space",
   "ui.space.leave": "Return to surface",
-  "ui.space.controls": "WASD/mouse fly · 1–9 system · LMB use · V view · E land/dock · L return · F enter ship",
+  "ui.space.controls": "WASD/mouse fly · 1–9 system · LMB use · V view · E land/dock · L return · F enter ship · F1 feedback",
   "ui.space.controls_pad": "Left stick fly · Right stick steer · RB fire · (X) land/dock · (Y) view",
   "ui.space.sys_laser": "Laser",
   "ui.space.sys_tractor": "Tractor",

--- a/deploy/reports/.env.example
+++ b/deploy/reports/.env.example
@@ -5,8 +5,9 @@
 # Image tag to run — deploy.yml pins this to an immutable sha-<short> tag; rollback = previous tag.
 REPORTS_TAG=latest
 
-# Public domain (needs a Strato DNS A record -> the VPS; certificate is issued via plain HTTP-01
-# because this is an explicit Caddy site — the on-demand-TLS /ask flow is not involved).
+# Public domain (needs a DNS A record -> the VPS; the .de zone is managed in Cloudflare — create the
+# record as "DNS only" / NO proxy, because the certificate is issued via plain HTTP-01: this is an
+# explicit Caddy site, the on-demand-TLS /ask flow is not involved).
 BBS_REPORTS_DOMAIN=reports.blocksbeyondthestars.de
 
 # SECRETS — generate long random values (e.g. `openssl rand -hex 24`); keep them only in this file.

--- a/docs/developer/PLAYER_FEEDBACK.md
+++ b/docs/developer/PLAYER_FEEDBACK.md
@@ -2,8 +2,9 @@
 
 The **F1** hotkey lets any player send a bug report **or** a feature wish — one
 form, no type distinction: a title, a description, an optional e-mail, and a short note that game data plus
-a screenshot are attached. On send the client posts the report to the website API and also fires the
-existing `/bump` snapshot. (F1 is advertised in the on-foot HUD controls hint, `ui.hud.hint`.)
+a screenshot are attached. On send the client posts the report to the official report inbox (the
+ReportHost on the VPS — see [REPORT_HOST](REPORT_HOST.md)) and also fires the existing `/bump`
+snapshot. (F1 is advertised in the on-foot HUD controls hint, `ui.hud.hint`.)
 
 This is deliberately **player-facing** and separate from the developer `/bump` chat command (which still
 exists and produces the rich local diagnostic snapshot — see [BUG_REPORTS](BUG_REPORTS.md) if present, or
@@ -17,7 +18,7 @@ F1
    ▼
 FeedbackUi dialog  (title, description, optional e-mail, privacy hint)
    │  Send
-   ├──────────────► FeedbackUploader.Upload()  ──HTTPS POST──►  www.blocksbeyondthestars.com/_functions/bugreport
+   ├──────────────► FeedbackUploader.Upload()  ──HTTPS POST──►  reports.blocksbeyondthestars.de/api/bugreport
    │                (client-direct; reaches the devs on ANY server)
    └──────────────► NetworkClient.SendBumpReport()  ──►  GameServer  (rich local snapshot on own/SP server)
 ```
@@ -50,8 +51,10 @@ a background `Task`; the report (which reads Unity APIs) is built on the main th
 ## The API key (spam gate, not a secret)
 
 The key only gates spam/abuse for the alpha — it ships inside the client and can be extracted, so the
-website endpoint must accept feedback **only**, cap payload size, and rate-limit. See the requirements
-document for the Wix/Velo backend (`http-functions.js`, the `BugReports` CMS collection, media upload).
+endpoint must accept feedback **only**, cap payload size, and rate-limit. The ReportHost does exactly
+that (see [REPORT_HOST](REPORT_HOST.md)); the CI secret's value is its `BBS_REPORTS_WRITE_KEY`.
+(Historical: the original inbox was a Wix/Velo function at `www.blocksbeyondthestars.com/_functions/bugreport`
+on the same wire contract — builds released before the cutover still post there.)
 
 `BugReportBuildSecrets.ApiKey` is empty in committed/dev builds (so dev builds never post to production;
 the dialog then reports `sent_local` after writing the `/bump` snapshot). A release build injects the real
@@ -63,14 +66,14 @@ client/Assets/BlocksBeyondTheStars/Scripts/BugReportBuildSecrets.Generated.cs   
 
 ### CI step (release builds)
 
-Add to the release workflow, using a GitHub **Environment secret** `WIX_BUGREPORT_API_KEY` (scoped to the
-`release` environment / `v*` tags) — and never echo it:
+The release workflows write the partial from the GitHub **Environment secret** `BBS_BUGREPORT_API_KEY`
+(scoped to the `release` environment / `v*` tags) — never echo it:
 
 ```yaml
 - name: Generate feedback API-key secret
   shell: pwsh
   env:
-    WIX_BUGREPORT_API_KEY: ${{ secrets.WIX_BUGREPORT_API_KEY }}
+    BBS_BUGREPORT_API_KEY: ${{ secrets.BBS_BUGREPORT_API_KEY }}
   run: |
     $path = "client/Assets/BlocksBeyondTheStars/Scripts/BugReportBuildSecrets.Generated.cs"
     @"
@@ -78,7 +81,7 @@ Add to the release workflow, using a GitHub **Environment secret** `WIX_BUGREPOR
     {
         public static partial class BugReportBuildSecrets
         {
-            static partial void ApplyApiKey(ref string key) => key = "$env:WIX_BUGREPORT_API_KEY";
+            static partial void ApplyApiKey(ref string key) => key = "$env:BBS_BUGREPORT_API_KEY";
         }
     }
     "@ | Set-Content $path
@@ -86,7 +89,7 @@ Add to the release workflow, using a GitHub **Environment secret** `WIX_BUGREPOR
 
 ## Open items
 
-- Stand up the Wix/Velo endpoint (`/_functions/bugreport`) per the requirements doc, then wire the CI step
-  above and the `WIX_BUGREPORT_API_KEY` secret.
-- Optional: keep a local copy of a feedback report when the upload fails, for a later retry.
+- Set the `BBS_BUGREPORT_API_KEY` Environment secret to the deployed ReportHost's write key (the old
+  `WIX_BUGREPORT_API_KEY` secret is obsolete after the cutover).
+- Keep the legacy Wix endpoint accepting until pre-cutover builds have died out, then retire its key.
 - Confirm the GDPR/privacy note on the website matches `ui.feedback.hint`.

--- a/docs/developer/PLAYER_FEEDBACK.md
+++ b/docs/developer/PLAYER_FEEDBACK.md
@@ -4,7 +4,8 @@ The **F1** hotkey lets any player send a bug report **or** a feature wish — on
 form, no type distinction: a title, a description, an optional e-mail, and a short note that game data plus
 a screenshot are attached. On send the client posts the report to the official report inbox (the
 ReportHost on the VPS — see [REPORT_HOST](REPORT_HOST.md)) and also fires the existing `/bump`
-snapshot. (F1 is advertised in the on-foot HUD controls hint, `ui.hud.hint`.)
+snapshot. (F1 is advertised in the on-foot HUD controls hint, `ui.hud.hint`, and in the space-flight
+cruise hint, `ui.space.controls` — it works in both modes; only menus/chat/death-prompt block it.)
 
 This is deliberately **player-facing** and separate from the developer `/bump` chat command (which still
 exists and produces the rich local diagnostic snapshot — see [BUG_REPORTS](BUG_REPORTS.md) if present, or
@@ -17,9 +18,13 @@ F1
    │  capture full-frame JPG  (HUD visible, dialog NOT yet shown)
    ▼
 FeedbackUi dialog  (title, description, optional e-mail, privacy hint)
-   │  Send
-   ├──────────────► FeedbackUploader.Upload()  ──HTTPS POST──►  reports.blocksbeyondthestars.de/api/bugreport
-   │                (client-direct; reaches the devs on ANY server)
+   │  Send  (body serialized ONCE on the main thread)
+   ├──────────────► HTTPS POST ──►  reports.blocksbeyondthestars.de/api/bugreport
+   │                desktop: FeedbackUploader.UploadRawJson on a background Task
+   │                WebGL:   UnityWebRequest coroutine (no HttpClient/threads in WASM;
+   │                         the ReportHost answers the CORS preflight)
+   │                on failure ──► FeedbackSpool (persistentDataPath/feedback) — retried on later
+   │                              session starts, max 5 attempts, then parked in givenup/
    └──────────────► NetworkClient.SendBumpReport()  ──►  GameServer  (rich local snapshot on own/SP server)
 ```
 
@@ -36,7 +41,9 @@ server, the server still writes its rich snapshot (inventory, position, surround
 |---|---|
 | Payload model | `src/BlocksBeyondTheStars.Client.Core/Feedback/FeedbackReport.cs` |
 | HTTP uploader (testable, no Unity) | `src/BlocksBeyondTheStars.Client.Core/Feedback/FeedbackUploader.cs` |
+| Bounded offline retry queue | `src/BlocksBeyondTheStars.Client.Core/Feedback/FeedbackSpool.cs` |
 | Tests (local `HttpListener` endpoint) | `tests/BlocksBeyondTheStars.Client.Tests/FeedbackUploaderTests.cs` |
+| Tests (spool life cycle) | `tests/BlocksBeyondTheStars.Client.Tests/FeedbackSpoolTests.cs` |
 | UI + capture + dual send | `client/Assets/BlocksBeyondTheStars/Scripts/FeedbackUi.cs` |
 | Wired into the world | `client/Assets/BlocksBeyondTheStars/Scripts/WorldRig.cs` |
 | API key (build secret) | `client/Assets/BlocksBeyondTheStars/Scripts/BugReportBuildSecrets.cs` |
@@ -46,7 +53,15 @@ server, the server still writes its rich snapshot (inventory, position, surround
 The uploader lives in the Unity-free `Client.Core` assembly and uses `System.Net.Http.HttpClient` (not
 `UnityWebRequest`) so the **exact same code** runs in the Unity player and in the headless test suite, which
 points it at a local `HttpListener` ("simulierte lokale Schnittstelle"). Only the blocking HTTP POST runs on
-a background `Task`; the report (which reads Unity APIs) is built on the main thread first.
+a background `Task`; the report (which reads Unity APIs) is built and serialized on the main thread first.
+**Exception: WebGL** — WASM has neither sockets nor threads, so `FeedbackUi` posts the identical serialized
+body via a `UnityWebRequest` coroutine instead (same endpoint + `x-bugreport-key` header; the ReportHost's
+CORS answer on `/api/bugreport` makes the cross-origin call possible from play.* / glitch.fun pages).
+
+A failed upload is never lost: the body is queued in `FeedbackSpool` (`persistentDataPath/feedback`,
+IndexedDB-backed on WebGL) and retried on later session starts — bounded to `MaxAttempts = 5` per report
+(counted in the file name), after which the file is parked in `givenup/` for a manual send. The player sees
+`ui.feedback.queued` instead of an error.
 
 ## The API key (spam gate, not a secret)
 

--- a/docs/developer/REPORT_HOST.md
+++ b/docs/developer/REPORT_HOST.md
@@ -96,9 +96,10 @@ reports.example.com {
   `BBS_CRASH_REPORT_KEY=<write key>` (or `CrashReportEndpoint`/`CrashReportApiKey` in `server.json`).
   Self-hosters can run their own inbox this way; the default stays **off** (no phone-home).
 - **Client F1 feedback** — the endpoint is the `FeedbackUploader.DefaultEndpoint` constant (by design
-  the client always reports to the *official* inbox, from any server). Switching the official inbox
-  from Wix to a ReportHost deployment is a one-line release change plus the CI key secret — planned as
-  its own small PR once the public deployment exists.
+  the client always reports to the *official* inbox, from any server). Since the cutover it points at
+  `https://reports.blocksbeyondthestars.de/api/bugreport`; the CI secret `BBS_BUGREPORT_API_KEY`
+  (release environment) must hold that deployment's `BBS_REPORTS_WRITE_KEY`. Builds released before
+  the cutover keep posting to the legacy Wix endpoint until players update.
 - Smoke test: `scripts/test-feedback-endpoint.ps1` can be pointed at
   `http://localhost:31418/api/bugreport` with the write key.
 

--- a/scripts/test-feedback-endpoint.ps1
+++ b/scripts/test-feedback-endpoint.ps1
@@ -4,7 +4,7 @@
   so you can verify the live Wix/Velo endpoint (and the API key) end to end.
 
 .DESCRIPTION
-  Resolves the API key in this order: -ApiKey arg → $env:WIX_BUGREPORT_API_KEY → the local git-ignored
+  Resolves the API key in this order: -ApiKey arg → $env:BBS_BUGREPORT_API_KEY → the local git-ignored
   BugReportBuildSecrets.Generated.cs (so it "just works" after a local build setup, without putting the key
   in this script). Posts the payload and prints the HTTP status + response body.
 
@@ -13,10 +13,10 @@
 .EXAMPLE
   ./scripts/test-feedback-endpoint.ps1
   ./scripts/test-feedback-endpoint.ps1 -BadKey
-  ./scripts/test-feedback-endpoint.ps1 -ApiKey "..." -Url "https://www.blocksbeyondthestars.com/_functions/bugreport"
+  ./scripts/test-feedback-endpoint.ps1 -ApiKey "..." -Url "https://reports.blocksbeyondthestars.de/api/bugreport"
 #>
 param(
-    [string]$Url = "https://www.blocksbeyondthestars.com/_functions/bugreport",
+    [string]$Url = "https://reports.blocksbeyondthestars.de/api/bugreport",
     [string]$ApiKey = "",
     [switch]$BadKey,
     [switch]$NoScreenshot
@@ -26,7 +26,7 @@ $ErrorActionPreference = 'Stop'
 $repo = Split-Path -Parent $PSScriptRoot
 
 # --- Resolve the API key --------------------------------------------------------------------------------
-if ([string]::IsNullOrWhiteSpace($ApiKey)) { $ApiKey = $env:WIX_BUGREPORT_API_KEY }
+if ([string]::IsNullOrWhiteSpace($ApiKey)) { $ApiKey = $env:BBS_BUGREPORT_API_KEY }
 if ([string]::IsNullOrWhiteSpace($ApiKey)) {
     $gen = Join-Path $repo 'client/Assets/BlocksBeyondTheStars/Scripts/BugReportBuildSecrets.Generated.cs'
     if (Test-Path $gen) {
@@ -35,7 +35,7 @@ if ([string]::IsNullOrWhiteSpace($ApiKey)) {
     }
 }
 if ([string]::IsNullOrWhiteSpace($ApiKey)) {
-    throw "No API key. Pass -ApiKey, set WIX_BUGREPORT_API_KEY, or create BugReportBuildSecrets.Generated.cs."
+    throw "No API key. Pass -ApiKey, set BBS_BUGREPORT_API_KEY, or create BugReportBuildSecrets.Generated.cs."
 }
 if ($BadKey) { $ApiKey = "definitely-wrong-key" }
 

--- a/src/BlocksBeyondTheStars.Client.Core/Feedback/FeedbackSpool.cs
+++ b/src/BlocksBeyondTheStars.Client.Core/Feedback/FeedbackSpool.cs
@@ -1,0 +1,187 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace BlocksBeyondTheStars.Client.Feedback
+{
+    /// <summary>
+    /// The durable local queue for F1 player feedback whose upload failed (offline, inbox down): the exact
+    /// request body is kept on disk and retried on later sessions — with a BOUNDED number of attempts,
+    /// unlike the crash spool's retry-forever. Failed attempts are counted in the file name
+    /// (<c>…_try2.json</c>; incrementing is an atomic rename, no sidecar state). A report that exhausts
+    /// <see cref="MaxAttempts"/> is parked in <c>givenup/</c> — kept, never silently deleted, so a player
+    /// can still attach it to a manual report — and an accepted one is moved to <c>sent/</c>. Stores opaque
+    /// JSON strings (the same body the uploader posts); Unity-free + best-effort (never throws), so it runs
+    /// in the player and in the headless tests.
+    /// </summary>
+    public sealed class FeedbackSpool
+    {
+        /// <summary>Automatic retry attempts per queued report (one per session start) before it is parked
+        /// in <c>givenup/</c>. The failed live send that queued the report is not counted.</summary>
+        public const int MaxAttempts = 5;
+
+        private const string FilePrefix = "feedback_";
+        private const string AttemptMarker = "_try";
+
+        private readonly string _directory;
+        private readonly object _gate = new object();
+        private int _seq;
+
+        /// <param name="directory">Folder for the queue (typically <c>persistentDataPath/feedback</c>).
+        /// Empty disables the spool.</param>
+        public FeedbackSpool(string directory)
+        {
+            _directory = directory ?? string.Empty;
+        }
+
+        /// <summary>The queue folder (for a UI hint pointing the player at unsent files).</summary>
+        public string DirectoryPath => _directory;
+
+        /// <summary>Queues one already-serialized report body under a uniquely-named <c>…_try0.json</c>
+        /// file. Returns its path, or null when nothing was written (no directory configured, empty body,
+        /// or a write failure — all swallowed).</summary>
+        public string? Write(string json, string? timestampStem = null)
+        {
+            if (string.IsNullOrEmpty(json) || string.IsNullOrEmpty(_directory))
+            {
+                return null;
+            }
+
+            try
+            {
+                Directory.CreateDirectory(_directory);
+
+                int n;
+                lock (_gate)
+                {
+                    n = ++_seq;
+                }
+
+                string stamp = Sanitize(timestampStem ?? DateTime.UtcNow.ToString("yyyyMMdd_HHmmss"));
+                string file = Path.Combine(_directory, $"{FilePrefix}{stamp}_{n:D3}{AttemptMarker}0.json");
+                File.WriteAllText(file, json);
+                return file;
+            }
+            catch
+            {
+                return null; // losing one queued report must never hurt the game
+            }
+        }
+
+        /// <summary>The queued report files awaiting a retry (best-effort; empty on any error). The
+        /// <c>sent/</c> and <c>givenup/</c> subfolders are excluded because the scan is non-recursive.</summary>
+        public IReadOnlyList<string> ListPending()
+        {
+            if (string.IsNullOrEmpty(_directory) || !Directory.Exists(_directory))
+            {
+                return Array.Empty<string>();
+            }
+
+            try
+            {
+                return Directory.GetFiles(_directory, FilePrefix + "*.json");
+            }
+            catch
+            {
+                return Array.Empty<string>();
+            }
+        }
+
+        /// <summary>Reads one queued report's body, or null if it can't be read (locked / mid-write / gone).</summary>
+        public string? Read(string path)
+        {
+            try
+            {
+                return File.ReadAllText(path);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        /// <summary>Moves an accepted report into <c>sent/</c> so <see cref="ListPending"/> no longer returns
+        /// it. Best-effort; on failure the file stays queued and is retried (a harmless duplicate send).</summary>
+        public void MarkSent(string path)
+        {
+            try
+            {
+                Move(path, "sent");
+            }
+            catch
+            {
+                // best-effort
+            }
+        }
+
+        /// <summary>Counts one failed retry: renames <c>…_tryN</c> to <c>…_tryN+1</c>, or parks the report in
+        /// <c>givenup/</c> once it has used its <see cref="MaxAttempts"/> attempts. Returns true while the
+        /// report stays queued for another session.</summary>
+        public bool RegisterFailedAttempt(string path)
+        {
+            try
+            {
+                string name = Path.GetFileNameWithoutExtension(path);
+                int attempts = 0;
+                string stem = name;
+                int idx = name.LastIndexOf(AttemptMarker, StringComparison.Ordinal);
+                if (idx >= 0 && int.TryParse(name.Substring(idx + AttemptMarker.Length), out int parsed))
+                {
+                    attempts = parsed;
+                    stem = name.Substring(0, idx);
+                }
+
+                attempts++;
+                if (attempts >= MaxAttempts)
+                {
+                    Move(path, "givenup");
+                    return false;
+                }
+
+                string next = Path.Combine(_directory, stem + AttemptMarker + attempts + ".json");
+                if (File.Exists(next))
+                {
+                    File.Delete(next);
+                }
+
+                File.Move(path, next);
+                return true;
+            }
+            catch
+            {
+                return false; // unknown state — promise nothing
+            }
+        }
+
+        private void Move(string path, string subfolder)
+        {
+            string dir = Path.Combine(_directory, subfolder);
+            Directory.CreateDirectory(dir);
+            string target = Path.Combine(dir, Path.GetFileName(path));
+            if (File.Exists(target))
+            {
+                File.Delete(target);
+            }
+
+            File.Move(path, target);
+        }
+
+        private static string Sanitize(string name)
+        {
+            if (string.IsNullOrEmpty(name))
+            {
+                return "feedback";
+            }
+
+            foreach (var c in Path.GetInvalidFileNameChars())
+            {
+                name = name.Replace(c, '_');
+            }
+
+            return name;
+        }
+    }
+}

--- a/src/BlocksBeyondTheStars.Client.Core/Feedback/FeedbackUploader.cs
+++ b/src/BlocksBeyondTheStars.Client.Core/Feedback/FeedbackUploader.cs
@@ -27,7 +27,7 @@ namespace BlocksBeyondTheStars.Client.Feedback
     }
 
     /// <summary>
-    /// Posts a <see cref="FeedbackReport"/> (JSON + optional base64 screenshot) to the website API. Uses
+    /// Posts a <see cref="FeedbackReport"/> (JSON + optional base64 screenshot) to the report inbox. Uses
     /// <see cref="HttpClient"/> rather than UnityWebRequest so the exact same code runs inside the Unity
     /// player AND inside the headless test suite, which points it at a local <see cref="System.Net.HttpListener"/>
     /// ("simulierte lokale Schnittstelle"). The call is synchronous (blocking); the Unity layer runs it on a
@@ -38,10 +38,11 @@ namespace BlocksBeyondTheStars.Client.Feedback
     /// </summary>
     public sealed class FeedbackUploader
     {
-        /// <summary>Production endpoint (Wix/Velo HTTP function).</summary>
-        public const string DefaultEndpoint = "https://www.blocksbeyondthestars.com/_functions/bugreport";
+        /// <summary>Production endpoint — the ReportHost inbox on the VPS (docs/developer/REPORT_HOST.md).</summary>
+        public const string DefaultEndpoint = "https://reports.blocksbeyondthestars.de/api/bugreport";
 
-        /// <summary>Header carrying the spam-gate key (matches the Wix backend's <c>x-bugreport-key</c>).</summary>
+        /// <summary>Header carrying the spam-gate key (the ReportHost's <c>x-bugreport-key</c>; the same
+        /// header the original Wix backend used, so old and new inbox share one wire contract).</summary>
         public const string ApiKeyHeader = "x-bugreport-key";
 
         /// <summary>Upper bound for the base64 screenshot length; larger shots are dropped (the report is

--- a/src/BlocksBeyondTheStars.ReportHost/Program.cs
+++ b/src/BlocksBeyondTheStars.ReportHost/Program.cs
@@ -122,6 +122,27 @@ object ToItem(BugReportRecord r)
     };
 }
 
+// CORS, ingest only: the WebGL client posts feedback cross-origin (from play.* / glitch.fun pages),
+// which needs the OPTIONS preflight answered and the POST response readable. Any origin is fine —
+// the endpoint already requires the write key and rate-limits, so this widens nothing else.
+app.Use(async (ctx, next) =>
+{
+    if (ctx.Request.Path == "/api/bugreport")
+    {
+        ctx.Response.Headers.AccessControlAllowOrigin = "*";
+        if (HttpMethods.IsOptions(ctx.Request.Method))
+        {
+            ctx.Response.Headers.AccessControlAllowMethods = "POST, OPTIONS";
+            ctx.Response.Headers.AccessControlAllowHeaders = "content-type, x-bugreport-key";
+            ctx.Response.Headers.AccessControlMaxAge = "86400";
+            ctx.Response.StatusCode = StatusCodes.Status204NoContent;
+            return;
+        }
+    }
+
+    await next();
+});
+
 app.MapGet("/healthz", () => Results.Text("ok\n"));
 app.MapGet("/", () => Results.Redirect("/admin"));
 

--- a/src/BlocksBeyondTheStars.Shared/Configuration/ServerConfig.cs
+++ b/src/BlocksBeyondTheStars.Shared/Configuration/ServerConfig.cs
@@ -84,11 +84,11 @@ public sealed class ServerConfig
     /// (BBTS_AI_TIMEOUT, default 30 s) so the backend's template fallback beats this deadline.</summary>
     public int AiTimeoutSeconds { get; set; } = 35;
 
-    /// <summary>Endpoint the server POSTs automatic crash reports to — the website's bug-report function, shared
+    /// <summary>Endpoint the server POSTs automatic crash reports to — the ReportHost bug-report inbox, shared
     /// with player feedback + client crashes (server reports are shaped to the same contract). Uploading stays
     /// OFF until <see cref="CrashReportApiKey"/> is also set, so a self-hosted server never phones home unless
     /// its operator opts in; reports are written to the local <c>crashreports/</c> folder regardless.</summary>
-    public string CrashReportEndpoint { get; set; } = "https://www.blocksbeyondthestars.com/_functions/bugreport";
+    public string CrashReportEndpoint { get; set; } = "https://reports.blocksbeyondthestars.de/api/bugreport";
 
     /// <summary>Spam-gate key sent with an automatic crash report (the <c>x-bugreport-key</c> header). Empty
     /// (the default) leaves crash uploading disabled regardless of the endpoint — official builds inject it.</summary>

--- a/tests/BlocksBeyondTheStars.Client.Tests/FeedbackSpoolTests.cs
+++ b/tests/BlocksBeyondTheStars.Client.Tests/FeedbackSpoolTests.cs
@@ -1,0 +1,100 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using System;
+using System.IO;
+using BlocksBeyondTheStars.Client.Feedback;
+using Xunit;
+
+namespace BlocksBeyondTheStars.Client.Tests;
+
+/// <summary>The bounded feedback retry queue: a failed F1 upload survives on disk, every later failed
+/// attempt is counted in the file name, and a report leaves the queue either as <c>sent/</c> or — after
+/// <see cref="FeedbackSpool.MaxAttempts"/> — as <c>givenup/</c>: it never retries forever and is never
+/// silently deleted.</summary>
+public sealed class FeedbackSpoolTests : IDisposable
+{
+    private readonly string _dir;
+
+    public FeedbackSpoolTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "bbts_feedbackspool_" + Guid.NewGuid().ToString("N"));
+    }
+
+    [Fact]
+    public void Write_ThenListAndRead_RoundTrips()
+    {
+        var spool = new FeedbackSpool(_dir);
+        Assert.Empty(spool.ListPending());
+
+        string? path = spool.Write("{\"description\":\"door ate my hat\"}", "20260715_120000");
+        Assert.NotNull(path);
+        Assert.True(File.Exists(path));
+        Assert.StartsWith("feedback_", Path.GetFileName(path!));
+        Assert.EndsWith("_try0.json", Path.GetFileName(path!));
+
+        Assert.Single(spool.ListPending());
+        Assert.Equal("{\"description\":\"door ate my hat\"}", spool.Read(path!));
+    }
+
+    [Fact]
+    public void MarkSent_MovesOutOfPending_ButKeepsFile()
+    {
+        var spool = new FeedbackSpool(_dir);
+        string? path = spool.Write("{\"a\":1}", "ts");
+        Assert.NotNull(path);
+
+        spool.MarkSent(path!);
+
+        Assert.Empty(spool.ListPending());
+        Assert.False(File.Exists(path));
+        Assert.Single(Directory.GetFiles(Path.Combine(_dir, "sent")));
+    }
+
+    [Fact]
+    public void RegisterFailedAttempt_CountsUp_AndParksAfterMaxAttempts()
+    {
+        var spool = new FeedbackSpool(_dir);
+        Assert.NotNull(spool.Write("{\"a\":1}", "ts"));
+
+        // Attempts 1 … MaxAttempts-1 keep the report queued, each under the next _tryN name.
+        for (int attempt = 1; attempt < FeedbackSpool.MaxAttempts; attempt++)
+        {
+            string queued = Assert.Single(spool.ListPending());
+            Assert.True(spool.RegisterFailedAttempt(queued));
+            Assert.EndsWith($"_try{attempt}.json", Path.GetFileName(Assert.Single(spool.ListPending())));
+        }
+
+        // The final permitted attempt parks it in givenup/ — gone from the queue, kept on disk.
+        Assert.False(spool.RegisterFailedAttempt(Assert.Single(spool.ListPending())));
+        Assert.Empty(spool.ListPending());
+        Assert.Single(Directory.GetFiles(Path.Combine(_dir, "givenup")));
+    }
+
+    [Fact]
+    public void EmptyDirectoryOrBody_DisablesSpool_NeverThrows()
+    {
+        var disabled = new FeedbackSpool(string.Empty);
+        Assert.Null(disabled.Write("{\"a\":1}", "ts"));
+        Assert.Empty(disabled.ListPending());
+
+        var spool = new FeedbackSpool(_dir);
+        Assert.Null(spool.Write("", "ts"));
+        Assert.Empty(spool.ListPending());
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_dir))
+            {
+                Directory.Delete(_dir, recursive: true);
+            }
+        }
+        catch
+        {
+            // best-effort temp cleanup
+        }
+    }
+}


### PR DESCRIPTION
Cherry-picked from a parallel worker's `feat/feedback-vps-cutover` (6 thematically separated commits) for the v0.8.1 release.

## What's in it
- **ReportHost answers the CORS preflight** on `/api/bugreport` — prerequisite for browser feedback (write key + rate limit unchanged). (a24fc3c)
- **Endpoint cutover:** `FeedbackUploader.DefaultEndpoint` and the server's `CrashReportEndpoint` default now point at `https://reports.blocksbeyondthestars.de/api/bugreport`; CI secret renamed `WIX_BUGREPORT_API_KEY` → `BBS_BUGREPORT_API_KEY` (release.yml ×4, webgl-only.yml, test script). (cd7e26a)
- **F1 during space flight:** `canLaunch` no longer blocks on `SpaceViewActive`; the dialog restores the prior cursor state on close. (6e0886c)
- **WebGL fix:** the report is serialized once on the main thread and posted via a `UnityWebRequest` coroutine — WASM has neither `HttpClient` nor threads, so the browser build could never send feedback before. (1440371)
- **Local spool with bounded retries:** failed uploads queue in `persistentDataPath/feedback`, retried on later starts (max 5, then parked in `givenup/`, never deleted); new `ui.feedback.queued` (DE+EN); `FeedbackSpoolTests` cover the lifecycle. (ba2dabe)
- **Docs:** PLAYER_FEEDBACK.md, REPORT_HOST.md, TODO.md status + ops checklist. (0619448)

## ⚠️ Ops steps required (feature is silent otherwise)
1. Cloudflare A-record `reports.blocksbeyondthestars.de` → 31.70.113.90 (**DNS-only**, no proxy — cert via HTTP-01 through Caddy).
2. `/opt/bbs/reports/.env` on the VPS (write/read key, admin creds).
3. `deploy.yml` with `service=reports`.
4. New GitHub environment secret `BBS_BUGREPORT_API_KEY` = the deployed ReportHost's write key. Missing → CI still builds, feedback disabled (loud CI log note).

Already-shipped builds keep posting to the old Wix endpoint — leave it running for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)