### PR TITLE
fix(glitch): stable install-derived name claim + honor the requested name

### DIFF
--- a/client/Assets/BlocksBeyondTheStars/Scripts/AppShell.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/AppShell.cs
@@ -53,6 +53,12 @@ namespace BlocksBeyondTheStars.Client
         /// attached to in-game player reports. Must stay empty for singleplayer/LAN/self-host joins.</summary>
         public string HostedWorldId = "";
 
+        /// <summary>Name-claim token for a glitch.fun arcade session (install-derived, from the session
+        /// gateway). Overrides the browser-local <see cref="ClientSettings.PlayerToken"/> for the join,
+        /// because that storage resets with every Glitch deployment and would lock returning guests out
+        /// of their own claimed name. Must stay empty for every non-arcade join.</summary>
+        public string ArcadeNameToken = "";
+
         /// <summary>One-shot notice shown on the main menu (e.g. why the last join was refused).</summary>
         public string MenuNotice = "";
 
@@ -181,7 +187,7 @@ namespace BlocksBeyondTheStars.Client
 
         private IEnumerator RequestArcadeJoin()
         {
-            yield return GlitchIntegration.RequestArcadeSession((session, error) =>
+            yield return GlitchIntegration.RequestArcadeSession(PlayerName, (session, error) =>
             {
                 if (session == null)
                 {
@@ -194,6 +200,7 @@ namespace BlocksBeyondTheStars.Client
                 Host = session.wssUrl;
                 HostedToken = session.joinToken;
                 HostedWorldId = session.worldId;
+                ArcadeNameToken = session.nameToken ?? "";
                 _autoJoinWhenReady = true; // the Update() gate joins once content + menu are ready
             });
         }
@@ -534,6 +541,7 @@ namespace BlocksBeyondTheStars.Client
             MenuNotice = "";
             HostedToken = "";
             HostedWorldId = "";
+            ArcadeNameToken = "";
             Password = "";
             HostInfo = "";
             _hostLocal = false;

--- a/client/Assets/BlocksBeyondTheStars/Scripts/GlitchIntegration.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/GlitchIntegration.cs
@@ -125,14 +125,19 @@ namespace BlocksBeyondTheStars.Client
             public string playerName;
             public string wssUrl;
             public string joinToken;
+            public string nameToken; // install-derived name-claim token — stable across deployments
         }
 
         /// <summary>Requests an arcade session from the configured portal. Reports (session, null) on
-        /// success or (null, error) on failure — run via StartCoroutine from AppShell.</summary>
-        public static IEnumerator RequestArcadeSession(Action<ArcadeSession, string> done)
+        /// success or (null, error) on failure — run via StartCoroutine from AppShell. The menu's
+        /// player name rides along as the requested name; the gateway sanitizes it and keeps the
+        /// stable per-install suffix.</summary>
+        public static IEnumerator RequestArcadeSession(string requestedName, Action<ArcadeSession, string> done)
         {
             string url = PortalUrl + "/api/glitch/session";
-            string body = "{\"installId\":\"" + JsonEscape(ArcadeInstallId) + "\"}";
+            string body = string.IsNullOrWhiteSpace(requestedName)
+                ? "{\"installId\":\"" + JsonEscape(ArcadeInstallId) + "\"}"
+                : "{\"installId\":\"" + JsonEscape(ArcadeInstallId) + "\",\"playerName\":\"" + JsonEscape(requestedName.Trim()) + "\"}";
             using (var request = new UnityWebRequest(url, "POST"))
             {
                 request.uploadHandler = new UploadHandlerRaw(Encoding.UTF8.GetBytes(body));

--- a/client/Assets/BlocksBeyondTheStars/Scripts/UiMainMenu.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/UiMainMenu.cs
@@ -180,6 +180,7 @@ namespace BlocksBeyondTheStars.Client
                 shell.Settings.Save();
                 shell.HostedToken = ""; // never let an official-worlds grant leak into SP/LAN/manual joins
                 shell.HostedWorldId = "";
+                shell.ArcadeNameToken = "";
                 return true;
             }
 
@@ -265,6 +266,7 @@ namespace BlocksBeyondTheStars.Client
                 shell.Password = pass[0] ?? "";
                 shell.HostedToken = ""; // manual join: no official-worlds grant
                 shell.HostedWorldId = "";
+                shell.ArcadeNameToken = "";
                 shell.StartJoin();
             }, "btn_join");
             UiKit.AddButton(dlg, 310f, 432f, 260f, 54f, shell.L("ui.menu.back"), () => connect.SetActive(false), "btn_exit");
@@ -1107,6 +1109,7 @@ namespace BlocksBeyondTheStars.Client
                 shell.Password = "";
                 shell.HostedToken = r.JoinToken; // the grant the server-side token gate verifies
                 shell.HostedWorldId = worldId; // attached to in-game player reports
+                shell.ArcadeNameToken = ""; // portal join: the browser-local PlayerToken IS the identity
                 shell.StartJoin();
             }
 

--- a/client/Assets/BlocksBeyondTheStars/Scripts/WorldRig.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/WorldRig.cs
@@ -34,7 +34,11 @@ namespace BlocksBeyondTheStars.Client
             boot.Port = int.TryParse(shell.Port, out var p) && p > 0 ? p : 31415;
             boot.PlayerName = string.IsNullOrWhiteSpace(shell.PlayerName) ? "Pilot" : shell.PlayerName;
             boot.Password = shell.Password ?? "";
-            boot.Token = shell.Settings.PlayerToken ?? "";
+            // Arcade sessions claim their name with the install-derived gateway token — the browser-local
+            // PlayerToken resets with every Glitch deployment and would lock returning guests out.
+            boot.Token = !string.IsNullOrEmpty(shell.ArcadeNameToken)
+                ? shell.ArcadeNameToken
+                : shell.Settings.PlayerToken ?? "";
             boot.HostedToken = shell.HostedToken ?? ""; // official-worlds join grant (empty for SP/LAN/self-host)
             boot.HostedWorldId = shell.HostedWorldId ?? ""; // which official world — attached to player reports
             boot.PortalUrl = shell.Settings.PortalUrl ?? "";

--- a/src/BlocksBeyondTheStars.WorldHost/GlitchGateway.cs
+++ b/src/BlocksBeyondTheStars.WorldHost/GlitchGateway.cs
@@ -18,7 +18,8 @@ public sealed record GlitchSessionResult(
     string PlayerName = "",
     string WssUrl = "",
     string JoinToken = "",
-    long TokenExpiresUnix = 0);
+    long TokenExpiresUnix = 0,
+    string NameToken = "");
 
 /// <summary>
 /// The glitch.fun arcade gateway: instant, account-less entry into a small pool of persistent
@@ -175,7 +176,8 @@ public sealed class GlitchGateway
             PlayerName: playerName,
             WssUrl: grant.WssUrl,
             JoinToken: grant.JoinToken,
-            TokenExpiresUnix: grant.TokenExpiresUnix);
+            TokenExpiresUnix: grant.TokenExpiresUnix,
+            NameToken: DeriveNameToken(installId));
     }
 
     /// <summary>Relays a client heartbeat to Glitch's install endpoint (their playtime/payout signal),
@@ -575,6 +577,17 @@ public sealed class GlitchGateway
         return (null, "All arcade worlds are full right now — please try again in a few minutes.");
     }
 
+    /// <summary>Derives the guest's name-verification token from the install id. The instance's name
+    /// claim must NOT key on the client's browser-local PlayerToken: Unity WebGL storage is scoped to
+    /// the page URL path and Glitch serves every deployment from a new content path, so each release
+    /// would present a fresh random token against the persisted claim and lock every returning guest
+    /// out of their own name. The install id is already the credential that authorizes the session, so
+    /// deriving the claim from it adds no new attack surface — and gives the same install the same
+    /// claim in every browser and across every deployment.</summary>
+    public static string DeriveNameToken(string installId)
+        => Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes("bbs-glitch-name-claim:" + installId)))
+            .ToLowerInvariant();
+
     /// <summary>Resolves the guest's in-game name: the requested name, else the Glitch account name,
     /// else "Explorer" — reserved/blocked base names fall back too — plus a stable 3-hex-char suffix
     /// derived from the install id. The suffix gives every install the SAME identity on every visit
@@ -594,6 +607,14 @@ public sealed class GlitchGateway
 
         string suffix = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(installId)))
             .ToLowerInvariant().Substring(0, 3);
+
+        // The menu echoes the assigned (already suffixed) name back into the name field, so a retry
+        // resends it as the requested name — strip our own suffix instead of stacking "-abc-abc".
+        if (baseName.EndsWith("-" + suffix, StringComparison.OrdinalIgnoreCase) && baseName.Length > suffix.Length + 1)
+        {
+            baseName = baseName.Substring(0, baseName.Length - suffix.Length - 1);
+        }
+
         return baseName + "-" + suffix;
     }
 

--- a/src/BlocksBeyondTheStars.WorldHost/Program.cs
+++ b/src/BlocksBeyondTheStars.WorldHost/Program.cs
@@ -416,6 +416,7 @@ app.MapPost("/api/glitch/session", async (HttpContext ctx, GlitchSessionRequest 
         wssUrl = result.WssUrl,
         joinToken = result.JoinToken,
         tokenExpiresUnix = result.TokenExpiresUnix,
+        nameToken = result.NameToken,
     });
 });
 

--- a/tests/BlocksBeyondTheStars.Tests/GlitchGatewayTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/GlitchGatewayTests.cs
@@ -316,6 +316,37 @@ public sealed class GlitchGatewayTests : IDisposable
         Assert.True(longName.Length <= 24, longName);
     }
 
+    [Fact]
+    public void ResolvePlayerName_DoesNotStackTheOwnSuffix()
+    {
+        var (gateway, _, _, _) = NewGateway();
+
+        // The menu echoes the assigned name back into the name field, so a retry resends the already
+        // suffixed name — resolving it again must yield the same identity, not "Maxi-abc-abc".
+        string assigned = gateway.ResolvePlayerName("Maxi", "Gamer123", Install);
+        Assert.Equal(assigned, gateway.ResolvePlayerName(assigned, "Gamer123", Install));
+    }
+
+    [Fact]
+    public async Task Session_ReturnsTheInstallDerivedNameToken_StableAcrossDeploymentsAsync()
+    {
+        var (gateway, _, _, _) = NewGateway();
+
+        var first = await gateway.SessionAsync(Install);
+        var second = await gateway.SessionAsync(Install);
+
+        // The name claim must NOT depend on browser-local state (which resets with every Glitch
+        // deployment): the gateway hands out the same install-derived token on every visit.
+        Assert.True(first.Ok, first.Error);
+        Assert.NotEmpty(first.NameToken);
+        Assert.Equal(first.NameToken, second.NameToken);
+        Assert.Equal(GlitchGateway.DeriveNameToken(Install), first.NameToken);
+
+        // ...and it is per-install: another guest gets a different claim.
+        var other = await gateway.SessionAsync("5f9dd262-840c-4df8-a30b-366fc0c7e1d8");
+        Assert.NotEqual(first.NameToken, other.NameToken);
+    }
+
     // ---------------- Heartbeat relay ----------------
 
     [Fact]


### PR DESCRIPTION
Closes #345, closes #346.

## What

Two arcade-identity fixes for glitch.fun, found in the first post-v0.8.1 live test:

1. **Stable name claim across deployments (#345)** — the session gateway now returns a `nameToken` derived from the install id (`SHA-256("bbs-glitch-name-claim:" + installId)`), and the arcade client presents it as its join token instead of the browser-local `ClientSettings.PlayerToken`. Unity WebGL storage is scoped to the page URL path and Glitch serves every deployment from a new S3 content path, so the local token reset with every release and the game server rejected returning guests over their own persisted name claim. The install-derived token gives the same install the same claim in every browser and across every deployment. Non-arcade joins (portal, LAN, desktop, self-host) keep using the local PlayerToken unchanged — `ArcadeNameToken` is cleared at every non-arcade join site alongside `HostedToken`.

2. **Requested name is honored (#346)** — the menu's player-name field now rides along as `playerName` in the session request (the API already accepted it; the client never sent it). The gateway keeps the stable 3-hex install suffix and strips its own echoed suffix so a retry cannot stack `-abc-abc`.

## Verification

- Full suite green: **1033 server + 129 client tests**, including 2 new gateway tests (install-derived token is stable across sessions and distinct per install; suffix dedup on resent names).
- `dotnet format` clean.
- Local Unity WebGL build succeeded.

## Ops note for the deploy

Existing arcade worlds hold stale GUID-based claims from before the fix — clear the affected player rows' `NameTokenHash` once at deploy time (currently one row: `ai_cat_coder-4fd` in the `cf56d2d22cdb` pool world), or the affected guests stay locked out despite the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)