### PR TITLE
fix(worldhost): forward crash-report key to world instances

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -99,6 +99,18 @@ Per-item detail lives in the dated work log below.
 
 ---
 
+### ★ Fleet crash reports: WorldHost forwards the ReportHost write key to world instances (#363, 2026-07-16)
+Hosted worlds never uploaded crash reports: the dedicated server has supported
+`BBS_CRASH_REPORT_ENDPOINT`/`BBS_CRASH_REPORT_KEY` since the ReportHost cutover (endpoint even defaults to the
+official inbox), but `DockerCliLauncher.BuildRunArgs` builds a fixed env list and never passed a key — so fleet
+crashes stayed in each container's local queue. New operator settings `BBS_WH_CRASH_REPORT_KEY` (= the ReportHost's
+`BBS_REPORTS_WRITE_KEY`; empty = off, no-phone-home default) and optional `BBS_WH_CRASH_REPORT_ENDPOINT` (self-hosted
+fleets with their own inbox) are forwarded into every world container, picked up on the next wake — same mechanics as
+the announce token. Compose/.env.example passthrough + docs (HOSTED_WORLDS.md, REPORT_HOST.md) + `BuildRunArgs` tests.
+No game release needed (worldhost-image.yml builds on push to main). **Ops after merge**: pin `WORLDHOST_TAG`, set
+`BBS_WH_CRASH_REPORT_KEY` in `/opt/bbs/worldhost/.env`, add the two passthrough lines to the VPS compose, recreate
+worldhost, recycle running worlds.
+
 ### ★ F1 feedback: VPS ReportHost cutover, works in space flight + WebGL, offline spool (2026-07-15, local branch feat/feedback-vps-cutover)
 The F1 player feedback now goes to **our own inbox**: `FeedbackUploader.DefaultEndpoint` (and the server's
 `CrashReportEndpoint` default) point at `https://reports.blocksbeyondthestars.de/api/bugreport` (ReportHost,

--- a/deploy/worldhost/.env.example
+++ b/deploy/worldhost/.env.example
@@ -27,6 +27,12 @@ BBS_WH_ADMIN_PASSWORD=
 # Maintenance announcements (#249): shared secret between WorldHost and each world instance's POST
 # /announce (forwarded to world containers as BBS_ANNOUNCE_TOKEN on their next wake). Empty = off.
 BBS_WH_ANNOUNCE_TOKEN=
+# Server crash reports (#363): the ReportHost write key (= that deployment's BBS_REPORTS_WRITE_KEY),
+# forwarded to world containers as BBS_CRASH_REPORT_KEY on their next wake — crashed worlds then
+# upload their queued crash reports to the inbox. Empty = crash upload off. Only set the endpoint
+# override when running your OWN ReportHost; the server default is the official inbox.
+BBS_WH_CRASH_REPORT_KEY=
+#BBS_WH_CRASH_REPORT_ENDPOINT=
 
 # Fleet AI texts (optional): the internal-only ai container (deploy/ai). Empty = AI off. TextOnly =
 # NPC lines + board flavour text, no auto-published AI missions.

--- a/deploy/worldhost/docker-compose.yml
+++ b/deploy/worldhost/docker-compose.yml
@@ -40,6 +40,11 @@ services:
       # Maintenance announcements (#249): shared secret forwarded to each world as BBS_ANNOUNCE_TOKEN;
       # worlds only pick it up on their next wake. Empty = announcements off.
       BBS_WH_ANNOUNCE_TOKEN: ${BBS_WH_ANNOUNCE_TOKEN:-}
+      # Server crash reports (#363): the ReportHost write key, forwarded to each world as
+      # BBS_CRASH_REPORT_KEY (picked up on the next wake). Empty = crash upload off. The endpoint
+      # override is only for fleets with their own ReportHost — the server default is the official inbox.
+      BBS_WH_CRASH_REPORT_KEY: ${BBS_WH_CRASH_REPORT_KEY:-}
+      BBS_WH_CRASH_REPORT_ENDPOINT: ${BBS_WH_CRASH_REPORT_ENDPOINT:-}
       # Legal pages (Impressum/Datenschutz); empty = "not configured" notice on those pages.
       BBS_WH_LEGAL_NAME: ${BBS_WH_LEGAL_NAME:-}
       BBS_WH_LEGAL_ADDRESS: ${BBS_WH_LEGAL_ADDRESS:-}

--- a/docs/developer/HOSTED_WORLDS.md
+++ b/docs/developer/HOSTED_WORLDS.md
@@ -248,6 +248,16 @@ aligned (`BBTS_AI_TIMEOUT` 30 s < `BBS_AI_TIMEOUT_SECONDS` 35 s) so the backend'
 always beats the server's deadline. Official fleet model: Mistral Small on OVHcloud AI Endpoints
 (EU; ~0.5 s per line — Qwen3.5 was measured unusable there: forced reasoning, no think-off switch).
 
+## Fleet crash reports (optional)
+
+When `BBS_WH_CRASH_REPORT_KEY` is set (the ReportHost deployment's write key), WorldHost forwards it
+into every world instance as `BBS_CRASH_REPORT_KEY`, so a crashed world uploads its queued crash
+reports to the bug-report inbox (docs/developer/REPORT_HOST.md) on its next start. The endpoint
+defaults to the official inbox inside the server; a self-hosted fleet sets
+`BBS_WH_CRASH_REPORT_ENDPOINT` to point at its own ReportHost. Empty key (default) = crash upload
+off — the usual no-phone-home stance. Like the announce token, running worlds only pick the key up
+on their next wake.
+
 ## Operator admin UI
 
 `/admin` on the portal domain (Basic Auth via `BBS_WH_ADMIN_USER`/`_PASSWORD`; off when unset — the

--- a/docs/developer/REPORT_HOST.md
+++ b/docs/developer/REPORT_HOST.md
@@ -95,6 +95,10 @@ reports.example.com {
   `BBS_CRASH_REPORT_ENDPOINT=https://reports.example.com/api/bugreport` and
   `BBS_CRASH_REPORT_KEY=<write key>` (or `CrashReportEndpoint`/`CrashReportApiKey` in `server.json`).
   Self-hosters can run their own inbox this way; the default stays **off** (no phone-home).
+- **Hosted-worlds fleet** (#363) — WorldHost forwards its `BBS_WH_CRASH_REPORT_KEY` (and the optional
+  `BBS_WH_CRASH_REPORT_ENDPOINT` override) into every world container as the two variables above, so
+  fleet crashes land in the inbox too. Worlds pick the key up on their next wake. Empty = off, same
+  no-phone-home default as everywhere else.
 - **Client F1 feedback** — the endpoint is the `FeedbackUploader.DefaultEndpoint` constant (by design
   the client always reports to the *official* inbox, from any server). Since the cutover it points at
   `https://reports.blocksbeyondthestars.de/api/bugreport`; the CI secret `BBS_BUGREPORT_API_KEY`

--- a/src/BlocksBeyondTheStars.WorldHost/InstanceLauncher.cs
+++ b/src/BlocksBeyondTheStars.WorldHost/InstanceLauncher.cs
@@ -115,6 +115,18 @@ public sealed class DockerCliLauncher : IInstanceLauncher
             args.AddRange(new[] { "-e", $"BBS_ANNOUNCE_TOKEN={config.AnnounceToken}" });
         }
 
+        // Server crash reports (#363): with the write key set, a crashed instance uploads its queued
+        // crash reports on its next start. The endpoint stays the server's built-in default (the
+        // official ReportHost inbox) unless a self-hosted fleet overrides it.
+        if (!string.IsNullOrEmpty(config.CrashReportKey))
+        {
+            args.AddRange(new[] { "-e", $"BBS_CRASH_REPORT_KEY={config.CrashReportKey}" });
+            if (!string.IsNullOrEmpty(config.CrashReportEndpoint))
+            {
+                args.AddRange(new[] { "-e", $"BBS_CRASH_REPORT_ENDPOINT={config.CrashReportEndpoint}" });
+            }
+        }
+
         // Optional fleet AI: the instance reaches the internal-only ai container by name on the shared
         // network. Level TextOnly = NPC lines + board flavour, no auto-published AI missions.
         if (!string.IsNullOrEmpty(config.AiBackendUrl))

--- a/src/BlocksBeyondTheStars.WorldHost/WorldHostConfig.cs
+++ b/src/BlocksBeyondTheStars.WorldHost/WorldHostConfig.cs
@@ -154,6 +154,21 @@ public sealed class WorldHostConfig
     /// on POST /announce. Empty (default) = announcements off (both sides keep the endpoint disabled).</summary>
     public string AnnounceToken { get; set; } = string.Empty;
 
+    // --- Server crash reports (optional). The dedicated server queues crash reports locally and only
+    // uploads them when it has an API key (ServerConfig.CrashReportApiKey — deliberate no-phone-home
+    // default). With the key set here, every world instance receives it as BBS_CRASH_REPORT_KEY, so
+    // fleet crashes land in the ReportHost inbox (docs/developer/REPORT_HOST.md). ---
+
+    /// <summary>Crash-report write key forwarded to world instances as BBS_CRASH_REPORT_KEY
+    /// (BBS_WH_CRASH_REPORT_KEY) — the ReportHost's <c>BBS_REPORTS_WRITE_KEY</c>. Empty (default) =
+    /// crash upload stays off in the instances.</summary>
+    public string CrashReportKey { get; set; } = string.Empty;
+
+    /// <summary>Optional crash-report endpoint override forwarded as BBS_CRASH_REPORT_ENDPOINT
+    /// (BBS_WH_CRASH_REPORT_ENDPOINT). Empty (default) keeps the server's built-in default (the
+    /// official inbox) — a self-hosted fleet points this at ITS OWN ReportHost.</summary>
+    public string CrashReportEndpoint { get; set; } = string.Empty;
+
     // --- Per-instance resource limits. One runaway world must never take down the host: each world
     // container gets a hard memory cap (which .NET's cgroup-aware GC also uses to apply pressure
     // BEFORE the OOM kill), a CPU ceiling and a pids cap. The capacity gate bounds the SUM. ---
@@ -302,6 +317,8 @@ public sealed class WorldHostConfig
         if (Env("BBS_WH_LEGAL_ADDRESS") is { } legalAddress) { c.LegalAddress = legalAddress; }
         if (Env("BBS_WH_LEGAL_EMAIL") is { } legalEmail) { c.LegalEmail = legalEmail; }
         if (Env("BBS_WH_ANNOUNCE_TOKEN") is { } announceToken) { c.AnnounceToken = announceToken; }
+        if (Env("BBS_WH_CRASH_REPORT_KEY") is { } crashKey) { c.CrashReportKey = crashKey; }
+        if (Env("BBS_WH_CRASH_REPORT_ENDPOINT") is { } crashEndpoint) { c.CrashReportEndpoint = crashEndpoint; }
         if (Env("BBS_WH_AI_BACKEND_URL") is { } aiUrl) { c.AiBackendUrl = aiUrl; }
         if (Env("BBS_WH_AI_LEVEL") is { } aiLevel) { c.AiLevel = aiLevel; }
         if (Env("BBS_WH_INSTANCE_MEMORY") is { } mem) { c.InstanceMemory = mem == "none" ? string.Empty : mem; }

--- a/tests/BlocksBeyondTheStars.Tests/WorldHostTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/WorldHostTests.cs
@@ -524,7 +524,34 @@ public sealed class WorldHostTests : IDisposable
         Assert.DoesNotContain("--memory", joined);
         Assert.DoesNotContain("--cpus", joined);
         Assert.DoesNotContain("BBS_AI_BACKEND_URL", joined);
+        Assert.DoesNotContain("BBS_CRASH_REPORT", joined); // no key configured = no crash-report env at all
         Assert.Contains("--pids-limit 256", joined); // the pids fence is unconditional
+    }
+
+    [Fact]
+    public void BuildRunArgs_ForwardsCrashReportKey_AndOptionalEndpointOverride()
+    {
+        var world = new WorldRecord("abc123abc123", "acct", "My World", "secret", 32001, WorldStatus.Stopped, "", 0, 0);
+
+        // Key only (the fleet case): the endpoint stays the server's built-in default.
+        var keyOnly = new WorldHostConfig { CrashReportKey = "write-key" };
+        string joined = string.Join(" ", DockerCliLauncher.BuildRunArgs(keyOnly, world, "/tmp/saves"));
+        Assert.Contains("BBS_CRASH_REPORT_KEY=write-key", joined);
+        Assert.DoesNotContain("BBS_CRASH_REPORT_ENDPOINT", joined);
+
+        // Key + endpoint override (self-hosted fleet with its own ReportHost).
+        var selfHosted = new WorldHostConfig
+        {
+            CrashReportKey = "write-key",
+            CrashReportEndpoint = "https://reports.example.com/api/bugreport",
+        };
+        joined = string.Join(" ", DockerCliLauncher.BuildRunArgs(selfHosted, world, "/tmp/saves"));
+        Assert.Contains("BBS_CRASH_REPORT_KEY=write-key", joined);
+        Assert.Contains("BBS_CRASH_REPORT_ENDPOINT=https://reports.example.com/api/bugreport", joined);
+
+        // An endpoint WITHOUT a key must not leak through — upload is off without the key anyway.
+        var endpointOnly = new WorldHostConfig { CrashReportEndpoint = "https://reports.example.com/api/bugreport" };
+        Assert.DoesNotContain("BBS_CRASH_REPORT", string.Join(" ", DockerCliLauncher.BuildRunArgs(endpointOnly, world, "/tmp/saves")));
     }
 
     // ---------------- Fleet capacity gate ----------------


### PR DESCRIPTION
Closes #363.

## What

Fleet worlds never uploaded crash reports: the dedicated server supports `BBS_CRASH_REPORT_ENDPOINT`/`BBS_CRASH_REPORT_KEY` since the ReportHost cutover (#342) — the endpoint even defaults to the official inbox — but `DockerCliLauncher.BuildRunArgs` builds a fixed env list and never passed a key, so crashes of hosted worlds stayed in each container's local queue forever.

## How

Follows the existing `BBS_WH_ANNOUNCE_TOKEN` pattern:

- `WorldHostConfig`: new `BBS_WH_CRASH_REPORT_KEY` (empty = off, no-phone-home default) and optional `BBS_WH_CRASH_REPORT_ENDPOINT` (self-hosted fleets with their own ReportHost)
- `DockerCliLauncher.BuildRunArgs`: forwards `BBS_CRASH_REPORT_KEY` (+ endpoint override) into every world container; the endpoint is never forwarded without a key
- `deploy/worldhost/docker-compose.yml` + `.env.example`: passthrough + docs
- Docs: HOSTED_WORLDS.md (new "Fleet crash reports" section), REPORT_HOST.md, TODO.md
- Tests: new `BuildRunArgs_ForwardsCrashReportKey_AndOptionalEndpointOverride` (key-only, key+endpoint, endpoint-without-key) + omission assertion in the existing unconfigured test

## Verification

Full server test suite locally: **1034/1034 green** (build with `-warnaserror`, 0 warnings).

## Ops after merge (no game release needed)

`worldhost-image.yml` builds the image on push to main. On the VPS: pin `WORLDHOST_TAG` to the new `sha-…`, add the two passthrough lines to the compose, set `BBS_WH_CRASH_REPORT_KEY` (= the ReportHost write key) in `/opt/bbs/worldhost/.env`, recreate the worldhost, recycle running worlds so instances pick the key up on their next wake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)