### PR TITLE
perf: quick wins — HUD throttle, mobile DPR cap, browser-SP stream time budget, per-frame alloc cleanup

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7,7 +7,7 @@ plans live under [docs/](docs/) (committed); the long-range direction is the str
 keep it current when controls/features change. Last consolidated 2026-06-04.
 
 **Build:** `scripts/build-client.ps1` (Windows) or `scripts/build-client.sh` (Linux) — publishes shared libs + bundled server + Unity player.
-**Test:** `./scripts/run-tests.sh` — currently **998 server + 118 client passing** (2026-07-14). Locale parity (en/de) is enforced by a test.
+**Test:** `./scripts/run-tests.sh` — currently **1034 server + 129 client passing** (2026-07-16). Locale parity (en/de) is enforced by a test.
 CI runs two tiers: PRs skip the 31 tests marked `[Trait("Category", "Slow")]` (~6 min gate); pushes to `main` and the release workflow run the full suite.
 **Conventions:** English docs/comments; in-game text bilingual DE+EN; commit to `main` with the
 Claude `Co-Authored-By` trailer; OpenAI texture + ElevenLabs sound generation is blanket-approved
@@ -98,6 +98,22 @@ Per-item detail lives in the dated work log below.
   single-source-of-truth working end-to-end (validated: published the initial Windows zip).
 
 ---
+
+### ★ Performance quick wins: HUD throttle, mobile DPR cap, browser-SP stream budget, per-frame alloc cleanup (#349–#352, 2026-07-16, branch perf/quick-wins)
+First slice of the 2026-07-16 performance analysis (full backlog: issues #349–#362, `performance` label).
+**HUD (#349)** — the text-heavy `HudUi.Refresh()` now runs at ~10 Hz instead of every frame (dozens of
+interpolated strings were per-frame GC churn); the compass stays per-frame (blips counter-rotate with the
+camera, with the distance string rebuilt only on value change) and a hotbar selection change forces an
+immediate refresh. **WebGL mobile (#350)** — the template caps `config.devicePixelRatio = 1` for phone/tablet
+user agents (DPR 2–3 meant 4–9× the pixels on the weakest GPUs); desktop browsers keep native DPR.
+**Browser singleplayer (#351)** — new `ServerConfig.ChunkStreamBudgetMs` (0 = off): a wall-clock budget that
+cuts a `StreamChunks` pass short once spent (≥1 chunk always streams; nearest-first order unchanged);
+`BrowserLocalServer` sets 6 ms so synchronous first-visit chunk generation can no longer stall the frame
+(the tick shares the render thread there). Dedicated servers are unaffected. Test:
+`StreamTimeBudget_CutsAStreamingPassShort_ButAlwaysMakesProgress`. **Entity views (#352)** — CreatureView,
+WorldEntities, SpeederView and SpaceView.SyncEntities reuse scratch `HashSet`/`List` fields instead of
+allocating per frame. Verified: 1034 server + 129 client tests green, format clean, local Unity build green.
+Open (tracked): profiling baselines #353; medium tier #354–#358; large tier #359–#362.
 
 ### ★ Fleet crash reports: WorldHost forwards the ReportHost write key to world instances (#363, 2026-07-16)
 Hosted worlds never uploaded crash reports: the dedicated server has supported

--- a/client/Assets/BlocksBeyondTheStars/Scripts/BrowserLocalServer.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/BrowserLocalServer.cs
@@ -96,6 +96,13 @@ namespace BlocksBeyondTheStars.Client
                     EnableWebSocket = false,   // the loopback IS the wire; no gateway, no sockets
                     IdleShutdownMinutes = 0,   // the tab's lifetime is the session; never self-exit
                     AiLevel = AiLevel.Off,     // the LLM backend is unreachable from a browser (internal-only)
+
+                    // The tick runs ON the render thread here, and each first-visit chunk generates
+                    // synchronously inside StreamChunks — up to ChunkStreamPerTick (16) gens in one frame,
+                    // multiplied by the MaxTicksPerFrame catch-up, is the main browser-SP hitch source.
+                    // A wall-clock budget keeps cheap ticks streaming at full speed but cuts generation
+                    // bursts off mid-loop (rest resumes next tick, nearest-first order unchanged).
+                    ChunkStreamBudgetMs = 6.0,
                 };
 
 #if UNITY_WEBGL && !UNITY_EDITOR

--- a/client/Assets/BlocksBeyondTheStars/Scripts/CreatureView.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/CreatureView.cs
@@ -42,6 +42,11 @@ namespace BlocksBeyondTheStars.Client
 
         private readonly Dictionary<string, Entry> _creatures = new Dictionary<string, Entry>();
 
+        // Reused across frames: allocating these per Update is steady-state GC churn (worst on WebGL,
+        // where all garbage lands on the single thread).
+        private readonly HashSet<string> _seenScratch = new HashSet<string>();
+        private readonly List<string> _staleScratch = new List<string>();
+
         private void Update()
         {
             if (Game == null)
@@ -49,7 +54,8 @@ namespace BlocksBeyondTheStars.Client
                 return;
             }
 
-            var seen = new HashSet<string>();
+            var seen = _seenScratch;
+            seen.Clear();
             foreach (var c in Game.Creatures)
             {
                 seen.Add(c.Id);
@@ -170,7 +176,8 @@ namespace BlocksBeyondTheStars.Client
 
             if (_creatures.Count > seen.Count)
             {
-                var stale = new List<string>();
+                var stale = _staleScratch;
+                stale.Clear();
                 foreach (var id in _creatures.Keys)
                 {
                     if (!seen.Contains(id))

--- a/client/Assets/BlocksBeyondTheStars/Scripts/HudUi.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/HudUi.cs
@@ -72,6 +72,14 @@ namespace BlocksBeyondTheStars.Client
 
         private int _lastSelSlot = -1; // hotbar selection tick state
 
+        // Perf: the text-heavy HUD refresh runs at ~10 Hz, not every frame — rebuilding dozens of strings
+        // per frame is pure GC churn and the readouts (vitals, clock, prompts) don't change faster than
+        // that anyway. Motion-coupled elements (compass blips) still update per frame, and a hotbar
+        // selection change forces an immediate refresh so input feedback never lags.
+        private const float RefreshInterval = 0.1f;
+        private float _refreshTimer;
+        private int _lastCompassDist = int.MinValue;
+
         /// <summary>Set while a HUD exists so world-side FX (MiningFx) can hand off pickup fly-ins.</summary>
         public static HudUi Instance { get; private set; }
         private Canvas _flyCanvas; // own overlay canvas so the visor distortion can't bend the fly-ins
@@ -96,7 +104,15 @@ namespace BlocksBeyondTheStars.Client
 
             if (show)
             {
-                Refresh();
+                RefreshCompass(); // per frame: blips counter-rotate with the camera, throttling would judder
+
+                _refreshTimer -= Time.deltaTime;
+                bool force = Game.SelectedHotbarSlot != _lastSelSlot;
+                if (force || _refreshTimer <= 0f)
+                {
+                    _refreshTimer = RefreshInterval;
+                    Refresh();
+                }
             }
         }
 
@@ -503,7 +519,6 @@ namespace BlocksBeyondTheStars.Client
             _vitalsPanel.GetComponent<RectTransform>().sizeDelta = new Vector2(226, ship ? 196 : 116);
 
             RefreshHotbar(loc);
-            RefreshCompass();
             RefreshTimeOfDay(loc);
             RefreshPlaytime(loc);
 
@@ -744,7 +759,14 @@ namespace BlocksBeyondTheStars.Client
             const float radius = 44f;
             PlaceBlip(_compassWp, Game.Waypoint.HasValue, Game.Waypoint ?? Vector3.zero, radius);
             PlaceBlip(_compassShip, Game.ShipPosition.HasValue, Game.ShipPosition ?? Vector3.zero, radius, out float dist);
-            _compassDist.text = Game.ShipPosition.HasValue ? $"{Mathf.RoundToInt(dist)} m" : string.Empty;
+
+            // This runs per frame, so only rebuild the distance string when the rounded value changed.
+            int distNow = Game.ShipPosition.HasValue ? Mathf.RoundToInt(dist) : -1;
+            if (distNow != _lastCompassDist)
+            {
+                _lastCompassDist = distNow;
+                _compassDist.text = distNow >= 0 ? $"{distNow} m" : string.Empty;
+            }
 
             // Player-placed beacons (item 37): amber blips, pooled since their count varies.
             var beacons = Game.Beacons;

--- a/client/Assets/BlocksBeyondTheStars/Scripts/SpaceView.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/SpaceView.cs
@@ -206,6 +206,9 @@ namespace BlocksBeyondTheStars.Client
         private int _appliedHullRgb = -1; // last hull colour applied (cube material tint or voxel re-mesh), to detect live changes
         private AudioSource _engine;
         private readonly Dictionary<string, GameObject> _entities = new Dictionary<string, GameObject>();
+        // Reused by the per-frame SyncEntities pass (same pattern as _remoteSeen/_remoteRemove below).
+        private readonly HashSet<string> _entitySeen = new HashSet<string>();
+        private readonly List<string> _entityRemove = new List<string>();
 
         // Other players sharing this space instance, drawn as a ship or a floating EVA suit (R2 visibility).
         private sealed class RemoteAvatar { public GameObject Root; public GameObject Ship; public GameObject Suit; public Material HullMat; public bool Voxel; public int HullRgb = -1; }
@@ -3369,7 +3372,8 @@ namespace BlocksBeyondTheStars.Client
         private void SyncEntities()
         {
             var space = Game.Space;
-            var seen = new HashSet<string>();
+            var seen = _entitySeen;
+            seen.Clear();
             if (space != null)
             {
                 foreach (var e in space.Entities)
@@ -3414,7 +3418,8 @@ namespace BlocksBeyondTheStars.Client
 
             if (_entities.Count > seen.Count)
             {
-                var stale = new List<string>();
+                var stale = _entityRemove;
+                stale.Clear();
                 foreach (var id in _entities.Keys)
                 {
                     if (!seen.Contains(id))

--- a/client/Assets/BlocksBeyondTheStars/Scripts/SpeederView.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/SpeederView.cs
@@ -56,10 +56,15 @@ namespace BlocksBeyondTheStars.Client
             DrainFx();
         }
 
+        // Reused across frames — Reconcile runs every Update; fresh sets/lists there are steady GC churn.
+        private readonly HashSet<string> _liveScratch = new HashSet<string>();
+        private readonly List<string> _staleScratch = new List<string>();
+
         private void Reconcile()
         {
             // Build the set of ids the server currently reports.
-            var live = new HashSet<string>();
+            var live = _liveScratch;
+            live.Clear();
             foreach (var s in Game.Speeders)
             {
                 if (s != null && !string.IsNullOrEmpty(s.Id))
@@ -69,7 +74,8 @@ namespace BlocksBeyondTheStars.Client
             }
 
             // Drop speeders that are gone (packed up, destroyed, owner left, world switch).
-            var stale = new List<string>();
+            var stale = _staleScratch;
+            stale.Clear();
             foreach (var kv in _objs)
             {
                 if (!live.Contains(kv.Key))

--- a/client/Assets/BlocksBeyondTheStars/Scripts/WorldEntities.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/WorldEntities.cs
@@ -38,6 +38,10 @@ namespace BlocksBeyondTheStars.Client
         }
 
         private readonly Dictionary<string, Entry> _enemies = new();
+
+        // Reused across frames — per-Update allocations are steady-state GC churn (worst on WebGL).
+        private readonly HashSet<string> _seenScratch = new();
+        private readonly List<string> _staleScratch = new();
         private bool _subscribed;
         private WeaponFx _weapons; // shared VFX layer (laser beams), resolved lazily
         private static Material _hideMat, _hideDarkMat, _eyeMat, _clawMat;
@@ -59,7 +63,8 @@ namespace BlocksBeyondTheStars.Client
                 _subscribed = true;
             }
 
-            var seen = new HashSet<string>();
+            var seen = _seenScratch;
+            seen.Clear();
             foreach (var e in Game.PlanetEnemies)
             {
                 seen.Add(e.Id);
@@ -140,7 +145,8 @@ namespace BlocksBeyondTheStars.Client
             // Remove enemies whose entity is gone (killed / out of range).
             if (_enemies.Count > seen.Count)
             {
-                var stale = new List<string>();
+                var stale = _staleScratch;
+                stale.Clear();
                 foreach (var id in _enemies.Keys)
                 {
                     if (!seen.Contains(id))

--- a/client/Assets/WebGLTemplates/BlocksBeyondTheStars/index.html
+++ b/client/Assets/WebGLTemplates/BlocksBeyondTheStars/index.html
@@ -106,6 +106,9 @@
         meta.name = 'viewport';
         meta.content = 'width=device-width, height=device-height, initial-scale=1.0, user-scalable=no, shrink-to-fit=yes';
         document.getElementsByTagName('head')[0].appendChild(meta);
+        // Phone/tablet GPUs can't afford the native devicePixelRatio (2-3 → 4-9× the pixels of a laptop
+        // for the same CSS size): render at 1:1 CSS pixels. Desktop keeps native DPR so text stays crisp.
+        config.devicePixelRatio = 1;
       }
       // Desktop and mobile alike fill the whole browser client area (the CSS pins the canvas to the
       // viewport); Unity keeps the render target matched to the DOM size, so no manual resize handling.

--- a/src/BlocksBeyondTheStars.GameServer/GameServer.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServer.cs
@@ -1421,6 +1421,13 @@ public sealed partial class GameServer
     {
         int perTickBudget = System.Math.Max(1, _config.ChunkStreamPerTick);
 
+        // Optional wall-clock budget (browser singleplayer: the tick shares the render thread). Started
+        // before any generation so a burst of expensive first-visit gens is cut off mid-loop; at least one
+        // chunk per tick always goes out so streaming can never starve entirely.
+        var streamTimer = _config.ChunkStreamBudgetMs > 0
+            ? System.Diagnostics.Stopwatch.StartNew()
+            : null;
+
         // Chunk band the build height maps to — the streamed column is clamped into it so a spoofed player
         // position can't make the server generate/cache chunks at arbitrary heights (memory DoS). See MinBuildY.
         int minChunkY = WorldConstants.WorldToChunk(MinBuildY);
@@ -1491,6 +1498,12 @@ public sealed partial class GameServer
             foreach (var (coord, _) in pending)
             {
                 if (sent >= perTickBudget)
+                {
+                    break;
+                }
+
+                // Time budget spent (see above) — but only after at least one send, so progress is guaranteed.
+                if (streamTimer != null && sent > 0 && streamTimer.Elapsed.TotalMilliseconds >= _config.ChunkStreamBudgetMs)
                 {
                     break;
                 }

--- a/src/BlocksBeyondTheStars.Shared/Configuration/ServerConfig.cs
+++ b/src/BlocksBeyondTheStars.Shared/Configuration/ServerConfig.cs
@@ -50,6 +50,13 @@ public sealed class ServerConfig
     /// a host seeing tick overruns on weak hardware can lower it; a strong host can raise it for snappier fill.</summary>
     public int ChunkStreamPerTick { get; set; } = 16;
 
+    /// <summary>Optional wall-clock budget (milliseconds) for chunk streaming per tick; 0 = off. When set,
+    /// StreamChunks stops sending once the budget is spent — remaining chunks come next tick, nearest-first
+    /// order unchanged. Meant for hosts where the tick shares a thread with rendering (the in-browser
+    /// singleplayer): a cheap tick still streams the full ChunkStreamPerTick, but a burst of expensive
+    /// first-visit generations can't stall the frame. Dedicated servers leave this off.</summary>
+    public double ChunkStreamBudgetMs { get; set; }
+
     public string Difficulty { get; set; } = "normal";
     public bool AllowGuests { get; set; } = true;
 

--- a/tests/BlocksBeyondTheStars.Tests/ChunkStreamingTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/ChunkStreamingTests.cs
@@ -28,7 +28,7 @@ public sealed class ChunkStreamingTests : IDisposable
         _content = ContentLoader.LoadFromDirectory(TestPaths.DataDir());
     }
 
-    private int ChunksLoadedAfterOneTick(string name, int budget)
+    private int ChunksLoadedAfterOneTick(string name, int budget, double timeBudgetMs = 0)
     {
         var repo = new SqliteWorldRepository(new SaveGamePaths(_root, name));
         var st = new LoopbackServerTransport(new LoopbackLink());
@@ -40,6 +40,7 @@ public sealed class ChunkStreamingTests : IDisposable
             PlaceStarterShip = false,
             ViewDistanceChunks = 4,
             ChunkStreamPerTick = budget,
+            ChunkStreamBudgetMs = timeBudgetMs,
         };
         var server = new SvGameServer(config, _content, st, repo);
         server.Start();
@@ -61,6 +62,20 @@ public sealed class ChunkStreamingTests : IDisposable
 
         Assert.True(small <= 4, $"one tick must not stream more than the budget (got {small} for budget 4)");
         Assert.True(large > small, $"a larger budget should fill faster (large={large}, small={small})");
+    }
+
+    [Fact]
+    public void StreamTimeBudget_CutsAStreamingPassShort_ButAlwaysMakesProgress()
+    {
+        // The wall-clock budget exists for hosts whose tick shares the render thread (in-browser
+        // singleplayer): a burst of synchronous first-visit generations must not stall the frame. A
+        // near-zero budget is spent after the first send, so exactly one guaranteed chunk goes out —
+        // while the same count budget without a time budget streams the full per-tick allowance.
+        int unbudgeted = ChunksLoadedAfterOneTick("timebudget_off", 16);
+        int budgeted = ChunksLoadedAfterOneTick("timebudget_on", 16, timeBudgetMs: 0.000001);
+
+        Assert.True(budgeted >= 1, "a spent time budget must still stream at least one chunk (no starvation)");
+        Assert.True(budgeted < unbudgeted, $"the time budget should cut the pass short (budgeted={budgeted}, unbudgeted={unbudgeted})");
     }
 
     [Fact]


### PR DESCRIPTION
First slice of the 2026-07-16 performance analysis (full backlog: #349-#362, `performance` label).

## What

- **HUD refresh throttle (closes #349):** `HudUi.Refresh()` (dozens of interpolated strings) now runs at ~10 Hz instead of every frame. The compass stays per-frame — its blips counter-rotate with the camera and would judder at 10 Hz — with the distance string rebuilt only when the rounded value changes. A hotbar selection change forces an immediate refresh so input feedback never lags.
- **Mobile devicePixelRatio cap (closes #350):** the WebGL template sets `config.devicePixelRatio = 1` in the existing phone/tablet UA branch. DPR 2-3 meant rendering 4-9x the pixels of a laptop on exactly the weakest GPUs (glitch.fun mobile). Desktop browsers keep native DPR so text stays crisp.
- **Chunk-stream time budget (closes #351):** new `ServerConfig.ChunkStreamBudgetMs` (default 0 = off). When set, a `StreamChunks` pass stops once the wall-clock budget is spent — at least one chunk always streams (no starvation), nearest-first order unchanged, the rest resumes next tick. `BrowserLocalServer` sets 6 ms: in browser singleplayer the tick shares the render thread and up to 16 synchronous first-visit chunk generations (x the tick catch-up) could land in one frame — the main browser-SP hitch source. Dedicated/desktop servers are unaffected. A plain count reduction was rejected because it would slow the initial terrain fill; the time budget only bites when generation is actually expensive.
- **Per-frame allocation cleanup (closes #352):** `CreatureView`, `WorldEntities`, `SpeederView` and `SpaceView.SyncEntities` reuse scratch `HashSet`/`List` fields instead of allocating fresh ones every frame (steady-state GC churn; worst on WebGL where all garbage lands on the single thread).

## Verification

- 1034 server + 129 client tests green (includes the new `StreamTimeBudget_CutsAStreamingPassShort_ButAlwaysMakesProgress`)
- `dotnet format --verify-no-changes` clean
- Local Unity Windows build green in a fresh worktree (bundled server republished — the Shared config change is included)
- Not yet playtested in a browser: the DPR cap and the 6 ms budget deserve a quick play.glitch.fun smoke after the next WebGL deploy

## Follow-ups (tracked)

Profiling baselines #353; medium tier #354-#358 (mesher pooling, collider-only greedy, RLE chunk payload, preset MSAA/HDR/renderScale, VisorHud gate); large tier #359-#362.

🤖 Generated with [Claude Code](https://claude.com/claude-code)