### PR TITLE
feat(perf): PerfProbe — automated frame-time/GC baseline capture

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -99,6 +99,17 @@ Per-item detail lives in the dated work log below.
 
 ---
 
+### ★ PerfProbe: automated desktop performance baselines (#353, 2026-07-17, branch perf/profiling-baseline)
+New `-perfProbe` flag (pattern: ScreenshotDirector): starts a fixed-seed singleplayer world and records
+frame-time/GC stats over an **idle** (30 s standing) and a **walk** phase (60 s scripted straight-line
+traversal via the new additive `InputMap.ScriptedMove` source, so chunk streaming/meshing churns). Optional
+`-perfPreset`/`-perfVd` overrides for comparable runs — the player's `client_settings.json` is snapshotted
+and restored so probe runs never change real settings. Output: JSON + txt (`-perfOut <dir>`); process exits
+when done. First baselines (Ryzen 9 7940HS / RTX 2000 Ada laptop, v-dev): High/VD8 42 FPS + **~25 GC/s** in
+walk (47 frames >33 ms/min); Medium/VD4 48–53 FPS, ~11 GC/s; Low/VD4 72–75 FPS, ~8 GC/s, zero hitches →
+GC/alloc churn confirmed as the top CPU lever (#354), preset step Low→Medium is expensive (SSAO/depth
+textures), MSAA/HDR not preset-gated (#357). Full numbers in issue #353. Browser baseline still open.
+
 ### ★ Performance quick wins: HUD throttle, mobile DPR cap, browser-SP stream budget, per-frame alloc cleanup (#349–#352, 2026-07-16, branch perf/quick-wins)
 First slice of the 2026-07-16 performance analysis (full backlog: issues #349–#362, `performance` label).
 **HUD (#349)** — the text-heavy `HudUi.Refresh()` now runs at ~10 Hz instead of every frame (dozens of

--- a/TODO.md
+++ b/TODO.md
@@ -108,7 +108,12 @@ and restored so probe runs never change real settings. Output: JSON + txt (`-per
 when done. First baselines (Ryzen 9 7940HS / RTX 2000 Ada laptop, v-dev): High/VD8 42 FPS + **~25 GC/s** in
 walk (47 frames >33 ms/min); Medium/VD4 48–53 FPS, ~11 GC/s; Low/VD4 72–75 FPS, ~8 GC/s, zero hitches →
 GC/alloc churn confirmed as the top CPU lever (#354), preset step Low→Medium is expensive (SSAO/depth
-textures), MSAA/HDR not preset-gated (#357). Full numbers in issue #353. Browser baseline still open.
+textures), MSAA/HDR not preset-gated (#357). Browser baseline (headed Playwright Chromium, real GPU, local
+fast-local WebGL build, `?singleplayer=1`): idle 46 FPS / walk 37 FPS with a bimodal profile — p50 16.7 ms
+but p95 ~50 ms; during traversal 22% of frames >33 ms and >10% of wall time in main-thread long tasks
+(single-threaded mesh/collider/JSON path → #354/#355); worst case capped at 150 ms (one frame >100 ms in
+90 s — the #351 stream budget works). Startup logs 3 truncated `ERROR: Shader` lines — investigate. Full
+numbers in issue #353. Headless/SwiftShader is useless for frame times (~1 FPS software rendering).
 
 ### ★ Performance quick wins: HUD throttle, mobile DPR cap, browser-SP stream budget, per-frame alloc cleanup (#349–#352, 2026-07-16, branch perf/quick-wins)
 First slice of the 2026-07-16 performance analysis (full backlog: issues #349–#362, `performance` label).

--- a/client/Assets/BlocksBeyondTheStars/Scripts/InputMap.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/InputMap.cs
@@ -179,11 +179,15 @@ namespace BlocksBeyondTheStars.Client
         // instead of Input.GetAxis / GetButton / GetMouseButton. The touch source is zero unless a touch UI
         // is live, so on desktop these equal the keyboard/mouse (+ pad) behaviour exactly.
 
+        /// <summary>Scripted locomotion injected by automation (PerfProbe traversal). Zero in normal play;
+        /// additive like the other sources, so a real key press still wins the clamp.</summary>
+        public static Vector2 ScriptedMove;
+
         /// <summary>Strafe axis, −1..1 — replaces <c>Input.GetAxis("Horizontal")</c>.</summary>
-        public static float MoveX() => Mathf.Clamp(_desktop.MoveX() + _pad.MoveX() + _touch.MoveX(), -1f, 1f);
+        public static float MoveX() => Mathf.Clamp(_desktop.MoveX() + _pad.MoveX() + _touch.MoveX() + ScriptedMove.x, -1f, 1f);
 
         /// <summary>Forward axis, −1..1 — replaces <c>Input.GetAxis("Vertical")</c>.</summary>
-        public static float MoveY() => Mathf.Clamp(_desktop.MoveY() + _pad.MoveY() + _touch.MoveY(), -1f, 1f);
+        public static float MoveY() => Mathf.Clamp(_desktop.MoveY() + _pad.MoveY() + _touch.MoveY() + ScriptedMove.y, -1f, 1f);
 
         /// <summary>Yaw look delta (caller still multiplies by sensitivity) — replaces <c>GetAxis("Mouse X")</c>.</summary>
         public static float LookX() => _desktop.LookX() + _pad.LookX() + _touch.LookX();

--- a/client/Assets/BlocksBeyondTheStars/Scripts/PerfProbe.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/PerfProbe.cs
@@ -1,0 +1,372 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using UnityEngine;
+
+namespace BlocksBeyondTheStars.Client
+{
+    /// <summary>
+    /// Automated performance baseline capture (issue #353). When the player is launched with
+    /// <c>-perfProbe</c>, this self-installs (same pattern as <see cref="ScreenshotDirector"/>), starts a
+    /// fixed-seed singleplayer world and records frame-time / GC statistics over two phases:
+    /// <list type="number">
+    ///   <item><b>idle</b> — standing still after the spawn area has fully meshed (steady-state cost)</item>
+    ///   <item><b>walk</b> — scripted straight-line traversal via <see cref="InputMap.ScriptedMove"/>, so
+    ///   chunk streaming + meshing churn continuously (the historical stutter scenario)</item>
+    /// </list>
+    /// Results go to <c>&lt;out&gt;/perf_baseline_&lt;platform&gt;.json</c> plus a human-readable .txt and the
+    /// log; the process exits when done, so a script can run this end-to-end. Flags: <c>-perfProbe</c>,
+    /// <c>-perfOut &lt;dir&gt;</c>, <c>-seed &lt;n&gt;</c>, <c>-perfIdle &lt;sec&gt;</c>, <c>-perfWalk &lt;sec&gt;</c>.
+    /// The numbers are a coarse CPU/GC baseline (wall-clock frame times), not a GPU profile — for the deep
+    /// dive attach the Unity Profiler to a development build.
+    /// </summary>
+    public sealed class PerfProbe : MonoBehaviour
+    {
+        private const string WorldName = "PerfProbe";
+        private const long DefaultSeed = 424242L;      // same reproducible world the marketing shots use
+        private const float WorldLoadTimeout = 120f;
+        private const float ChunkSettle = 12f;         // post-WorldReady settle so 'idle' measures steady state
+        private const float HitchMs33 = 1000f / 30f;   // frame longer than a 30 FPS frame
+        private const float HitchMs100 = 100f;         // a visible stall
+
+        private long _seed = DefaultSeed;
+        private string _outDir;
+        private float _idleSeconds = 30f;
+        private float _walkSeconds = 60f;
+        private string _presetOverride;   // -perfPreset Potato|Low|Medium|High; null = keep the player's settings
+        private int _vdOverride = -1;     // -perfVd 1..8; -1 = keep
+
+        // The player's real settings file, snapshotted before any override — AppShell paths call
+        // Settings.Save(), so an in-memory override could otherwise clobber the user's persisted settings.
+        private byte[] _settingsBackup;
+        private bool _settingsExisted;
+        private bool _didBackup; // restore only when a backup was actually taken (i.e. an override ran)
+
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
+        private static void AutoInstall()
+        {
+            var args = Environment.GetCommandLineArgs();
+            bool on = false;
+            long seed = DefaultSeed;
+            string outDir = null;
+            float idle = 30f, walk = 60f;
+            string preset = null;
+            int vd = -1;
+            for (int i = 0; i < args.Length; i++)
+            {
+                string a = args[i];
+                if (string.Equals(a, "-perfProbe", StringComparison.OrdinalIgnoreCase))
+                {
+                    on = true;
+                }
+                else if (string.Equals(a, "-perfPreset", StringComparison.OrdinalIgnoreCase) && i + 1 < args.Length)
+                {
+                    preset = args[i + 1];
+                }
+                else if (string.Equals(a, "-perfVd", StringComparison.OrdinalIgnoreCase) && i + 1 < args.Length && int.TryParse(args[i + 1], out var v))
+                {
+                    vd = Mathf.Clamp(v, 1, 8);
+                }
+                else if (string.Equals(a, "-perfOut", StringComparison.OrdinalIgnoreCase) && i + 1 < args.Length)
+                {
+                    outDir = args[i + 1];
+                }
+                else if (string.Equals(a, "-seed", StringComparison.OrdinalIgnoreCase) && i + 1 < args.Length && long.TryParse(args[i + 1], out var s))
+                {
+                    seed = s;
+                }
+                else if (string.Equals(a, "-perfIdle", StringComparison.OrdinalIgnoreCase) && i + 1 < args.Length && float.TryParse(args[i + 1], out var fi))
+                {
+                    idle = Mathf.Clamp(fi, 5f, 600f);
+                }
+                else if (string.Equals(a, "-perfWalk", StringComparison.OrdinalIgnoreCase) && i + 1 < args.Length && float.TryParse(args[i + 1], out var fw))
+                {
+                    walk = Mathf.Clamp(fw, 5f, 600f);
+                }
+            }
+
+            if (!on)
+            {
+                return;
+            }
+
+            var go = new GameObject("PerfProbe");
+            DontDestroyOnLoad(go);
+            var p = go.AddComponent<PerfProbe>();
+            p._seed = seed;
+            p._outDir = outDir;
+            p._idleSeconds = idle;
+            p._walkSeconds = walk;
+            p._presetOverride = preset;
+            p._vdOverride = vd;
+        }
+
+        private void Start() => StartCoroutine(Run());
+
+        private IEnumerator Run()
+        {
+            var shell = FindAnyObjectByType<AppShell>();
+            if (shell == null)
+            {
+                Debug.LogError("[PerfProbe] No AppShell in the scene.");
+                Quit(1);
+                yield break;
+            }
+
+            yield return WaitForPhase(shell, ShellPhase.MainMenu, 30f);
+
+            // Optional settings overrides for comparable runs. Snapshot the real settings file first and
+            // restore it on exit — AppShell may persist settings mid-run, and the probe must never change
+            // what the player actually configured.
+            if (!string.IsNullOrEmpty(_presetOverride) || _vdOverride > 0)
+            {
+                BackupSettingsFile();
+                if (!string.IsNullOrEmpty(_presetOverride)
+                    && Enum.TryParse<QualityPreset>(_presetOverride, ignoreCase: true, out var qp))
+                {
+                    shell.Settings.Preset = qp;
+                }
+
+                if (_vdOverride > 0)
+                {
+                    shell.Settings.ViewDistanceChunks = _vdOverride;
+                }
+
+                shell.Settings.Apply();
+            }
+
+            Debug.Log($"[PerfProbe] Starting world (seed {_seed}, preset {shell.Settings.Preset}, view distance {shell.Settings.ViewDistanceChunks}).");
+            shell.StartSingleplayerWorld(WorldName, _seed, creativeUnlockAll: false, creativeAllShips: false, creativeKit: false);
+
+            yield return WaitForPhase(shell, ShellPhase.InGame, WorldLoadTimeout);
+            var boot = shell.CurrentBoot;
+            if (boot == null || boot.Network == null)
+            {
+                Debug.LogError("[PerfProbe] World did not start (bundled server missing?).");
+                Quit(1);
+                yield break;
+            }
+
+            yield return WaitUntil(() => boot.WorldReady, WorldLoadTimeout);
+            yield return new WaitForSecondsRealtime(ChunkSettle);
+
+            var phases = new List<PhaseResult>
+            {
+                null, // idle, filled below
+                null, // walk
+            };
+
+            // Phase 1: idle — steady-state cost with the spawn area fully streamed.
+            yield return Sample("idle", _idleSeconds, r => phases[0] = r);
+
+            // Phase 2: walk — scripted forward traversal; fresh chunks stream/mesh the whole time.
+            InputMap.ScriptedMove = new Vector2(0f, 1f);
+            yield return Sample("walk", _walkSeconds, r => phases[1] = r);
+            InputMap.ScriptedMove = Vector2.zero;
+
+            WriteResults(shell, phases);
+            RestoreSettingsFile();
+            Quit(0);
+        }
+
+        private static string SettingsPath => Path.Combine(Application.persistentDataPath, "client_settings.json");
+
+        private void BackupSettingsFile()
+        {
+            try
+            {
+                _settingsExisted = File.Exists(SettingsPath);
+                _settingsBackup = _settingsExisted ? File.ReadAllBytes(SettingsPath) : null;
+                _didBackup = true;
+            }
+            catch (Exception ex)
+            {
+                Debug.LogWarning($"[PerfProbe] Could not snapshot settings: {ex.Message}");
+            }
+        }
+
+        private void RestoreSettingsFile()
+        {
+            if (!_didBackup)
+            {
+                return; // no override ran — never touch the player's settings file
+            }
+
+            try
+            {
+                if (_settingsExisted && _settingsBackup != null)
+                {
+                    File.WriteAllBytes(SettingsPath, _settingsBackup);
+                }
+                else if (!_settingsExisted && File.Exists(SettingsPath))
+                {
+                    File.Delete(SettingsPath); // fresh install: leave no trace of the override
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.LogWarning($"[PerfProbe] Could not restore settings: {ex.Message}");
+            }
+        }
+
+        private void OnApplicationQuit() => RestoreSettingsFile(); // belt & braces if the run is aborted
+
+        [Serializable]
+        private sealed class PhaseResult
+        {
+            public string name;
+            public int frames;
+            public float seconds;
+            public float avgMs;
+            public float p50Ms;
+            public float p95Ms;
+            public float p99Ms;
+            public float maxMs;
+            public int framesOver33Ms;
+            public int framesOver100Ms;
+            public int gcGen0;
+            public int gcGen1;
+            public int gcGen2;
+            public long managedMemDeltaBytes;
+        }
+
+        [Serializable]
+        private sealed class ProbeResult
+        {
+            public string capturedUtc;
+            public string appVersion;
+            public string unity;
+            public string platform;
+            public string qualityPreset;
+            public int viewDistanceChunks;
+            public long seed;
+            public string device;
+            public PhaseResult[] phases;
+        }
+
+        private IEnumerator Sample(string name, float seconds, Action<PhaseResult> done)
+        {
+            Debug.Log($"[PerfProbe] Phase '{name}' — sampling {seconds:0}s...");
+            var samples = new List<float>(Mathf.CeilToInt(seconds) * 300); // generous: fits 300 FPS without regrowth
+            int gc0 = GC.CollectionCount(0), gc1 = GC.CollectionCount(1), gc2 = GC.CollectionCount(2);
+            long mem = GC.GetTotalMemory(false);
+
+            float t = 0f;
+            yield return null; // don't count the setup frame
+            while (t < seconds)
+            {
+                float dt = Time.unscaledDeltaTime;
+                samples.Add(dt * 1000f);
+                t += dt;
+                yield return null;
+            }
+
+            var r = new PhaseResult
+            {
+                name = name,
+                frames = samples.Count,
+                seconds = t,
+                gcGen0 = GC.CollectionCount(0) - gc0,
+                gcGen1 = GC.CollectionCount(1) - gc1,
+                gcGen2 = GC.CollectionCount(2) - gc2,
+                managedMemDeltaBytes = GC.GetTotalMemory(false) - mem,
+            };
+
+            float sum = 0f, max = 0f;
+            foreach (float ms in samples)
+            {
+                sum += ms;
+                if (ms > max) max = ms;
+                if (ms > HitchMs33) r.framesOver33Ms++;
+                if (ms > HitchMs100) r.framesOver100Ms++;
+            }
+
+            samples.Sort();
+            r.avgMs = samples.Count > 0 ? sum / samples.Count : 0f;
+            r.p50Ms = Percentile(samples, 0.50f);
+            r.p95Ms = Percentile(samples, 0.95f);
+            r.p99Ms = Percentile(samples, 0.99f);
+            r.maxMs = max;
+            done(r);
+        }
+
+        private static float Percentile(List<float> sorted, float p)
+        {
+            if (sorted.Count == 0) return 0f;
+            int i = Mathf.Clamp(Mathf.RoundToInt(p * (sorted.Count - 1)), 0, sorted.Count - 1);
+            return sorted[i];
+        }
+
+        private void WriteResults(AppShell shell, List<PhaseResult> phases)
+        {
+            var result = new ProbeResult
+            {
+                capturedUtc = DateTime.UtcNow.ToString("yyyy-MM-dd HH:mm:ss"),
+                appVersion = Application.version,
+                unity = Application.unityVersion,
+                platform = Application.platform.ToString(),
+                qualityPreset = shell.Settings.Preset.ToString(),
+                viewDistanceChunks = shell.Settings.ViewDistanceChunks,
+                seed = _seed,
+                device = $"{SystemInfo.processorType} / {SystemInfo.graphicsDeviceName} / {SystemInfo.systemMemorySize} MB",
+                phases = phases.ToArray(),
+            };
+
+            string dir = !string.IsNullOrEmpty(_outDir) ? _outDir : Path.Combine(Application.persistentDataPath, "perf");
+            Directory.CreateDirectory(dir);
+            string baseName = $"perf_baseline_{Application.platform}_{result.qualityPreset}_vd{result.viewDistanceChunks}";
+            string jsonPath = Path.Combine(dir, baseName + ".json");
+            File.WriteAllText(jsonPath, JsonUtility.ToJson(result, prettyPrint: true));
+
+            var txt = new StringBuilder();
+            txt.AppendLine($"Perf baseline — {result.capturedUtc} UTC — v{result.appVersion} — {result.platform}");
+            txt.AppendLine($"Preset {result.qualityPreset}, view distance {result.viewDistanceChunks}, seed {result.seed}");
+            txt.AppendLine(result.device);
+            foreach (var ph in result.phases)
+            {
+                txt.AppendLine($"[{ph.name}] {ph.frames} frames / {ph.seconds:0.0}s — avg {ph.avgMs:0.00} ms ({1000f / Mathf.Max(0.001f, ph.avgMs):0} FPS), "
+                             + $"p50 {ph.p50Ms:0.00}, p95 {ph.p95Ms:0.00}, p99 {ph.p99Ms:0.00}, max {ph.maxMs:0.0} ms; "
+                             + $">33ms: {ph.framesOver33Ms}, >100ms: {ph.framesOver100Ms}; "
+                             + $"GC {ph.gcGen0}/{ph.gcGen1}/{ph.gcGen2}, managed Δ {ph.managedMemDeltaBytes / (1024f * 1024f):0.0} MB");
+            }
+
+            string txtPath = Path.Combine(dir, baseName + ".txt");
+            File.WriteAllText(txtPath, txt.ToString());
+            Debug.Log($"[PerfProbe] Results written to {jsonPath}\n{txt}");
+        }
+
+        private static IEnumerator WaitForPhase(AppShell shell, ShellPhase phase, float timeout)
+        {
+            float t = 0f;
+            while (shell.Phase != phase && t < timeout)
+            {
+                t += Time.unscaledDeltaTime;
+                yield return null;
+            }
+        }
+
+        private static IEnumerator WaitUntil(Func<bool> cond, float timeout)
+        {
+            float t = 0f;
+            while (!cond() && t < timeout)
+            {
+                t += Time.unscaledDeltaTime;
+                yield return null;
+            }
+        }
+
+        private static void Quit(int code)
+        {
+#if UNITY_EDITOR
+            UnityEditor.EditorApplication.isPlaying = false;
+#else
+            Application.Quit(code);
+#endif
+        }
+    }
+}

--- a/client/Assets/BlocksBeyondTheStars/Scripts/PerfProbe.cs.meta
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/PerfProbe.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: eb9ea459eb4c96f4aaca671773e2e9e6


### PR DESCRIPTION
Tooling for #353 (does not close it — the browser baseline is still open).

## What

- New `-perfProbe` flag (same self-install pattern as `ScreenshotDirector`): starts a fixed-seed singleplayer world and records frame-time/GC statistics over two phases — **idle** (30 s standing, spawn area fully meshed) and **walk** (60 s scripted straight-line traversal, so chunk streaming/meshing churn continuously).
- New additive `InputMap.ScriptedMove` source drives the traversal; zero in normal play, a real key press still wins the clamp.
- Optional `-perfPreset Potato|Low|Medium|High` and `-perfVd 1..8` for comparable runs. The player''s `client_settings.json` is snapshotted before an override and restored on exit (incl. `OnApplicationQuit` for aborted runs) — probe runs never change real settings.
- Output: `perf_baseline_<platform>_<preset>_vd<N>.json` + human-readable `.txt` (`-perfOut <dir>`); the process exits when done. The device string contains CPU/GPU model + RAM only — no hostname, no user paths.

## First desktop baselines

Captured on a Ryzen 9 7940HS / RTX 2000 Ada laptop (dev build); full numbers as a comment in #353. Headline: at High/VD8 the walk phase shows **~25 GC collections/second** and 47 frames >33 ms per minute; Low/VD4 runs 72-75 FPS with zero >33 ms frames. Confirms the GC/allocation churn thesis (#354) and the missing MSAA/HDR preset gating (#357).

## Verification

- Local Unity Windows build green; three end-to-end probe runs completed (exit 0, plausible stats, settings file restored).
- .NET suites untouched by this change (client-only scripts); 1034+129 were green on the merge base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)