### PR TITLE
perf(graphics): preset GPU tiers — MSAA/HDR/renderScale + VisorHud gate

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -100,6 +100,17 @@ Per-item detail lives in the dated work log below.
 
 ---
 
+### ★ Preset GPU tiers: MSAA/HDR/renderScale + VisorHud gate (#357+#358, 2026-07-17, branch perf/gpu-preset-tiers — LOCAL, not yet PR'd, stacked on perf/collider-greedy)
+The single URP asset had MSAA 4x + HDR baked on for EVERY preset (Potato and WebGL included).
+`ClientSettings.Apply()` now scales them: MSAA off on Potato/Low, 2x Medium, 4x High; HDR off on Potato;
+Potato renders 3D at 75% URP renderScale (UI stays crisp, unlike a DPR cap). The VisorHud RT pipeline
+(second full-screen camera into a screen-sized RT + composite, previously always on) only runs when
+VisorEffects is on AND preset ≥ Medium; below that the existing flat-overlay path serves the HUD, and the
+pause-menu toggles engage/tear the pipeline down live (new `UiKit.RetargetDiegeticCanvases()` moves
+existing canvases between camera and overlay mode). PerfProbe vs #353 baseline: Low/VD4 walk 72→97 FPS
+(idle 75→98), zero >33 ms frames; Medium within noise (GPU-bound on SSAO/depth); High unchanged (keeps
+the full look). Verified: 1035+129 tests green, local Unity build green.
+
 ### ★ Collider-only greedy meshing (#355, 2026-07-17, branch perf/collider-greedy — LOCAL, not yet PR'd)
 The collision mesh gets its own vertex list and its cube faces are greedy-merged into maximal rectangles
 per direction + slice. The main loop stays the single source of which faces exist (it records per-cell

--- a/client/Assets/BlocksBeyondTheStars/Scripts/ClientSettings.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/ClientSettings.cs
@@ -426,6 +426,20 @@ namespace BlocksBeyondTheStars.Client
                     _ => 90f,
                 };
 
+                // MSAA / HDR / render scale live in the same single URP asset, so without this they were baked
+                // on for EVERY preset (4x MSAA + HDR even on Potato and WebGL). Scale them with the preset:
+                // MSAA off on Potato/Low, 2x on Medium, the tuned 4x on High; HDR off on Potato only (bloom/
+                // grading fall back to LDR there); Potato additionally renders the 3D view at 75% resolution
+                // via URP renderScale — unlike a devicePixelRatio cap this keeps the UI text crisp.
+                urp.msaaSampleCount = Preset switch
+                {
+                    QualityPreset.Potato or QualityPreset.Low => 1,
+                    QualityPreset.Medium => 2,
+                    _ => 4,
+                };
+                urp.supportsHDR = Preset > QualityPreset.Potato;
+                urp.renderScale = Preset == QualityPreset.Potato ? 0.75f : 1f;
+
                 // Depth + opaque copies feed the screen-space effects (volumetric fog, SSR, water refraction).
                 // They cost a prepass + a colour copy, so the two weakest presets turn them off entirely —
                 // which also disables every dependent effect for free (the features early-out without the textures).

--- a/client/Assets/BlocksBeyondTheStars/Scripts/UiKit.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/UiKit.cs
@@ -196,16 +196,56 @@ namespace BlocksBeyondTheStars.Client
         public static Canvas CreateDiegeticCanvas(string name, float refW = 1920f, float refH = 1080f)
         {
             var canvas = CreateCanvas(name, refW, refH);
+            DiegeticCanvases.Add(canvas);
+            ApplyDiegeticTarget(canvas);
+            return canvas;
+        }
+
+        // Live diegetic canvases, so the visor pipeline can re-target them when it engages/tears down at
+        // RUNTIME (the preset/visor toggle in the pause menu). Destroyed canvases go stale in here and are
+        // pruned on the next retarget.
+        private static readonly System.Collections.Generic.List<Canvas> DiegeticCanvases
+            = new System.Collections.Generic.List<Canvas>();
+
+        /// <summary>Points one diegetic canvas at the CURRENT visor state: through the HUD camera when the
+        /// visor RT pipeline is up, else a plain screen-space overlay (the flat-HUD fallback path).</summary>
+        private static void ApplyDiegeticTarget(Canvas canvas)
+        {
             if (HudCamera != null && HudLayer >= 0)
             {
                 canvas.renderMode = RenderMode.ScreenSpaceCamera;
                 canvas.worldCamera = HudCamera;
                 canvas.planeDistance = 1f;
                 canvas.gameObject.layer = HudLayer;
-                canvas.gameObject.AddComponent<HudLayerEnforcer>().Layer = HudLayer;
+                if (canvas.gameObject.GetComponent<HudLayerEnforcer>() == null)
+                {
+                    canvas.gameObject.AddComponent<HudLayerEnforcer>().Layer = HudLayer;
+                }
             }
+            else
+            {
+                // Overlay mode draws the canvas directly (no camera involved), so a canvas that keeps its
+                // HUD layer + enforcer from an earlier visor phase still shows correctly.
+                canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+                canvas.worldCamera = null;
+            }
+        }
 
-            return canvas;
+        /// <summary>Re-points every live diegetic canvas at the current visor state. Called by
+        /// <see cref="VisorHud"/> when its RT pipeline engages or tears down at runtime.</summary>
+        public static void RetargetDiegeticCanvases()
+        {
+            for (int i = DiegeticCanvases.Count - 1; i >= 0; i--)
+            {
+                var canvas = DiegeticCanvases[i];
+                if (canvas == null)
+                {
+                    DiegeticCanvases.RemoveAt(i); // canvas was destroyed (world teardown)
+                    continue;
+                }
+
+                ApplyDiegeticTarget(canvas);
+            }
         }
 
         // The HUD canvases use a smaller reference than the 1920×1080 menus, so ScaleWithScreenSize draws the

--- a/client/Assets/BlocksBeyondTheStars/Scripts/VisorHud.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/VisorHud.cs
@@ -11,8 +11,11 @@ namespace BlocksBeyondTheStars.Client
     /// camera into a render texture; a fullscreen <c>BlocksBeyondTheStars/Visor</c> pass then composites that over
     /// the post-processed world with barrel curvature, chromatic fringing, scanlines, a fresnel rim glow,
     /// glow and a faint reflection — so the HUD reads as projected onto the inside of the suit visor.
-    /// Always on. Degrades safely: if the layer or shader is unavailable the HUD stays a normal
-    /// screen-space overlay (<see cref="UiKit.HudCamera"/> stays null), so it is never lost.
+    /// GATED by cost: the RT camera + composite only run when the visor effect is enabled AND the preset is
+    /// Medium+ — a second full-screen camera into a screen-sized RT every frame is constant fill-rate the
+    /// weak presets (and WebGL's Low first-run default) cannot afford. Below that (or if the layer/shader is
+    /// unavailable) the HUD stays a normal screen-space overlay (<see cref="UiKit.HudCamera"/> stays null),
+    /// so it is never lost; the pause-menu toggles engage/tear the pipeline down live.
     /// </summary>
     public sealed class VisorHud : MonoBehaviour
     {
@@ -49,6 +52,14 @@ namespace BlocksBeyondTheStars.Client
             }
         }
 
+        private int _layer = -1;
+        private Shader _shader;
+
+        /// <summary>The RT pipeline only earns its constant fill-rate cost when the player wants the visor
+        /// look AND the preset can afford it. Off (or on Potato/Low) the flat overlay path serves the HUD.</summary>
+        private bool PipelineWanted()
+            => Settings == null || (Settings.VisorEffects && Settings.Preset >= QualityPreset.Medium);
+
         private void Start()
         {
             if (MainCamera == null)
@@ -59,21 +70,31 @@ namespace BlocksBeyondTheStars.Client
 
             // Prefer the named layer (nice in the Editor) but fall back to a fixed free index: a batch build
             // doesn't always bake a freshly-added layer NAME, yet the index works the same for cull masks.
-            int layer = LayerMask.NameToLayer("VisorHud");
-            if (layer < 0)
+            _layer = LayerMask.NameToLayer("VisorHud");
+            if (_layer < 0)
             {
-                layer = HudLayerIndex;
+                _layer = HudLayerIndex;
             }
 
-            var shader = Shader.Find("BlocksBeyondTheStars/Visor");
-            if (shader == null)
+            _shader = Shader.Find("BlocksBeyondTheStars/Visor");
+            if (_shader == null)
             {
                 Debug.LogWarning("[VisorHud] disabled — BlocksBeyondTheStars/Visor shader not found; flat HUD fallback.");
                 enabled = false;
                 return;
             }
 
-            UiKit.HudLayer = layer;
+            if (PipelineWanted())
+            {
+                EngagePipeline();
+            }
+        }
+
+        /// <summary>Builds the RT + HUD camera + composite. Safe to call again after
+        /// <see cref="DisengagePipeline"/> (the pause-menu preset/visor toggles flip it live).</summary>
+        private void EngagePipeline()
+        {
+            UiKit.HudLayer = _layer;
             CreateRt();
 
             var camGo = new GameObject("HUD Camera");
@@ -81,7 +102,7 @@ namespace BlocksBeyondTheStars.Client
             _hudCam = camGo.AddComponent<Camera>();
             _hudCam.clearFlags = CameraClearFlags.SolidColor;
             _hudCam.backgroundColor = new Color(0f, 0f, 0f, 0f); // transparent: only the HUD ends up in the RT
-            _hudCam.cullingMask = 1 << layer;
+            _hudCam.cullingMask = 1 << _layer;
             _hudCam.nearClipPlane = 0.1f;
             _hudCam.farClipPlane = 100f;
             _hudCam.depth = MainCamera.depth - 1; // render the HUD RT before the main camera composites it
@@ -91,27 +112,68 @@ namespace BlocksBeyondTheStars.Client
             _hudCam.targetTexture = _rt;
 
             // Keep the diegetic HUD out of the main camera's image so only the visor pass shows it.
-            MainCamera.cullingMask &= ~(1 << layer);
+            MainCamera.cullingMask &= ~(1 << _layer);
 
             if (GraphicsSettings.currentRenderPipeline != null)
             {
                 // URP: composite via a render-graph blit pass after post (OnRenderImage never runs under URP).
-                _urp = new VisorUrpCompositor(MainCamera, shader);
+                _urp = new VisorUrpCompositor(MainCamera, _shader);
             }
             else
             {
                 _composite = MainCamera.gameObject.AddComponent<VisorComposite>();
-                _composite.VisorShader = shader;
+                _composite.VisorShader = _shader;
                 _composite.Hud = _rt;
                 _composite.Intensity = _intensity;
                 _composite.Effects = Settings == null || Settings.VisorEffects;
             }
 
             UiKit.HudCamera = _hudCam; // diegetic canvases created from here on target this camera
+            UiKit.RetargetDiegeticCanvases(); // canvases built while the pipeline was down move onto it
             _lastEuler = MainCamera.transform.eulerAngles;
             _active = true;
-            Debug.Log($"[VisorHud] engaged — holographic HUD on layer {layer}, RT {_w}x{_h}, pipeline: "
+            Debug.Log($"[VisorHud] engaged — holographic HUD on layer {_layer}, RT {_w}x{_h}, pipeline: "
                       + (GraphicsSettings.currentRenderPipeline != null ? "URP (render graph)" : "Built-in (OnRenderImage)") + ".");
+        }
+
+        /// <summary>Tears the RT pipeline down and returns every diegetic canvas to the flat screen-space
+        /// overlay path — the HUD itself never disappears, only the visor stylisation does.</summary>
+        private void DisengagePipeline()
+        {
+            _active = false;
+            if (UiKit.HudCamera == _hudCam)
+            {
+                UiKit.HudCamera = null;
+            }
+
+            if (MainCamera != null)
+            {
+                MainCamera.cullingMask |= 1 << _layer; // restore (the layer only ever holds HUD canvases)
+            }
+
+            if (_composite != null)
+            {
+                Destroy(_composite);
+                _composite = null;
+            }
+
+            _urp?.Dispose();
+            _urp = null;
+
+            if (_hudCam != null)
+            {
+                Destroy(_hudCam.gameObject);
+                _hudCam = null;
+            }
+
+            if (_rt != null)
+            {
+                _rt.Release();
+                Destroy(_rt);
+                _rt = null;
+            }
+
+            UiKit.RetargetDiegeticCanvases(); // existing canvases fall back to the plain overlay
         }
 
         private void CreateRt()
@@ -133,6 +195,21 @@ namespace BlocksBeyondTheStars.Client
 
         private void LateUpdate()
         {
+            // Live gate: the player can flip VisorEffects or change the preset in the pause menu at any
+            // time — engage or tear down the RT pipeline on the spot (canvases are re-targeted either way).
+            bool want = PipelineWanted();
+            if (want != _active)
+            {
+                if (want)
+                {
+                    EngagePipeline();
+                }
+                else
+                {
+                    DisengagePipeline();
+                }
+            }
+
             if (!_active)
             {
                 return;
@@ -214,6 +291,7 @@ namespace BlocksBeyondTheStars.Client
             if (_composite != null)
             {
                 Destroy(_composite);
+                _composite = null;
             }
 
             _urp?.Dispose();
@@ -223,6 +301,7 @@ namespace BlocksBeyondTheStars.Client
             {
                 _rt.Release();
                 Destroy(_rt);
+                _rt = null;
             }
         }
     }


### PR DESCRIPTION
Closes #357, closes #358 — 2026-07-16 performance analysis, medium tier. Second of three stacked perf PRs (after #369, before the RLE chunk payload #356).

## What

**#357 — the quality presets finally control MSAA/HDR/renderScale.** All six quality levels bind the same URP asset, so MSAA 4x + HDR were baked on for every preset — Potato and WebGL (first-run Low) included. `ClientSettings.Apply()` now scales them:

| Preset | MSAA | HDR | renderScale |
|---|---|---|---|
| Potato | off | off | 0.75 (3D only — UI stays crisp, unlike a DPR cap) |
| Low | off | on | 1.0 |
| Medium | 2x | on | 1.0 |
| High | 4x | on | 1.0 |

**#358 — the VisorHud RT pipeline is gated by cost.** The holographic visor rendered a second full-screen camera into a screen-sized RT + a full-screen composite every frame on every preset. It now only runs when `VisorEffects` is on AND the preset is Medium+; below that the existing flat-overlay fallback serves the HUD. The pause-menu toggles engage/tear the pipeline down live — the new `UiKit.RetargetDiegeticCanvases()` moves existing HUD canvases between camera and overlay mode, so the HUD never disappears.

## Measured (PerfProbe, Ryzen 9 7940HS / RTX 2000 Ada)

- **Low/VD4 walk: 72 → 97 FPS** (idle 75 → 98), zero >33 ms frames — MSAA off + visor RT off
- Medium/VD4: within noise (GPU-bound on SSAO/depth textures, as the baseline predicted)
- High/VD8: unchanged (keeps the full look) — regression check green

## Verification

1035 + 129 tests green, local Unity build green, manual playtest of preset switching + visor toggle on the stacked local build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)