### PR TITLE
perf(net): RLE-compress the chunk Blocks payload (browser-focused)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -100,7 +100,7 @@ Per-item detail lives in the dated work log below.
 
 ---
 
-### ★ RLE chunk payload (#356, 2026-07-17, branch perf/rle-chunk-payload — LOCAL, not yet PR'd, stacked on perf/gpu-preset-tiers)
+### ★ RLE chunk payload (#356, 2026-07-17, branch perf/rle-chunk-payload)
 `ChunkDataMessage` gains `BlocksRle` (flat value/run-length ushort pairs, new `ChunkBlocksRle` codec in
 Networking); the server ships whichever representation is smaller (terrain almost always RLE — a
 checkerboard-degenerate chunk stays dense), the client + test harness decode both via
@@ -112,7 +112,7 @@ join-time check keeps old clients off newer servers; fleet pins versions in lock
 local Unity build green, PerfProbe walk = live socket streaming smoke. OPEN: browser smoke on the next
 WebGL deploy (the biggest beneficiary).
 
-### ★ Preset GPU tiers: MSAA/HDR/renderScale + VisorHud gate (#357+#358, 2026-07-17, branch perf/gpu-preset-tiers — LOCAL, not yet PR'd, stacked on perf/collider-greedy)
+### ★ Preset GPU tiers: MSAA/HDR/renderScale + VisorHud gate (#357+#358, 2026-07-17, PR #370)
 The single URP asset had MSAA 4x + HDR baked on for EVERY preset (Potato and WebGL included).
 `ClientSettings.Apply()` now scales them: MSAA off on Potato/Low, 2x Medium, 4x High; HDR off on Potato;
 Potato renders 3D at 75% URP renderScale (UI stays crisp, unlike a DPR cap). The VisorHud RT pipeline
@@ -123,7 +123,7 @@ existing canvases between camera and overlay mode). PerfProbe vs #353 baseline: 
 (idle 75→98), zero >33 ms frames; Medium within noise (GPU-bound on SSAO/depth); High unchanged (keeps
 the full look). Verified: 1035+129 tests green, local Unity build green.
 
-### ★ Collider-only greedy meshing (#355, 2026-07-17, branch perf/collider-greedy — LOCAL, not yet PR'd)
+### ★ Collider-only greedy meshing (#355, 2026-07-17, PR #369)
 The collision mesh gets its own vertex list and its cube faces are greedy-merged into maximal rectangles
 per direction + slice. The main loop stays the single source of which faces exist (it records per-cell
 direction bits wherever it used to emit a per-face collider quad), so the merged collider covers the

--- a/TODO.md
+++ b/TODO.md
@@ -100,6 +100,18 @@ Per-item detail lives in the dated work log below.
 
 ---
 
+### ★ RLE chunk payload (#356, 2026-07-17, branch perf/rle-chunk-payload — LOCAL, not yet PR'd, stacked on perf/gpu-preset-tiers)
+`ChunkDataMessage` gains `BlocksRle` (flat value/run-length ushort pairs, new `ChunkBlocksRle` codec in
+Networking); the server ships whichever representation is smaller (terrain almost always RLE — a
+checkerboard-degenerate chunk stays dense), the client + test harness decode both via
+`ChunkDataMessage.DecodeBlocks` (malformed RLE → chunk dropped, same as a wrong-length dense payload).
+Decisive on the browser JSON path: ~15-25 KB of JSON numbers per chunk → usually a few hundred bytes
+(glitch.fun join time + VPS egress); native MessagePack payloads shrink too. Protocol.Version 1→2 (the
+join-time check keeps old clients off newer servers; fleet pins versions in lockstep). Verified:
+1039+129 tests green (4 new: round-trip, degenerate fallback, malformed-stream rejection, wire-size),
+local Unity build green, PerfProbe walk = live socket streaming smoke. OPEN: browser smoke on the next
+WebGL deploy (the biggest beneficiary).
+
 ### ★ Preset GPU tiers: MSAA/HDR/renderScale + VisorHud gate (#357+#358, 2026-07-17, branch perf/gpu-preset-tiers — LOCAL, not yet PR'd, stacked on perf/collider-greedy)
 The single URP asset had MSAA 4x + HDR baked on for EVERY preset (Potato and WebGL included).
 `ClientSettings.Apply()` now scales them: MSAA off on Potato/Low, 2x Medium, 4x High; HDR off on Potato;

--- a/client/Assets/BlocksBeyondTheStars/Scripts/GameBootstrap.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/GameBootstrap.cs
@@ -1419,16 +1419,19 @@ namespace BlocksBeyondTheStars.Client
             // Reject a malformed/short chunk payload: ChunkData.FromRaw requires exactly BlocksPerChunk cells and
             // throws otherwise, which would bubble out of the network dispatch. Drop + warn instead, so a bad
             // packet can neither crash the client nor be stored as solid terrain (which the player would read as
-            // a floor and then fall through). A normal chunk is ~8-25 KB of JSON — well under the codec cap, so
-            // this only fires on a genuinely truncated/dropped payload; the warning is the diagnostic to watch.
+            // a floor and then fall through). DecodeBlocks handles both representations the server may send —
+            // the RLE payload (usual) or the dense array — and returns null for an undecodable RLE stream, so
+            // this only fires on a genuinely truncated/corrupt payload; the warning is the diagnostic to watch.
             int expected = WorldConstants.BlocksPerChunk;
-            if (m.Blocks == null || m.Blocks.Length != expected)
+            var blocks = m.DecodeBlocks(expected);
+            if (blocks == null || blocks.Length != expected)
             {
-                Debug.LogWarning($"[Chunk] Dropped malformed chunk {coord}: expected {expected} blocks, got {(m.Blocks?.Length ?? 0)}.");
+                Debug.LogWarning($"[Chunk] Dropped malformed chunk {coord}: expected {expected} blocks, got "
+                    + (m.BlocksRle != null && m.BlocksRle.Length > 0 ? $"an undecodable RLE payload ({m.BlocksRle.Length} entries)" : $"{blocks?.Length ?? 0}") + ".");
                 return;
             }
 
-            World.StoreChunk(coord, m.Blocks, m.ModIndex, m.ModTint, m.ModGlow, m.ShapeIndex, m.ShapeData);
+            World.StoreChunk(coord, blocks, m.ModIndex, m.ModTint, m.ModGlow, m.ShapeIndex, m.ShapeData);
             MarkChunkAndNeighborsDirty(coord);
         }
 

--- a/src/BlocksBeyondTheStars.GameServer/GameServer.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServer.cs
@@ -1514,13 +1514,26 @@ public sealed partial class GameServer
                 }
 
                 var chunk = _world.GetOrLoadChunk(coord);
+                var dense = chunk.ToArray();
+                // Ship the run-length-encoded payload when it is smaller (terrain almost always is; a rare
+                // unrunnable chunk goes dense). Decisive on the browser JSON path — ~15-25 KB of JSON
+                // numbers per chunk shrink to usually a few hundred bytes — and it trims native payloads
+                // and VPS egress too. The client accepts both representations (ChunkDataMessage.DecodeBlocks).
+                var rle = ChunkBlocksRle.Encode(dense);
                 var msg = new ChunkDataMessage
                 {
                     Cx = coord.X,
                     Cy = coord.Y,
                     Cz = coord.Z,
-                    Blocks = chunk.ToArray(),
                 };
+                if (rle.Length < dense.Length)
+                {
+                    msg.BlocksRle = rle;
+                }
+                else
+                {
+                    msg.Blocks = dense;
+                }
                 PackChunkModifiers(chunk, msg); // dyed-block / coloured-light cells, if any
                 Send(session, msg);
                 session.SentChunks.Add(coord);

--- a/src/BlocksBeyondTheStars.Networking/ChunkBlocksRle.cs
+++ b/src/BlocksBeyondTheStars.Networking/ChunkBlocksRle.cs
@@ -1,0 +1,83 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+namespace BlocksBeyondTheStars.Networking;
+
+/// <summary>
+/// Run-length codec for the chunk block payload: flat (value, runLength) ushort pairs. Terrain chunks are
+/// highly runnable (large air/stone spans in cell-index order), so this typically shrinks the 4096-cell
+/// array by an order of magnitude — decisive on the browser JSON path, where every cell is otherwise a
+/// plain JSON number, and a welcome cut to native MessagePack payloads and VPS egress too. The server
+/// only sends the RLE form when it is actually smaller, so a degenerate (unrunnable) chunk ships dense.
+/// </summary>
+public static class ChunkBlocksRle
+{
+    /// <summary>Encodes a dense cell array as flat (value, runLength) pairs. A run is capped at
+    /// ushort.MaxValue, comfortably above the 4096 cells a chunk holds.</summary>
+    public static ushort[] Encode(ushort[] dense)
+    {
+        if (dense.Length == 0)
+        {
+            return System.Array.Empty<ushort>();
+        }
+
+        var runs = new List<ushort>(64);
+        ushort value = dense[0];
+        int count = 1;
+        for (int i = 1; i < dense.Length; i++)
+        {
+            if (dense[i] == value && count < ushort.MaxValue)
+            {
+                count++;
+                continue;
+            }
+
+            runs.Add(value);
+            runs.Add((ushort)count);
+            value = dense[i];
+            count = 1;
+        }
+
+        runs.Add(value);
+        runs.Add((ushort)count);
+        return runs.ToArray();
+    }
+
+    /// <summary>Decodes flat (value, runLength) pairs into a dense array of exactly
+    /// <paramref name="expectedLength"/> cells. Null when the stream is malformed (odd pair count,
+    /// zero-length run, or a total that does not match) — callers drop the chunk, mirroring how a
+    /// wrong-length dense payload is handled.</summary>
+    public static ushort[]? Decode(ushort[] rle, int expectedLength)
+    {
+        if (rle.Length == 0 || (rle.Length & 1) != 0)
+        {
+            return null;
+        }
+
+        var dense = new ushort[expectedLength];
+        int pos = 0;
+        for (int i = 0; i < rle.Length; i += 2)
+        {
+            ushort value = rle[i];
+            int count = rle[i + 1];
+            if (count == 0 || pos + count > expectedLength)
+            {
+                return null;
+            }
+
+            if (value == 0)
+            {
+                pos += count; // the array is zero-initialised — air runs are free
+            }
+            else
+            {
+                for (int k = 0; k < count; k++)
+                {
+                    dense[pos++] = value;
+                }
+            }
+        }
+
+        return pos == expectedLength ? dense : null;
+    }
+}

--- a/src/BlocksBeyondTheStars.Networking/Messages.cs
+++ b/src/BlocksBeyondTheStars.Networking/Messages.cs
@@ -559,7 +559,20 @@ public sealed class ChunkDataMessage
     public int Cx { get; set; }
     public int Cy { get; set; }
     public int Cz { get; set; }
+
+    /// <summary>Dense per-cell block ids. Empty when <see cref="BlocksRle"/> carries the payload instead —
+    /// the server sends whichever representation is smaller (a rare unrunnable chunk ships dense).</summary>
     public ushort[] Blocks { get; set; } = System.Array.Empty<ushort>();
+
+    /// <summary>Run-length-encoded block payload as flat (value, runLength) pairs — terrain chunks are
+    /// highly runnable, and on the browser JSON path this shrinks ~15-25 KB of numbers per chunk to
+    /// usually a few hundred bytes (join time + VPS egress). Empty when <see cref="Blocks"/> is set.</summary>
+    public ushort[] BlocksRle { get; set; } = System.Array.Empty<ushort>();
+
+    /// <summary>The dense cell array, whichever representation this message carries. Null when an RLE
+    /// payload is malformed — callers drop the chunk (same handling as a wrong-length dense array).</summary>
+    public ushort[]? DecodeBlocks(int expectedLength)
+        => BlocksRle.Length > 0 ? ChunkBlocksRle.Decode(BlocksRle, expectedLength) : Blocks;
 
     // Sparse per-voxel colour modifiers (dyed surface tint / glow light colour), parallel arrays
     // keyed by local cell index. Empty for the overwhelming majority of chunks (no colour edits).

--- a/src/BlocksBeyondTheStars.Networking/Protocol.cs
+++ b/src/BlocksBeyondTheStars.Networking/Protocol.cs
@@ -6,8 +6,10 @@ namespace BlocksBeyondTheStars.Networking;
 /// <summary>Shared protocol constants for client/server compatibility.</summary>
 public static class Protocol
 {
-    /// <summary>Bumped whenever the wire format or message set changes incompatibly.</summary>
-    public const int Version = 1;
+    /// <summary>Bumped whenever the wire format or message set changes incompatibly.
+    /// v2: ChunkDataMessage carries the run-length-encoded BlocksRle payload (older clients
+    /// cannot decode it, so the join-time version check keeps them off newer servers).</summary>
+    public const int Version = 2;
 
     public const int DefaultGameplayPort = 31415;
     public const int DefaultAdminPort = 31416;

--- a/tests/BlocksBeyondTheStars.Client.Tests/ClientServerHarness.cs
+++ b/tests/BlocksBeyondTheStars.Client.Tests/ClientServerHarness.cs
@@ -89,7 +89,8 @@ public sealed class ClientServerHarness : IDisposable
             Chunks[(m.Cx, m.Cy, m.Cz)] = m;
             World.StoreChunk(
                 new Shared.World.ChunkCoord(m.Cx, m.Cy, m.Cz),
-                m.Blocks, m.ModIndex, m.ModTint, m.ModGlow, m.ShapeIndex, m.ShapeData);
+                m.DecodeBlocks(Shared.World.WorldConstants.BlocksPerChunk)!, // server sends RLE or dense
+                m.ModIndex, m.ModTint, m.ModGlow, m.ShapeIndex, m.ShapeData);
         };
     }
 

--- a/tests/BlocksBeyondTheStars.Tests/NetworkingTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/NetworkingTests.cs
@@ -35,6 +35,70 @@ public class NetworkingTests
     }
 
     [Fact]
+    public void ChunkRle_RoundTrips_TerrainLikeAndAwkwardPayloads()
+    {
+        // Terrain-like: big air span, a stone body, a thin surface strip — the shape RLE is built for.
+        var terrain = new ushort[4096];
+        for (int i = 0; i < 1800; i++) terrain[i] = 1;      // stone
+        for (int i = 1800; i < 1860; i++) terrain[i] = 4;   // surface layer
+        // cells 1860..4095 stay 0 (air)
+        var rle = ChunkBlocksRle.Encode(terrain);
+        Assert.True(rle.Length < 32, $"terrain chunk should collapse to a handful of runs, got {rle.Length}");
+        Assert.Equal(terrain, ChunkBlocksRle.Decode(rle, terrain.Length));
+
+        // Awkward: single cell, all-same, and a trailing lone value must all survive the round trip.
+        var single = new ushort[] { 7 };
+        Assert.Equal(single, ChunkBlocksRle.Decode(ChunkBlocksRle.Encode(single), 1));
+        var allSame = new ushort[4096];
+        for (int i = 0; i < allSame.Length; i++) allSame[i] = 9;
+        Assert.Equal(allSame, ChunkBlocksRle.Decode(ChunkBlocksRle.Encode(allSame), allSame.Length));
+        var tail = new ushort[] { 5, 5, 5, 8 };
+        Assert.Equal(tail, ChunkBlocksRle.Decode(ChunkBlocksRle.Encode(tail), 4));
+    }
+
+    [Fact]
+    public void ChunkRle_WorstCase_IsLargerThanDense_SoTheServerShipsDense()
+    {
+        // A checkerboard has no runs: RLE doubles the size, so the server's "smaller wins" pick keeps dense.
+        var checker = new ushort[4096];
+        for (int i = 0; i < checker.Length; i++) checker[i] = (ushort)(i & 1);
+        var rle = ChunkBlocksRle.Encode(checker);
+        Assert.True(rle.Length > checker.Length);
+        Assert.Equal(checker, ChunkBlocksRle.Decode(rle, checker.Length)); // still decodes correctly
+    }
+
+    [Fact]
+    public void ChunkRle_Decode_RejectsMalformedStreams()
+    {
+        Assert.Null(ChunkBlocksRle.Decode(Array.Empty<ushort>(), 4096));          // empty
+        Assert.Null(ChunkBlocksRle.Decode(new ushort[] { 1, 2, 3 }, 4096));       // odd pair count
+        Assert.Null(ChunkBlocksRle.Decode(new ushort[] { 1, 0 }, 4096));          // zero-length run
+        Assert.Null(ChunkBlocksRle.Decode(new ushort[] { 1, 5000 }, 4096));       // overflows the chunk
+        Assert.Null(ChunkBlocksRle.Decode(new ushort[] { 1, 10 }, 4096));         // underfills the chunk
+    }
+
+    [Fact]
+    public void ChunkDataMessage_RleShrinksTheWirePayload_AndRoundTripsTheCodec()
+    {
+        var terrain = new ushort[4096];
+        for (int i = 0; i < 2000; i++) terrain[i] = 1;
+
+        var denseMsg = new ChunkDataMessage { Cx = 1, Cy = 2, Cz = 3, Blocks = terrain };
+        var rleMsg = new ChunkDataMessage { Cx = 1, Cy = 2, Cz = 3, BlocksRle = ChunkBlocksRle.Encode(terrain) };
+
+        // The RLE form must round-trip the binary codec and decode back to the identical dense cells.
+        var typed = Assert.IsType<ChunkDataMessage>(NetCodec.Decode(NetCodec.Encode(rleMsg)));
+        Assert.Equal(terrain, typed.DecodeBlocks(terrain.Length));
+
+        // Wire-size assertions: dominant on the JSON path (browser websocket / WebGL loopback), and the
+        // MessagePack payload shrinks too.
+        int jsonDense = System.Text.Json.JsonSerializer.Serialize(denseMsg).Length;
+        int jsonRle = System.Text.Json.JsonSerializer.Serialize(rleMsg).Length;
+        Assert.True(jsonRle < jsonDense / 20, $"JSON: RLE {jsonRle} B should be far under dense {jsonDense} B");
+        Assert.True(NetCodec.Encode(rleMsg).Length < NetCodec.Encode(denseMsg).Length);
+    }
+
+    [Fact]
     public void Codec_RoundTrips_FloraRegrowStarted()
     {
         var msg = new FloraRegrowStarted { X = 102, Y = 100, Z = -5, Block = 77, Seconds = 30f };


### PR DESCRIPTION
Closes #356 — 2026-07-16 performance analysis, medium tier. Last of the three stacked perf PRs (after #369 and #370); with this, the whole medium tier (#354–#358) is shipped.

## What

- `ChunkDataMessage` gains **`BlocksRle`** — flat (value, runLength) ushort pairs via the new `ChunkBlocksRle` codec in Networking.
- The **server ships whichever representation is smaller**: terrain is highly runnable, so it almost always goes RLE; a degenerate unrunnable chunk (checkerboard) stays dense.
- The **client and the test harness accept both** via `ChunkDataMessage.DecodeBlocks`; a malformed RLE stream drops the chunk exactly like a wrong-length dense payload always has (no crash surface).
- **`Protocol.Version` 1 → 2**: older clients cannot decode `BlocksRle`, so the existing join-time version check keeps them off newer servers with a clear message. The fleet pins client/server versions in lockstep, so real-world exposure is small.

## Why

The browser wire path is JSON (MessagePack contractless dies under IL2CPP/WASM), so every chunk was ~15-25 KB of plain JSON numbers — and an initial VD4 view fill is ~390 chunks, several MB over the websocket. That dominates glitch.fun join time and VPS egress; permessage-deflate is not available on the HttpListener websocket transport, so payload-level compression is the practical route. Native MessagePack payloads shrink too (varint packing already helped there, so the win is smaller but real). The in-process browser-singleplayer loopback also pays the full JSON encode/decode round trip per chunk — fewer JSON numbers = less main-thread parse time.

## Tests

4 new tests in `NetworkingTests`: RLE round-trip (terrain-like + awkward payloads), degenerate worst-case falls back to dense, malformed-stream rejection (odd pairs, zero runs, over-/underflow), and wire-size assertions — the JSON payload is asserted **>20x smaller** for a terrain-like chunk. Full suite 1039 + 129 green (the 129 client tests stream real RLE chunks through the loopback harness end-to-end); local Unity build green; PerfProbe walk on the local build doubles as a live socket-streaming smoke.

## Follow-up

Browser smoke on play.glitch.fun after the next WebGL deploy (the biggest beneficiary), together with the pending #350/#351 browser checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)