### PR TITLE
fix(feedback): forward SP crash reports and /bump snapshots to the report inbox

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -100,6 +100,21 @@ Per-item detail lives in the dated work log below.
 
 ---
 
+### ★ Singleplayer feedback reaches the VPS: SP crash-report key + /bump snapshot forwarding (#372, 2026-07-17, PR #373)
+Two gaps closed so singleplayer feedback fully reaches the report inbox. (The F1 dialog itself already
+posted client-direct from SP in release builds — what never arrived was the rich server context.)
+**A — SP crash reports:** `LocalServerLauncher` now passes the client's baked-in feedback key to the
+bundled server as `BBS_CRASH_REPORT_KEY` (release builds only; dev builds keep the empty key = local-only),
+so the SP server's queued crash reports upload automatically via the existing 60 s flush. **B — `/bump`
+snapshot forwarding:** `GameServer.HandleBump` additionally posts each snapshot (inventory, surroundings,
+30 s history — WITHOUT the image; the client's own POST already carries the screenshot) through the
+`CrashUploader` sink, wire-shaped like a crash report but deliberately without `reportJson.kind`, so the
+inbox files it as category *feedback* / `source: "server"` / `reportType: "bump"`. Local `bumps/` file
+stays the source of truth; one best-effort background send, no retry queue. Also active on the fleet
+(worlds already carry the key since #363). `CrashUploader` promoted internal→public for host/test wiring.
+Tests: `BumpReport_WithConfiguredSink_ForwardsSnapshotWithoutImage`, `BumpCommand_WithoutSink_…`.
+Docs: PLAYER_FEEDBACK.md + REPORT_HOST.md.
+
 ### ★ RLE chunk payload (#356, 2026-07-17, branch perf/rle-chunk-payload)
 `ChunkDataMessage` gains `BlocksRle` (flat value/run-length ushort pairs, new `ChunkBlocksRle` codec in
 Networking); the server ships whichever representation is smaller (terrain almost always RLE — a

--- a/client/Assets/BlocksBeyondTheStars/Scripts/LocalServerLauncher.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/LocalServerLauncher.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Diagnostics;
 using System.IO;
+using BlocksBeyondTheStars.Build;
 using UnityEngine;
 using Debug = UnityEngine.Debug;
 
@@ -210,6 +211,18 @@ namespace BlocksBeyondTheStars.Client
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
             };
+
+            // Hand the client's baked-in feedback key to the bundled server so its crash reports and /bump
+            // snapshots reach the report inbox too (ServerConfig reads BBS_CRASH_REPORT_KEY; the endpoint
+            // default already points at the ReportHost). Release builds only — dev builds have an empty key
+            // and keep the local-only behavior. The key is the same spam-gate the client itself ships, so
+            // passing it to the child process on the same machine exposes nothing new.
+            string crashKey = BugReportBuildSecrets.ApiKey;
+            if (!string.IsNullOrEmpty(crashKey))
+            {
+                _pendingPsi.EnvironmentVariables["BBS_CRASH_REPORT_KEY"] = crashKey;
+            }
+
             return true;
 #endif
         }

--- a/docs/developer/PLAYER_FEEDBACK.md
+++ b/docs/developer/PLAYER_FEEDBACK.md
@@ -26,6 +26,8 @@ FeedbackUi dialog  (title, description, optional e-mail, privacy hint)
    │                on failure ──► FeedbackSpool (persistentDataPath/feedback) — retried on later
    │                              session starts, max 5 attempts, then parked in givenup/
    └──────────────► NetworkClient.SendBumpReport()  ──►  GameServer  (rich local snapshot on own/SP server)
+                                                            │  when a crash-upload sink is configured
+                                                            └──► same snapshot (minus image) ──► report inbox
 ```
 
 ### Why client-direct for the web upload
@@ -34,6 +36,21 @@ The web POST is sent **from the client**, not relayed through the game server, s
 developers even when the player is on someone else's dedicated server. It is fully decoupled from the game
 protocol. The parallel `/bump` message is kept so that, when the player *is* on their own / singleplayer
 server, the server still writes its rich snapshot (inventory, position, surroundings, 30 s history).
+
+### Server-side snapshot forwarding (singleplayer + fleet)
+
+The rich `/bump` snapshot no longer stays local-only: when the server has a crash-upload sink configured
+(`CrashReportEndpoint` + `CrashReportApiKey`, see [REPORT_HOST](REPORT_HOST.md)), `GameServer` also posts
+the snapshot to the inbox — wrapped in the same wire shape as crash reports (`reportJson.reportType:
+"bump"`, `source: "server"`, deliberately **no** `reportJson.kind` so the inbox files it under category
+*feedback*, not *crash*). The screenshot is never re-sent (the client's own POST already carries it) and
+the send is one best-effort background attempt; the on-disk `bumps/` file remains the source of truth.
+
+Who has a sink: **singleplayer** — `LocalServerLauncher` hands the client's baked-in feedback key to the
+bundled server as `BBS_CRASH_REPORT_KEY` (release builds only; dev builds have an empty key and stay
+local-only). This also means SP server **crash reports** now upload automatically. **Hosted fleet** —
+world instances get the key from the WorldHost (`BBS_WH_CRASH_REPORT_KEY`, #363). **Self-hosted
+dedicated servers** — off by default (no phone-home), opt-in via the config/env above.
 
 ## Code map
 

--- a/docs/developer/REPORT_HOST.md
+++ b/docs/developer/REPORT_HOST.md
@@ -99,6 +99,13 @@ reports.example.com {
   `BBS_WH_CRASH_REPORT_ENDPOINT` override) into every world container as the two variables above, so
   fleet crashes land in the inbox too. Worlds pick the key up on their next wake. Empty = off, same
   no-phone-home default as everywhere else.
+- **Singleplayer** — `LocalServerLauncher` passes the client's baked-in feedback key to the bundled
+  server as `BBS_CRASH_REPORT_KEY` (release builds only; dev builds carry an empty key), so SP server
+  crashes upload automatically. No new exposure: it is the same spam-gate key the client already ships.
+- **`/bump` snapshots** — any server with a configured sink (SP, fleet, opted-in self-hosts) also
+  forwards each `/bump`/F1 snapshot (without the screenshot) to the inbox, wire-shaped like a crash
+  report but **without** `reportJson.kind` so it is filed under category *feedback* with
+  `source: "server"` and `reportJson.reportType: "bump"`. The local `bumps/` file stays authoritative.
 - **Client F1 feedback** — the endpoint is the `FeedbackUploader.DefaultEndpoint` constant (by design
   the client always reports to the *official* inbox, from any server). Since the cutover it points at
   `https://reports.blocksbeyondthestars.de/api/bugreport`; the CI secret `BBS_BUGREPORT_API_KEY`

--- a/src/BlocksBeyondTheStars.GameServer/GameServerBump.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerBump.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
+using System.Threading.Tasks;
 using BlocksBeyondTheStars.Networking.Messages;
 using BlocksBeyondTheStars.Persistence;
 using BlocksBeyondTheStars.Shared.Geometry;
@@ -294,6 +295,13 @@ public sealed partial class GameServer
 
             _log.Info($"Bump #{_bumpCount} captured for {p.Name}: \"{description}\"{(hasImage ? " (+screenshot)" : string.Empty)} -> {file}");
             Send(session, new ServerMessage { Text = $"Debug snapshot #{_bumpCount} saved: {Path.GetFileName(file)}" });
+
+            // Forward the snapshot (without the image — the client's F1 path uploads the screenshot itself,
+            // and its base64 would triple the payload) to the report inbox when a crash-upload sink is
+            // configured: singleplayer gets the key from the bundled launcher, fleet worlds from the
+            // WorldHost. The local file above stays the source of truth; this send is one best-effort
+            // attempt with no retry queue.
+            ForwardBumpSnapshot(description, p.PlayerId, p.Name, snapshot);
         }
         catch (Exception e)
         {
@@ -301,6 +309,68 @@ public sealed partial class GameServer
             Send(session, new ServerMessage { Text = "Bump failed: " + e.Message });
         }
     }
+
+    /// <summary>Wraps a bump snapshot in the report inbox's wire shape (the same contract as
+    /// <see cref="BlocksBeyondTheStars.Persistence.CrashReportWriter"/> uses for crashes — title/description
+    /// up front, the snapshot verbatim in <c>reportJson</c>) and posts it through <see cref="CrashUploader"/>
+    /// on a background task. No-op when no sink is configured; never throws into the tick.</summary>
+    private void ForwardBumpSnapshot(string description, string playerId, string playerName, object snapshot)
+    {
+        var sink = CrashUploader;
+        if (sink is null || !sink.IsConfigured)
+        {
+            return;
+        }
+
+        try
+        {
+            var wire = new
+            {
+                title = TruncateWire($"Bump [{_meta.WorldName}]: {(string.IsNullOrEmpty(description) ? playerName : description)}", 110),
+                description = string.IsNullOrEmpty(description) ? "(no description)" : description,
+                email = string.Empty,
+                gameVersion = ServerVersionString,
+                buildNumber = string.Empty,
+                playerId = playerId ?? string.Empty,
+                playerName = playerName ?? string.Empty,
+                sessionId = string.Empty,
+                platform = "server",
+                clientTimestamp = DateTime.UtcNow.ToString("o"),
+                // No "kind" here on purpose: the ReportHost triages any reportJson.kind as category
+                // "crash"; a bump is player feedback context, so it stays category "feedback" with
+                // source "server" and the reportType marker for filtering.
+                reportJson = new
+                {
+                    schemaVersion = 1,
+                    reportType = "bump",
+                    source = "server",
+                    world = _meta.WorldName,
+                    serverVersion = ServerVersionString,
+                    snapshot,
+                },
+            };
+
+            string json = JsonSerializer.Serialize(wire);
+            _ = Task.Run(() =>
+            {
+                try
+                {
+                    sink.Send(json);
+                }
+                catch
+                {
+                    // one best-effort attempt; the local bump file remains the source of truth
+                }
+            });
+        }
+        catch
+        {
+            // forwarding must never break the local bump write or the tick
+        }
+    }
+
+    private static string TruncateWire(string value, int max)
+        => value.Length <= max ? value : value.Substring(0, max);
 
     /// <summary>Flattens an inventory's non-empty slots into a serialisable list (slot index + item + count).</summary>
     private static List<object> ItemList(BlocksBeyondTheStars.Shared.State.Inventory inv)

--- a/src/BlocksBeyondTheStars.GameServer/GameServerResilience.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerResilience.cs
@@ -118,8 +118,9 @@ public sealed partial class GameServer
     private int _crashFlushRunning; // 0/1 guard so only one background flush runs at a time (Interlocked)
 
     /// <summary>The optional uploader for automatic crash sending, set by the host once it has read config.
-    /// Null / not-configured ⇒ reports just accumulate on disk (the source of truth) for a manual send.</summary>
-    internal ICrashReportSink? CrashUploader { get; set; }
+    /// Null / not-configured ⇒ reports just accumulate on disk (the source of truth) for a manual send.
+    /// Also carries <c>/bump</c> snapshots to the report inbox (see <c>GameServerBump</c>).</summary>
+    public ICrashReportSink? CrashUploader { get; set; }
 
     /// <summary>Once per <see cref="CrashFlushIntervalSeconds"/>, hands the on-disk queue to a background task
     /// so live faults reach the website within the same session — WITHOUT blocking the single-threaded tick on

--- a/tests/BlocksBeyondTheStars.Tests/BumpTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/BumpTests.cs
@@ -84,6 +84,68 @@ public sealed class BumpTests : IDisposable
         Assert.Contains(Path.GetFileName(jpgFiles[0]), json);
     }
 
+    [Fact]
+    public void BumpReport_WithConfiguredSink_ForwardsSnapshotWithoutImage()
+    {
+        var (server, client, _) = StartWorld();
+        var sink = new ForwardSink();
+        server.CrashUploader = sink;
+
+        var image = new byte[] { 0xFF, 0xD8, 0xFF, 0xE0, 9, 8, 7, 6, 5 };
+        client.Send(NetCodec.Encode(new BumpReport { Description = "[feedback] jetpack stuck in ceiling", Image = image }), DeliveryMode.ReliableOrdered);
+        server.Tick(0.1);
+
+        // The send runs on a background task — wait for the sink, not a fixed sleep.
+        Assert.True(sink.Sent.Wait(TimeSpan.FromSeconds(10)), "bump was not forwarded to the sink");
+
+        string json = sink.LastJson!;
+        Assert.Contains("[feedback] jetpack stuck in ceiling", json);       // description up front
+        Assert.Contains("\"platform\":\"server\"", json);                   // wire shape matches crash reports
+        using (var doc = System.Text.Json.JsonDocument.Parse(json))
+        {
+            var reportJson = doc.RootElement.GetProperty("reportJson");
+            Assert.Equal("bump", reportJson.GetProperty("reportType").GetString());
+            // No reportJson.kind — the ReportHost triages any kind as category "crash", and a bump
+            // must stay category "feedback" (source "server").
+            Assert.False(reportJson.TryGetProperty("kind", out _));
+            Assert.Equal("server", reportJson.GetProperty("source").GetString());
+        }
+        Assert.Contains("inventory", json);                                  // rich snapshot rides in reportJson
+        Assert.DoesNotContain(Convert.ToBase64String(image), json);          // image is never forwarded
+
+        // The local snapshot is still written — forwarding is an addition, not a replacement.
+        Assert.Equal(1, server.BumpsWritten);
+    }
+
+    [Fact]
+    public void BumpCommand_WithoutSink_StillWritesLocalSnapshotOnly()
+    {
+        var (server, client, _) = StartWorld();
+        Assert.Null(server.CrashUploader); // default: nothing configured, nothing sent
+
+        client.Send(NetCodec.Encode(new ChatIntent { Text = "/bump no sink here" }), DeliveryMode.ReliableOrdered);
+        server.Tick(0.1);
+
+        Assert.Equal(1, server.BumpsWritten);
+    }
+
+    /// <summary>Captures the forwarded wire JSON and signals the test thread (the send is fire-and-forget
+    /// on a background task, so the test waits on the semaphore instead of sleeping).</summary>
+    private sealed class ForwardSink : ICrashReportSink
+    {
+        public string? LastJson;
+        public System.Threading.SemaphoreSlim Sent { get; } = new(0);
+
+        public bool IsConfigured => true;
+
+        public bool Send(string json)
+        {
+            LastJson = json;
+            Sent.Release();
+            return true;
+        }
+    }
+
     private (SvGameServer server, LoopbackClientTransport client, SaveGamePaths paths) StartWorld()
     {
         var paths = new SaveGamePaths(_root, _world);


### PR DESCRIPTION
Fixes #372

## What

Two gaps closed so singleplayer feedback fully reaches the ReportHost inbox. (The F1 dialog itself already posted client-direct from SP in release builds — what never arrived was the rich server-side context.)

**A — SP crash reports upload automatically.** `LocalServerLauncher` passes the client's baked-in feedback key to the bundled server as `BBS_CRASH_REPORT_KEY`. The whole upload pipeline (60 s background flush, sent/ relocation) already existed — only the key was missing. Release builds only; dev builds ship an empty key and keep today's local-only behavior. No new exposure: it is the same spam-gate key the client binary already ships.

**B — `/bump` snapshots are forwarded.** `GameServer.HandleBump` additionally posts each snapshot (inventory, surroundings, 30 s history) through the `CrashUploader` sink:
- **without the screenshot** — the client's own POST already carries it, and its base64 would triple the payload;
- **without `reportJson.kind`** — the ReportHost triages any `kind` as category *crash*; a bump is feedback context, so it is filed as category *feedback* with `source: "server"` and `reportJson.reportType: "bump"`;
- one best-effort background send, no retry queue — the local `bumps/` file stays the source of truth.

Also active on the hosted fleet, which has carried the key since #363. Self-hosted dedicated servers keep the no-phone-home default.

`CrashUploader` is promoted internal → public for host/test wiring.

## Tests & verification

- New: `BumpReport_WithConfiguredSink_ForwardsSnapshotWithoutImage` (wire shape, no image, no `kind`, category-relevant fields parsed from the actual JSON), `BumpCommand_WithoutSink_StillWritesLocalSnapshotOnly`.
- 1037 server + 129 client tests green (Release).
- Local Unity build green (client/Assets changed); bundled-server publish included.

## Player impact

Ships with the next release (client + bundled server change). After that, SP players' F1 feedback arrives with the full server snapshot, and SP crashes finally reach the inbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)