### PR TITLE
feat(feedback): forward the bump/F1 screenshot to the report inbox (#381)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -100,6 +100,18 @@ Per-item detail lives in the dated work log below.
 
 ---
 
+### ★ Bump/F1 screenshot forwarded to the report inbox (#381, 2026-07-18)
+Follow-up to #372: the server-side `/bump` forward now carries the screenshot too, so it shows in the
+ReportHost admin detail view. `GameServer.HandleBump` passes the JPG bytes into `ForwardBumpSnapshot`,
+which adds a top-level `screenshot` node (base64 + `mimeType: image/jpeg`) matching the F1 wire contract
+the ReportHost already decodes (`ReportIngest.ExtractScreenshot`) and displays — **no ReportHost change**.
+Null node when there is no image (ingest skips it). Rationale: the client-direct F1 upload (#380) is
+best-effort and may not run on older/native builds, so the server forward is the reliable path for the
+picture; oversized shots are dropped upstream (2 MB cap) / by the ReportHost base64 cap, keeping the
+report either way. Real-world trigger: report `eff679…` (Halon-11 graphics feedback) arrived image-less.
+Tests: `BumpReport_WithConfiguredSink_ForwardsSnapshotWithScreenshot`, `BumpCommand_WithoutImage_ForwardsNullScreenshot`.
+Docs: PLAYER_FEEDBACK.md + REPORT_HOST.md.
+
 ### ★ Singleplayer feedback reaches the VPS: SP crash-report key + /bump snapshot forwarding (#372, 2026-07-17, PR #373)
 Two gaps closed so singleplayer feedback fully reaches the report inbox. (The F1 dialog itself already
 posted client-direct from SP in release builds — what never arrived was the rich server context.)

--- a/docs/developer/PLAYER_FEEDBACK.md
+++ b/docs/developer/PLAYER_FEEDBACK.md
@@ -45,8 +45,10 @@ The rich `/bump` snapshot no longer stays local-only: when the server has a cras
 (`CrashReportEndpoint` + `CrashReportApiKey`, see [REPORT_HOST](REPORT_HOST.md)), `GameServer` also posts
 the snapshot to the inbox — wrapped in the same wire shape as crash reports (`reportJson.reportType:
 "bump"`, `source: "server"`, deliberately **no** `reportJson.kind` so the inbox files it under category
-*feedback*, not *crash*). The screenshot is never re-sent (the client's own POST already carries it) and
-the send is one best-effort background attempt; the on-disk `bumps/` file remains the source of truth.
+*feedback*, not *crash*). When the client attached a screenshot it rides along as a top-level `screenshot`
+node (base64 JPG) so the inbox stores + shows it like an F1 screenshot — this is the reliable path for the
+picture, since the client-direct F1 upload may not run on older/native builds. The send is one best-effort
+background attempt; the on-disk `bumps/` file remains the source of truth.
 
 Who has a sink: **singleplayer** — `LocalServerLauncher` hands the client's baked-in feedback key to the
 bundled server as `BBS_CRASH_REPORT_KEY` (release builds only; dev builds have an empty key and stay

--- a/docs/developer/REPORT_HOST.md
+++ b/docs/developer/REPORT_HOST.md
@@ -103,9 +103,13 @@ reports.example.com {
   server as `BBS_CRASH_REPORT_KEY` (release builds only; dev builds carry an empty key), so SP server
   crashes upload automatically. No new exposure: it is the same spam-gate key the client already ships.
 - **`/bump` snapshots** — any server with a configured sink (SP, fleet, opted-in self-hosts) also
-  forwards each `/bump`/F1 snapshot (without the screenshot) to the inbox, wire-shaped like a crash
-  report but **without** `reportJson.kind` so it is filed under category *feedback* with
-  `source: "server"` and `reportJson.reportType: "bump"`. The local `bumps/` file stays authoritative.
+  forwards each `/bump`/F1 snapshot to the inbox, wire-shaped like a crash report but **without**
+  `reportJson.kind` so it is filed under category *feedback* with `source: "server"` and
+  `reportJson.reportType: "bump"`. When the client sent a screenshot it rides along as a top-level
+  `screenshot` node (base64 JPG), so it stores + shows in the admin detail view exactly like an F1
+  screenshot — the server forward is the reliable path for it, since the client-direct F1 upload may not
+  run on older builds. Oversized shots are dropped upstream (2 MB cap) / by the ReportHost base64 cap,
+  keeping the report either way. The local `bumps/` file stays authoritative.
 - **Client F1 feedback** — the endpoint is the `FeedbackUploader.DefaultEndpoint` constant (by design
   the client always reports to the *official* inbox, from any server). Since the cutover it points at
   `https://reports.blocksbeyondthestars.de/api/bugreport`; the CI secret `BBS_BUGREPORT_API_KEY`

--- a/src/BlocksBeyondTheStars.GameServer/GameServerBump.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerBump.cs
@@ -296,12 +296,13 @@ public sealed partial class GameServer
             _log.Info($"Bump #{_bumpCount} captured for {p.Name}: \"{description}\"{(hasImage ? " (+screenshot)" : string.Empty)} -> {file}");
             Send(session, new ServerMessage { Text = $"Debug snapshot #{_bumpCount} saved: {Path.GetFileName(file)}" });
 
-            // Forward the snapshot (without the image — the client's F1 path uploads the screenshot itself,
-            // and its base64 would triple the payload) to the report inbox when a crash-upload sink is
-            // configured: singleplayer gets the key from the bundled launcher, fleet worlds from the
-            // WorldHost. The local file above stays the source of truth; this send is one best-effort
-            // attempt with no retry queue.
-            ForwardBumpSnapshot(description, p.PlayerId, p.Name, snapshot);
+            // Forward the snapshot to the report inbox when a crash-upload sink is configured: singleplayer
+            // gets the key from the bundled launcher, fleet worlds from the WorldHost. The image rides along
+            // as base64 so it shows in the ReportHost admin detail view — the client's F1 client-direct path
+            // (#380) is best-effort and may not run for older/native builds, so this is the only reliable way
+            // the picture reaches the inbox. The local file above stays the source of truth; this send is one
+            // best-effort attempt with no retry queue.
+            ForwardBumpSnapshot(description, p.PlayerId, p.Name, snapshot, hasImage ? image : null, imageName);
         }
         catch (Exception e)
         {
@@ -313,8 +314,10 @@ public sealed partial class GameServer
     /// <summary>Wraps a bump snapshot in the report inbox's wire shape (the same contract as
     /// <see cref="BlocksBeyondTheStars.Persistence.CrashReportWriter"/> uses for crashes — title/description
     /// up front, the snapshot verbatim in <c>reportJson</c>) and posts it through <see cref="CrashUploader"/>
-    /// on a background task. No-op when no sink is configured; never throws into the tick.</summary>
-    private void ForwardBumpSnapshot(string description, string playerId, string playerName, object snapshot)
+    /// on a background task. When an <paramref name="image"/> is present it travels as a top-level
+    /// <c>screenshot</c> node (base64 JPG), which the ReportHost decodes and stores like any F1 screenshot so
+    /// it shows in the admin detail view. No-op when no sink is configured; never throws into the tick.</summary>
+    private void ForwardBumpSnapshot(string description, string playerId, string playerName, object snapshot, byte[]? image, string? imageName)
     {
         var sink = CrashUploader;
         if (sink is null || !sink.IsConfigured)
@@ -336,6 +339,14 @@ public sealed partial class GameServer
                 sessionId = string.Empty,
                 platform = "server",
                 clientTimestamp = DateTime.UtcNow.ToString("o"),
+                // The screenshot (when the client sent one) as base64, matching the F1 wire contract the
+                // ReportHost already decodes (ReportIngest.ExtractScreenshot reads screenshot.base64 +
+                // mimeType). Null when there is no image → the ingest simply skips it. Oversized shots were
+                // already dropped upstream (2 MB cap in HandleBumpReport); the ReportHost drops anything past
+                // its own base64 cap, keeping the report either way.
+                screenshot = image is { Length: > 0 }
+                    ? new { fileName = imageName ?? "bump.jpg", mimeType = "image/jpeg", base64 = Convert.ToBase64String(image) }
+                    : null,
                 // No "kind" here on purpose: the ReportHost triages any reportJson.kind as category
                 // "crash"; a bump is player feedback context, so it stays category "feedback" with
                 // source "server" and the reportType marker for filtering.

--- a/tests/BlocksBeyondTheStars.Tests/BumpTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/BumpTests.cs
@@ -85,7 +85,7 @@ public sealed class BumpTests : IDisposable
     }
 
     [Fact]
-    public void BumpReport_WithConfiguredSink_ForwardsSnapshotWithoutImage()
+    public void BumpReport_WithConfiguredSink_ForwardsSnapshotWithScreenshot()
     {
         var (server, client, _) = StartWorld();
         var sink = new ForwardSink();
@@ -109,11 +109,35 @@ public sealed class BumpTests : IDisposable
             // must stay category "feedback" (source "server").
             Assert.False(reportJson.TryGetProperty("kind", out _));
             Assert.Equal("server", reportJson.GetProperty("source").GetString());
+
+            // The screenshot travels as a top-level node in the ReportHost's F1 wire shape (base64 JPG +
+            // mimeType), so ReportIngest.ExtractScreenshot stores it and the admin detail view shows it.
+            var shot = doc.RootElement.GetProperty("screenshot");
+            Assert.Equal("image/jpeg", shot.GetProperty("mimeType").GetString());
+            Assert.Equal(Convert.ToBase64String(image), shot.GetProperty("base64").GetString());
         }
         Assert.Contains("inventory", json);                                  // rich snapshot rides in reportJson
-        Assert.DoesNotContain(Convert.ToBase64String(image), json);          // image is never forwarded
 
         // The local snapshot is still written — forwarding is an addition, not a replacement.
+        Assert.Equal(1, server.BumpsWritten);
+    }
+
+    [Fact]
+    public void BumpCommand_WithoutImage_ForwardsNullScreenshot()
+    {
+        var (server, client, _) = StartWorld();
+        var sink = new ForwardSink();
+        server.CrashUploader = sink;
+
+        // A plain /bump (chat command) carries no screenshot — the forwarded wire must still be valid and
+        // simply carry a null screenshot node, which the ReportHost ingest skips.
+        client.Send(NetCodec.Encode(new ChatIntent { Text = "/bump no picture here" }), DeliveryMode.ReliableOrdered);
+        server.Tick(0.1);
+
+        Assert.True(sink.Sent.Wait(TimeSpan.FromSeconds(10)), "bump was not forwarded to the sink");
+
+        using var doc = System.Text.Json.JsonDocument.Parse(sink.LastJson!);
+        Assert.Equal(System.Text.Json.JsonValueKind.Null, doc.RootElement.GetProperty("screenshot").ValueKind);
         Assert.Equal(1, server.BumpsWritten);
     }
 


### PR DESCRIPTION
## What

The server-side `/bump` forward now carries the **screenshot** too, so a bump/F1 report shows its image in the ReportHost admin detail view — closing the gap where the picture only existed on the world container.

`GameServer.HandleBump` passes the JPG bytes into `ForwardBumpSnapshot`, which adds a top-level `screenshot` node (base64 + `mimeType: image/jpeg`). This matches the F1 wire contract the ReportHost **already** decodes (`ReportIngest.ExtractScreenshot`) and displays (`ReportHostPages` renders `<img>` + a 📷 in the list) — so **no ReportHost change**. The node is `null` when there is no image, which the ingest simply skips.

## Why

The client-direct F1 upload (#380) is best-effort and may not run on older/native builds; the server forward is the reliable path for the picture. Real-world trigger: report `eff679…` (a Halon-11 graphics-feedback bump) arrived **image-less** in the inbox while the JPG sat on the world container.

## Scope / safety

- Chosen approach: Option 1 from #381, implemented **without an env flag** (always forwards when a sink is configured — which is already key-gated, so no change to phone-home posture).
- Size: oversized shots are already dropped upstream (2 MB cap in `HandleBumpReport`); the ReportHost drops anything past its own base64 cap, keeping the report either way.
- Server-side only — no client/Unity change.

## Tests

- `BumpReport_WithConfiguredSink_ForwardsSnapshotWithScreenshot` — the forwarded wire carries `screenshot.base64` (= the JPG) + `mimeType image/jpeg`.
- `BumpCommand_WithoutImage_ForwardsNullScreenshot` — a plain `/bump` forwards a null screenshot node.
- Full Bump suite (5 tests) green locally.

## Docs

PLAYER_FEEDBACK.md, REPORT_HOST.md, TODO.md updated.

closes #381

🤖 Generated with [Claude Code](https://claude.com/claude-code)
