### PR TITLE
fix(graphics): edge-bevel corners no longer render white (#382)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -100,6 +100,17 @@ Per-item detail lives in the dated work log below.
 
 ---
 
+### ★ Edge-bevel corners/edges no longer render white (#382, 2026-07-18)
+The render-only T0 edge bevel (`ChunkMesher.EmitBevel`) drew small white triangles at exposed convex block
+corners/edges — most visible on bottom corners, and independent of the block's own texture (sand, stone and
+the red `data_cache` all showed the same white). Root cause: every chamfer/corner vertex was written with a
+single shared UV (`uv.center`), giving each polygon a **zero-area UV footprint**. On the mipmapped, gutter-less
+block atlas that samples a coarse cross-tile average which resolves to near-white. Fix: give each bevel vertex a
+**real per-vertex UV** — project its cell-local position onto the plane perpendicular to the polygon's dominant
+axis and map it across the block's own tile (clamped to the tile rect). The chamfer now samples the block's own
+texel, correctly lit. Render-only, no collider/data/wire change; unbeveled geometry (flora, glass, fluids,
+shaped blocks) untouched.
+
 ### ★ Bump/F1 screenshot forwarded to the report inbox (#381, 2026-07-18)
 Follow-up to #372: the server-side `/bump` forward now carries the screenshot too, so it shows in the
 ReportHost admin detail view. `GameServer.HandleBump` passes the JPG bytes into `ForwardBumpSnapshot`,

--- a/client/Assets/BlocksBeyondTheStars/Scripts/ChunkMesher.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/ChunkMesher.cs
@@ -1506,7 +1506,6 @@ namespace BlocksBeyondTheStars.Client
             float sky, Vector3 bl, Vector3 blDir)
         {
             float b = BevelAmount;
-            Vector2 uvC = uv.center;
             bool Open(int axis, int sign) => (openMask & (1 << FaceIndexFor(axis, sign))) != 0;
 
             void AddPoly(Vector3 a, Vector3 v1, Vector3 v2, bool isQuad, Vector3 v3, Vector3 outward)
@@ -1525,9 +1524,22 @@ namespace BlocksBeyondTheStars.Client
                 var tan = new Vector4(tan3.x, tan3.y, tan3.z, -1f);
                 int baseIdx = verts.Count;
 
+                // Per-vertex UVs: project each vertex's cell-local position onto the plane perpendicular to
+                // the polygon's dominant axis and map it across the block's tile. A single shared UV (uv.center)
+                // gave every chamfer/corner a zero-area UV footprint, which on the mipmapped, gutter-less atlas
+                // sampled a coarse cross-tile average that resolved to near-white — the "white corners" bug. A
+                // real (non-degenerate) footprint makes the chamfer sample the block's own texel, correctly lit.
+                Vector3 nAbs = new Vector3(Mathf.Abs(outward.x), Mathf.Abs(outward.y), Mathf.Abs(outward.z));
+                int domAxis = nAbs.x >= nAbs.y && nAbs.x >= nAbs.z ? 0 : (nAbs.y >= nAbs.z ? 1 : 2);
+                int uAxis = domAxis == 0 ? 1 : 0;
+                int vAxis = domAxis == 2 ? 1 : 2;
+
                 void Push(Vector3 p)
                 {
-                    verts.Add(p); colors.Add(col); uvs.Add(uvC); tangents.Add(tan);
+                    Vector3 loc = p - cell;
+                    var uvv = new Vector2(uv.xMin + Mathf.Clamp01(loc[uAxis]) * uv.width,
+                                          uv.yMin + Mathf.Clamp01(loc[vAxis]) * uv.height);
+                    verts.Add(p); colors.Add(col); uvs.Add(uvv); tangents.Add(tan);
                     skyUv.Add(new Vector2(sky, tintMode)); leafUv.Add(leaf); blockLight.Add(bl); blockLightDir.Add(blDir);
                 }
 


### PR DESCRIPTION
## What & why

Fixes #382 — the render-only T0 **edge bevel** drew small **white triangles at exposed convex block corners/edges** (most visible on *bottom* corners). The white was **independent of the block's own texture** — sand, stone and the red `data_cache` all showed the same white — because the micro-geometry wasn't sampling the block's tile at all.

**Root cause:** `ChunkMesher.EmitBevel` wrote every chamfer/corner vertex with a single shared UV (`uv.center`), so each bevel polygon had a **zero-area UV footprint**. On the mipmapped, gutter-less block atlas a degenerate footprint samples a coarse cross-tile average that resolves to near-white. (The "white base of a cactus / plants" reports were the same bug on the *surrounding* sand/stone — flora itself isn't beveled.)

## Fix

Give each bevel vertex a **real per-vertex UV**: project its cell-local position onto the plane perpendicular to the polygon's dominant axis and map it across the block's own tile (clamped to the tile rect) — the same "span the tile" idea the shaped-block path already uses. The chamfer now samples the block's own texel and is correctly lit.

- Render-only: **no collider / data / wire change**.
- Unbeveled geometry (flora, glass/fields, fluids, shaped blocks) is untouched.
- `data_cache`, sand, stone chamfers now carry their own texture instead of flat white.

## Verification

Compile + full test suite run in CI (client Unity build + server tests). Visual confirmation is best done in-world on the Halon-11 bump scene from the issue (sand / stone / `data_cache` corners at close + far range).

closes #382

🤖 Generated with [Claude Code](https://claude.com/claude-code)