### PR TITLE
feat(space): show player nameplates on ships in the flight view

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -100,6 +100,17 @@ Per-item detail lives in the dated work log below.
 
 ---
 
+### ★ Player nameplates on ships in space flight (#385, 2026-07-18)
+On the ground every remote player carries a floating nameplate, but in the flight view the other pilots'
+ships/EVA suits showed **no name** — you couldn't tell who was who. The data was already on the wire
+(`NetSpacePlayer.Name`, filled by `OtherPlayersInSpace`); only the client render was missing. Fix (client-only,
+no server/network change): `SpaceView.SyncRemotePlayers` now caches `rp.Name` on the `RemoteAvatar`, and a new
+`DrawRemoteNameplates` (called from `LateUpdate` during the cruise phase) pushes a floating label over each
+ship/suit via the shared `ScreenLabelLayer` — the same mechanism as the ground `RemotePlayers`, with the flight
+camera and radar-scale distance fade (90→140 m). Empty names (the synthetic NPC-trader poses on the same
+remote-ship path) are skipped by the label layer, so traders get no plate. The in-space `Stealthed` marker
+(orbiters hidden on the ground so no ghost avatar lingers on the pad) is unchanged.
+
 ### ★ Edge-bevel corners/edges no longer render white (#382, 2026-07-18)
 The render-only T0 edge bevel (`ChunkMesher.EmitBevel`) drew small white triangles at exposed convex block
 corners/edges — most visible on bottom corners, and independent of the block's own texture (sand, stone and

--- a/client/Assets/BlocksBeyondTheStars/Scripts/SpaceView.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/SpaceView.cs
@@ -211,7 +211,7 @@ namespace BlocksBeyondTheStars.Client
         private readonly List<string> _entityRemove = new List<string>();
 
         // Other players sharing this space instance, drawn as a ship or a floating EVA suit (R2 visibility).
-        private sealed class RemoteAvatar { public GameObject Root; public GameObject Ship; public GameObject Suit; public Material HullMat; public bool Voxel; public int HullRgb = -1; }
+        private sealed class RemoteAvatar { public GameObject Root; public GameObject Ship; public GameObject Suit; public Material HullMat; public bool Voxel; public int HullRgb = -1; public string Name = string.Empty; }
         private readonly Dictionary<string, RemoteAvatar> _remotePlayers = new Dictionary<string, RemoteAvatar>();
         private readonly HashSet<string> _remoteSeen = new HashSet<string>();
         private readonly List<string> _remoteRemove = new List<string>();
@@ -3297,6 +3297,7 @@ namespace BlocksBeyondTheStars.Client
                         _remotePlayers[rp.PlayerId] = av;
                     }
 
+                    av.Name = rp.Name ?? string.Empty; // shown as a floating nameplate (item 385); NPC traders arrive with an empty name and get no plate
                     av.Root.transform.localPosition = new Vector3(rp.X, rp.Y, rp.Z);
                     av.Root.transform.localRotation = Quaternion.Euler(0f, rp.Yaw, 0f);
 
@@ -3969,6 +3970,36 @@ namespace BlocksBeyondTheStars.Client
 
             // Ship-systems quick-bar: icon cells, the selected one bright + scaled (same look as the hotbar).
             RefreshSystemSlots();
+
+            // Floating nameplates over the other pilots so you can tell who is who out here (item 385).
+            if (_phase == Phase.Cruise)
+            {
+                DrawRemoteNameplates();
+            }
+        }
+
+        /// <summary>Draws a floating name label over each other pilot's ship/suit — the flight-view counterpart to
+        /// the ground nameplates (<see cref="RemotePlayers"/>). Names fade with distance (roughly radar range) so
+        /// nearby mates stay identifiable without cluttering the far field. Empty names — the synthetic NPC-trader
+        /// poses that ride the same remote-ship path — are skipped by <see cref="ScreenLabelLayer"/>.</summary>
+        private void DrawRemoteNameplates()
+        {
+            if (Camera == null || _remotePlayers.Count == 0)
+            {
+                return;
+            }
+
+            var labels = ScreenLabelLayer.Instance;
+            foreach (var av in _remotePlayers.Values)
+            {
+                if (av.Root == null || string.IsNullOrEmpty(av.Name))
+                {
+                    continue;
+                }
+
+                // ~2 m above the hull clears both the half-scale flight ship and a floating EVA suit.
+                labels.World(Camera, av.Root.transform.position + Vector3.up * 2f, av.Name, UiKit.TextCol, false, 90f, 140f);
+            }
         }
 
         /// <summary>Draws the ship-systems quick-bar as icon cells (laser / tractor / …) matching the on-foot


### PR DESCRIPTION
## What

Adds a floating **name label over each other pilot's ship / EVA suit** in the space-flight view, so you can tell who is who out there — the flight-view counterpart to the existing ground nameplates.

Closes #385.

## Why

On the ground every remote player carries a nameplate (`RemotePlayers` + `ScreenLabelLayer`). In space, other players are already rendered as ships/EVA suits by `SpaceView.SyncRemotePlayers`, but their name was never drawn. The data was already on the wire — the server fills `NetSpacePlayer.Name` in `OtherPlayersInSpace` — so this is a pure client-render gap.

## How

- `RemoteAvatar` gains a `Name` field; `SyncRemotePlayers` caches `rp.Name` on it.
- New `DrawRemoteNameplates`, called from `LateUpdate` during the cruise phase, pushes a label over each ship/suit through the shared `ScreenLabelLayer`, using the flight `Camera` and a radar-scale distance fade (90 → 140 m).
- Empty names (the synthetic NPC-trader poses that ride the same remote-ship path) are skipped by the label layer, so traders get no plate.
- The in-space `Stealthed` marker (orbiters hidden on the ground so no ghost avatar lingers on the launch pad) is unchanged.

**Client-only — no server or networking change.**

## Verification

- Unity Windows player **compiles clean (0 errors)** against the warm main-repo Library (`build: Succeeded`). Note: the PR CI gate does not compile the Unity client, so this was verified locally.
- Behavioural check (does the plate follow the ship / fade / show on EVA / skip traders) needs a hands-on multiplayer space playtest on a build.

## Acceptance criteria (from #385)

- [x] Each other real pilot's ship shows their name floating above it
- [x] The name follows the ship and fades with distance
- [x] EVA (floating suit) also shows the name
- [x] NPC traders on the remote-ship path show no bogus/empty plate
- [x] Own ship shows no self-plate (only remotes are in `_remotePlayers`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)