### PR TITLE
perf(graphics,server): half-res SSAO for Medium + PerfProbe itemization + fleet worldgen budget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ the richer, screenshot-laden versions live there. `(#123)` references the pull r
 - **Browser feedback actually reaches the inbox now.** The WebGL build was uploading an empty `{}` body (IL2CPP stripped the report type's metadata), so reports were silently dropped while the game said "queued". The type is now preserved, and a server rejection shows a real error instead of a false "saved, will retry". (#378)
 - **The two admin inboxes now point at each other** — the fleet admin and the ReportHost admin each note what the other one holds, so in-game feedback isn't hunted for on the wrong page. (#379)
 
+### ⚡ Medium preset: ambient occlusion at half the cost
+- Itemised the Medium preset's GPU cost on the reference laptop (Ryzen 9 7940HS / RTX 2000 Ada) with a new per-feature probe: **SSAO was the entire Low→Medium frame-time cliff** — everything else Medium switches on (depth/opaque copies, SMAA, ground scatter) sat within measurement noise. Medium now runs **SSAO at half resolution**: it keeps ambient occlusion but roughly halves the pass cost (~2.8 ms vs ~4–7 ms full-res across runs), recovering a few milliseconds per frame. **High is unchanged** (full-res SSAO). (#374)
+- The main-light shadowmap also drops 4096 → 2048 below High — free on the reference GPU, a small win on weaker ones; High keeps 4096. (#374)
+- The PerfProbe harness gained per-feature toggles (`-perfFeature ssao=off|half|full,depth=off,smaa=off,scatter=off,shadowmap=…,shadowdist=…`) so one preset feature's cost can be isolated in a single thermal session, plus an optional dense night scene (`-perfDense`: Extreme creature abundance at forced midnight) to measure the glowing-entity light cost for a future pass. (#374)
+
+### 🌐 Fleet: bounded worldgen per tick
+- Hosted worlds now cap chunk streaming — and the first-visit worldgen that happens inside it — at a per-tick wall-clock budget (default **25 ms**), so one player's fresh join or fast flight over new terrain can no longer stall the shared tick for everyone else in that world. At least one chunk always streams; the rest resume the next tick, nearest-first. Tunable via `BBS_WH_CHUNK_STREAM_BUDGET_MS` (0 = off); dedicated servers can set it directly with `--chunk-stream-budget-ms` / `BBS_CHUNK_STREAM_BUDGET_MS`. (#360)
+
 ## [0.8.3] — 2026-07-17
 
 The performance release: a measured pass over the whole stack — meshing, physics, graphics presets and the network wire. Every claim below comes from automated before/after captures on the same reference laptop (Ryzen 9 7940HS / RTX 2000 Ada); the tool that produced them ships in this release too.

--- a/TODO.md
+++ b/TODO.md
@@ -115,6 +115,31 @@ stays the source of truth; one best-effort background send, no retry queue. Also
 Tests: `BumpReport_WithConfiguredSink_ForwardsSnapshotWithoutImage`, `BumpCommand_WithoutSink_…`.
 Docs: PLAYER_FEEDBACK.md + REPORT_HOST.md.
 
+### ★ Medium preset SSAO retune + PerfProbe itemization + fleet worldgen budget (#374, #360, 2026-07-18, branch perf/medium-preset-server-budget)
+Three of the four open large-tier perf issues, code-verified and measured on the reference laptop
+(Ryzen 9 7940HS / RTX 2000 Ada). **PerfProbe tooling (enabler):** new `-perfFeature` toggles
+(`ssao=off|half|full,depth=off,smaa=off,scatter=off,shadowmap=N,shadowdist=N`) apply on top of the active
+preset so ONE feature's frame-time contribution is isolable in a single thermal session, plus `-perfDense`
+(Extreme creature abundance via `WorldCreationOptions` + forced visual midnight via `SetCaptureEnvironment(0f)`
+on a breathable `jungle` planet) adds a third *dense* phase for the glowing-entity light cost (#361, measured
+later). **#374 — Medium GPU cliff itemized:** at Medium/VD4, SSAO was the WHOLE Low→Medium cost — walk p50
+SSAO full 29.6 / half 25.3 / off 22.5 ms (same session); depth/opaque copies, SMAA and ground scatter all
+sat within thermal-drift noise (~±1.7 ms); the shadowmap 4096→2048 change measured **0 ms** on this GPU
+(kept anyway — free, helps weak iGPUs). Retune = a NEW `BlocksBeyondTheStarsURP_Renderer_Medium.asset`
+(index 2, SSAO `Downsample: 1`) selected by Medium only; High stays index 0 (full-res), Potato/Low index 1
+(off). Half-res keeps AO at ~half the cost. Shadowmap scaled per-preset in `ClientSettings.Apply`
+(High 4096, ≤Medium 2048). GOTCHA relearned: absolute PerfProbe FPS is NOT comparable across runs (thermal
+throttling — a hot session read 25 ms where a cool one read 18 ms); only same-session adjacent deltas are
+trustworthy, which is exactly why the `ssao=full|half|off` tokens exist. Visual check: jungle Medium
+screenshot renders correctly, AO present. **#360 — fleet worldgen budget:** `ServerConfig.ChunkStreamBudgetMs`
+(+ `ChunkStreamPerTick`) gained CLI (`--chunk-stream-budget-ms`) + env (`BBS_CHUNK_STREAM_BUDGET_MS`) mappings
+(previously unreachable on the fleet — the issue's "one config change" was wrong); `WorldHostConfig`
+forwards a default 25 ms to every hosted world via `InstanceLauncher` (`BBS_WH_CHUNK_STREAM_BUDGET_MS`, 0 = off),
+so a cold-worldgen burst can't stall a shared world's tick. Budget-first only — the risky worker-pool
+(shared mutable generator state + single-conn SQLite) stays deferred. Verified: server build 0 warnings,
+**1045 server tests green** (+4 new), local Unity build green ×4, format clean. Deliberately NOT touched:
+#359 (measure-first, gated on a post-deploy browser trace), #361 light budget (gated on the new dense probe).
+
 ### ★ RLE chunk payload (#356, 2026-07-17, branch perf/rle-chunk-payload)
 `ChunkDataMessage` gains `BlocksRle` (flat value/run-length ushort pairs, new `ChunkBlocksRle` codec in
 Networking); the server ships whichever representation is smaller (terrain almost always RLE — a

--- a/client/Assets/BlocksBeyondTheStars/Scripts/ClientSettings.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/ClientSettings.cs
@@ -440,6 +440,12 @@ namespace BlocksBeyondTheStars.Client
                 urp.supportsHDR = Preset > QualityPreset.Potato;
                 urp.renderScale = Preset == QualityPreset.Potato ? 0.75f : 1f;
 
+                // The shared asset bakes a 4096 main-light shadowmap for every level, but only High reaches far
+                // enough (90 m) to justify it — Medium and below cover 70 m or less, where 2048 is visually
+                // indistinguishable yet halves the shadow render cost. Keep High on 4096, drop the rest to 2048
+                // (irrelevant on Potato, which turns shadows off via shadowDistance 0 above).
+                urp.mainLightShadowmapResolution = Preset >= QualityPreset.High ? 4096 : 2048;
+
                 // Depth + opaque copies feed the screen-space effects (volumetric fog, SSR, water refraction).
                 // They cost a prepass + a colour copy, so the two weakest presets turn them off entirely —
                 // which also disables every dependent effect for free (the features early-out without the textures).
@@ -463,7 +469,8 @@ namespace BlocksBeyondTheStars.Client
 
         /// <summary>Pushes the per-camera look settings to the gameplay camera: post-processing on (the global
         /// Volume — bloom/tonemap/grade — and SMAA both need it), SMAA from <see cref="Smaa"/> (Medium+), and the
-        /// renderer choice — index 0 carries SSAO, index 1 (Potato/Low) drops it for the frame-time budget.</summary>
+        /// renderer choice — index 0 = full-res SSAO (High), index 2 = half-res SSAO (Medium), index 1 = SSAO-free
+        /// (Potato/Low). SSAO was the measured Low→Medium frame-time cliff (#374).</summary>
         public void ApplyCameraLook()
         {
             var cd = ActiveCameraData;
@@ -473,7 +480,16 @@ namespace BlocksBeyondTheStars.Client
             }
 
             cd.renderPostProcessing = true;
-            cd.SetRenderer(Preset >= QualityPreset.Medium ? 0 : 1);
+            // Renderer index carries the SSAO cost tier: 0 = full-resolution SSAO (High), 2 = half-resolution
+            // SSAO (Medium — Downsample renderer), 1 = SSAO-free (Potato/Low). Measured (#374): SSAO was the
+            // whole Low→Medium frame-time cliff on the reference laptop, so Medium keeps ambient occlusion but
+            // at half resolution — most of the look, ~half the cost — while High stays untouched at full res.
+            cd.SetRenderer(Preset switch
+            {
+                QualityPreset.High => 0,
+                QualityPreset.Medium => 2,
+                _ => 1,
+            });
 
             bool smaa = Smaa && Preset >= QualityPreset.Medium;
             cd.antialiasing = smaa ? AntialiasingMode.SubpixelMorphologicalAntiAliasing : AntialiasingMode.None;

--- a/client/Assets/BlocksBeyondTheStars/Scripts/PerfProbe.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/PerfProbe.cs
@@ -7,23 +7,31 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using UnityEngine;
+using UnityEngine.Rendering;
+using UnityEngine.Rendering.Universal;
 
 namespace BlocksBeyondTheStars.Client
 {
     /// <summary>
     /// Automated performance baseline capture (issue #353). When the player is launched with
     /// <c>-perfProbe</c>, this self-installs (same pattern as <see cref="ScreenshotDirector"/>), starts a
-    /// fixed-seed singleplayer world and records frame-time / GC statistics over two phases:
+    /// fixed-seed singleplayer world and records frame-time / GC statistics over these phases:
     /// <list type="number">
     ///   <item><b>idle</b> — standing still after the spawn area has fully meshed (steady-state cost)</item>
     ///   <item><b>walk</b> — scripted straight-line traversal via <see cref="InputMap.ScriptedMove"/>, so
     ///   chunk streaming + meshing churn continuously (the historical stutter scenario)</item>
+    ///   <item><b>dense</b> (only with <c>-perfDense</c>) — Extreme creature abundance at forced visual midnight,
+    ///   so the glowing-entity point-light cost (#361) is exercised instead of the sparse baseline walk</item>
     /// </list>
     /// Results go to <c>&lt;out&gt;/perf_baseline_&lt;platform&gt;.json</c> plus a human-readable .txt and the
     /// log; the process exits when done, so a script can run this end-to-end. Flags: <c>-perfProbe</c>,
-    /// <c>-perfOut &lt;dir&gt;</c>, <c>-seed &lt;n&gt;</c>, <c>-perfIdle &lt;sec&gt;</c>, <c>-perfWalk &lt;sec&gt;</c>.
+    /// <c>-perfOut &lt;dir&gt;</c>, <c>-seed &lt;n&gt;</c>, <c>-perfIdle &lt;sec&gt;</c>, <c>-perfWalk &lt;sec&gt;</c>,
+    /// <c>-perfPreset &lt;name&gt;</c>, <c>-perfVd &lt;n&gt;</c>, and <c>-perfFeature "ssao=off|half|full,depth=off,
+    /// smaa=off,scatter=off,shadowmap=2048,shadowdist=40"</c> (isolate one preset feature's cost — see #374).
     /// The numbers are a coarse CPU/GC baseline (wall-clock frame times), not a GPU profile — for the deep
-    /// dive attach the Unity Profiler to a development build.
+    /// dive attach the Unity Profiler to a development build. When the preset is GPU-bound (the Medium cliff
+    /// in #374), the wall-clock frame time still moves with each feature toggle, so a <c>-perfFeature</c>
+    /// sweep at fixed preset/VD gives a usable first-order cost split without a GPU capture.
     /// </summary>
     public sealed class PerfProbe : MonoBehaviour
     {
@@ -41,6 +49,23 @@ namespace BlocksBeyondTheStars.Client
         private string _presetOverride;   // -perfPreset Potato|Low|Medium|High; null = keep the player's settings
         private int _vdOverride = -1;     // -perfVd 1..8; -1 = keep
 
+        // -perfFeature "ssao=off,depth=off,smaa=off,scatter=off,shadowmap=2048,shadowdist=40": after the preset
+        // is applied, force individual cost-bearing features off (or to a value) so a run isolates ONE feature's
+        // frame-time contribution. This is how the Medium-preset cost split (#374) gets itemized: hold the preset
+        // at Medium and toggle one feature per run. Null/empty = no per-feature override.
+        private string _featureSpec;
+        private string _featureTag;       // sanitized summary of what the override actually changed (for the filename)
+
+        // -perfDense: adds a third "dense" phase (settlement/creature-pack-at-night stand-in for #361). The world
+        // is created with Extreme creature abundance on a breathable planet so fauna auto-spawns in the 18–45 block
+        // ring around the player; the phase then forces visual midnight (SetCaptureEnvironment) so the glowing
+        // entities' point lights dominate a dark frame. Caveat: this pins the CLIENT visual clock only — the server
+        // clock stays daytime, so strictly nocturnal glow species may be under-represented; cathemeral/passive
+        // species and the raw entity-view density still populate the scene. A first dense probe, refine later.
+        private bool _dense;
+        private const float DenseSettle = 12f; // extra settle so the creature ring fills toward its cap before sampling
+        private const string DensePlanet = "jungle"; // breathable + vegetated ⇒ dense fauna (incl. glowers)
+
         // The player's real settings file, snapshotted before any override — AppShell paths call
         // Settings.Save(), so an in-memory override could otherwise clobber the user's persisted settings.
         private byte[] _settingsBackup;
@@ -57,6 +82,8 @@ namespace BlocksBeyondTheStars.Client
             float idle = 30f, walk = 60f;
             string preset = null;
             int vd = -1;
+            string feature = null;
+            bool dense = false;
             for (int i = 0; i < args.Length; i++)
             {
                 string a = args[i];
@@ -88,6 +115,14 @@ namespace BlocksBeyondTheStars.Client
                 {
                     walk = Mathf.Clamp(fw, 5f, 600f);
                 }
+                else if (string.Equals(a, "-perfFeature", StringComparison.OrdinalIgnoreCase) && i + 1 < args.Length)
+                {
+                    feature = args[i + 1];
+                }
+                else if (string.Equals(a, "-perfDense", StringComparison.OrdinalIgnoreCase))
+                {
+                    dense = true;
+                }
             }
 
             if (!on)
@@ -104,6 +139,8 @@ namespace BlocksBeyondTheStars.Client
             p._walkSeconds = walk;
             p._presetOverride = preset;
             p._vdOverride = vd;
+            p._featureSpec = feature;
+            p._dense = dense;
         }
 
         private void Start() => StartCoroutine(Run());
@@ -140,8 +177,14 @@ namespace BlocksBeyondTheStars.Client
                 shell.Settings.Apply();
             }
 
-            Debug.Log($"[PerfProbe] Starting world (seed {_seed}, preset {shell.Settings.Preset}, view distance {shell.Settings.ViewDistanceChunks}).");
-            shell.StartSingleplayerWorld(WorldName, _seed, creativeUnlockAll: false, creativeAllShips: false, creativeKit: false);
+            // Dense scene (#361): Extreme creature abundance on a breathable, vegetated planet so a heavy
+            // creature pack (incl. glowers) auto-spawns around the player. Baseline runs pass no options.
+            WorldCreationOptions worldOptions = _dense
+                ? new WorldCreationOptions { Creatures = 4 /* Extreme */, StartPlanetType = DensePlanet }
+                : null;
+
+            Debug.Log($"[PerfProbe] Starting world (seed {_seed}, preset {shell.Settings.Preset}, view distance {shell.Settings.ViewDistanceChunks}{(_dense ? ", dense scene" : "")}).");
+            shell.StartSingleplayerWorld(WorldName, _seed, creativeUnlockAll: false, creativeAllShips: false, creativeKit: false, worldOptions);
 
             yield return WaitForPhase(shell, ShellPhase.InGame, WorldLoadTimeout);
             var boot = shell.CurrentBoot;
@@ -155,19 +198,37 @@ namespace BlocksBeyondTheStars.Client
             yield return WaitUntil(() => boot.WorldReady, WorldLoadTimeout);
             yield return new WaitForSecondsRealtime(ChunkSettle);
 
-            var phases = new List<PhaseResult>
+            // Per-feature overrides run AFTER the preset is applied and the gameplay camera exists (so the SSAO
+            // renderer / SMAA choice on ActiveCameraData is live), isolating one feature's cost for #374.
+            _featureTag = ApplyFeatureOverrides();
+            if (_featureTag != null)
             {
-                null, // idle, filled below
-                null, // walk
-            };
+                Debug.Log($"[PerfProbe] Feature overrides applied: {_featureTag}");
+            }
+
+            var phases = new List<PhaseResult>();
 
             // Phase 1: idle — steady-state cost with the spawn area fully streamed.
-            yield return Sample("idle", _idleSeconds, r => phases[0] = r);
+            PhaseResult r = null;
+            yield return Sample("idle", _idleSeconds, x => r = x);
+            phases.Add(r);
 
             // Phase 2: walk — scripted forward traversal; fresh chunks stream/mesh the whole time.
             InputMap.ScriptedMove = new Vector2(0f, 1f);
-            yield return Sample("walk", _walkSeconds, r => phases[1] = r);
+            yield return Sample("walk", _walkSeconds, x => r = x);
             InputMap.ScriptedMove = Vector2.zero;
+            phases.Add(r);
+
+            // Phase 3 (optional): dense — force visual midnight and stand among the Extreme creature pack so the
+            // glowing entities' point lights dominate the frame (#361). Walking first left a filled ring; a short
+            // extra settle lets it top up before sampling.
+            if (_dense)
+            {
+                boot.SetCaptureEnvironment(0f); // midnight — see the DensePlanet/caveat note on the field above
+                yield return new WaitForSecondsRealtime(DenseSettle);
+                yield return Sample("dense", _idleSeconds, x => r = x);
+                phases.Add(r);
+            }
 
             WriteResults(shell, phases);
             RestoreSettingsFile();
@@ -216,6 +277,79 @@ namespace BlocksBeyondTheStars.Client
 
         private void OnApplicationQuit() => RestoreSettingsFile(); // belt & braces if the run is aborted
 
+        /// <summary>Applies the <c>-perfFeature</c> overrides on top of the active preset, mutating the same
+        /// runtime knobs <see cref="ClientSettings.Apply"/> owns (URP asset + the gameplay camera's URP data +
+        /// the ground-scatter gate). Returns a short sanitized tag of what actually changed (for the output
+        /// filename), or null when nothing was overridden. The process exits after the run, so this leaves no
+        /// lasting state — no restore needed.</summary>
+        private string ApplyFeatureOverrides()
+        {
+            if (string.IsNullOrEmpty(_featureSpec))
+            {
+                return null;
+            }
+
+            var urp = GraphicsSettings.currentRenderPipeline as UniversalRenderPipelineAsset;
+            var cam = ClientSettings.ActiveCameraData;
+            var tags = new List<string>();
+
+            foreach (var raw in _featureSpec.Split(','))
+            {
+                var token = raw.Trim();
+                if (token.Length == 0)
+                {
+                    continue;
+                }
+
+                var parts = token.Split('=');
+                string key = parts[0].Trim().ToLowerInvariant();
+                string val = parts.Length > 1 ? parts[1].Trim() : "off";
+
+                switch (key)
+                {
+                    case "ssao":
+                        // Force a specific SSAO tier by renderer index so full/half/off can be compared in ONE
+                        // thermal session (the SSAO cost split for #374): 0 = full-res, 2 = half-res, 1 = off.
+                        if (cam != null)
+                        {
+                            switch (val)
+                            {
+                                case "full": cam.SetRenderer(0); tags.Add("ssaoFull"); break;
+                                case "half": cam.SetRenderer(2); tags.Add("ssaoHalf"); break;
+                                default: cam.SetRenderer(1); tags.Add("ssaoOff"); break;
+                            }
+                        }
+                        break;
+                    case "depth":
+                    case "depthopaque":
+                        // Drop the depth prepass + opaque colour copy (and tell the shaders they're gone, so
+                        // water/fog fall back cleanly instead of sampling unbound textures).
+                        if (urp != null) { urp.supportsCameraDepthTexture = false; urp.supportsCameraOpaqueTexture = false; }
+                        Shader.SetGlobalFloat("_Sc_ScreenFx", 0f);
+                        tags.Add("depthOff");
+                        break;
+                    case "smaa":
+                        if (cam != null) { cam.antialiasing = AntialiasingMode.None; tags.Add("smaaOff"); }
+                        break;
+                    case "scatter":
+                        GroundScatter.Enabled = false;
+                        tags.Add("scatterOff");
+                        break;
+                    case "shadowmap":
+                        if (urp != null && int.TryParse(val, out var sm) && sm > 0) { urp.mainLightShadowmapResolution = sm; tags.Add($"sm{sm}"); }
+                        break;
+                    case "shadowdist":
+                        if (urp != null && float.TryParse(val, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out var sd) && sd >= 0f) { urp.shadowDistance = sd; tags.Add($"sd{sd:0}"); }
+                        break;
+                    default:
+                        Debug.LogWarning($"[PerfProbe] Unknown -perfFeature token '{token}' ignored.");
+                        break;
+                }
+            }
+
+            return tags.Count > 0 ? string.Join("-", tags) : null;
+        }
+
         [Serializable]
         private sealed class PhaseResult
         {
@@ -246,6 +380,7 @@ namespace BlocksBeyondTheStars.Client
             public int viewDistanceChunks;
             public long seed;
             public string device;
+            public string featureOverride; // null unless -perfFeature changed something (the itemization run)
             public PhaseResult[] phases;
         }
 
@@ -314,18 +449,25 @@ namespace BlocksBeyondTheStars.Client
                 viewDistanceChunks = shell.Settings.ViewDistanceChunks,
                 seed = _seed,
                 device = $"{SystemInfo.processorType} / {SystemInfo.graphicsDeviceName} / {SystemInfo.systemMemorySize} MB",
+                featureOverride = _featureTag,
                 phases = phases.ToArray(),
             };
 
             string dir = !string.IsNullOrEmpty(_outDir) ? _outDir : Path.Combine(Application.persistentDataPath, "perf");
             Directory.CreateDirectory(dir);
-            string baseName = $"perf_baseline_{Application.platform}_{result.qualityPreset}_vd{result.viewDistanceChunks}";
+            string featureSuffix = string.IsNullOrEmpty(_featureTag) ? "" : $"_{_featureTag}";
+            string denseSuffix = _dense ? "_dense" : "";
+            string baseName = $"perf_baseline_{Application.platform}_{result.qualityPreset}_vd{result.viewDistanceChunks}{denseSuffix}{featureSuffix}";
             string jsonPath = Path.Combine(dir, baseName + ".json");
             File.WriteAllText(jsonPath, JsonUtility.ToJson(result, prettyPrint: true));
 
             var txt = new StringBuilder();
             txt.AppendLine($"Perf baseline — {result.capturedUtc} UTC — v{result.appVersion} — {result.platform}");
             txt.AppendLine($"Preset {result.qualityPreset}, view distance {result.viewDistanceChunks}, seed {result.seed}");
+            if (!string.IsNullOrEmpty(result.featureOverride))
+            {
+                txt.AppendLine($"Feature override: {result.featureOverride}");
+            }
             txt.AppendLine(result.device);
             foreach (var ph in result.phases)
             {

--- a/client/Assets/Settings/BlocksBeyondTheStarsURP.asset
+++ b/client/Assets/Settings/BlocksBeyondTheStarsURP.asset
@@ -19,6 +19,7 @@ MonoBehaviour:
   m_RendererDataList:
   - {fileID: 11400000, guid: bbec306f57a6b2d40a30a42399c76f6b, type: 2}
   - {fileID: 11400000, guid: a7f3c1e9b2d04e5f8c6a1b3d9e0f4a72, type: 2}
+  - {fileID: 11400000, guid: 13e44a053e484d86ab7bc1f09824b54e, type: 2}
   m_DefaultRendererIndex: 0
   m_RequireDepthTexture: 1
   m_RequireOpaqueTexture: 1

--- a/client/Assets/Settings/BlocksBeyondTheStarsURP_Renderer_Medium.asset
+++ b/client/Assets/Settings/BlocksBeyondTheStarsURP_Renderer_Medium.asset
@@ -1,0 +1,82 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &-6443500088809077745
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f62c9c65cf3354c93be831c8bc075510, type: 3}
+  m_Name: ScreenSpaceAmbientOcclusion
+  m_EditorClassIdentifier: Unity.RenderPipelines.Universal.Runtime::UnityEngine.Rendering.Universal.ScreenSpaceAmbientOcclusion
+  m_Active: 1
+  m_Settings:
+    AOMethod: 0
+    Downsample: 1
+    AfterOpaque: 1
+    Source: 0
+    NormalSamples: 1
+    Intensity: 0.5
+    DirectLightingStrength: 0.25
+    Radius: 0.3
+    Samples: 1
+    BlurQuality: 0
+    Falloff: 100
+    SampleCount: -1
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: de640fe3d0db1804a85f9fc8f5cadab6, type: 3}
+  m_Name: BlocksBeyondTheStarsURP_Renderer_Medium
+  m_EditorClassIdentifier: Unity.RenderPipelines.Universal.Runtime::UnityEngine.Rendering.Universal.UniversalRendererData
+  debugShaders:
+    debugReplacementPS: {fileID: 4800000, guid: cf852408f2e174538bcd9b7fda1c5ae7, type: 3}
+    hdrDebugViewPS: {fileID: 4800000, guid: 573620ae32aec764abd4d728906d2587, type: 3}
+    probeVolumeSamplingDebugComputeShader: {fileID: 7200000, guid: 53626a513ea68ce47b59dc1299fe3959, type: 3}
+  probeVolumeResources:
+    probeVolumeDebugShader: {fileID: 0}
+    probeVolumeFragmentationDebugShader: {fileID: 0}
+    probeVolumeOffsetDebugShader: {fileID: 0}
+    probeVolumeSamplingDebugShader: {fileID: 0}
+    probeSamplingDebugMesh: {fileID: 0}
+    probeSamplingDebugTexture: {fileID: 0}
+    probeVolumeBlendStatesCS: {fileID: 0}
+  m_RendererFeatures:
+  - {fileID: -6443500088809077745}
+  m_RendererFeatureMap: 0f4456f0ce1694a6
+  m_UseNativeRenderPass: 0
+  postProcessData: {fileID: 11400000, guid: 41439944d30ece34e96484bdb6645b55, type: 2}
+  m_AssetVersion: 3
+  m_PrepassLayerMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_OpaqueLayerMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_TransparentLayerMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_DefaultStencilState:
+    overrideStencilState: 0
+    stencilReference: 0
+    stencilCompareFunction: 8
+    passOperation: 2
+    failOperation: 0
+    zFailOperation: 0
+  m_ShadowTransparentReceive: 1
+  m_RenderingMode: 0
+  m_DepthPrimingMode: 0
+  m_CopyDepthMode: 1
+  m_DepthAttachmentFormat: 0
+  m_DepthTextureFormat: 0
+  m_AccurateGbufferNormals: 0
+  m_IntermediateTextureMode: 1

--- a/client/Assets/Settings/BlocksBeyondTheStarsURP_Renderer_Medium.asset.meta
+++ b/client/Assets/Settings/BlocksBeyondTheStarsURP_Renderer_Medium.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 13e44a053e484d86ab7bc1f09824b54e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/deploy/worldhost/docker-compose.yml
+++ b/deploy/worldhost/docker-compose.yml
@@ -45,6 +45,10 @@ services:
       # override is only for fleets with their own ReportHost — the server default is the official inbox.
       BBS_WH_CRASH_REPORT_KEY: ${BBS_WH_CRASH_REPORT_KEY:-}
       BBS_WH_CRASH_REPORT_ENDPOINT: ${BBS_WH_CRASH_REPORT_ENDPOINT:-}
+      # Per-tick chunk-stream budget (ms) forwarded to every world as BBS_CHUNK_STREAM_BUDGET_MS (#360):
+      # bounds cold-worldgen bursts so one player's fresh join/fast-flight can't stall the world's tick for
+      # everyone else. Default 25 (generous headroom under the ~66 ms tick); 0 = off (unbounded).
+      BBS_WH_CHUNK_STREAM_BUDGET_MS: ${BBS_WH_CHUNK_STREAM_BUDGET_MS:-25}
       # Legal pages (Impressum/Datenschutz); empty = "not configured" notice on those pages.
       BBS_WH_LEGAL_NAME: ${BBS_WH_LEGAL_NAME:-}
       BBS_WH_LEGAL_ADDRESS: ${BBS_WH_LEGAL_ADDRESS:-}

--- a/src/BlocksBeyondTheStars.Shared/Configuration/ServerConfig.cs
+++ b/src/BlocksBeyondTheStars.Shared/Configuration/ServerConfig.cs
@@ -345,6 +345,13 @@ public sealed class ServerConfig
                 case "view-distance-chunks":
                     if (int.TryParse(value, out var vd)) { ViewDistanceChunks = vd; applied.Add("view-distance"); }
                     break;
+                case "chunk-stream-per-tick":
+                    if (int.TryParse(value, out var cspt) && cspt >= 1) { ChunkStreamPerTick = cspt; applied.Add("chunk-stream-per-tick"); }
+                    break;
+                case "chunk-stream-budget-ms":
+                case "chunk-budget-ms":
+                    if (double.TryParse(value, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out var csb) && csb >= 0) { ChunkStreamBudgetMs = csb; applied.Add("chunk-stream-budget-ms"); }
+                    break;
                 case "free-flight":
                     if (bool.TryParse(value, out var ff)) { Rules.FreeSpaceFlight = ff; applied.Add("free-flight"); }
                     break;
@@ -541,6 +548,8 @@ public sealed class ServerConfig
         if (Env("BBS_START_PLANET") is { } startPlanet) { StartPlanet = startPlanet.Trim(); applied.Add("BBS_START_PLANET"); }
         if (Env("BBS_TICK_RATE") is { } tickStr && int.TryParse(tickStr, out var tick)) { TickRate = tick; applied.Add("BBS_TICK_RATE"); }
         if (Env("BBS_VIEW_DISTANCE") is { } vdStr && int.TryParse(vdStr, out var vd)) { ViewDistanceChunks = vd; applied.Add("BBS_VIEW_DISTANCE"); }
+        if (Env("BBS_CHUNK_STREAM_PER_TICK") is { } csptStr && int.TryParse(csptStr, out var cspt) && cspt >= 1) { ChunkStreamPerTick = cspt; applied.Add("BBS_CHUNK_STREAM_PER_TICK"); }
+        if (Env("BBS_CHUNK_STREAM_BUDGET_MS") is { } csbStr && double.TryParse(csbStr, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out var csb) && csb >= 0) { ChunkStreamBudgetMs = csb; applied.Add("BBS_CHUNK_STREAM_BUDGET_MS"); }
         if (Env("BBS_FREE_FLIGHT") is { } ffStr && bool.TryParse(ffStr, out var ff)) { Rules.FreeSpaceFlight = ff; applied.Add("BBS_FREE_FLIGHT"); }
         if (Env("BBS_SPACE_COMBAT") is { } scStr && Enum.TryParse<SpaceCombatMode>(scStr, ignoreCase: true, out var sc)) { Rules.SpaceCombat = sc; applied.Add("BBS_SPACE_COMBAT"); }
         if (Env("BBS_SHIP_WEAPONS") is { } swStr && Enum.TryParse<ShipWeaponMode>(swStr, ignoreCase: true, out var sw)) { Rules.ShipWeapons = sw; applied.Add("BBS_SHIP_WEAPONS"); }

--- a/src/BlocksBeyondTheStars.WorldHost/InstanceLauncher.cs
+++ b/src/BlocksBeyondTheStars.WorldHost/InstanceLauncher.cs
@@ -108,6 +108,14 @@ public sealed class DockerCliLauncher : IInstanceLauncher
 
         args.AddRange(new[] { "--pids-limit", "256" });
 
+        // Per-tick chunk-stream budget (#360): a hosted world's tick is single-threaded, so a cold-worldgen
+        // burst would otherwise stall simulation for everyone in that world. Forward the operator's budget so
+        // the instance caps gen+send time per tick (>=1 chunk still streams, the rest resume next tick). 0 = off.
+        if (config.ChunkStreamBudgetMs > 0)
+        {
+            args.AddRange(new[] { "-e", $"BBS_CHUNK_STREAM_BUDGET_MS={config.ChunkStreamBudgetMs.ToString(System.Globalization.CultureInfo.InvariantCulture)}" });
+        }
+
         // Maintenance announcements (#249): the shared secret the control plane presents on the instance's
         // POST /announce. Without it neither side enables the endpoint.
         if (!string.IsNullOrEmpty(config.AnnounceToken))

--- a/src/BlocksBeyondTheStars.WorldHost/WorldHostConfig.cs
+++ b/src/BlocksBeyondTheStars.WorldHost/WorldHostConfig.cs
@@ -48,6 +48,16 @@ public sealed class WorldHostConfig
     /// saves and exits after this long; the reaper then marks it stopped in the registry.</summary>
     public int IdleShutdownMinutes { get; set; } = 20;
 
+    /// <summary>Per-tick wall-clock budget (ms) each hosted world spends streaming chunks, forwarded as
+    /// <c>BBS_CHUNK_STREAM_BUDGET_MS</c> (<c>BBS_WH_CHUNK_STREAM_BUDGET_MS</c>). A hosted world runs its tick
+    /// on a single thread with no render loop, so a burst of cold first-visit worldgen (a fresh join, fast
+    /// flight over new terrain) would otherwise run all ChunkStreamPerTick generations in one tick and push
+    /// it over the ~66 ms tick window — stalling simulation for the OTHER players in that world. This caps
+    /// that: at least one chunk always streams, the rest resume next tick (nearest-first order unchanged).
+    /// The default 25 ms is generous headroom under the tick window — it only trims pathological bursts, not
+    /// normal fill. 0 = off (unbounded, the historical behaviour).</summary>
+    public double ChunkStreamBudgetMs { get; set; } = 25.0;
+
     /// <summary>How long a join request waits for a woken instance to answer its /status probe.</summary>
     public int WakeTimeoutSeconds { get; set; } = 90;
 
@@ -288,6 +298,7 @@ public sealed class WorldHostConfig
         if (Env("BBS_WH_MAX_WORLDS_PER_ACCOUNT") is { } mwStr && int.TryParse(mwStr, out var mw)) { c.MaxWorldsPerAccount = mw; }
         if (Env("BBS_WH_MAX_PLAYERS") is { } mpStr && int.TryParse(mpStr, out var mp)) { c.MaxPlayersPerWorld = mp; }
         if (Env("BBS_WH_IDLE_MINUTES") is { } idleStr && int.TryParse(idleStr, out var idle)) { c.IdleShutdownMinutes = idle; }
+        if (Env("BBS_WH_CHUNK_STREAM_BUDGET_MS") is { } csbStr && double.TryParse(csbStr, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out var csb) && csb >= 0) { c.ChunkStreamBudgetMs = csb; }
         if (Env("BBS_WH_WAKE_TIMEOUT_SECONDS") is { } wtStr && int.TryParse(wtStr, out var wt)) { c.WakeTimeoutSeconds = wt; }
         if (Env("BBS_WH_SESSION_DAYS") is { } sdStr && int.TryParse(sdStr, out var sd)) { c.SessionDays = sd; }
         if (Env("BBS_WH_RESERVED_NAMES") is { } reserved)

--- a/tests/BlocksBeyondTheStars.Tests/ServerConfigTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/ServerConfigTests.cs
@@ -43,6 +43,59 @@ public sealed class ServerConfigTests
     }
 
     [Fact]
+    public void ApplyCommandLine_MapsChunkStreamBudgetAndPerTick()
+    {
+        var config = new ServerConfig();
+        var applied = config.ApplyCommandLine(new[]
+        {
+            "--chunk-stream-per-tick", "24",
+            "--chunk-stream-budget-ms", "12.5", // invariant decimal point, must parse regardless of host locale
+        });
+
+        Assert.Equal(24, config.ChunkStreamPerTick);
+        Assert.Equal(12.5, config.ChunkStreamBudgetMs);
+        Assert.Contains("chunk-stream-per-tick", applied);
+        Assert.Contains("chunk-stream-budget-ms", applied);
+    }
+
+    [Fact]
+    public void ApplyCommandLine_RejectsInvalidChunkStreamValues()
+    {
+        var config = new ServerConfig();
+        var applied = config.ApplyCommandLine(new[]
+        {
+            "--chunk-stream-per-tick", "0",     // must be >= 1
+            "--chunk-stream-budget-ms", "-3",   // must be >= 0
+        });
+
+        Assert.Equal(16, config.ChunkStreamPerTick);     // untouched default
+        Assert.Equal(0.0, config.ChunkStreamBudgetMs);   // untouched default (off)
+        Assert.DoesNotContain("chunk-stream-per-tick", applied);
+        Assert.DoesNotContain("chunk-stream-budget-ms", applied);
+    }
+
+    [Fact]
+    public void ApplyEnvironment_MapsChunkStreamBudgetAndPerTick()
+    {
+        var vars = new Dictionary<string, string?>
+        {
+            ["BBS_CHUNK_STREAM_PER_TICK"] = "20",
+            ["BBS_CHUNK_STREAM_BUDGET_MS"] = "25",
+        };
+
+        WithEnvironment(vars, () =>
+        {
+            var config = new ServerConfig();
+            var applied = config.ApplyEnvironment();
+
+            Assert.Equal(20, config.ChunkStreamPerTick);
+            Assert.Equal(25.0, config.ChunkStreamBudgetMs);
+            Assert.Contains("BBS_CHUNK_STREAM_PER_TICK", applied);
+            Assert.Contains("BBS_CHUNK_STREAM_BUDGET_MS", applied);
+        });
+    }
+
+    [Fact]
     public void ApplyCommandLine_OverridesSpaceRules()
     {
         var config = new ServerConfig();

--- a/tests/BlocksBeyondTheStars.Tests/WorldHostTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/WorldHostTests.cs
@@ -554,6 +554,20 @@ public sealed class WorldHostTests : IDisposable
         Assert.DoesNotContain("BBS_CRASH_REPORT", string.Join(" ", DockerCliLauncher.BuildRunArgs(endpointOnly, world, "/tmp/saves")));
     }
 
+    [Fact]
+    public void BuildRunArgs_ForwardsChunkStreamBudget_AndOmitsWhenOff()
+    {
+        var world = new WorldRecord("abc123abc123", "acct", "My World", "secret", 32001, WorldStatus.Stopped, "", 0, 0);
+
+        // Default (25 ms): bounds cold-worldgen bursts so one player's fresh join can't stall the world's tick.
+        var on = new WorldHostConfig();
+        Assert.Contains("BBS_CHUNK_STREAM_BUDGET_MS=25", string.Join(" ", DockerCliLauncher.BuildRunArgs(on, world, "/tmp/saves")));
+
+        // Explicitly off (0): no env forwarded — the instance keeps the unbounded historical behaviour.
+        var off = new WorldHostConfig { ChunkStreamBudgetMs = 0 };
+        Assert.DoesNotContain("BBS_CHUNK_STREAM_BUDGET_MS", string.Join(" ", DockerCliLauncher.BuildRunArgs(off, world, "/tmp/saves")));
+    }
+
     // ---------------- Fleet capacity gate ----------------
 
     [Fact]


### PR DESCRIPTION
Three of the four open large-tier performance issues, code-verified and **measured** on the reference laptop (Ryzen 9 7940HS / RTX 2000 Ada).

## #374 — itemize the Medium preset's GPU cost
New PerfProbe `-perfFeature` toggles (`ssao=off|half|full,depth=off,smaa=off,scatter=off,shadowmap=N,shadowdist=N`) apply on top of the active preset so one feature's frame-time contribution is isolable in a **single thermal session**. A Medium/VD4 sweep found:

| SSAO (walk p50) | ms | vs off |
|---|---|---|
| full (High) | 29.6 | +7.1 |
| **half (new Medium)** | **25.3** | **+2.8** |
| off (Low) | 22.5 | — |

**SSAO was the entire Low→Medium cliff.** Depth/opaque copies, SMAA and ground scatter all sat within thermal-drift noise (~±1.7 ms); the shadowmap 4096→2048 change measured **0 ms** on this GPU (kept anyway — free, helps weak iGPUs).

**Retune:** a new `BlocksBeyondTheStarsURP_Renderer_Medium` renderer (SSAO `Downsample: 1`, half-resolution) is selected by Medium only; **High keeps full-res SSAO** (index 0), Potato/Low keep the SSAO-free renderer (index 1). Medium keeps ambient occlusion at ~half the cost. Shadowmap scaled per-preset in `ClientSettings.Apply` (High 4096, ≤Medium 2048). Visual check: a jungle Medium screenshot renders correctly with AO present.

PerfProbe also gained `-perfDense` (Extreme creature abundance at forced visual midnight) as a third phase for the glowing-entity light cost — the enabler for a later #361 pass.

> ⚠️ Relearned gotcha: absolute PerfProbe FPS is **not** comparable across runs (thermal throttling — a hot session read 25 ms where a cool one read 18 ms). Only same-session adjacent deltas are trustworthy, which is exactly why the `ssao=full|half|off` tokens exist.

## #360 — bound worldgen time per tick (budget-first)
`ServerConfig.ChunkStreamBudgetMs` (+ `ChunkStreamPerTick`) gained CLI (`--chunk-stream-budget-ms`) and env (`BBS_CHUNK_STREAM_BUDGET_MS`) mappings — previously **unreachable on the fleet** (the issue's "one config change" was inaccurate). `WorldHostConfig` forwards a default **25 ms** budget to every hosted world via `InstanceLauncher` (`BBS_WH_CHUNK_STREAM_BUDGET_MS`, 0 = off), so a cold-worldgen burst from one player's join/fast-flight can't stall the shared tick for everyone else (≥1 chunk always streams, the rest resume next tick). The risky worker-pool escalation (shared mutable generator state + single-connection SQLite) stays **deferred**.

## Not touched (deliberately)
- **#359** (AOT MessagePack) — measure-first, gated on a post-deploy browser trace; RLE (#356) already removed the dominant JSON cost.
- **#361** light budget — gated on the new dense-scene probe; baseline shows zero hitches.

## Verification
- Server build **0 warnings**, **1045 server tests green** (+4 new: chunk-budget CLI/env mapping, invalid-value rejection, WorldHost forward/omit).
- Local Unity Windows build green; `dotnet format` clean.
- Jungle Medium screenshot rendered correctly (new renderer valid, AO visible).

Closes #374
Closes #360

🤖 Generated with [Claude Code](https://claude.com/claude-code)