### PR TITLE
fix(reports): stamp real build version instead of 1.0.0 on server-originated reports

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -89,6 +89,10 @@ jobs:
           platforms: ${{ inputs.platforms }}
           push: ${{ inputs.push }}
           tags: ${{ steps.img.outputs.tags }}
+          # Bake the version into the server assemblies so /bump-forwarded and crash reports carry the
+          # release version instead of the .NET default 1.0.0 (release.yml passes the tag as `tag`).
+          build-args: |
+            VERSION=${{ inputs.tag }}
           cache-from: type=gha
           # Only non-tag runs export the layer cache: this workflow is workflow_call'ed by release.yml
           # on tag refs, and tag-scoped caches are unreadable by every other ref — they only crowded

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,7 +180,7 @@ jobs:
 
       - name: Publish bundled local server (win-x64)
         shell: pwsh
-        run: ./scripts/publish-local-server.ps1 -Runtime win-x64
+        run: ./scripts/publish-local-server.ps1 -Runtime win-x64 -Version ${{ needs.version.outputs.version }}
 
       # Restore-only: release runs on tag refs, and a tag-scoped cache can never be restored by any
       # other ref (not even the next release tag) — writing them only evicted the useful main-scoped
@@ -288,7 +288,7 @@ jobs:
         run: ./scripts/sync-velopack-libs.sh
 
       - name: Publish bundled local server (linux-x64)
-        run: ./scripts/publish-local-server.sh linux-x64
+        run: ./scripts/publish-local-server.sh linux-x64 ${{ needs.version.outputs.version }}
 
       # Restore-only: release runs on tag refs, and a tag-scoped cache can never be restored by any
       # other ref (not even the next release tag) — writing them only evicted the useful main-scoped

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ the richer, screenshot-laden versions live there. `(#123)` references the pull r
 
 ## [Unreleased]
 
+### 🐛 Reports show the right version
+- Bug reports and feedback in the report inbox showed the game version `1.0.0` for reports that came in through the server (a `/bump`, its feedback forward, or a server crash), because the dedicated-server build never stamped its version and defaulted to `1.0.0`. The server build now bakes in the release version, and a `/bump` additionally carries the reporting player's own client build so the inbox shows the player's version rather than the server's. (#389)
+
 ### 🐛 Browser feedback fixes
 - **Feedback in the browser no longer needs F1** — F1 opens the browser's own help, so the in-game feedback dialog now opens with **F2** in WebGL builds (F1 stays on desktop). The HUD and flight hints show the right key per platform. (#376)
 - **Raw `ui.*` keys no longer stick in the browser UI.** On WebGL the locale files load asynchronously, so a screen built during that window (e.g. the main menu) could show untranslated resource keys and never refresh. Cached shell screens are now rebuilt once the language finishes loading, and the missing `ui.feedback.send` label was added. (#377)

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,14 +10,20 @@ FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
 COPY . .
 
+# The release version to bake into the server assemblies (passed by docker.yml from the release tag).
+# Defaults to a dev marker for hand-built images. Without this the assemblies carry the .NET default
+# 1.0.0, which the server then stamps onto /bump-forwarded and crash reports (GameServer.ServerVersionString).
+# .git is excluded by .dockerignore, so InformationalVersion stays a clean string with no +sha suffix.
+ARG VERSION=0.0.0-dev
+
 # Publish the three headless server projects into one folder, framework-dependent (the runtime image
 # already ships the .NET + ASP.NET runtime). We publish the projects individually on purpose: the .sln
 # also contains the net8.0-windows WinForms launcher, which cannot build on Linux.
 # GameServer is multi-target (net10.0 exe + netstandard2.1 sim library for the Unity/WebGL
 # in-process singleplayer) — publish needs the explicit framework since the split.
-RUN dotnet publish src/BlocksBeyondTheStars.GameServer/BlocksBeyondTheStars.GameServer.csproj -c Release -f net10.0 -o /app \
- && dotnet publish src/BlocksBeyondTheStars.Api/BlocksBeyondTheStars.Api.csproj               -c Release -o /app \
- && dotnet publish src/BlocksBeyondTheStars.Tools/BlocksBeyondTheStars.Tools.csproj           -c Release -o /app \
+RUN dotnet publish src/BlocksBeyondTheStars.GameServer/BlocksBeyondTheStars.GameServer.csproj -c Release -f net10.0 -o /app -p:InformationalVersion="$VERSION" \
+ && dotnet publish src/BlocksBeyondTheStars.Api/BlocksBeyondTheStars.Api.csproj               -c Release -o /app -p:InformationalVersion="$VERSION" \
+ && dotnet publish src/BlocksBeyondTheStars.Tools/BlocksBeyondTheStars.Tools.csproj           -c Release -o /app -p:InformationalVersion="$VERSION" \
  && cp -r data /app/data
 
 # ---- runtime ----

--- a/TODO.md
+++ b/TODO.md
@@ -100,6 +100,20 @@ Per-item detail lives in the dated work log below.
 
 ---
 
+### ★ Reports show version 1.0.0 → real build version (#389, 2026-07-18)
+The report inbox (`reports.blocksbeyondthestars.de`) showed game version **1.0.0** for reports that arrived
+through the server — a `/bump`, its F1/F2 feedback forward (`GameServerBump.ForwardBumpSnapshot`), or a server
+crash report. Cause: `GameServer.ServerVersionString` reads the assembly's `AssemblyInformationalVersion`, but
+the dedicated-server build never stamped a version, so it defaulted to `1.0.0`. The client-direct F1/F2 upload
+path was always correct (`FeedbackUi` uses `AppShell.Version`). Two-part fix: **(1)** bake the release version
+into the server assemblies at publish time — `Dockerfile` `ARG VERSION` → `-p:InformationalVersion` on the three
+publishes, wired from `docker.yml` (`build-args: VERSION=<tag>`) and the bundled-server scripts
+(`publish-local-server.ps1/.sh` gained a version arg, passed from `release.yml`); **(2)** `BumpReport` now
+carries the reporter's `ClientVersion` (MessagePack contractless → backward compatible, no new codec id), which
+the server stamps onto the forwarded report's `gameVersion` so a player-filed bump shows the *player's* build,
+falling back to the server version for older clients and the text-only `/bump`. Tests in `BumpTests` assert both
+the client-version passthrough and the server-version fallback.
+
 ### ★ Player nameplates on ships in space flight (#385, 2026-07-18)
 On the ground every remote player carries a floating nameplate, but in the flight view the other pilots'
 ships/EVA suits showed **no name** — you couldn't tell who was who. The data was already on the wire

--- a/client/Assets/BlocksBeyondTheStars/Scripts/ChatUi.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/ChatUi.cs
@@ -248,7 +248,7 @@ namespace BlocksBeyondTheStars.Client
 
             if (jpg != null && jpg.Length > 0)
             {
-                Game.Network.SendBumpReport(description, jpg);
+                Game.Network.SendBumpReport(description, jpg, AppShell.Version);
             }
             else
             {

--- a/client/Assets/BlocksBeyondTheStars/Scripts/FeedbackUi.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/FeedbackUi.cs
@@ -255,7 +255,7 @@ namespace BlocksBeyondTheStars.Client
 
             // Path A — rich server snapshot via the existing /bump pipeline (meaningful on own/SP servers).
             string serverNote = string.IsNullOrEmpty(title) ? desc : title + " — " + desc;
-            Game?.Network?.SendBumpReport("[feedback] " + serverNote, jpg ?? Array.Empty<byte>());
+            Game?.Network?.SendBumpReport("[feedback] " + serverNote, jpg ?? Array.Empty<byte>(), AppShell.Version);
 
             // Path B — client-direct upload to the report inbox. The body is serialized ONCE here on the
             // main thread; only the POST leaves the game loop.

--- a/scripts/publish-local-server.ps1
+++ b/scripts/publish-local-server.ps1
@@ -15,9 +15,13 @@
 .EXAMPLE
   ./scripts/publish-local-server.ps1
   ./scripts/publish-local-server.ps1 -Runtime win-x64
+  ./scripts/publish-local-server.ps1 -Runtime win-x64 -Version 0.8.3
 #>
 param(
-    [string] $Runtime = 'win-x64'
+    [string] $Runtime = 'win-x64',
+    # Baked into the server assembly so its reports (e.g. a server crash) carry the release version instead
+    # of the .NET default 1.0.0 (release.yml passes the resolved tag). Defaults to a dev marker locally.
+    [string] $Version = '0.0.0-dev'
 )
 
 $ErrorActionPreference = 'Stop'
@@ -27,10 +31,11 @@ $out = Join-Path $repo 'client/Assets/StreamingAssets/server'
 if (Test-Path $out) { Remove-Item $out -Recurse -Force }
 New-Item -ItemType Directory -Force $out | Out-Null
 
-Write-Host "Publishing dedicated server ($Runtime) into the client ..." -ForegroundColor Cyan
+Write-Host "Publishing dedicated server ($Runtime, v$Version) into the client ..." -ForegroundColor Cyan
 dotnet publish (Join-Path $repo 'src/BlocksBeyondTheStars.GameServer') `
     -c Release -f net10.0 -r $Runtime --self-contained true `
     -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true `
+    -p:InformationalVersion=$Version `
     -o $out | Out-Null
 
 Write-Host "Bundled local server into $out" -ForegroundColor Green

--- a/scripts/publish-local-server.sh
+++ b/scripts/publish-local-server.sh
@@ -11,6 +11,9 @@ set -euo pipefail
 
 REPO="$(cd "$(dirname "$0")/.." && pwd)"
 RUNTIME="${1:-linux-x64}"
+# Baked into the server assembly so its reports (e.g. a server crash) carry the release version instead of
+# the .NET default 1.0.0 (release.yml passes the resolved tag). Defaults to a dev marker locally.
+VERSION="${2:-0.0.0-dev}"
 OUT="$REPO/client/Assets/StreamingAssets/server"
 
 if [ -d "$OUT" ]; then
@@ -18,10 +21,11 @@ if [ -d "$OUT" ]; then
 fi
 mkdir -p "$OUT"
 
-echo "==> Publishing dedicated server ($RUNTIME) into the client ..."
+echo "==> Publishing dedicated server ($RUNTIME, v$VERSION) into the client ..."
 dotnet publish "$REPO/src/BlocksBeyondTheStars.GameServer" \
     -c Release -f net10.0 -r "$RUNTIME" --self-contained true \
     -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true \
+    -p:InformationalVersion="$VERSION" \
     -o "$OUT" >/dev/null
 
 echo "Bundled local server into $OUT"

--- a/src/BlocksBeyondTheStars.Client.Core/NetworkClient.cs
+++ b/src/BlocksBeyondTheStars.Client.Core/NetworkClient.cs
@@ -237,9 +237,16 @@ namespace BlocksBeyondTheStars.Client
             => Send(new VoiceFrame { Opus = opus ?? Array.Empty<byte>(), Sequence = sequence }, DeliveryMode.Unreliable);
 
         /// <summary>Sends a <c>/bump</c> bug report with an optional in-game screenshot (JPG bytes). The server
-        /// persists a rich snapshot of the reporter's situation and writes the image alongside it.</summary>
-        public void SendBumpReport(string description, byte[] image)
-            => Send(new BumpReport { Description = description ?? string.Empty, Image = image ?? Array.Empty<byte>() });
+        /// persists a rich snapshot of the reporter's situation and writes the image alongside it. The
+        /// caller passes the client's build version so a forwarded report shows the reporter's build rather
+        /// than the server's (see <see cref="BumpReport.ClientVersion"/>).</summary>
+        public void SendBumpReport(string description, byte[] image, string clientVersion = "")
+            => Send(new BumpReport
+            {
+                Description = description ?? string.Empty,
+                Image = image ?? Array.Empty<byte>(),
+                ClientVersion = clientVersion ?? string.Empty,
+            });
 
         // Admin/cheat console (server validates IsAdmin + the CheatsAllowed rule and replies with a ServerMessage).
         public void SendAdminCommand(string command, string? stringArg = null, int intArg = 0,

--- a/src/BlocksBeyondTheStars.GameServer/GameServerBump.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerBump.cs
@@ -99,7 +99,7 @@ public sealed partial class GameServer
             image = null;
         }
 
-        HandleBump(session, SanitizeBumpDescription(report.Description), image);
+        HandleBump(session, SanitizeBumpDescription(report.Description), image, report.ClientVersion);
     }
 
     /// <summary>Bounds + cleans a client-supplied bump description before it is written to the log and a
@@ -124,7 +124,7 @@ public sealed partial class GameServer
         return sb.ToString().Trim();
     }
 
-    private void HandleBump(PlayerSession session, string description, byte[]? image = null)
+    private void HandleBump(PlayerSession session, string description, byte[]? image = null, string clientVersion = "")
     {
         var p = session.State;
         var (systemName, planetName) = ActiveLocationNames();
@@ -302,7 +302,7 @@ public sealed partial class GameServer
             // (#380) is best-effort and may not run for older/native builds, so this is the only reliable way
             // the picture reaches the inbox. The local file above stays the source of truth; this send is one
             // best-effort attempt with no retry queue.
-            ForwardBumpSnapshot(description, p.PlayerId, p.Name, snapshot, hasImage ? image : null, imageName);
+            ForwardBumpSnapshot(description, p.PlayerId, p.Name, snapshot, hasImage ? image : null, imageName, clientVersion);
         }
         catch (Exception e)
         {
@@ -316,14 +316,19 @@ public sealed partial class GameServer
     /// up front, the snapshot verbatim in <c>reportJson</c>) and posts it through <see cref="CrashUploader"/>
     /// on a background task. When an <paramref name="image"/> is present it travels as a top-level
     /// <c>screenshot</c> node (base64 JPG), which the ReportHost decodes and stores like any F1 screenshot so
-    /// it shows in the admin detail view. No-op when no sink is configured; never throws into the tick.</summary>
-    private void ForwardBumpSnapshot(string description, string playerId, string playerName, object snapshot, byte[]? image, string? imageName)
+    /// it shows in the admin detail view. No-op when no sink is configured; never throws into the tick.
+    /// The report's <c>gameVersion</c> is the reporter's client build (<paramref name="clientVersion"/>) when
+    /// the client sent one — so the inbox shows the player's build, not the server's — and falls back to the
+    /// server version for older clients / the text-only <c>/bump</c>.</summary>
+    private void ForwardBumpSnapshot(string description, string playerId, string playerName, object snapshot, byte[]? image, string? imageName, string clientVersion = "")
     {
         var sink = CrashUploader;
         if (sink is null || !sink.IsConfigured)
         {
             return;
         }
+
+        string reportVersion = string.IsNullOrWhiteSpace(clientVersion) ? ServerVersionString : clientVersion;
 
         try
         {
@@ -332,7 +337,7 @@ public sealed partial class GameServer
                 title = TruncateWire($"Bump [{_meta.WorldName}]: {(string.IsNullOrEmpty(description) ? playerName : description)}", 110),
                 description = string.IsNullOrEmpty(description) ? "(no description)" : description,
                 email = string.Empty,
-                gameVersion = ServerVersionString,
+                gameVersion = reportVersion,
                 buildNumber = string.Empty,
                 playerId = playerId ?? string.Empty,
                 playerName = playerName ?? string.Empty,

--- a/src/BlocksBeyondTheStars.Networking/Messages.cs
+++ b/src/BlocksBeyondTheStars.Networking/Messages.cs
@@ -1464,6 +1464,12 @@ public sealed class BumpReport
     /// <summary>JPG-encoded screenshot, or empty when the client could not capture one (the server then
     /// falls back to a snapshot without an image).</summary>
     public byte[] Image { get; set; } = System.Array.Empty<byte>();
+
+    /// <summary>The reporting client's build version (<c>Application.version</c>). The server stamps this
+    /// onto the forwarded report's <c>gameVersion</c> so the inbox shows the player's build, not the
+    /// server's. Empty from older clients (and the text-only <c>/bump</c>), in which case the server falls
+    /// back to its own version. MessagePack is contractless, so this extra field is backward compatible.</summary>
+    public string ClientVersion { get; set; } = string.Empty;
 }
 
 /// <summary>A broadcast chat line (server→clients).</summary>

--- a/tests/BlocksBeyondTheStars.Tests/BumpTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/BumpTests.cs
@@ -92,7 +92,7 @@ public sealed class BumpTests : IDisposable
         server.CrashUploader = sink;
 
         var image = new byte[] { 0xFF, 0xD8, 0xFF, 0xE0, 9, 8, 7, 6, 5 };
-        client.Send(NetCodec.Encode(new BumpReport { Description = "[feedback] jetpack stuck in ceiling", Image = image }), DeliveryMode.ReliableOrdered);
+        client.Send(NetCodec.Encode(new BumpReport { Description = "[feedback] jetpack stuck in ceiling", Image = image, ClientVersion = "0.8.3" }), DeliveryMode.ReliableOrdered);
         server.Tick(0.1);
 
         // The send runs on a background task — wait for the sink, not a fixed sleep.
@@ -103,6 +103,10 @@ public sealed class BumpTests : IDisposable
         Assert.Contains("\"platform\":\"server\"", json);                   // wire shape matches crash reports
         using (var doc = System.Text.Json.JsonDocument.Parse(json))
         {
+            // gameVersion is the reporter's client build (not the server's), so the inbox shows the
+            // player's version — the whole point of BumpReport.ClientVersion (issue #389).
+            Assert.Equal("0.8.3", doc.RootElement.GetProperty("gameVersion").GetString());
+
             var reportJson = doc.RootElement.GetProperty("reportJson");
             Assert.Equal("bump", reportJson.GetProperty("reportType").GetString());
             // No reportJson.kind — the ReportHost triages any kind as category "crash", and a bump
@@ -138,6 +142,9 @@ public sealed class BumpTests : IDisposable
 
         using var doc = System.Text.Json.JsonDocument.Parse(sink.LastJson!);
         Assert.Equal(System.Text.Json.JsonValueKind.Null, doc.RootElement.GetProperty("screenshot").ValueKind);
+        // A text-only /bump (ChatIntent) carries no client version, so gameVersion falls back to the
+        // server's version — never left empty.
+        Assert.False(string.IsNullOrEmpty(doc.RootElement.GetProperty("gameVersion").GetString()));
         Assert.Equal(1, server.BumpsWritten);
     }
 


### PR DESCRIPTION
## Problem
On `reports.blocksbeyondthestars.de` the issues view shows game version **1.0.0** for reports that arrive through the server (a `/bump`, its F1/F2 feedback forward, or a server crash report). A test report sent from a **0.8.3** build displayed as **1.0.0**.

Root cause: `GameServer.ServerVersionString` reads the assembly's `AssemblyInformationalVersion`, but the dedicated-server build never stamped a version and defaulted to `1.0.0`. The client-direct F1/F2 upload path was always correct (`FeedbackUi` uses `AppShell.Version`).

## Fix
**1. Stamp the server build with the release version** (also fixes server crash reports):
- `Dockerfile`: `ARG VERSION` → `-p:InformationalVersion` on the three server publishes (`.git` is excluded from the build context, so no `+sha` suffix).
- `docker.yml`: passes `build-args: VERSION=<tag>`.
- `scripts/publish-local-server.ps1` / `.sh`: gained a version arg for the bundled server, passed from `release.yml`.

**2. Carry the reporter's client version on a bump** so a player-filed bump shows the *player's* build, not the server's:
- `BumpReport` gained `ClientVersion` (MessagePack contractless → backward compatible, **no new codec id**). Filled by `ChatUi`/`FeedbackUi` with `AppShell.Version`.
- The server stamps it onto the forwarded report's `gameVersion`, falling back to the server version for older clients and the text-only `/bump`.

## Tests
`BumpTests` now assert both the client-version passthrough (`gameVersion == "0.8.3"`) and the server-version fallback (non-empty) for the text-only path. All 5 Bump tests pass; GameServer + Client.Core build clean (0 warnings).

## Notes
- Client change is a trivial same-namespace call (`AppShell.Version`, already used in `FeedbackUi`) — no Unity-side logic change.
- Takes effect for fleet worlds on the next Docker image build/deploy, and for native/SP on the next release.

Closes #389

🤖 Generated with [Claude Code](https://claude.com/claude-code)