### PR TITLE
feat(graphics): smooth day↔night transition with a real twilight/golden hour

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -100,6 +100,24 @@ Per-item detail lives in the dated work log below.
 
 ---
 
+### ★ Smooth day↔night transition — real twilight/golden-hour dusk & dawn (#391, 2026-07-18)
+Crossing the day/night terminator on a planet — and standing still while the local day advances — snapped
+almost instantly to a dark, starry sky: there was no visible dusk/dawn. The cycle only lerped the sky
+`nightSky→daySky` by the day fraction (no warm colour), the light stayed bright then dropped to the night
+floor at the last moment, and the stars faded on a **fixed** 1.4 s rate decoupled from the sky and the planet's
+day length — so they popped on. Fix (client-visual only, no server/network change):
+- **`Sky.cs`** now computes a smoothstepped **twilight** weight that peaks with the sun on the horizon and is a
+  function of sun *height*, so its real-time length scales with each planet's `DayLengthSeconds` automatically
+  (a long day → a long, lazy dusk; a short day → a quick one). It drives a warm **golden-hour horizon glow**
+  (star-hue biased, washed out by heavy weather) blended into the sky colour — which the distance fog inherits —
+  and a **warm amber cast** on the block light + sun disc + god-rays at low sun angles. Airless / `SpaceSky`
+  bodies keep a **hard** terminator (no atmosphere → no scattering), which also sets them apart.
+- **`Starfield.cs`** stars now rise as the sun sinks past the horizon (matched to Sky's twilight) instead of on a
+  still-bright sky, smoothstepped; the follow rate is scaled to the planet's day length (clamped) so short-day
+  worlds keep their stars in step and long-day worlds ease in — no more pop. Works both standing still and when
+  crossing the terminator on foot/speeder. Verified: Unity Windows player compiles clean (0 errors) against the
+  warm main-repo Library; visual sign-off pending a playtest.
+
 ### ★ Reports show version 1.0.0 → real build version (#389, 2026-07-18)
 The report inbox (`reports.blocksbeyondthestars.de`) showed game version **1.0.0** for reports that arrived
 through the server — a `/bump`, its F1/F2 feedback forward (`GameServerBump.ForwardBumpSnapshot`), or a server

--- a/client/Assets/BlocksBeyondTheStars/Scripts/Sky.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/Sky.cs
@@ -40,6 +40,11 @@ namespace BlocksBeyondTheStars.Client
         private static readonly int FogId = Shader.PropertyToID("_Sc_Fog");
         private float _indoor; // smoothed ship-interior fill (0 outside → 1 aboard)
 
+        /// <summary>Twilight band half-width in sun-height units: dusk/dawn is active while the sun is within this
+        /// of the horizon (|sin(sunAngle)| ≤ band). 0.34 ≈ the sun within ~20° of the horizon — a civil+nautical
+        /// dusk wide enough to read as a real sunset. Larger = a longer, softer golden hour.</summary>
+        private const float TwilightBand = 0.34f;
+
         private Light _sun;
         private Transform _sunDisc;     // visible glowing sun billboard in the sky
         private Material _sunDiscMat;
@@ -231,8 +236,26 @@ namespace BlocksBeyondTheStars.Client
             float brightness = constantLight ? 1f : Mathf.Lerp(0.35f, 1f, dayLit); // night floor → noon
             float weatherDim = constantLight ? 1f : Mathf.Lerp(1f, 0.65f, weatherIntensity); // storms darken
 
+            // Twilight (golden hour): peaks with the sun sitting on the horizon (sunHeight → 0) and fades out by
+            // full day / deep night. Off in airless (space) skies — no atmosphere means no scattering, so there the
+            // terminator IS a hard line (which also sets airless worlds apart). Because it's a function of the sun
+            // HEIGHT, its real-time length scales with each planet's day length on its own: a long day gets a long,
+            // lazy dusk, a short day a quick one — no per-planet tuning needed. Smoothstepped into a soft ramp so
+            // there's no hard edge where the band begins.
+            float twilight = spaceSky ? 0f : Mathf.Clamp01(1f - Mathf.Abs(sunHeight) / TwilightBand);
+            twilight = twilight * twilight * (3f - 2f * twilight);
+
+            // Star hue (the sun colour normalised to a pure hue, brightness removed) — reused for the daytime sky
+            // tint and the dusk glow so a red star burns a redder sunset and a blue-white star a cooler one.
+            float sunMax = Mathf.Max(sunColor.r, Mathf.Max(sunColor.g, sunColor.b));
+            Color sunHue = sunMax > 0.001f ? new Color(sunColor.r / sunMax, sunColor.g / sunMax, sunColor.b / sunMax) : Color.white;
+
+            // The star warms toward amber as it nears the horizon — the whole world (block light, sun disc, god-rays)
+            // takes on the golden-hour cast, then cools back to its true colour high in the sky. Kept off on stations.
+            Color warmSun = constantLight ? sunColor : Color.Lerp(sunColor, sunColor * new Color(1f, 0.72f, 0.5f), twilight * 0.7f);
+
             // Stations use a clean neutral interior light (not the system sun's tint).
-            Color tint = constantLight ? new Color(0.95f, 0.96f, 1f) : sunColor * (brightness * weatherDim);
+            Color tint = constantLight ? new Color(0.95f, 0.96f, 1f) : warmSun * (brightness * weatherDim);
             tint.a = 1f; // marks the global as "set" for the shaders
             Shader.SetGlobalColor(LightId, ShaderColor.Srgb(tint));
 
@@ -262,17 +285,22 @@ namespace BlocksBeyondTheStars.Client
                 Color daySky = Color.Lerp(skyBase, new Color(0.6f, 0.62f, 0.68f), weatherIntensity);
 
                 // Tint the daytime sky a touch toward the system star's hue, so a warm / red star gives a warmer
-                // sky and a blue-white star a cooler one (B37). Normalise the sun colour to a pure hue first so
-                // only its tint shifts the sky, not its brightness. Kept light (0.2) so the per-world atmosphere
+                // sky and a blue-white star a cooler one (B37). Kept light (0.2) so the per-world atmosphere
                 // colour above reads through. The directional sun light + block diffuse already use the star colour.
-                float sm = Mathf.Max(sunColor.r, Mathf.Max(sunColor.g, sunColor.b));
-                Color sunHue = sm > 0.001f ? new Color(sunColor.r / sm, sunColor.g / sm, sunColor.b / sm) : Color.white;
                 daySky = Color.Lerp(daySky, daySky * sunHue, 0.2f);
 
                 // Night sky: a dark base nudged toward the world's atmosphere hue, so a green/red-skied world also
                 // tints its night instead of always reading the same blue-black.
                 Color nightSky = Color.Lerp(new Color(0.03f, 0.04f, 0.09f), skyBase * 0.12f, 0.5f);
                 sky = Color.Lerp(nightSky, daySky, day);
+
+                // Golden-hour horizon glow: a warm sunset amber (star-hue biased), washed out by heavy weather.
+                // Blended over the day/night lerp so dusk and dawn read as a real colour change that lifts the sky
+                // through the fast darkening at the terminator — turning the old snap-to-black into a sunset. The
+                // fog below inherits this `sky`, so the far horizon warms with it too.
+                Color glow = new Color(1f, 0.45f, 0.22f);
+                glow = Color.Lerp(glow, glow * sunHue, 0.5f);
+                sky = Color.Lerp(sky, glow, twilight * 0.6f * (1f - weatherIntensity));
             }
             sky.a = 1f;
             // The shader global gets the linear value; the engine-managed consumers below (ambient, camera
@@ -296,14 +324,14 @@ namespace BlocksBeyondTheStars.Client
 
             if (_sun != null)
             {
-                _sun.color = sunColor;
+                _sun.color = warmSun;
                 _sun.intensity = brightness;
                 _sun.transform.rotation = Quaternion.Euler(time * 360f - 90f, 160f, 0f);
                 // The lit block shader reads the sun direction from this global (direction TO the sun).
                 Shader.SetGlobalVector(SunDirId, -_sun.transform.forward);
             }
 
-            UpdateSunDisc(sunHeight, sunColor, spaceSky);
+            UpdateSunDisc(sunHeight, warmSun, spaceSky);
             SetGrade(Game?.Environment?.Biome, sunColor);
         }
 

--- a/client/Assets/BlocksBeyondTheStars/Scripts/Starfield.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/Starfield.cs
@@ -84,7 +84,15 @@ namespace BlocksBeyondTheStars.Client
             bool hardSky = Game.SpaceViewActive || !string.IsNullOrEmpty(Game.StationName)
                            || (Game.Environment != null && Game.Environment.SpaceSky) || Game.OnFootInSpace;
             float target = TargetBrightness();
-            _brightness = hardSky ? target : Mathf.MoveTowards(_brightness, target, Time.deltaTime * 0.7f);
+
+            // Follow rate for the planet dusk/dawn fade. On a planet the target already ramps gradually across
+            // twilight (it tracks the sun height, so its speed scales with the world's day length), and this rate
+            // only needs to smooth jitter and ease a sudden jump — crossing the terminator on a speeder, or a
+            // teleport. Scale it to the day length so a short-day world's quicker dusk still keeps its stars in
+            // step, while a long-day world eases in gently; clamped so it never snaps and never crawls.
+            float dayLen = Game.Environment != null ? Mathf.Max(30f, Game.Environment.DayLengthSeconds) : 600f;
+            float rate = Mathf.Clamp(240f / dayLen, 0.25f, 1.0f);
+            _brightness = hardSky ? target : Mathf.MoveTowards(_brightness, target, Time.deltaTime * rate);
             _mat.SetFloat("_Brightness", _brightness * MaxBrightness);
         }
 
@@ -100,10 +108,13 @@ namespace BlocksBeyondTheStars.Client
                 return 1f;
             }
 
-            // Match Sky's day curve so stars track the same dusk/dawn the lighting uses.
+            // Stars come up as the sun sinks past the horizon and fill in through nautical dusk — matched to Sky's
+            // twilight so they rise as the warm horizon glow fades rather than popping on above a still-bright sky.
+            // They begin to show just before the sun reaches the horizon (0.12) and reach full once it is ~24° down
+            // (-0.4), smoothstepped for a soft wash. Symmetric at dawn: they sink back as the sun climbs out.
             float sunHeight = Mathf.Sin((Game.LocalTimeOfDay - 0.25f) * Mathf.PI * 2f);
-            float day = Mathf.Clamp01(sunHeight * 0.5f + 0.5f);
-            return Mathf.Clamp01(1f - day * 1.4f); // gone by mid-morning, full after dusk
+            float t = Mathf.Clamp01((0.12f - sunHeight) / 0.52f);
+            return t * t * (3f - 2f * t); // full deep-night, gone by well after sunrise
         }
 
         /// <summary>A soft round dot (bright core → transparent rim) used for every star sprite.</summary>


### PR DESCRIPTION
## What & why
Crossing the day/night terminator on a planet — and standing still while the local day advances — snapped almost instantly from daylight to a dark, starry sky, with no visible dusk/dawn (user report). Causes: the sky only lerped `nightSky → daySky` by the day fraction (no warm colour), the light stayed bright then dropped to the night floor at the last moment, and the stars faded on a **fixed** 1.4 s rate decoupled from the sky and the planet's day length — so they popped on.

Closes #391.

## Changes (client-visual only — no server/networking change)
**`Sky.cs`**
- Computes a smoothstepped **twilight** weight that peaks with the sun on the horizon. Because it's a function of sun *height*, its real-time length scales with each planet's `DayLengthSeconds` on its own — a long day gets a long, lazy dusk, a short day a quick one, no per-planet tuning.
- Drives a warm **golden-hour horizon glow** (star-hue biased so a red star burns a redder sunset; washed out by heavy weather) blended into the sky colour — which the distance fog inherits, so the horizon warms too.
- Adds a warm **amber cast** on the block light, sun disc and god-rays at low sun angles.
- Airless / `SpaceSky` bodies keep a **hard** terminator (no atmosphere → no scattering), which also differentiates those worlds.

**`Starfield.cs`**
- Stars now rise as the sun sinks *past* the horizon (matched to Sky's twilight) instead of on a still-bright sky, smoothstepped.
- The follow rate is scaled to the planet's day length (clamped) so short-day worlds keep their stars in step and long-day worlds ease in — no more pop.

## Behaviour
- Works both **standing still** through dusk/dawn and when **crossing the terminator** on foot or speeder.
- Different planets read differently: day length sets the dusk duration; atmosphere sets whether there's a twilight at all (airless = sharp).
- No change to the space view, orbital stations, or the menu attract scene (twilight is gated off for space/airless skies).

## Verification
- Unity Windows player **compiles clean (0 errors)** against the warm main-repo Library (`BlocksBeyondTheStars.Client.dll` built, `script compilation time: 6.2 s`, no `error CS`).
- No shared/server code touched, so the .NET headless suites are unaffected (CI runs them).
- ⚠️ **Visual sign-off pending a playtest** — the look (glow colour `#FF7338` @ 0.6, `TwilightBand` 0.34, warm-sun 0.72/0.5) is tuned by eye and easy to nudge.
