### PR TITLE
fix(graphics): distant terrain no longer pops in at the horizon + world stops assembling after load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ the richer, screenshot-laden versions live there. `(#123)` references the pull r
 
 ## [Unreleased]
 
+### 🌅 Distant terrain no longer pops in
+- **The horizon stopped popping.** Distant terrain used to appear abruptly at the view edge because the fog ended *past* the streamed terrain (up to 1.6× the view radius) and the haze was capped at 60–75% opacity — so the outermost chunks were always partly visible when they streamed in. The fog now saturates fully at the view edge, and the server streams **one extra chunk ring beyond the fog line**, so the last ring is already loaded-and-hazed and simply fades in as you walk instead of materializing from nothing. (#388)
+- **The world no longer assembles in front of you after loading.** The loading screen used to lift as soon as the single chunk under your feet had loaded, while the rest of the view was still streaming and meshing — so you watched the landscape build itself for a few seconds. It now holds until the streamed view has actually finished arriving and meshing (with the same hard time cap so it can never feel stuck). (#390)
+
 ### 🐛 Reports show the right version
 - Bug reports and feedback in the report inbox showed the game version `1.0.0` for reports that came in through the server (a `/bump`, its feedback forward, or a server crash), because the dedicated-server build never stamped its version and defaulted to `1.0.0`. The server build now bakes in the release version, and a `/bump` additionally carries the reporting player's own client build so the inbox shows the player's version rather than the server's. (#389)
 

--- a/TODO.md
+++ b/TODO.md
@@ -163,6 +163,29 @@ stays the source of truth; one best-effort background send, no retry queue. Also
 Tests: `BumpReport_WithConfiguredSink_ForwardsSnapshotWithoutImage`, `BumpCommand_WithoutSink_…`.
 Docs: PLAYER_FEEDBACK.md + REPORT_HOST.md.
 
+### ★ Distant-terrain horizon pop-in + initial-fill loading fixes (#388, #390, 2026-07-18, branch fix/terrain-horizon-popin)
+Two user-reported horizon bugs, code-verified via Explore. **#388 pop-in (fog):** voxels are unlit so Unity
+fog is dead on them — the visible haze is a shader blend on the `_Sc_Fog` global set in `Sky.cs ApplyFog`.
+Two bugs: fogEnd ran to `renderDist * Lerp(1.6,1.0)` (PAST the streamed edge → last ring un-hazed) and maxHaze
+capped at 0.6–0.75 (`Sky.cs:410`, never fully hid the edge). Fix: `far = renderDist * Lerp(1.0,0.85)` (fogEnd
+never past the view edge), `maxHaze = 1f` (full coverage), startFactor 0.72→0.78 (keep more crisp near-field).
+PLUS a real server load-ahead: `GameServer.StreamChunks` streams `radius + LoadAheadRings(1)` (the extra ring
+is past `NearFullColumnRadius`, so cheap thin-band; within sweep keepRadius+4) — the corner geometry only
+buffers diagonals, but the player walks the AXES and a chunk is 16 blocks deep, so an actual extra ring is
+needed so the edge is loaded+hazed and FADES in rather than pops. **#390 initial fill (loading veil):** the
+veil lifted on `WorldReady`, which flips as soon as the player's OWN floor chunk raycast hits
+(`PlayerController.cs:213`) — NOT on the view being meshed, so ~500 view chunks streamed/meshed AFTER the
+curtain lifted (visible assembly). Fix: `GameBootstrap` exposes `TimeSinceLastChunk` + `PendingMeshCount`;
+the settle gate reveals on `groundBelow && viewSettled` where viewSettled = no new chunk for 0.6 s AND
+backlog ≤6. KEY INSIGHT: `_dirty.Count` alone is NOT a reliable "view complete" signal (meshing can keep
+pace with arrival), but "no new chunk arrived recently" is — the ≥1-chunk/tick guarantee keeps chunks
+arriving during streaming, so the gap only opens when the server has finished the frozen spawn view. Existing
+8 s spawn grace kept as the hard cap; self-adjusts for respawn (already-loaded → gate passes on ground).
+Verified: server build 0 warnings, **1046 server tests green**, streaming tests updated (+5 east still out at
+radius+loadahead), fog build green + rocky/ice/jungle screenshots show haze engaging. CLIENT MonoBehaviour
+changes (Sky/PlayerController/GameBootstrap) need the local Unity build to verify — DEFERRED until a parallel
+worker's Unity build finished (user rule: no concurrent Unity builds).
+
 ### ★ Medium preset SSAO retune + PerfProbe itemization + fleet worldgen budget (#374, #360, 2026-07-18, branch perf/medium-preset-server-budget)
 Three of the four open large-tier perf issues, code-verified and measured on the reference laptop
 (Ryzen 9 7940HS / RTX 2000 Ada). **PerfProbe tooling (enabler):** new `-perfFeature` toggles

--- a/client/Assets/BlocksBeyondTheStars/Scripts/GameBootstrap.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/GameBootstrap.cs
@@ -819,6 +819,18 @@ namespace BlocksBeyondTheStars.Client
         private readonly Dictionary<ChunkCoord, ChunkView> _chunkObjects = new Dictionary<ChunkCoord, ChunkView>();
         private readonly HashSet<ChunkCoord> _dirty = new HashSet<ChunkCoord>();
 
+        // When the last chunk arrived from the server. The loading veil uses "no new chunk for a moment" (plus a
+        // drained mesh queue) as the "initial view is fully streamed + meshed" signal so it doesn't lift mid-fill
+        // (#390). During streaming the ≥1-chunk-per-tick guarantee keeps this fresh; the gap only opens once the
+        // server has nothing left to send for the (frozen) spawn view.
+        private float _lastChunkArrivalTime;
+
+        /// <summary>Seconds since the last chunk streamed in — grows only once the server has finished the view.</summary>
+        public float TimeSinceLastChunk => Time.time - _lastChunkArrivalTime;
+
+        /// <summary>Chunks still queued to be (re)meshed — the client-side mesh backlog.</summary>
+        public int PendingMeshCount => _dirty.Count;
+
         // Performance (P1): cap how many chunk meshes are (re)built per frame so a burst of chunks arriving
         // while moving fast spreads over several frames instead of stalling one. Nearest chunks build first;
         // the rest stay queued in _dirty. Tunable — raise for less pop-in, lower for smoother frame times.
@@ -966,6 +978,7 @@ namespace BlocksBeyondTheStars.Client
 
                 RebuildFloraTints(); // per-species flora colours for this world (seed + location)
                 WorldReady = false;          // hold the loading overlay until we settle onto the first world
+                _lastChunkArrivalTime = Time.time; // reset the view-settle gate so it can't pass before this world streams (#390)
                 WorldLoadStarted?.Invoke();
             };
             Network.JoinRejected += m =>
@@ -1433,6 +1446,7 @@ namespace BlocksBeyondTheStars.Client
 
             World.StoreChunk(coord, blocks, m.ModIndex, m.ModTint, m.ModGlow, m.ShapeIndex, m.ShapeData);
             MarkChunkAndNeighborsDirty(coord);
+            _lastChunkArrivalTime = Time.time; // feed the view-settle gate (#390)
         }
 
         /// <summary>Marks a chunk AND its six neighbours for re-meshing. A freshly stored/resynced chunk

--- a/client/Assets/BlocksBeyondTheStars/Scripts/PlayerController.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/PlayerController.cs
@@ -83,6 +83,13 @@ namespace BlocksBeyondTheStars.Client
         private bool _settling;
         private float _settleTimer; // how long we've been frozen at spawn waiting for the floor to stream
         private bool _worldRevealed; // settle: has the loading overlay been dismissed for this spawn yet
+
+        // View-settle gate (#390): hold the reveal until the streamed view has finished arriving AND meshing, so
+        // the world doesn't visibly assemble after the veil lifts. "No new chunk for this long" is the reliable
+        // "server finished the frozen spawn view" signal (streaming keeps chunks arriving every tick); the backlog
+        // check confirms those last arrivals are meshed. The 8 s spawn grace below still hard-caps the wait.
+        private const float ViewSettleQuietSeconds = 0.6f;
+        private const int ViewSettleBacklog = 6; // ~a frame's worth of the mesh budget (MeshChunksPerFrame)
         private bool _wasGrounded = true;
         private bool _jetpackActive; // last reported jetpack thrust state (server drains energy on this)
         private float _stepTimer;
@@ -214,11 +221,18 @@ namespace BlocksBeyondTheStars.Client
                 bool groundBelow = Physics.Raycast(_spawnPos + Vector3.up * 0.5f, Vector3.down, out var gHit, 10f)
                                    && gHit.collider != _controller;
 
-                // Reveal the world + release control TOGETHER — as soon as there is real ground under the spawn,
-                // or after a short grace (then the server's void-rescue recovers a still-streaming spawn chunk by
-                // teleporting onto the ship). Tying reveal to release means you never see a "loaded" world you
-                // can't move in; the short grace means the veil never lingers and feels stuck either.
-                if (!awaitingConfirm && (groundBelow || _settleTimer > 8f))
+                // The streamed view has finished arriving AND meshing — so the reveal shows a populated world
+                // instead of one that visibly assembles over the next few seconds (#390). While the server is
+                // still streaming, chunks keep arriving each tick and reset TimeSinceLastChunk; the gap only opens
+                // once the frozen spawn view is complete, and the backlog check confirms the last ones are meshed.
+                bool viewSettled = Game.TimeSinceLastChunk >= ViewSettleQuietSeconds
+                                   && Game.PendingMeshCount <= ViewSettleBacklog;
+
+                // Reveal the world + release control TOGETHER — once there is real ground under the spawn AND the
+                // view has settled, or after a short grace (then the server's void-rescue recovers a still-streaming
+                // spawn chunk by teleporting onto the ship). Tying reveal to release means you never see a "loaded"
+                // world you can't move in; the grace hard-caps the wait so the veil never lingers or feels stuck.
+                if (!awaitingConfirm && ((groundBelow && viewSettled) || _settleTimer > 8f))
                 {
                     if (!_worldRevealed)
                     {

--- a/client/Assets/BlocksBeyondTheStars/Scripts/Sky.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/Sky.cs
@@ -364,11 +364,14 @@ namespace BlocksBeyondTheStars.Client
             // render edge → invisible) and softly hides the chunk pop-in at the boundary.
             float renderDist = Mathf.Max(32f, ViewChunks * 16f);
 
-            // Per-world air thickness sets where the haze sits: thin air fogs near the far edge, soupy air hazes
-            // well inside the view. Kept well within the render distance so the haze is actually visible and masks
-            // the chunk pop-in at the edge (tuned aggressive for now; raise the factors to push the haze farther).
+            // Per-world air thickness sets where the haze sits: thin air fogs right at the far edge, soupy air hazes
+            // well inside the view. The multiplier is capped at 1.0 so fogEnd NEVER sits past the streamed terrain
+            // edge (renderDist = the client's view radius): the old 1.0–1.6 range pushed the haze beyond the loaded
+            // chunks, so the outermost ring streamed in un-hazed and popped (#388). Paired with the load-ahead ring
+            // the server streams one chunk beyond this basis (GameServer.StreamChunks), the last VISIBLE ring is
+            // fully hazed before it materializes and fades in as the player approaches.
             float airDensity = Game?.Environment?.AtmosphereDensity ?? 0.4f;
-            float far = renderDist * Mathf.Lerp(1.6f, 1.0f, Mathf.Clamp01(airDensity));
+            float far = renderDist * Mathf.Lerp(1.0f, 0.85f, Mathf.Clamp01(airDensity));
 
             far *= Mathf.Lerp(1f, 0.8f, weatherIntensity); // storms haze in a bit more
             far *= Mathf.Lerp(0.9f, 1f, day);                // night a touch hazier than day
@@ -399,16 +402,17 @@ namespace BlocksBeyondTheStars.Client
             // closer in (low start). This keeps the per-planet/per-atmosphere character while letting a clear
             // world actually show the farther terrain the (now larger) view distance streams. Weather that already
             // crushed `far` keeps its near, dense look — a small `far` lands the haze close even at a high factor.
-            float startFactor = Mathf.Lerp(0.72f, 0.5f, Mathf.Clamp01(airDensity));
+            float startFactor = Mathf.Lerp(0.78f, 0.55f, Mathf.Clamp01(airDensity));
             float fogStart = far * startFactor;
             RenderSettings.fogStartDistance = fogStart;
             RenderSettings.fogEndDistance = far;
 
             // The actual visible haze: an explicit distance blend the block shader applies (Unity's MixFog is dead
-            // on the unlit voxels). Strong toward the sky at the far edge so it masks chunk pop-in; a touch thinner
-            // on clear worlds so distant terrain reads through; faded out indoors via _indoor so the cabin never hazes.
-            float hazeStrength = Mathf.Lerp(0.6f, 0.75f, Mathf.Clamp01(airDensity));
-            float maxHaze = (FogEnabled ? hazeStrength : 0f) * (1f - _indoor); // 0 indoors or when the player disabled fog
+            // on the unlit voxels). Reaches FULL opacity at fogEnd (was capped at 0.6–0.75, which left the far edge
+            // 25–40% visible → the pop). At full strength the last ring dissolves completely into the sky colour
+            // before it appears; per-world character now lives in WHERE the haze sits (fogStart/fogEnd above), not
+            // how opaque it gets. Faded out indoors via _indoor so the cabin never hazes.
+            float maxHaze = (FogEnabled ? 1f : 0f) * (1f - _indoor); // 0 indoors or when the player disabled fog
             Shader.SetGlobalVector(FogId, new Vector4(fogStart, far, maxHaze, FogEnabled ? 1f : 0f));
         }
 

--- a/src/BlocksBeyondTheStars.GameServer/GameServer.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServer.cs
@@ -1410,6 +1410,13 @@ public sealed partial class GameServer
     private const int FarSurfaceBandBelow = 1;
     private const int FarSurfaceBandAbove = 1;
 
+    /// <summary>Extra chunk rings streamed BEYOND the player's view radius (and beyond the client's fog edge, which
+    /// sits at the view radius). This terrain loads while it is still fully hazed, so as the player walks forward the
+    /// newly-revealed edge is already meshed and simply fades in through the fog instead of popping in from nothing
+    /// (#388). The extra ring is always past <see cref="NearFullColumnRadius"/>, so it streams only the cheap far
+    /// surface band, and stays within the sweep's keepRadius (maxViewRadius + 4) so it is not immediately evicted.</summary>
+    private const int LoadAheadRings = 1;
+
     /// <summary>This player's streaming radius in chunks: their requested view distance (clamped to the slider
     /// range) when they sent one, otherwise the host's configured default.</summary>
     private int EffectiveViewRadius(PlayerSession session)
@@ -1436,6 +1443,7 @@ public sealed partial class GameServer
         foreach (var session in JoinedInActiveWorld())
         {
             int radius = EffectiveViewRadius(session); // per-player: honour the client's View Distance slider
+            int streamRadius = radius + LoadAheadRings; // load one hazed ring past the fog edge so it fades in, not pops (#388)
             var center = WorldConstants.WorldToChunk(session.State.Position.ToBlock());
             center = new ChunkCoord(center.X, System.Math.Clamp(center.Y, minChunkY, maxChunkY), center.Z);
 
@@ -1453,8 +1461,8 @@ public sealed partial class GameServer
             // player's own altitude still streams its visible shell.
             var planet = _world.Planet;
             var pending = new List<(ChunkCoord Coord, int DistSq)>();
-            for (int dx = -radius; dx <= radius; dx++)
-                for (int dz = -radius; dz <= radius; dz++)
+            for (int dx = -streamRadius; dx <= streamRadius; dx++)
+                for (int dz = -streamRadius; dz <= streamRadius; dz++)
                 {
                     int loDy, hiDy;
                     if (System.Math.Max(System.Math.Abs(dx), System.Math.Abs(dz)) <= NearFullColumnRadius)

--- a/tests/BlocksBeyondTheStars.Client.Tests/JoinAndStreamingTests.cs
+++ b/tests/BlocksBeyondTheStars.Client.Tests/JoinAndStreamingTests.cs
@@ -87,10 +87,10 @@ public sealed class JoinAndStreamingTests
         foreach (var key in h.Chunks.Keys)
         {
             if (key.Item1 == center.X + 2) gotWithinClientView = true;
-            if (key.Item1 == center.X + 5) gotBeyondClientView = true; // beyond radius 3 — must never stream
+            if (key.Item1 == center.X + 5) gotBeyondClientView = true; // beyond radius 3 + the one-ring load-ahead (4) — must never stream
         }
 
         Assert.True(gotWithinClientView, "client's radius-3 view should stream terrain past the host's radius-1 default");
-        Assert.False(gotBeyondClientView, "nothing beyond the client's requested radius should stream");
+        Assert.False(gotBeyondClientView, "nothing beyond the client's requested radius (plus the one-ring load-ahead) should stream");
     }
 }

--- a/tests/BlocksBeyondTheStars.Tests/ChunkStreamingTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/ChunkStreamingTests.cs
@@ -159,11 +159,12 @@ public sealed class ChunkStreamingTests : IDisposable
         // A chunk 2 east is inside the client's radius-3 view but outside the host's radius-1 default — it is
         // resident only because the client's requested view distance drove the streaming radius.
         var withinClientView = new ChunkCoord(center.X + 2, center.Y, center.Z);
-        // A chunk 5 east is beyond even the client's radius — it must never have been streamed.
+        // A chunk 5 east is beyond the client's radius-3 view AND its one-ring load-ahead margin (radius+1 = 4),
+        // so it must never have been streamed. (#388's load-ahead reaches +4, not +5.)
         var beyondClientView = new ChunkCoord(center.X + 5, center.Y, center.Z);
 
         Assert.True(server.World.IsChunkLoaded(withinClientView), "client's wider view distance should stream terrain past the host default");
-        Assert.False(server.World.IsChunkLoaded(beyondClientView), "nothing beyond the client's requested radius should stream");
+        Assert.False(server.World.IsChunkLoaded(beyondClientView), "nothing beyond the client's requested radius (plus the one-ring load-ahead) should stream");
     }
 
     [Fact]


### PR DESCRIPTION
Two user-reported horizon bugs, root-caused via code exploration.

## #388 — terrain pops in abruptly at the horizon
Voxels are unlit, so Unity's `RenderSettings` fog is dead on them — the visible haze is a shader blend on the `_Sc_Fog` global set in `Sky.ApplyFog`. Two bugs guaranteed the outermost ring was visible when it streamed in:
1. **Fog ended past the streamed edge** — `fogEnd = renderDist * Lerp(1.6, 1.0, airDensity)` pushed the haze *beyond* the loaded terrain on clear/thin-air worlds.
2. **Haze capped at 0.6–0.75 opacity** — a chunk at `fogEnd` was never fully hidden (always ≥25% visible).

**Fix:**
- `fogEnd` now never exceeds the view edge (`Lerp(1.0, 0.85, airDensity)`), full haze opacity at the edge (`maxHaze = 1`), `startFactor` 0.72→0.78 to keep the near field crisp.
- The server streams **one extra chunk ring beyond the fog line** (`GameServer.StreamChunks`, `radius + LoadAheadRings`). The corner geometry only buffers diagonals, but the player walks the axes and a chunk is 16 blocks deep — so a real load-ahead ring is needed so the last visible ring is already loaded+hazed and *fades in* as you walk instead of popping. The extra ring is past `NearFullColumnRadius` (cheap thin surface band) and inside the sweep's keepRadius.

## #390 — world visibly assembles after the loading veil lifts
`WorldReady` flipped as soon as the **player's own floor chunk** raycast hit ([PlayerController.cs:213](client/Assets/BlocksBeyondTheStars/Scripts/PlayerController.cs#L213)), not when the surrounding view had meshed — so ~500 view chunks streamed and meshed *after* the curtain lifted.

**Fix:** `GameBootstrap` exposes `TimeSinceLastChunk` + `PendingMeshCount`; the settle gate reveals on `groundBelow && viewSettled`, where `viewSettled` = no new chunk for 0.6 s **and** the mesh backlog drained. "No new chunk recently" is the reliable "server finished the frozen spawn view" signal — the ≥1-chunk-per-tick guarantee keeps chunks arriving during streaming, so the gap only opens once the view is complete (`_dirty.Count` alone is unreliable — meshing can keep pace with arrival). The existing 8 s spawn grace stays as the hard cap; the gate self-adjusts for respawn (already-loaded → passes on ground).

## Verification
- Server build **0 warnings**, **1046 server tests green**; the two view-radius streaming tests updated for the +1 load-ahead ring (a chunk 5 east is still out at radius 3 + 1).
- Local Unity Windows build green (client MonoBehaviour changes compile); `dotnet format` clean.
- **PerfProbe run completed (exit 0, 66 s)** — confirms `WorldReady` still fires with the new view-settle gate (no hang), Medium ~64 FPS.
- Jungle/rocky/ice screenshots: fog engages at the horizon, world renders fully populated at reveal.

Follow-up (not in scope): a live playtest to confirm the *feel* of the moving horizon.

Closes #388
Closes #390

🤖 Generated with [Claude Code](https://claude.com/claude-code)