### PR TITLE
fix(graphics): flora no longer renders a see-through "transparent floor" (#382)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -100,6 +100,26 @@ Per-item detail lives in the dated work log below.
 
 ---
 
+### ★ Flora no longer renders a see-through "transparent floor" (#382, 2026-07-18)
+On planets the ground **under** cross-plant flora and at the **base** of solid flora (puffball/cactus/crystal
+domes) showed a see-through hole to the bright sky/fog — a "weißer/transparenter Boden". Mip-independent
+(confirmed still present with the atlas mipmaps disabled). This is the **second, separate cause** behind
+#382's "white plant floor" symptom — the #384 edge-bevel-UV fix resolved the chamfer/corner white but not
+this, so the plant floor persisted and #382 was reopened. Root cause was a git-confirmed **regression**: the
+mesher's
+face-cull (`ChunkMesher.BuildGeometry` `drawFace`) sealed an opaque block's face against **any**
+non-air/non-transparent neighbour, and `IsTransparent` lists only glass/force_field/water/fire/energy_fence/
+energy_gate — **not flora/foliage**. So the ground-top face under every flora cell was culled, while flora
+renders only a thin billboard / rounded shaped block → a hole. `AoOccluder` already excluded flora/foliage;
+the face-cull had diverged when batch `27afca87` dropped the `IsFoliageBlock` term that `46a8a7f8` (B6) added
+(and it never covered **solid** flora at all). Fix (client-render only, no collider/data/wire change): the
+opaque branch now treats **both** `IsFloraBlock` (all `flora_*`, incl. solid flora) and `IsFoliageBlock`
+neighbours as non-occluding — mirroring `AoOccluder` exactly — so ground/walls under and beside plants keep
+their faces; a dedicated `foliage` branch preserves the tree-crown thin-shell look untouched. Biome-agnostic
+(any opaque ground). Verified via a local Unity build across biomes; EditMode regression test asserts the
+ground top under a cross-plant flora AND a solid-flora neighbour is emitted while a genuine opaque neighbour
+still culls.
+
 ### ★ Smooth day↔night transition — real twilight/golden-hour dusk & dawn (#391, 2026-07-18)
 Crossing the day/night terminator on a planet — and standing still while the local day advances — snapped
 almost instantly to a dark, starry sky: there was no visible dusk/dawn. The cycle only lerped the sky

--- a/client/Assets/BlocksBeyondTheStars/Scripts/ChunkMesher.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/ChunkMesher.cs
@@ -511,7 +511,19 @@ namespace BlocksBeyondTheStars.Client
                     // Foliage is meshed as a thin shell (culled against its own kind), so the cutout holes in
                     // the near leaf faces show the sky/world BEHIND the tree — a clearly see-through crown,
                     // not a dense volume whose holes just reveal more leaves.
-                    bool drawFace = transparent ? nb.IsAir : (nb.IsAir || IsTransparent(content, nb));
+                    //
+                    // A FLORA/FOLIAGE neighbour never seals an opaque block's face: cross-plants are thin
+                    // billboards, tree crowns are cutout shells, and SOLID flora (cactus/puffball/crystal) is a
+                    // rounded shaped block that doesn't fill the cell's corners — none of them cover the ground/
+                    // wall behind. Dropping this (batch 27afca87) culled the ground top UNDER every plant →
+                    // see-through white holes ("the transparent plant floor"; solid-flora domes left white
+                    // corner slivers). Mirror AoOccluder's non-occluder set exactly (flora + foliage). Foliage's
+                    // OWN faces stay a thin shell — the `foliage` branch draws toward air/glass only, so it still
+                    // culls against opaque AND its own kind. (Solid flora meshes its own shape and never reaches
+                    // this loop, so it needs no branch here — only its opaque NEIGHBOURS must keep their faces.)
+                    bool drawFace = transparent ? nb.IsAir
+                        : foliage ? (nb.IsAir || IsTransparent(content, nb))
+                        : (nb.IsAir || IsTransparent(content, nb) || IsFloraBlock(content, nb) || IsFoliageBlock(content, nb));
 
                     // A non-cube SHAPED neighbour doesn't fill its cell, so it can't seal this face — draw toward
                     // it (otherwise a cube beside a sphere/ramp would leave a hole). Only checked when the face

--- a/client/Assets/Tests/EditMode/ChunkMesherFloraFloorEditModeTests.cs
+++ b/client/Assets/Tests/EditMode/ChunkMesherFloraFloorEditModeTests.cs
@@ -1,0 +1,119 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using System.IO;
+using BlocksBeyondTheStars.Client;
+using BlocksBeyondTheStars.Shared.Content;
+using BlocksBeyondTheStars.Shared.Primitives;
+using BlocksBeyondTheStars.Shared.World;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace BlocksBeyondTheStars.Client.Tests.EditMode
+{
+    /// <summary>
+    /// Regression test for the "transparent plant floor" bug: a flora/foliage neighbour must NOT cull the
+    /// adjacent opaque block's face. Flora renders only as a thin billboard (cross-plants), a cutout shell
+    /// (tree crowns) or a rounded shaped block (solid flora) — none of them fill the cell, so they can't seal
+    /// the ground/wall behind them. Batch 27afca87 dropped the flora term from the mesher's face-cull, which
+    /// culled the ground top UNDER every plant → a see-through hole showing the sky ("weißer/transparenter
+    /// Boden"; solid-flora domes left white corner slivers). See ChunkMesher.BuildGeometry `drawFace`.
+    ///
+    /// Runs headless with a null atlas (no textures, EditMode-safe): the flora branches that need an atlas are
+    /// skipped, but the face-cull — which keys off the NEIGHBOUR's block key via IsFloraBlock/IsFoliageBlock —
+    /// is exactly what we assert here.
+    /// </summary>
+    public sealed class ChunkMesherFloraFloorEditModeTests
+    {
+        private static GameContent LoadContentOrIgnore()
+        {
+            string dataDir = Path.Combine(Application.streamingAssetsPath, "data");
+            if (!File.Exists(Path.Combine(dataDir, "blocks.json")))
+            {
+                Assert.Ignore("StreamingAssets/data not present — run scripts/sync-client-libs.ps1 first.");
+            }
+
+            return ContentLoader.LoadFromDirectory(dataDir);
+        }
+
+        private static ushort IdOf(GameContent content, string key)
+        {
+            var def = content.GetBlock(key);
+            Assert.IsNotNull(def, $"Block '{key}' missing from content.");
+            return def.NumericId.Value;
+        }
+
+        /// <summary>Meshes a one-chunk world holding a single opaque <paramref name="groundId"/> cell with the
+        /// given <paramref name="aboveId"/> block directly on top, and returns whether the ground cell's TOP
+        /// face was emitted (a horizontal opaque triangle at the ground's top plane). A flora neighbour must
+        /// leave it visible; a genuine opaque neighbour must still cull it.</summary>
+        private static bool GroundTopEmitted(GameContent content, ushort groundId, ushort aboveId)
+        {
+            const int gx = 8, gy = 8, gz = 8; // chunk interior, so all neighbours are in-chunk
+            var chunk = new ChunkData(new ChunkCoord(0, 0, 0));
+            chunk.Set(gx, gy, gz, new BlockId(groundId));
+            chunk.Set(gx, gy + 1, gz, new BlockId(aboveId));
+
+            BlockId World(int x, int y, int z) =>
+                x >= 0 && y >= 0 && z >= 0 &&
+                x < WorldConstants.ChunkSize && y < WorldConstants.ChunkSize && z < WorldConstants.ChunkSize
+                    ? chunk.Get(x, y, z)
+                    : BlockId.Air;
+
+            var data = ChunkMesher.BuildGeometry(chunk, content, World); // atlas = null → no textures (EditMode-safe)
+            try
+            {
+                // The ground cube spans world-y ∈ [gy, gy+1]; its top face is the horizontal quad at y == gy+1.
+                // Only that face can have all three of a triangle's verts on that plane (a vertical face would
+                // straddle gy..gy+1). The flora cube's own bottom face there is culled against the ground, so a
+                // hit uniquely means the ground kept its top.
+                const float topY = gy + 1;
+                var verts = data.Verts;
+                var tris = data.OpaqueTris;
+                for (int t = 0; t + 2 < tris.Count; t += 3)
+                {
+                    Vector3 a = verts[tris[t]], b = verts[tris[t + 1]], c = verts[tris[t + 2]];
+                    if (Mathf.Abs(a.y - topY) < 1e-3f && Mathf.Abs(b.y - topY) < 1e-3f && Mathf.Abs(c.y - topY) < 1e-3f)
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+            finally
+            {
+                data.Release();
+            }
+        }
+
+        [Test]
+        public void GroundTop_UnderCrossPlantFlora_IsEmitted()
+        {
+            var content = LoadContentOrIgnore();
+            Assert.IsTrue(
+                GroundTopEmitted(content, IdOf(content, "dirt"), IdOf(content, "flora_fern")),
+                "Ground top under a cross-plant flora cell must render — otherwise it's a see-through hole.");
+        }
+
+        [Test]
+        public void GroundTop_UnderSolidFlora_IsEmitted()
+        {
+            var content = LoadContentOrIgnore();
+            Assert.IsTrue(
+                GroundTopEmitted(content, IdOf(content, "dirt"), IdOf(content, "flora_puffball")),
+                "Ground top under a solid-flora cell must render — otherwise white corner slivers show through.");
+        }
+
+        [Test]
+        public void GroundTop_UnderOpaqueBlock_IsCulled()
+        {
+            // Guard the other direction: a genuine opaque neighbour MUST still seal the shared face, so the fix
+            // opened the cull only for flora/foliage, not for everything.
+            var content = LoadContentOrIgnore();
+            Assert.IsFalse(
+                GroundTopEmitted(content, IdOf(content, "dirt"), IdOf(content, "stone")),
+                "An opaque neighbour must still cull the shared face.");
+        }
+    }
+}

--- a/client/Assets/Tests/EditMode/ChunkMesherFloraFloorEditModeTests.cs.meta
+++ b/client/Assets/Tests/EditMode/ChunkMesherFloraFloorEditModeTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ad42988abd624baab5a7ae377aae10cd


### PR DESCRIPTION
## Problem
On planets the ground **under** cross-plant flora and at the **base** of solid flora (puffball/cactus/crystal domes) shows a see-through hole to the bright sky/fog — a "weißer/transparenter Boden" (fresh Lumis-54 screenshots 2026-07-18). Confirmed **mip-independent** (still present with the atlas mipmaps disabled), so it is **not** a texture/atlas issue.

This is the **second, separate cause** behind #382's "white plant floor" symptom: the #384 edge-bevel-UV fix correctly resolved the chamfer/corner white, but the plant floor persisted — so #382 was reopened.

## Root cause (git-confirmed regression)
The mesher face-cull in `ChunkMesher.BuildGeometry`:
```
drawFace = transparent ? nb.IsAir : (nb.IsAir || IsTransparent(content, nb))
```
seals an opaque block's face against **any** non-air/non-transparent neighbour, and `IsTransparent` lists only glass/force_field/water/fire/energy_fence/energy_gate — **not flora/foliage**. So the ground-top face **under** every flora cell is culled, while flora renders only a thin billboard (cross-plants) or a rounded shaped block (solid flora) that doesn't fill the cell → a see-through hole; solid-flora domes leave white corner slivers.

`AoOccluder` already excludes flora/foliage from occluders — the face-cull had diverged. `git blame`: commit `46a8a7f8` (B6) had `|| IsFoliageBlock(content, nb)` in the opaque `drawFace`; batch `27afca87` (B43/B47/B49/B53/B57/B59) dropped it (intending only to make tree crowns a thin shell). It also never covered **solid** flora (needs `IsFloraBlock`).

## Fix
Client-render only (no collider/data/wire change). The opaque branch now treats **both** `IsFloraBlock` (all `flora_*`, incl. solid flora) and `IsFoliageBlock` neighbours as non-occluding — mirroring `AoOccluder` exactly. A dedicated `foliage` branch keeps the tree-crown thin-shell look **unchanged** (draws toward air/glass only → still culls against opaque + its own kind). Biome-agnostic (any opaque ground).

## Verification
- Local Unity Windows build, visually confirmed across flora types & biomes: the transparent floor and the solid-flora corner slivers are gone; tree crowns still read airy.
- **EditMode regression test** `ChunkMesherFloraFloorEditModeTests`: asserts the ground-top face under a cross-plant flora **and** a solid-flora neighbour is emitted, while a genuine opaque neighbour still culls the shared face.

Closes #382.