### PR TITLE
fix(graphics): surface sky bodies no longer render as black silhouettes by day (#399)

### DIFF
--- a/client/Assets/BlocksBeyondTheStars/Scripts/SkyBodiesView.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/SkyBodiesView.cs
@@ -41,6 +41,7 @@ namespace BlocksBeyondTheStars.Client
 
         private static readonly int SunDirId = Shader.PropertyToID("_Sc_SunDir");
         private static readonly int PhaseSunDirId = Shader.PropertyToID("_PhaseSunDir");
+        private static readonly int DayLightId = Shader.PropertyToID("_DayLight");
 
         private readonly List<SkyBody> _bodies = new();
         private string _builtFor = "\0"; // ActiveLocationId the current set was built for
@@ -181,6 +182,11 @@ namespace BlocksBeyondTheStars.Client
                 // now just an overall dim: bodies dominate the dark night sky and wash out toward day, fading at
                 // the horizon. (The lit/unlit split across the disc is the phase, handled in the shader.)
                 b.Mat.SetVector(PhaseSunDirId, sunDir);
+                // Daytime the sun and every visible body share the upper sky, so the pure sun-lit phase only shows
+                // the body's unlit far side ("new moon") — a black silhouette against the bright day sky. Ramp the
+                // shader from its true phase (night) toward a fully front-lit disc (day) so bodies stay a visible
+                // feature; the crescent/phase still reads at twilight and night. `day` is 0 at night → 1 at noon.
+                b.Mat.SetFloat(DayLightId, day);
                 float horizon = Mathf.Clamp01((dir.y + 0.04f) / 0.12f);
                 // Overall dim: bodies dominate the night sky and fade toward day — but keep a higher day-time floor
                 // so they don't wash to black against the bright ACES-tonemapped daytime sky (they're a feature).

--- a/client/Assets/BlocksBeyondTheStars/Shaders/SkyBodyPhase.shader
+++ b/client/Assets/BlocksBeyondTheStars/Shaders/SkyBodyPhase.shader
@@ -16,6 +16,12 @@ Shader "BlocksBeyondTheStars/SkyBodyPhase"
         _Earthshine ("Night-side floor", Range(0, 0.4)) = 0.12
         _TermSoft ("Terminator softness", Range(0.001, 0.4)) = 0.07
         _LimbDark ("Limb darkening", Range(0, 1)) = 0.35
+        // 0 = pure sun-lit phase (space view + night surface). 1 = fully front-lit visible disc. The surface sky
+        // (SkyBodiesView) ramps this up with daylight: by day the sun and every visible body share the upper
+        // hemisphere, so the pure phase shows only the unlit far side ("new moon") and reads as a black
+        // silhouette against the bright sky. Front-lighting it by day keeps the body a visible feature; the
+        // true crescent/phase is preserved at night/twilight where it looks right. Default 0 → space view unchanged.
+        _DayLight ("Daytime front-lit blend", Range(0, 1)) = 0
     }
 
     // ---------------- URP ----------------
@@ -40,6 +46,7 @@ Shader "BlocksBeyondTheStars/SkyBodyPhase"
             float _Earthshine;
             float _TermSoft;
             float _LimbDark;
+            float _DayLight;
 
             struct Attributes { float4 positionOS : POSITION; float3 normal : NORMAL; float2 uv : TEXCOORD0; };
             struct Varyings { float4 positionCS : SV_POSITION; float3 wn : TEXCOORD0; float2 uv : TEXCOORD1; float3 wp : TEXCOORD2; };
@@ -65,6 +72,10 @@ Shader "BlocksBeyondTheStars/SkyBodyPhase"
                 float lit = smoothstep(-_TermSoft, _TermSoft, ndl);
                 float wrap = saturate(ndl * 0.5 + 0.5);
                 float shade = max(lit, wrap * wrap * 0.35);
+                // Daytime: lift the sun-lit phase toward a fully front-lit disc so a back-lit body is a visible
+                // lit disc (limb darkening still gives it round depth) instead of a black silhouette. At night
+                // (_DayLight → 0) the crisp phase is untouched.
+                shade = lerp(shade, 1.0, _DayLight);
                 float3 tex = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, i.uv).rgb;
                 float3 col = _Color.rgb * tex * (_Earthshine + (1.0 - _Earthshine) * shade);
                 // Limb darkening via the world-space view direction: bright at the disc centre (normal toward the
@@ -99,6 +110,7 @@ Shader "BlocksBeyondTheStars/SkyBodyPhase"
             float _Earthshine;
             float _TermSoft;
             float _LimbDark;
+            float _DayLight;
 
             struct appdata { float4 vertex : POSITION; float3 normal : NORMAL; float2 uv : TEXCOORD0; };
             struct v2f { float4 pos : SV_POSITION; float3 wn : TEXCOORD0; float2 uv : TEXCOORD1; float3 wp : TEXCOORD2; };
@@ -121,6 +133,9 @@ Shader "BlocksBeyondTheStars/SkyBodyPhase"
                 float lit = smoothstep(-_TermSoft, _TermSoft, ndl);
                 float wrap = saturate(ndl * 0.5 + 0.5);
                 float shade = max(lit, wrap * wrap * 0.35);
+                // Daytime front-lit lift (see URP pass) so back-lit bodies read as a lit disc, not a black
+                // silhouette; the night phase (_DayLight → 0) is untouched.
+                shade = lerp(shade, 1.0, _DayLight);
                 fixed3 tex = tex2D(_MainTex, i.uv).rgb;
                 fixed3 col = _Color.rgb * tex * (_Earthshine + (1.0 - _Earthshine) * shade);
                 float3 Vw = normalize(_WorldSpaceCameraPos - i.wp);


### PR DESCRIPTION
Fixes #399.

## Problem

From a planet surface, the other planets / moons / asteroids hanging in the sky (`SkyBodiesView`) almost always render as **dark, near-black silhouette discs**, especially during the day. They are meant to be a visible ambience feature.

## Root cause

The bodies are spheres shaded by `SkyBodyPhase.shader`, lit from the real sky-sun direction. The lit fraction of the disc is the moon-phase. The sign and color space are **correct** — `SpaceView` uses the same shader/convention and looks fine, because in space the camera can sit on a body's anti-sun side.

The problem is geometric and specific to a surface viewpoint:

- The camera-facing point of a body only looks lit when the body is roughly **opposite** the sun in the sky.
- On a surface it is daytime whenever the sun is up, and every visible body also sits at positive elevation. Sun and body share the upper hemisphere → the camera sees the **unlit far side** ("new moon") → dark disc. This happens for essentially all bodies at once during the day.
- The night-side floor is only `_Earthshine = 0.12`; against the bright ACES-tonemapped day sky that reads as a black silhouette.

## Fix

- `SkyBodyPhase.shader`: add a `_DayLight` (0..1) property and blend the sun-lit `shade` toward a fully front-lit disc (`shade = lerp(shade, 1.0, _DayLight)`) in both the URP and Built-in passes. Limb darkening still gives the disc round depth.
- `SkyBodiesView.cs`: drive `_DayLight` with the existing `day` factor (0 at night → 1 at noon).

Result: by day, back-lit bodies become **visible lit discs** showing their real planet coloring instead of black silhouettes; at night/twilight the true crescent/phase is preserved. `_DayLight` defaults to `0`, so `SpaceView` and the menu background (which never set it) are **unchanged**.

## Verification

- Client-only change (Unity shader + MonoBehaviour); the .NET headless CI does not compile Unity assets, so CI green confirms nothing shared regressed.
- Change is small and self-contained; the new property defaults to 0 (no behavior change for existing shader consumers).
- Final daytime brightness/tuning wants a visual pass on a local Unity build. Reaches users via the next Velopack release.
