### PR TITLE
fix(singleplayer): quit saves your live position instead of dropping you above the ship on reload

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -100,6 +100,21 @@ Per-item detail lives in the dated work log below.
 
 ---
 
+### ★ Singleplayer quit now saves your live position (2026-07-18, branch fix/sp-quit-graceful-save)
+Quitting a native singleplayer session (to the menu or by closing the game) discarded everything since the
+last 5-minute autosave: `LocalServerLauncher.Stop()` **hard-killed** the bundled server process with
+`Process.Kill()`, so its graceful drain + `SaveAll()` never ran. On reload the server restored the last
+*durably* saved position — often the landing checkpoint, which stamps the player at the ship's heal-tank —
+so you'd reappear a few blocks **above your ship and fall onto the hull**, wherever you'd actually walked.
+Fix: a graceful stdin shutdown that mirrors the server's existing SIGINT→`RequestStop()`→`SaveAll()` path.
+The bundled host now passes `--stdin-stop`; the server arms a stdin watcher that calls `RequestStop()` when
+the client closes its redirected stdin on quit (or dies → OS stdin EOF), draining + saving the live player
+position on the tick thread before exit. `Stop()` closes stdin and waits (up to 5 s) for the clean save,
+falling back to `Kill()` only if the server wedges. Flag-guarded so dedicated/docker hosts (SIGTERM) are
+untouched; `--stdin-stop` gets a placeholder case in `ServerConfig.ApplyCommandLine` so the positional
+parser doesn't swallow the next flag (same pattern as `--no-config`). WebGL is unaffected (in-process
+`BrowserServer.StopAndSave()`). Reaches players with the next Velopack release.
+
 ### ★ Flora no longer renders a see-through "transparent floor" (#382, 2026-07-18)
 On planets the ground **under** cross-plant flora and at the **base** of solid flora (puffball/cactus/crystal
 domes) showed a see-through hole to the bright sky/fog — a "weißer/transparenter Boden". Mip-independent

--- a/client/Assets/BlocksBeyondTheStars/Scripts/LocalServerLauncher.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/LocalServerLauncher.cs
@@ -204,12 +204,15 @@ namespace BlocksBeyondTheStars.Client
             {
                 FileName = exe,
                 Arguments = $"--port {Port} --name \"{serverName}\" --world \"{worldName}\" " +
-                            $"--max-players {Mathf.Max(1, maxPlayers)} --saves \"{saves}\" --data \"{data}\" --usercontent \"{userContent}\"" + viewArg + seedArg + spaceArgs + voiceArg + startCubeArg + noConfigArg + creativeArgs + optionArgs + hostArgs,
+                            $"--max-players {Mathf.Max(1, maxPlayers)} --saves \"{saves}\" --data \"{data}\" --usercontent \"{userContent}\" --stdin-stop true" + viewArg + seedArg + spaceArgs + voiceArg + startCubeArg + noConfigArg + creativeArgs + optionArgs + hostArgs,
                 WorkingDirectory = Path.GetDirectoryName(exe),
                 UseShellExecute = false,
                 CreateNoWindow = true,
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
+                // Redirected so Stop() can close it as a graceful-shutdown signal (--stdin-stop): the server
+                // drains + saves the live player position instead of dying mid-session to Process.Kill().
+                RedirectStandardInput = true,
             };
 
             // Hand the client's baked-in feedback key to the bundled server so its crash reports and /bump
@@ -277,8 +280,18 @@ namespace BlocksBeyondTheStars.Client
             {
                 if (!_process.HasExited)
                 {
-                    _process.Kill();
-                    _process.WaitForExit(2000);
+                    // Ask the server to shut down GRACEFULLY first: closing its redirected stdin trips the
+                    // --stdin-stop watcher, which drains + saves (the live player position, ship, world) on the
+                    // tick thread before exiting. A hard Kill() here would lose everything since the last
+                    // autosave — the player would reload at a stale spawn (e.g. floating above their ship).
+                    try { _process.StandardInput.Close(); } catch { /* stdin already gone */ }
+
+                    // Give the drain + save a moment; Kill() only as a last resort if it wedges.
+                    if (!_process.WaitForExit(5000) && !_process.HasExited)
+                    {
+                        _process.Kill();
+                        _process.WaitForExit(2000);
+                    }
                 }
             }
             catch

--- a/src/BlocksBeyondTheStars.GameServer/Program.cs
+++ b/src/BlocksBeyondTheStars.GameServer/Program.cs
@@ -154,6 +154,42 @@ Console.CancelKeyPress += (_, e) =>
     server.RequestStop();
 };
 
+// Graceful stop via stdin, for the bundled singleplayer host (--stdin-stop). The in-game client can't send
+// SIGINT to this child process on Windows, and Process.Kill() would tear us down BEFORE the drain + save —
+// so a plain quit would lose everything since the last autosave (the player reloads at a stale spawn). The
+// client instead closes our redirected stdin on quit (or dies, which the OS turns into a stdin EOF); this
+// reader picks that up and RequestStop()s, taking the same drain + save path as SIGINT. Guarded by the flag
+// so the dedicated/docker hosts — which stop via SIGTERM/SIGINT and may have no stdin — never start it.
+if (Array.IndexOf(args, "--stdin-stop") >= 0)
+{
+    var stdinWatcher = new Thread(() =>
+    {
+        try
+        {
+            // ReadLine returns null on stdin EOF (the parent closed the pipe / exited) — either way, stop.
+            while (Console.In.ReadLine() is { } line)
+            {
+                if (line.Trim().Equals("stop", StringComparison.OrdinalIgnoreCase))
+                {
+                    break;
+                }
+            }
+        }
+        catch
+        {
+            // stdin unreadable → treat as closed and fall through to the graceful stop below.
+        }
+
+        logger.Info("Shutdown requested (host stdin closed)...");
+        server.RequestStop();
+    })
+    {
+        IsBackground = true, // never keep the process alive on its own
+        Name = "stdin-stop-watcher",
+    };
+    stdinWatcher.Start();
+}
+
 server.Start();
 
 // Automatic crash upload — opt-in. When config supplies an endpoint + key, the server sends queued reports

--- a/src/BlocksBeyondTheStars.Shared/Configuration/ServerConfig.cs
+++ b/src/BlocksBeyondTheStars.Shared/Configuration/ServerConfig.cs
@@ -321,6 +321,11 @@ public sealed class ServerConfig
                     // args (before Load) to skip the config file entirely. Recognized here only so its value
                     // token is consumed and can't shadow a following flag; nothing to apply to this config.
                     break;
+                case "stdin-stop":
+                    // Handled in Program.cs (reads --stdin-stop straight from the raw args to arm the stdin
+                    // graceful-shutdown watcher for the bundled singleplayer host). Recognized here only so its
+                    // value token is consumed and can't shadow a following flag; nothing to apply to this config.
+                    break;
                 case "database":
                 case "database-provider":
                     DatabaseProvider = value; applied.Add("database-provider");


### PR DESCRIPTION
## The bug

In native singleplayer, quitting somewhere on a planet and reloading dropped you **a few blocks above your ship**, where you'd then fall onto the hull — no matter where you'd actually walked.

## Root cause

Quitting hard-killed the bundled server process (`LocalServerLauncher.Stop()` → `Process.Kill()`) before its graceful drain + `SaveAll()` could run, so the live logoff position was never persisted. On reload the server restored the last **durably-saved** position — the last 5-minute autosave, or (if none fired since) the landing checkpoint, which stamps `Position` at the ship's heal-tank. The heal-tank sits above the deck, and the client's spawn-settle then releases the frozen player → the visible fall onto the ship.

## Fix

A graceful **stdin shutdown** that mirrors the server's existing `SIGINT → RequestStop() → SaveAll()` path:

- **Server** (`Program.cs`): with `--stdin-stop`, a background watcher calls `RequestStop()` when its redirected stdin closes (client quit → pipe close, or client crash → OS EOF), so the run loop drains + saves the live position on the tick thread before exit.
- **Launcher** (`LocalServerLauncher.cs`): passes `--stdin-stop`, sets `RedirectStandardInput = true`, and `Stop()` now closes stdin + waits up to 5 s for the clean save — `Kill()` only as a fallback if the server wedges.
- **Config** (`ServerConfig.cs`): placeholder case for `--stdin-stop` so the positional arg parser doesn't swallow the following flag (same pattern as `--no-config`).

Flag-guarded, so dedicated/docker hosts (which stop via SIGTERM) are untouched. WebGL is unaffected — it already saves gracefully via in-process `BrowserServer.StopAndSave()`.

## Verification

- ✅ Server build clean (0 warnings, warnaserror on)
- ✅ 34 config / respawn / persistence tests green
- ✅ Headless check of the **bundled build**: closing stdin logs `Shutdown requested (host stdin closed)...` → `Server stopped and world saved.` → clean exit (code 0), with `world.db` written to disk
- ⏳ Manual playtest (walk away from ship → quit to menu → reload → land where you left off) — pending

Reaches players with the next Velopack release (native client).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
