### PR TITLE
fix(enemies): walking ground robots now spawn on planets, not only drones (#398)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -100,6 +100,21 @@ Per-item detail lives in the dated work log below.
 
 ---
 
+### ★ Walking ground robots now actually spawn on planets — not only flying drones (#398, 2026-07-18)
+Two variants of the planet "Guardian machines" are meant to appear on the surface: the flying scan-drone and
+the walking three-eyed ground robots. In playtests only the drones ever showed up. Not a client/render bug
+(the client renders both kinds). Root cause was in the spawn loop
+([GameServerEnemies.cs](src/BlocksBeyondTheStars.GameServer/GameServerEnemies.cs)): the drone/robot mix keyed
+off the **raw live count** (`count % 5 < 2`), and the spawn guard only fires while `count < cap`. At the
+default cap (`PlanetEnemies = Normal` → `ActivityCount = 2`, single player → `cap = 2`) the count is always 0
+or 1 at decision time, so `asDrone` was **always true** — both slots filled as drones and the robot slots
+(`count % 5` in {2,3,4}) were never reached. Robots only appeared at Frequent/Extreme or with 2+ players.
+**Fix:** key the mix off how many drones are **already alive** — spawn a drone only while drones stay a
+minority (`droneCount*5 < (count+1)*2`) of the live population. Guarantees a walking robot even at cap 2
+(steady state 1 drone + 1 robot) while still converging on the ~2-in-5 drone ratio at larger caps. Server-only
+(no Unity build needed). Regression test `PlanetEnemies_IncludeWalkingRobots_NotOnlyDrones` added; full server
+suite green (1047, 0 warnings).
+
 ### ★ Singleplayer quit now saves your live position (2026-07-18, branch fix/sp-quit-graceful-save)
 Quitting a native singleplayer session (to the menu or by closing the game) discarded everything since the
 last 5-minute autosave: `LocalServerLauncher.Stop()` **hard-killed** the bundled server process with

--- a/src/BlocksBeyondTheStars.GameServer/GameServerEnemies.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerEnemies.cs
@@ -72,7 +72,17 @@ public sealed partial class GameServer
             _enemySpawnTimer = 0;
             // A fraction (~2 in 5) of the population spawns as the flying scan-drone variant (P4), the rest as
             // walking three-eyed ground robots — both within the same PlanetEnemies cap (count unchanged).
-            bool asDrone = Rules.PlanetDrones && (_planetEnemies.Count % 5) < 2;
+            // Key the mix off how many drones are ALREADY alive, not the raw spawn count: keying off the count
+            // (`count % 5 < 2`) front-loaded both slots as drones at the default cap (Normal + solo = 2, and the
+            // guard only spawns while count < 2), so the walking robots were never reached (#398). Spawning a
+            // drone only while drones stay a minority (< 2/5) of the live population guarantees a robot appears
+            // even at the smallest cap, while still converging on the ~2-in-5 drone ratio at larger caps.
+            int droneCount = 0;
+            foreach (var e in _planetEnemies)
+            {
+                if (e.Kind == CombatEntityKind.ScanDrone) { droneCount++; }
+            }
+            bool asDrone = Rules.PlanetDrones && droneCount * 5 < (_planetEnemies.Count + 1) * 2;
             SpawnPlanetEnemyNear(targets[_planetEnemies.Count % targets.Count].State, asDrone);
             BroadcastPlanetEnemies();
         }

--- a/tests/BlocksBeyondTheStars.Tests/EnemyMovementTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/EnemyMovementTests.cs
@@ -122,6 +122,30 @@ public sealed class EnemyMovementTests : IDisposable
     }
 
     [Fact]
+    public void PlanetEnemies_IncludeWalkingRobots_NotOnlyDrones()
+    {
+        // Regression (#398): at the default Normal activity a single player's cap is 2, and the old drone-mix
+        // keyed off the raw spawn count (`count % 5 < 2`) while the guard only spawns below the cap — so BOTH
+        // slots filled as flying scan-drones and the walking three-eyed ground robots were never reached.
+        // The live population must contain at least one walking robot (a non-drone kind).
+        var server = Started("robotmix", out var repo);
+        using (repo)
+        {
+            var pilot = server.AddLocalPlayer("Prey");
+            pilot.State.AboardShip = false; // on foot on the surface — a valid enemy target
+
+            // Fill to the cap (Normal + solo = 2). The spawner is interval-driven (5 s), so tick generously.
+            for (int i = 0; i < 200 && server.PlanetEnemies.Count < 2; i++)
+            {
+                server.Tick(0.5);
+            }
+
+            Assert.Equal(2, server.PlanetEnemies.Count);
+            Assert.Contains(server.PlanetEnemies, e => e.Kind != CombatEntityKind.ScanDrone);
+        }
+    }
+
+    [Fact]
     public void PlanetEnemies_IgnoreAPlayerWhoFledAboardTheShip()
     {
         // Regression: fleeing into the ship must break off the hunt entirely — the machine neither chases


### PR DESCRIPTION
## Problem
The planet **Guardian machines** are supposed to appear in two variants — the flying **scan-drone** and the walking three-eyed **ground robots** — but in numerous playtests only the flying drones ever showed up. The walking robots were never seen.

Not a client/render bug (the client renders both kinds correctly). Under the default configuration the robots were simply never reached.

## Root cause
Spawn loop in `GameServerEnemies.cs`:

```csharp
int cap = ActivityCount(Rules.PlanetEnemies) * targets.Count;   // Normal=2, solo -> cap = 2
if (_enemySpawnTimer >= EnemySpawnInterval && _planetEnemies.Count < cap)
    bool asDrone = Rules.PlanetDrones && (_planetEnemies.Count % 5) < 2;
```

The drone/robot mix keyed off the **raw live count**, and the spawn guard only fires while `count < cap`. With the default `PlanetEnemies = Normal` (`ActivityCount = 2`) and a single player (`cap = 2`), the count is always 0 or 1 at decision time, so `asDrone` is **always true** — both slots fill as drones and the robot slots (`count % 5` in {2,3,4}) are never reached. Robots only appeared at Frequent/Extreme activity or with 2+ players nearby.

## Fix
Key the mix off how many drones are **already alive** rather than the raw count: spawn a drone only while drones stay a minority of the live population (`droneCount * 5 < (count + 1) * 2`). This guarantees a walking robot appears even at the smallest cap (steady state at cap 2 = 1 drone + 1 robot) while still converging on the intended ~2-in-5 drone ratio at larger caps.

Server-only change — no client/Unity build needed.

## Tests
- Adds regression test `PlanetEnemies_IncludeWalkingRobots_NotOnlyDrones` (asserts the population at the default Normal/solo cap contains a non-drone kind).
- Full server suite green: **1047 passed, 0 warnings** (`-warnaserror`).

closes #398

🤖 Generated with [Claude Code](https://claude.com/claude-code)