### PR TITLE
fix(graphics): creatures no longer render as black silhouettes (#396)

### DIFF
--- a/client/Assets/BlocksBeyondTheStars/Scripts/CreatureBuilder.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/CreatureBuilder.cs
@@ -47,7 +47,7 @@ namespace BlocksBeyondTheStars.Client
 
             if (c.Asleep)
             {
-                baseColor *= 0.6f;
+                baseColor *= 0.85f; // a gentle dim only — the "z z z" already reads sleep; 0.6 crushed the (already tile+floor-dimmed) body to black
             }
 
             // Tamed companions read with a gentle friendly green-cyan cast (never the hostile red) so you can
@@ -416,10 +416,42 @@ namespace BlocksBeyondTheStars.Client
                 wrapMode = TextureWrapMode.Repeat,
                 filterMode = FilterMode.Point,
             };
-            tex.LoadRawTextureData(asset.bytes);
+            tex.LoadRawTextureData(Brighten(asset.bytes));
             tex.Apply();
             return tex;
         }
+
+        // The hide tiles are authored dark (~0.3 mean grey) but the body uses them as a MULTIPLY over the
+        // species colour (colour * tile) — a multiply-tint workflow needs near-white maps, or the tile alone
+        // eats ~70% of the brightness and the body reads black. Lift each tile toward white so it modulates as
+        // gentle DETAIL instead of a darkener: v' = 1 - (1 - v) * TileDetail (white stays white; only the
+        // shadows rise, so the pattern survives). Alpha is left alone (LitColor is opaque).
+        private const float TileDetail = 0.45f; // 0 = flat white, 1 = original (too dark). Tunable.
+
+        private static byte[] Brighten(byte[] raw)
+        {
+            var outp = new byte[raw.Length];
+            for (int p = 0; p < raw.Length; p += 4)
+            {
+                outp[p] = (byte)(255f - (255 - raw[p]) * TileDetail);
+                outp[p + 1] = (byte)(255f - (255 - raw[p + 1]) * TileDetail);
+                outp[p + 2] = (byte)(255f - (255 - raw[p + 2]) * TileDetail);
+                outp[p + 3] = raw[p + 3];
+            }
+
+            return outp;
+        }
+
+        // Ambient floor for creature bodies. Higher than the LitColor default (0.35) because a creature's
+        // textured, camera-away faces (a flier's belly seen from below, a back turned to the fixed key light)
+        // sit at the floor and otherwise sink to a black silhouette against a bright sky. Only creatures raise
+        // it — every other LitColor user keeps the 0.35 shader default.
+        private const float CreatureFloor = 0.62f;
+
+        // Fill light from the flank opposite the fixed key. The single key light leaves the away-facing side of
+        // a creature at the floor, so it still read dark; this unshadowed fill lifts that flank. Only creatures
+        // set it — every other LitColor user keeps the 0 default (single key light, unchanged).
+        private const float CreatureFill = 0.3f;
 
         private static Material Lit(Color color, Texture2D tex)
         {
@@ -428,6 +460,12 @@ namespace BlocksBeyondTheStars.Client
             if (tex != null)
             {
                 m.mainTexture = tex;
+            }
+
+            if (m.HasProperty("_Floor"))
+            {
+                m.SetFloat("_Floor", CreatureFloor); // no-op on the Unlit/Color fallback
+                m.SetFloat("_Fill", CreatureFill);
             }
 
             return m;

--- a/client/Assets/BlocksBeyondTheStars/Shaders/LitColor.shader
+++ b/client/Assets/BlocksBeyondTheStars/Shaders/LitColor.shader
@@ -12,6 +12,14 @@ Shader "BlocksBeyondTheStars/LitColor"
     {
         _Color ("Color", Color) = (1, 1, 1, 1)
         _MainTex ("Texture", 2D) = "white" {}
+        // Per-material ambient floor (the unlit/backlit brightness). Default 0.35 keeps every existing user
+        // (avatars, doors, ships, stations…) byte-identical; creatures raise it (CreatureBuilder) because their
+        // dark, textured, camera-away belly/back faces otherwise sink to a black silhouette against the sky.
+        _Floor ("Ambient floor", Range(0, 1)) = 0.35
+        // Per-material fill light from the side opposite the fixed key. Default 0 = single key light (every
+        // existing user unchanged); creatures raise it so the flank facing away from the key no longer stays
+        // at the floor and reads dark. Unshadowed, so it only lifts — never darkens.
+        _Fill ("Fill light", Range(0, 1)) = 0
     }
 
     // ---------------- URP ----------------
@@ -35,6 +43,8 @@ Shader "BlocksBeyondTheStars/LitColor"
             TEXTURE2D(_MainTex); SAMPLER(sampler_MainTex);
             float4 _MainTex_ST;
             float4 _Color;
+            float _Floor;
+            float _Fill;
             float4 _Sc_LampPos;
             float4 _Sc_LampDir;
             float4 _Sc_LampColor;
@@ -59,8 +69,9 @@ Shader "BlocksBeyondTheStars/LitColor"
                 float3 L = normalize(float3(0.4, 0.7, -0.55)); // fixed key light (sun-independent, like the preview)
                 float ndl = saturate(dot(N, L));
                 float shadow = MainLightRealtimeShadow(TransformWorldToShadowCoord(i.wp));
+                float fill = saturate(dot(N, normalize(float3(-0.55, 0.25, 0.5)))) * _Fill; // opposite flank, unshadowed
                 float3 tex = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, i.uv).rgb;
-                float3 col = _Color.rgb * tex * (0.35 + 0.75 * ndl * shadow);
+                float3 col = _Color.rgb * tex * (_Floor + (1.1 - _Floor) * ndl * shadow + fill); // peak stays 1.1 at _Floor==0.35, _Fill==0
 
                 if (_Sc_LampColor.a > 0.5)
                 {
@@ -130,6 +141,8 @@ Shader "BlocksBeyondTheStars/LitColor"
             #include "UnityCG.cginc"
 
             fixed4 _Color;
+            float _Floor;
+            float _Fill;
             sampler2D _MainTex;
             float4 _MainTex_ST;
             float4 _Sc_LampPos;   // headlamp: xyz world pos, w range
@@ -167,8 +180,9 @@ Shader "BlocksBeyondTheStars/LitColor"
                 float3 N = normalize(i.wn);
                 float3 L = normalize(float3(0.4, 0.7, -0.55));
                 float ndl = saturate(dot(N, L));
+                float fill = saturate(dot(N, normalize(float3(-0.55, 0.25, 0.5)))) * _Fill; // opposite flank, unshadowed
                 fixed3 tex = tex2D(_MainTex, i.uv).rgb;
-                fixed3 col = _Color.rgb * tex * (0.35 + 0.75 * ndl);
+                fixed3 col = _Color.rgb * tex * (_Floor + (1.1 - _Floor) * ndl + fill); // peak stays 1.1 at _Floor==0.35, _Fill==0
 
                 // Headlamp / flashlight (shared global with the block shader).
                 if (_Sc_LampColor.a > 0.5)


### PR DESCRIPTION
Closes #396.

## Symptom
Creature bodies rendered as flat **black silhouettes** in every world — wild and tamed, flying and ground. Only the belly and the cream eyes stayed visible.

## Root cause
The species colour arrives correct on the client (verified via a temporary diagnostic log: e.g. body `0xD68B99`, belly `0xF7C68A`). The body was crushed to near-black by a stack of multipliers, worst in linear space:

```
colour × grayscale-hide-tile (~0.3 mean, sRGB→~0.08 linear) × LitColor 0.35 ambient floor × 0.6 asleep dim
```

Each factor is individually fine; multiplied, the textured+lit body lands at ~15% of its true colour and reads black against the bright HDR sky. The belly escaped it (brighter accent colour, no asleep dim); the eyes are unlit constants — which is why only those stayed visible. This is why a plain data check looked fine and the earlier "textures are dark" hunch only told half the story.

## Fix — all isolated to creatures
Every other `LitColor` consumer (avatars, doors, ships, stations, held items…) stays **byte-identical**: the new shader properties default to the previous behaviour, and only `CreatureBuilder` overrides them.

- **`LitColor.shader`**: new per-material `_Floor` (default `0.35`) and `_Fill` (default `0`). With defaults the math is unchanged (`_Floor + (1.1-_Floor)·ndl` == old `0.35 + 0.75·ndl`). `_Fill` adds an unshadowed fill light from the flank opposite the fixed key, so the away-facing side no longer sits at the floor.
- **`CreatureBuilder.cs`**:
  - Hide tiles lifted toward near-white on load (`TileDetail`) — they are multiply-tint detail maps, not dark albedo; detail is preserved (only shadows rise).
  - Creatures set `_Floor = 0.62`, `_Fill = 0.3`.
  - Asleep dim softened `0.6 → 0.85` (the "z z z" already reads sleep).

Tuning knobs (`TileDetail`, `CreatureFloor`, `CreatureFill`, asleep dim) are named constants.

## Verification
Local Windows build in a worktree, verified in-game across several dusk worlds by @marceld23: bodies now show their true species colour with visible skin texture; belly/eyes still correct; avatars/doors/ships unchanged. Client/render-only → reaches players via the next Velopack release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)