### PR TITLE
fix(api): admin /api endpoints fail closed without a password on non-loopback binds (#411)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -100,6 +100,18 @@ Per-item detail lives in the dated work log below.
 
 ---
 
+### ★ Admin /api endpoints fail closed without a password on public binds (#411, 2026-07-19, branch fix/411-admin-api-fail-closed)
+The `/api` auth middleware only enforced the admin password **when one was configured** — with
+`BBS_ADMIN_PASSWORD` unset (the default) every admin route ran unauthenticated, including
+`PUT /api/config`, backups, missions, content packs and logs. Harmless on the loopback default bind,
+but the Docker image forces `BBS_ADMIN_BIND=0.0.0.0` and the TLS compose profile reverse-proxies
+`/api` publicly → full config takeover on password-less public deploys (audit finding S2). Now the
+policy lives in `AdminAuth` (unit-tested): no password ⇒ /api answers **401 on any non-loopback
+bind** (fail closed, matching WorldHost/ReportHost) and stays open only on loopback; a configured
+password is enforced with a fixed-time comparison. Public surfaces (`/portal`, `/play`,
+`/download*`, `/updates`) are unaffected. Startup log + `/api/status` warning explain the state;
+SELF_HOSTING.md documents it. Server-only — reaches the VPS via an image redeploy, no client release.
+
 ### ★ Marketing screenshots regenerated; capture director survives the #401 live-position save (2026-07-19, branch docs/screenshots-regen)
 The README/marketing screenshots (docs/screenshots/en, 13 shots) were regenerated against the v0.8.4
 engine — and the unattended capture run was broken in four independent ways, several caused by recent

--- a/docs/developer/SELF_HOSTING.md
+++ b/docs/developer/SELF_HOSTING.md
@@ -417,6 +417,11 @@ Configure with the `BBS_*` environment variables (see §3). At minimum set `BBS_
 exposing the admin port. Ports: **31415/udp** (native client), **31415/tcp** (browser WebSocket, only
 when `BBS_ENABLE_WEBSOCKET=true`), **31416/tcp** (admin + portal + download).
 
+> **Fail closed:** the container binds the admin UI to `0.0.0.0`. Without `BBS_ADMIN_PASSWORD` the
+> `/api` admin endpoints (config, backups, missions, content packs, logs) answer **401** on such a
+> non-loopback bind — only the public pages (`/portal`, `/play`, `/download*`, `/updates`) stay up.
+> Set the password (env var or `adminPassword` in `server_config.json`) to enable the dashboard.
+
 ### Or plain `docker run`
 
 ```bash

--- a/src/BlocksBeyondTheStars.Api/AdminAuth.cs
+++ b/src/BlocksBeyondTheStars.Api/AdminAuth.cs
@@ -1,0 +1,58 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using System.Net;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace BlocksBeyondTheStars.Api;
+
+/// <summary>
+/// Authorization policy for the /api admin endpoints (issue #411).
+///
+/// The admin password is optional for a loopback-only bind (the local dashboard case), but with a
+/// non-loopback bind — which the Docker image forces via BBS_ADMIN_BIND=0.0.0.0 — an unset password
+/// must FAIL CLOSED: every /api request is rejected until a password is configured. This mirrors
+/// WorldHost/ReportHost, whose admin surfaces are likewise disabled when no credential is set.
+/// </summary>
+public static class AdminAuth
+{
+    /// <summary>True when the admin UI bind address can only be reached from the local machine.</summary>
+    public static bool IsLoopbackBind(string? bindAddress)
+    {
+        if (string.IsNullOrWhiteSpace(bindAddress))
+        {
+            return false;
+        }
+
+        if (string.Equals(bindAddress.Trim(), "localhost", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        // Anything unparseable (Kestrel wildcards "*"/"+", host names) counts as non-loopback:
+        // when in doubt, fail closed.
+        return IPAddress.TryParse(bindAddress.Trim(), out var ip) && IPAddress.IsLoopback(ip);
+    }
+
+    /// <summary>
+    /// Decides whether an /api request is authorized. With a configured password the provided header
+    /// must match (fixed-time comparison); without one, only a loopback bind is allowed through.
+    /// </summary>
+    public static bool IsAuthorized(string? configuredPassword, string? providedPassword, bool loopbackBind)
+    {
+        if (string.IsNullOrEmpty(configuredPassword))
+        {
+            return loopbackBind;
+        }
+
+        return FixedTimeEquals(configuredPassword, providedPassword ?? string.Empty);
+    }
+
+    private static bool FixedTimeEquals(string expected, string provided)
+    {
+        byte[] expectedBytes = Encoding.UTF8.GetBytes(expected);
+        byte[] providedBytes = Encoding.UTF8.GetBytes(provided);
+        return CryptographicOperations.FixedTimeEquals(expectedBytes, providedBytes);
+    }
+}

--- a/src/BlocksBeyondTheStars.Api/AdminService.cs
+++ b/src/BlocksBeyondTheStars.Api/AdminService.cs
@@ -124,7 +124,9 @@ public sealed class AdminService
 
         if (!status.AdminPasswordSet)
         {
-            string adminWarning = "No admin password is set. Keep the admin port bound to localhost/LAN only.";
+            string adminWarning = AdminAuth.IsLoopbackBind(config.AdminBindAddress)
+                ? "No admin password is set. The admin UI is only reachable from this machine (loopback bind)."
+                : "No admin password is set — the /api admin endpoints are disabled on this non-loopback bind. Set BBS_ADMIN_PASSWORD (or adminPassword in server_config.json).";
             status.Warning = string.IsNullOrEmpty(status.Warning) ? adminWarning : status.Warning + " " + adminWarning;
         }
 

--- a/src/BlocksBeyondTheStars.Api/Program.cs
+++ b/src/BlocksBeyondTheStars.Api/Program.cs
@@ -35,23 +35,34 @@ var app = builder.Build();
 
 app.UseForwardedHeaders();
 
-// Admin authentication: when an admin password is configured, every /api request must
-// present it via the X-Admin-Password header. With no password set we rely on the bind
-// address (localhost/LAN) and surface a warning in the status.
+// Admin authentication (issue #411): every /api request must present the configured password via the
+// X-Admin-Password header. Without a configured password the endpoints FAIL CLOSED unless the UI is
+// bound to loopback only — the Docker image binds 0.0.0.0, so a public deploy without
+// BBS_ADMIN_PASSWORD must not expose PUT /api/config & friends to the world. The bind address is
+// fixed at startup, so the loopback decision is too; the password itself is re-read per request so a
+// password set later via the config file takes effect without a restart.
+bool loopbackBind = AdminAuth.IsLoopbackBind(startupConfig.AdminBindAddress);
+if (!loopbackBind && string.IsNullOrEmpty(startupConfig.AdminPassword))
+{
+    Console.WriteLine(
+        $"[api] WARNING: admin UI is bound to {startupConfig.AdminBindAddress} with no admin password — " +
+        "the /api admin endpoints are DISABLED until one is set (BBS_ADMIN_PASSWORD or adminPassword " +
+        "in server_config.json). Portal, downloads and /play remain available.");
+}
+
 app.Use(async (context, next) =>
 {
     if (context.Request.Path.StartsWithSegments("/api"))
     {
         var password = app.Services.GetRequiredService<AdminService>().LoadConfig().AdminPassword;
-        if (!string.IsNullOrEmpty(password))
+        var provided = context.Request.Headers["X-Admin-Password"].ToString();
+        if (!AdminAuth.IsAuthorized(password, provided, loopbackBind))
         {
-            var provided = context.Request.Headers["X-Admin-Password"].ToString();
-            if (provided != password)
-            {
-                context.Response.StatusCode = StatusCodes.Status401Unauthorized;
-                await context.Response.WriteAsync("Unauthorized");
-                return;
-            }
+            context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+            await context.Response.WriteAsync(string.IsNullOrEmpty(password)
+                ? "Unauthorized — admin endpoints are disabled: no admin password is configured. Set BBS_ADMIN_PASSWORD (or adminPassword in server_config.json) and retry."
+                : "Unauthorized");
+            return;
         }
     }
 

--- a/tests/BlocksBeyondTheStars.Tests/AdminAuthTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/AdminAuthTests.cs
@@ -1,0 +1,72 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using BlocksBeyondTheStars.Api;
+using Xunit;
+
+namespace BlocksBeyondTheStars.Tests;
+
+/// <summary>Fail-closed authorization for the /api admin endpoints (issue #411).</summary>
+public sealed class AdminAuthTests
+{
+    [Theory]
+    [InlineData("127.0.0.1")]
+    [InlineData("127.0.0.5")]
+    [InlineData("::1")]
+    [InlineData("localhost")]
+    [InlineData("LOCALHOST")]
+    [InlineData(" 127.0.0.1 ")]
+    public void IsLoopbackBind_TrueForLoopbackAddresses(string bind)
+    {
+        Assert.True(AdminAuth.IsLoopbackBind(bind));
+    }
+
+    [Theory]
+    [InlineData("0.0.0.0")]
+    [InlineData("::")]
+    [InlineData("192.168.1.5")]
+    [InlineData("10.0.0.1")]
+    [InlineData("*")]
+    [InlineData("+")]
+    [InlineData("example.com")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void IsLoopbackBind_FalseForEverythingElse(string? bind)
+    {
+        Assert.False(AdminAuth.IsLoopbackBind(bind));
+    }
+
+    [Fact]
+    public void NoPassword_LoopbackBind_Allows()
+    {
+        Assert.True(AdminAuth.IsAuthorized(configuredPassword: "", providedPassword: "", loopbackBind: true));
+    }
+
+    [Fact]
+    public void NoPassword_NonLoopbackBind_FailsClosed()
+    {
+        Assert.False(AdminAuth.IsAuthorized(configuredPassword: "", providedPassword: "", loopbackBind: false));
+        Assert.False(AdminAuth.IsAuthorized(configuredPassword: null, providedPassword: "anything", loopbackBind: false));
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void PasswordSet_CorrectHeader_Allows(bool loopbackBind)
+    {
+        Assert.True(AdminAuth.IsAuthorized("hunter2", "hunter2", loopbackBind));
+    }
+
+    [Theory]
+    [InlineData("wrong")]
+    [InlineData("")]
+    [InlineData(null)]
+    [InlineData("hunter")]
+    [InlineData("hunter22")]
+    public void PasswordSet_WrongOrMissingHeader_Rejects(string? provided)
+    {
+        // Even on a loopback bind a configured password must be enforced.
+        Assert.False(AdminAuth.IsAuthorized("hunter2", provided, loopbackBind: true));
+        Assert.False(AdminAuth.IsAuthorized("hunter2", provided, loopbackBind: false));
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the critical audit finding S2 (closes #411): with `BBS_ADMIN_PASSWORD` unset (the default), **every** `/api` admin route ran unauthenticated — `PUT /api/config`, backups, missions, content packs, logs. The Docker image forces `BBS_ADMIN_BIND=0.0.0.0` and `docker-compose.tls.yml` reverse-proxies `/api` publicly, so a password-less public deploy was open to full config takeover.

## Changes

- **New `AdminAuth` policy class** (unit-tested):
  - no password + **non-loopback** bind → every `/api` request answers **401** with a hint to set `BBS_ADMIN_PASSWORD` (fail closed — same posture as WorldHost `BasicAuth` / ReportHost)
  - no password + loopback bind → allowed as before (local dashboard use case)
  - configured password → enforced via **fixed-time comparison** (`CryptographicOperations.FixedTimeEquals`)
  - unparseable bind addresses (`*`, `+`, host names) count as non-loopback — when in doubt, fail closed
- Startup log warning when running password-less on a non-loopback bind; `/api/status` warning text now distinguishes both cases
- Public surfaces are **unaffected**: `/portal`, `/play`, `/download*`, `/updates` stay up either way
- SELF_HOSTING.md documents the fail-closed behavior; TODO.md work-log entry

## Testing

- 12 new `AdminAuthTests` cases (loopback classification + authorization matrix)
- Full server suite: **1071 passed, 0 failed**; CI-slnf build clean with `-warnaserror`

## Deploy note

Server-only change — reaches the VPS via an image redeploy, no client release needed. The VPS deploy sets `BBS_ADMIN_PASSWORD`, so nothing breaks there; self-hosters without a password lose only the (previously world-writable) admin endpoints, not the portal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)