### PR TITLE
fix(server): stop item duplication via duplicate trade-offer entries

### DIFF
--- a/src/BlocksBeyondTheStars.GameServer/GameServerTrade.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerTrade.cs
@@ -117,7 +117,14 @@ public sealed partial class GameServer
             return;
         }
 
-        var offer = items.Where(i => i.Count > 0).Select(i => new ItemAmount(i.Item, i.Count)).ToList();
+        // Aggregate per item id: duplicate entries (e.g. [{iron,50},{iron,50}]) would each pass the
+        // Has() check against the full owned count and then be Add()ed once per entry on commit —
+        // minting items from nothing. Summing through long clamps a wrap-around to an impossible
+        // amount, so an overflowing offer simply fails validation below.
+        var offer = items.Where(i => i.Count > 0)
+            .GroupBy(i => i.Item)
+            .Select(g => new ItemAmount(g.Key, (int)System.Math.Min(g.Sum(i => (long)i.Count), int.MaxValue)))
+            .ToList();
         // Validate against the offering player's OWN ship cargo, not the ship cursor (`_ship`). In normal
         // message dispatch the cursor already is this player, but keying off their own session removes the
         // cursor dependency so the check is correct regardless of who the server is currently serving.

--- a/tests/BlocksBeyondTheStars.Tests/TradeTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/TradeTests.cs
@@ -136,6 +136,42 @@ public sealed class TradeTests : IDisposable
     }
 
     [Fact]
+    public void DuplicateOfferEntries_BeyondStock_AreRejected_NoItemMinting()
+    {
+        var server = Started(out var repo);
+        using (repo)
+        {
+            TwoTradersTogether(server);
+            OpenTrade(server);
+
+            // Alice owns 10 iron_ore. Pre-fix, each duplicate entry passed the Has() check against
+            // the full owned count and was paid out per entry on commit — minting 10 extra (#406).
+            server.SetTradeOffer("Alice", new[] { new ItemAmount("iron_ore", 10), new ItemAmount("iron_ore", 10) });
+
+            Assert.Empty(server.ActiveTrade("Alice")!.OfferA); // aggregated 20 > 10 owned → rejected
+        }
+    }
+
+    [Fact]
+    public void DuplicateOfferEntries_WithinStock_AreMergedAndSwapOnce()
+    {
+        var server = Started(out var repo);
+        using (repo)
+        {
+            var (a, b) = TwoTradersTogether(server);
+            OpenTrade(server);
+
+            server.SetTradeOffer("Alice", new[] { new ItemAmount("iron_ore", 3), new ItemAmount("iron_ore", 4) });
+            server.ConfirmTrade("Alice");
+            server.ConfirmTrade("Bob"); // Bob offers nothing → still a valid one-sided gift
+
+            Assert.Null(server.ActiveTrade("Alice")); // committed
+            Assert.Equal(3, a.Inventory.CountOf("iron_ore")); // 10 − (3+4)
+            Assert.Equal(7, b.Inventory.CountOf("iron_ore")); // exactly the merged amount, no dupe
+        }
+    }
+
+    [Fact]
     public void Trade_RejectedWhenPartnersTooFarApart()
     {
         var server = Started(out var repo);


### PR DESCRIPTION
## Summary
- Fixes the critical item-duplication exploit from the static bug-hunt audit (`bugreports/bughunt.md` §1): a trade offer with duplicate item-id entries (e.g. `[{iron_ingot,50},{iron_ingot,50}]` with only 50 owned) passed validation per entry and paid out per entry on commit, minting `50·K` items per trade.
- `SetTradeOffer` now groups and sums the incoming offer per item id before it ever reaches `MaterialPool.Has`/`Remove`/`Add`. Summing goes through `long` and clamps to `int.MaxValue`, so an int-overflow offer simply fails the stock check instead of wrapping negative.
- Stored offers therefore never contain duplicate keys, which also keeps the commit-time re-validation and give-loop correct.

## Tests
- New: `DuplicateOfferEntries_BeyondStock_AreRejected_NoItemMinting` (the exact repro from the issue → rejected)
- New: `DuplicateOfferEntries_WithinStock_AreMergedAndSwapOnce` (legit duplicates merge; recipient gets exactly the merged amount)
- Full suite: 1049/1049 passing locally; server builds clean with `-warnaserror`.

closes #406

🤖 Generated with [Claude Code](https://claude.com/claude-code)