### PR TITLE
fix(client): dock/trade modal no longer permanently locks the cursor (#407)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -100,6 +100,18 @@ Per-item detail lives in the dated work log below.
 
 ---
 
+### ★ Dock/trade modal no longer permanently locks the cursor under the Tab menu (#407, 2026-07-19, branch fix-407-dock-modal-cursor)
+A dock/trade request arriving **while the Tab menu was open** locked the cursor for the rest of the
+session: PlayerInteractions freed the cursor only on the modal's *rising edge*, and GameMenu's close
+re-locks unconditionally — so once the edge was consumed under the menu, nothing ever unlocked again
+(audit finding C1, the worst case of the systemic #413). The modal cursor manager is now
+**level-triggered** like RespawnPrompt: while a dock/trade modal is up it re-asserts
+`MenuOpen` + a free cursor every frame, so closing the Tab menu reveals a clickable Accept/Decline
+panel instead of a dead session. On modal close the cursor is handed back to gameplay **unless the
+Tab menu is still open** (modal resolved remotely under it) — then the menu keeps ownership and
+re-locks on its own close (fixes stacking scenario (a) of M2 for this pair). Client-only; the
+broader cursor-ownership refactor stays with #413.
+
 ### ★ Failed local-server launch no longer strands the player in a silent void world (#409, 2026-07-19, branch fix/409-server-launch-swallowed)
 When the bundled singleplayer server failed to start (AV/SmartScreen block on a fresh install, broken
 update, port already bound) the client sailed on regardless: `LaunchPrepared()`'s bool result was never

--- a/client/Assets/BlocksBeyondTheStars/Scripts/GameMenu.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/GameMenu.cs
@@ -114,6 +114,10 @@ namespace BlocksBeyondTheStars.Client
         /// as the Tab key does (at the current tab), so a marketing shot can show the Tab menu over the cockpit.</summary>
         public void SetMenuOpen(bool open) => SetOpen(open);
 
+        /// <summary>Whether the Tab menu is currently open — read by <see cref="PlayerInteractions"/> to
+        /// decide who owns the cursor when its dock/trade modal closes (#407).</summary>
+        public bool IsOpen => _open;
+
         /// <summary>Opens the in-game Wiki ("Codex") screen — an always-available menu point.</summary>
         public void OpenWiki() { _browser = BrowserScreen.Wiki; SetOpen(true); }
 

--- a/client/Assets/BlocksBeyondTheStars/Scripts/PlayerInteractions.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/PlayerInteractions.cs
@@ -20,6 +20,7 @@ namespace BlocksBeyondTheStars.Client
     {
         public GameBootstrap Game;
         public RemotePlayers Remotes;
+        public GameMenu Menu; // Tab menu — cursor-ownership arbitration on modal close (#407)
 
         public float InteractRange = 6f;
 
@@ -33,20 +34,30 @@ namespace BlocksBeyondTheStars.Client
             }
 
             // Our windows are modal: while one is up, free the cursor and pause on-foot control.
+            // Level-triggered (like RespawnPrompt), not edge-triggered: a dock/trade request can
+            // arrive while the Tab menu is open, and GameMenu re-locks the cursor unconditionally
+            // on close — re-asserting every frame keeps the modal clickable instead of leaving the
+            // session with a permanently locked cursor (#407).
             bool modal = Game.TradeActive || !string.IsNullOrEmpty(Game.PendingDockFrom);
-            if (modal && !_managedCursor)
+            if (modal)
             {
                 Game.MenuOpen = true;
                 Cursor.lockState = CursorLockMode.None;
                 Cursor.visible = true;
                 _managedCursor = true;
             }
-            else if (!modal && _managedCursor)
+            else if (_managedCursor)
             {
-                Game.MenuOpen = false;
-                Cursor.lockState = CursorLockMode.Locked;
-                Cursor.visible = false;
                 _managedCursor = false;
+                // Hand the cursor back to gameplay — unless the Tab menu is still open above us
+                // (the modal resolved remotely under it); then the menu keeps cursor ownership
+                // and re-locks on its own close.
+                if (Menu == null || !Menu.IsOpen)
+                {
+                    Game.MenuOpen = false;
+                    Cursor.lockState = CursorLockMode.Locked;
+                    Cursor.visible = false;
+                }
             }
 
             if (modal || Game.MenuOpen || Game.SpaceViewActive || Game.ChatTyping)

--- a/client/Assets/BlocksBeyondTheStars/Scripts/WorldRig.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/WorldRig.cs
@@ -259,6 +259,7 @@ namespace BlocksBeyondTheStars.Client
             var interactions = root.AddComponent<PlayerInteractions>();
             interactions.Game = boot;
             interactions.Remotes = remotes;
+            interactions.Menu = menu;
 
             // Render planet enemies (M25).
             var entities = root.AddComponent<WorldEntities>();


### PR DESCRIPTION
## Problem (audit finding C1, critical)

A dock/trade request that arrives **while the Tab menu is open** permanently locked the cursor for the rest of the session:

- `PlayerInteractions` freed the cursor only on the modal's **rising edge** (`modal && !_managedCursor`).
- `GameMenu.SetOpen(false)` re-locks the cursor **unconditionally**.
- The dock panel (sortingOrder 22) renders under the crafting menu (50), so the Accept/Decline buttons sat invisible.

Once the edge was consumed under the open menu, closing the menu locked the cursor and no new edge could ever fire — cursor and all T/K/U interactions dead until restart. Same deadlock via trade + Tab.

## Fix

Level-triggered cursor management, matching the established `RespawnPrompt` pattern:

- While a dock/trade modal is up, `PlayerInteractions` re-asserts `MenuOpen` + a free, visible cursor **every frame**. Closing the Tab menu now reveals a clickable Accept/Decline panel instead of a dead session.
- On modal close the cursor is handed back to gameplay **unless the Tab menu is still open above it** (modal resolved remotely under the menu) — then the menu keeps cursor ownership and re-locks on its own close. This also fixes stacking scenario (a) of M2 for this pair (new `GameMenu.IsOpen` getter, wired in `WorldRig`).

The systemic cursor-ownership refactor (shared `MenuOpen` bool, ~8 panels) stays tracked in #413 — this PR is the targeted fix for the session-permanent worst case.

## Verification

- `scripts/run-tests.ps1`: both suites green (server + ClientCore, 129/129 client tests).
- Local Unity Windows player build from this branch: clean, no errors.

Closes #407

🤖 Generated with [Claude Code](https://claude.com/claude-code)