### PR TITLE
fix(client): failed local-server launch bails to menu with a notice instead of a silent void world (#409)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -100,6 +100,19 @@ Per-item detail lives in the dated work log below.
 
 ---
 
+### ★ Failed local-server launch no longer strands the player in a silent void world (#409, 2026-07-19, branch fix/409-server-launch-swallowed)
+When the bundled singleplayer server failed to start (AV/SmartScreen block on a fresh install, broken
+update, port already bound) the client sailed on regardless: `LaunchPrepared()`'s bool result was never
+consumed, the loading screen proceeded on its pure timing guard, and `Disconnected` never fires for a
+never-connected session — so after the 25 s veil timeout the player floated in a chunk-less void with
+no message (audit finding C3; exactly the first-run experience that makes new players uninstall). Now
+`AppShell.Update` **consumes the launch task's result** and watches for an **early process exit**
+during the never-connected window, and `GameBootstrap` raises a localized `ConnectFailedReason` once
+its 6×2 s connect retries are exhausted (also catching a mistyped multiplayer host/port); both drive
+the same bail-out as a rejected join — back to the main menu with a DE/EN notice (`ui.sp.server_failed`
+with an antivirus hint for local hosting, generic `ui.connect.failed` for remote joins). Client-only;
+reaches players with the next release.
+
 ### ★ WorldHost rate limits no longer spoofable via X-Forwarded-For; per-account login backoff (#418, 2026-07-19, branch fix/418-xff-ratelimit)
 The ForwardedHeaders middleware had `KnownIPNetworks`/`KnownProxies` **cleared**, which in ASP.NET
 means "trust any peer": whoever reached the bind directly could rotate a fabricated `X-Forwarded-For`

--- a/client/Assets/BlocksBeyondTheStars/Scripts/AppShell.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/AppShell.cs
@@ -86,7 +86,7 @@ namespace BlocksBeyondTheStars.Client
         /// Null until the first browser-singleplayer start; survives returns to the menu stopped.</summary>
         public BrowserLocalServer BrowserServer { get; private set; }
         private bool _serverPending;                          // prepared, waiting to spawn once the screen is up
-        private System.Threading.Tasks.Task _serverLaunch;    // the off-thread spawn (so Process.Start can't freeze us)
+        private System.Threading.Tasks.Task<bool> _serverLaunch; // the off-thread spawn (so Process.Start can't freeze us)
         private GameObject _gameRoot;
 
         public bool ContentReady { get; private set; }
@@ -1001,6 +1001,32 @@ namespace BlocksBeyondTheStars.Client
                 _serverLaunch = System.Threading.Tasks.Task.Run(() => _localServer.LaunchPrepared());
             }
 
+            // A failed local-server launch must never strand the player in an empty void (#409): consume
+            // the launch task's result (Process.Start refused — AV/SmartScreen block, broken bundle) and
+            // watch for an early process exit (port already bound, instant crash) while nothing is
+            // connected yet. Either way: back to the menu with a notice instead of a silent chunk-less
+            // world. Once the client is connected, a dying server fires Disconnected → DisconnectScreen,
+            // so this watcher only owns the never-connected window.
+            if (_hostLocal && _serverLaunch != null && _serverLaunch.IsCompleted)
+            {
+                bool launched = _serverLaunch.Status == System.Threading.Tasks.TaskStatus.RanToCompletion
+                                && _serverLaunch.Result;
+                var bootForNet = Phase == ShellPhase.InGame ? Boot() : null;
+                bool connected = bootForNet != null && bootForNet.Network != null && bootForNet.Network.Connected;
+                if (connected)
+                {
+                    _serverLaunch = null; // handed over to the normal disconnect handling — stop watching
+                }
+                else if (!launched || !_localServer.IsRunning)
+                {
+                    _serverLaunch = null;
+                    Debug.LogError("Local server failed to launch or exited before the first connect — returning to menu.");
+                    ReturnToMenu();
+                    MenuNotice = L("ui.sp.server_failed");
+                    return;
+                }
+            }
+
             // Settings + credits are uGUI now too (the whole shell is one design).
             if (Phase == ShellPhase.Settings && _uiSettings == null)
             {
@@ -1054,6 +1080,17 @@ namespace BlocksBeyondTheStars.Client
             if (igBoot != null && !string.IsNullOrEmpty(igBoot.JoinRejectedReason))
             {
                 MenuNotice = igBoot.JoinRejectedReason;
+                ReturnToMenu();
+                return;
+            }
+
+            // Never connected at all (#409): the bundled server never came up (blocked/crashed) or a
+            // multiplayer host/port was mistyped. Same bail-out as a rejected join — menu + reason —
+            // instead of an empty void once the loading veil times out. The local-server case gets the
+            // more helpful "server could not start" text (antivirus hint) over the generic connect error.
+            if (igBoot != null && !string.IsNullOrEmpty(igBoot.ConnectFailedReason))
+            {
+                MenuNotice = _hostLocal ? L("ui.sp.server_failed") : igBoot.ConnectFailedReason;
                 ReturnToMenu();
                 return;
             }

--- a/client/Assets/BlocksBeyondTheStars/Scripts/GameBootstrap.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/GameBootstrap.cs
@@ -726,6 +726,12 @@ namespace BlocksBeyondTheStars.Client
         /// AppShell watches this and returns to the menu showing the reason.</summary>
         public string JoinRejectedReason { get; private set; } = string.Empty;
 
+        /// <summary>Set when the transport never connected after every retry (the bundled singleplayer
+        /// server never came up, or a mistyped multiplayer host/port). AppShell watches this and returns
+        /// to the menu showing the reason — without it the player would sit in a chunk-less void once
+        /// the loading veil times out, with no hint anything went wrong (#409).</summary>
+        public string ConnectFailedReason { get; private set; } = string.Empty;
+
         /// <summary>Last server feedback line (craft result / rejection / message) for a HUD toast.</summary>
         public string LastMessage { get; private set; } = string.Empty;
 
@@ -1288,11 +1294,22 @@ namespace BlocksBeyondTheStars.Client
                     // Safety net: re-attempt the connection a few times (e.g. the local
                     // singleplayer server is still starting up).
                     _retryTimer += Time.deltaTime;
-                    if (_retryTimer >= 2f && _retries < 6)
+                    if (_retryTimer >= 2f)
                     {
-                        _retryTimer = 0f;
-                        _retries++;
-                        Network.Connect(Host, Port);
+                        if (_retries < 6)
+                        {
+                            _retryTimer = 0f;
+                            _retries++;
+                            Network.Connect(Host, Port);
+                        }
+                        else if (string.IsNullOrEmpty(ConnectFailedReason))
+                        {
+                            // All retries spent and still no connection: give up loudly. Disconnected
+                            // never fires for a never-connected session, so this flag is the only
+                            // signal AppShell gets to bail back to the menu with a message (#409).
+                            Debug.LogError($"Could not connect to {Host}:{Port} after {_retries} retries — giving up.");
+                            ConnectFailedReason = Localizer?.Get("ui.connect.failed") ?? "Could not connect to the server.";
+                        }
                     }
                 }
             }

--- a/data/locales/de.json
+++ b/data/locales/de.json
@@ -1018,6 +1018,8 @@
   "ui.sp.browser_failed": "Die Welt konnte in diesem Browser nicht gestartet werden - bitte lade die Seite neu und versuch es noch einmal.",
   "ui.settings.recovered_backup": "Deine Einstellungsdatei war beschaedigt - die letzte gute Sicherung wurde automatisch wiederhergestellt.",
   "ui.settings.reset_defaults": "Deine Einstellungsdatei war beschaedigt und wurde zurueckgesetzt - bitte pruefe deinen Namen und deine Optionen in den Einstellungen.",
+  "ui.sp.server_failed": "Der Welt-Server konnte nicht gestartet werden - vielleicht wurde er vom Virenschutz blockiert oder ein anderes Programm benutzt seinen Port. Bitte versuch es noch einmal oder starte das Spiel neu, wenn es wieder passiert.",
+  "ui.connect.failed": "Keine Verbindung zum Server moeglich - bitte pruefe Adresse und Port und versuch es noch einmal.",
   "ui.host.title": "WELT HOSTEN",
   "ui.host.subtitle": "Eine Welt für Freunde hosten: eine gespeicherte Welt wählen oder neu erstellen, dann die im Spiel angezeigte Adresse teilen.",
   "ui.host.max_players": "Max. Spieler",

--- a/data/locales/en.json
+++ b/data/locales/en.json
@@ -1017,6 +1017,8 @@
   "ui.sp.browser_failed": "The world could not be started in this browser - please reload the page and try again.",
   "ui.settings.recovered_backup": "Your settings file was damaged - the last good backup was restored automatically.",
   "ui.settings.reset_defaults": "Your settings file was damaged and has been reset to defaults - please check your name and options in Settings.",
+  "ui.sp.server_failed": "The world server could not be started - it may have been blocked by your antivirus or another program is using its port. Please try again, or restart the game if it keeps happening.",
+  "ui.connect.failed": "Could not connect to the server - please check the address and port and try again.",
   "ui.host.title": "HOST A WORLD",
   "ui.host.subtitle": "Host a world for friends: pick any saved world or create a new one, then share the address shown in-game.",
   "ui.host.max_players": "Max players",


### PR DESCRIPTION
## Summary

Fixes the swallowed local-server launch failure (audit finding C3, #409): when the bundled singleplayer server could not start - AV/SmartScreen blocking the freshly installed EXE, a broken update, or the port already bound - the client sailed on regardless and the player ended up floating in a chunk-less void with **no error message**. This hits exactly first-run players, who then silently uninstall.

## Root causes addressed

- `LaunchPrepared()`'s bool result was never consumed (`AppShell.cs`): the loading screen proceeded on a pure timing guard.
- `Disconnected` never fires for a never-connected session (`NetworkClient.cs`), so the DisconnectScreen could not trigger; `GameBootstrap` retried UDP connect 6x2s and then went quiet.

## Changes

- **AppShell.Update** consumes the off-thread launch task's result and additionally watches for an **early server-process exit** (port bound, instant crash) during the never-connected window. Either failure returns the player to the main menu with a localized notice. Once connected, the watcher hands over to the normal `Disconnected` -> DisconnectScreen path.
- **GameBootstrap** raises a new `ConnectFailedReason` once all 6 connect retries are exhausted (~14s, well before the 25s loading-veil `MaxShow`); AppShell handles it exactly like `JoinRejectedReason` (menu + reason). This also covers a **mistyped multiplayer host/port**.
- **Locales (DE+EN)**: `ui.sp.server_failed` (with an antivirus hint for the local-hosting case) and `ui.connect.failed` (generic, remote joins).
- TODO.md work-log entry.

## Verification

- Full test suite green locally: **1073 server + 129 client-core, 0 failures** (includes the en/de locale-parity test covering the new keys).
- Local Unity Windows client build succeeded in the worktree (client compiles with the changes).

Closes #409

🤖 Generated with [Claude Code](https://claude.com/claude-code)