### PR TITLE
fix(client): corrupt settings no longer destroy the PlayerToken (#410)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -5949,6 +5949,18 @@ is **pre-approved** (keys in `tools/ai-assets/.env`, run via `uv`).
 
 ---
 
+## ✅ Done (2026-07-19): corrupt settings can no longer destroy the PlayerToken (#410)
+
+A corrupt/truncated `client_settings.json` used to silently reset all settings **and** overwrite the only
+copy of the name-claim token — permanently locking the player out of their own multiplayer name.
+`ClientSettings.Save` is now atomic (temp + `File.Replace`) and keeps the previous file as
+`client_settings.json.bak`; `Load` recovers from the `.bak`, preserves the unreadable file as
+`client_settings.json.corrupt` (never clobbers it), and the token additionally lives in its own
+`player_token.txt` backup that settings rewrites never touch (restored even when settings + `.bak` are both
+gone; existing installs gain the backup on next launch). A one-shot localized main-menu notice tells the
+player when a recovery/reset happened. Covered by a new EditMode test suite
+(`ClientSettingsPersistenceEditModeTests`). Ships to players with the next client release.
+
 ## ✅ Done (2026-07-17): fast PR test gate again — Release tests, Slow-tier hygiene, duration guardrail
 
 The PR gate had silently decayed from its designed ~6 min back to ~15 min: new CPU-heavy tests were

--- a/client/Assets/BlocksBeyondTheStars/Scripts/ClientSettings.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/ClientSettings.cs
@@ -336,25 +336,52 @@ namespace BlocksBeyondTheStars.Client
             return true;
         }
 
-        private static string FilePath => Path.Combine(Application.persistentDataPath, "client_settings.json");
+        /// <summary>Directory the settings/token files live in; null = Unity's persistent data path. A static
+        /// seam (Load/Save are static) so the edit-mode tests can run against a scratch directory instead of
+        /// the developer's real settings.</summary>
+        public static string StorageDirOverride = null;
+
+        /// <summary>Locale KEY of a one-shot "settings were recovered / reset" notice set by <see cref="Load"/>.
+        /// Load runs before the localizer exists, so the main menu localizes it into
+        /// <see cref="AppShell.MenuNotice"/> at build time and clears this.</summary>
+        public static string LoadNoticeKey = "";
+
+        private static string StorageDir => string.IsNullOrEmpty(StorageDirOverride)
+            ? Application.persistentDataPath
+            : StorageDirOverride;
+
+        private static string FilePath => Path.Combine(StorageDir, "client_settings.json");
+
+        /// <summary>The previous settings file, kept by every atomic <see cref="Save"/> as the recovery source
+        /// when the main file is lost/corrupted (crash mid-write, disk hiccup, AV interference).</summary>
+        private static string BackupPath => FilePath + ".bak";
+
+        /// <summary>Where an unreadable settings file is moved (never deleted) so nothing is clobbered and a
+        /// bug report can include the evidence.</summary>
+        private static string CorruptPath => FilePath + ".corrupt";
+
+        /// <summary>Separate copy of just <see cref="PlayerToken"/>. The token is irreplaceable (it IS the
+        /// name claim on every server), so it gets its own tiny file that no settings rewrite ever touches —
+        /// the last line of defence when both the settings file and its .bak are gone (#410).</summary>
+        private static string TokenPath => Path.Combine(StorageDir, "player_token.txt");
 
         public static ClientSettings Load()
         {
-            // Capture before touching the file: a genuine first run is the only time we auto-pick the
+            // Capture before touching the files: a genuine first run is the only time we auto-pick the
             // language from the OS. Returning players keep whatever they chose (even an explicit "en").
-            bool freshInstall = !File.Exists(FilePath);
+            // Any surviving file — main, backup or token — counts as an existing install.
+            bool freshInstall = !File.Exists(FilePath) && !File.Exists(BackupPath) && !File.Exists(TokenPath);
 
-            ClientSettings settings = null;
-            try
+            ClientSettings settings = TryReadSettingsFile(FilePath);
+            bool recovering = settings == null && File.Exists(FilePath);
+            if (recovering)
             {
-                if (File.Exists(FilePath))
-                {
-                    settings = JsonUtility.FromJson<ClientSettings>(File.ReadAllText(FilePath));
-                }
-            }
-            catch (Exception e)
-            {
-                Debug.LogWarning($"Could not read client settings, using defaults: {e.Message}");
+                // The settings file exists but can't be parsed. Never reset it silently — that used to
+                // destroy the only copy of the name-claim token and permanently lock the player out of
+                // their own name (#410). Preserve the evidence, then fall back to the last good backup.
+                PreserveCorruptFile();
+                settings = TryReadSettingsFile(BackupPath);
+                LoadNoticeKey = settings != null ? "ui.settings.recovered_backup" : "ui.settings.reset_defaults";
             }
 
             settings ??= new ClientSettings();
@@ -373,10 +400,28 @@ namespace BlocksBeyondTheStars.Client
                 }
             }
 
+            bool tokenChanged = false;
+            if (string.IsNullOrEmpty(settings.PlayerToken))
+            {
+                // Both the settings and their backup lost the token (or a fresh install): restore it from
+                // its own backup file before ever minting a new one.
+                settings.PlayerToken = TryReadTokenBackup();
+                tokenChanged = !string.IsNullOrEmpty(settings.PlayerToken);
+            }
+
             if (string.IsNullOrEmpty(settings.PlayerToken))
             {
                 settings.PlayerToken = Guid.NewGuid().ToString("N");
-                settings.Save(); // persist the claim secret right away so it survives a crash before the next save
+                tokenChanged = true;
+            }
+
+            if (recovering || tokenChanged)
+            {
+                settings.Save(); // persist the recovered state / claim secret right away so it survives a crash
+            }
+            else
+            {
+                EnsureTokenBackup(settings.PlayerToken); // heal installs that predate the token backup file
             }
 
             return settings;
@@ -386,11 +431,94 @@ namespace BlocksBeyondTheStars.Client
         {
             try
             {
-                File.WriteAllText(FilePath, JsonUtility.ToJson(this, prettyPrint: true));
+                // Atomic write (#410): a crash mid-write may corrupt only the .tmp file, never the live
+                // settings. The previous file survives as .bak — Load's recovery source.
+                string tmp = FilePath + ".tmp";
+                File.WriteAllText(tmp, JsonUtility.ToJson(this, prettyPrint: true));
+                if (File.Exists(FilePath))
+                {
+                    try
+                    {
+                        File.Replace(tmp, FilePath, BackupPath);
+                    }
+                    catch (Exception)
+                    {
+                        // File.Replace can be unavailable (platform FS quirks) — same net result, just not atomic.
+                        File.Copy(FilePath, BackupPath, overwrite: true);
+                        File.Delete(FilePath);
+                        File.Move(tmp, FilePath);
+                    }
+                }
+                else
+                {
+                    File.Move(tmp, FilePath);
+                }
+
+                EnsureTokenBackup(PlayerToken);
             }
             catch (Exception e)
             {
                 Debug.LogWarning($"Could not save client settings: {e.Message}");
+            }
+        }
+
+        private static ClientSettings TryReadSettingsFile(string path)
+        {
+            try
+            {
+                if (!File.Exists(path)) return null;
+                return JsonUtility.FromJson<ClientSettings>(File.ReadAllText(path));
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning($"Could not read client settings from '{Path.GetFileName(path)}': {e.Message}");
+                return null;
+            }
+        }
+
+        /// <summary>Moves the unreadable settings file aside to <see cref="CorruptPath"/> (keeping only the
+        /// latest incident). Moving — not deleting — means the next Save can't shove corrupt content into
+        /// the .bak slot, and the player still has the raw file.</summary>
+        private static void PreserveCorruptFile()
+        {
+            try
+            {
+                if (File.Exists(CorruptPath)) File.Delete(CorruptPath);
+                File.Move(FilePath, CorruptPath);
+                Debug.LogWarning($"Preserved unreadable client settings as '{Path.GetFileName(CorruptPath)}'.");
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning($"Could not preserve the corrupt client settings file: {e.Message}");
+            }
+        }
+
+        private static string TryReadTokenBackup()
+        {
+            try
+            {
+                return File.Exists(TokenPath) ? File.ReadAllText(TokenPath).Trim() : "";
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning($"Could not read the player-token backup: {e.Message}");
+                return "";
+            }
+        }
+
+        private static void EnsureTokenBackup(string token)
+        {
+            if (string.IsNullOrEmpty(token)) return;
+            try
+            {
+                if (!File.Exists(TokenPath) || !string.Equals(File.ReadAllText(TokenPath).Trim(), token, StringComparison.Ordinal))
+                {
+                    File.WriteAllText(TokenPath, token);
+                }
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning($"Could not write the player-token backup: {e.Message}");
             }
         }
 

--- a/client/Assets/BlocksBeyondTheStars/Scripts/UiMainMenu.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/UiMainMenu.cs
@@ -50,6 +50,14 @@ namespace BlocksBeyondTheStars.Client
             GameObject official = null;
 
             // --- One-shot notice (e.g. why the last join was refused) ---
+            // A settings-recovery incident (#410) is claimed here rather than at load time: ClientSettings.Load
+            // runs before the localizer exists, so it can only stash the locale KEY of the notice.
+            if (string.IsNullOrEmpty(shell.MenuNotice) && !string.IsNullOrEmpty(ClientSettings.LoadNoticeKey))
+            {
+                shell.MenuNotice = shell.L(ClientSettings.LoadNoticeKey);
+                ClientSettings.LoadNoticeKey = "";
+            }
+
             if (!string.IsNullOrEmpty(shell.MenuNotice))
             {
                 UiKit.AddText(root, 90f, 286f, 1200f, 28f, shell.MenuNotice, 17,

--- a/client/Assets/Tests/EditMode/ClientSettingsPersistenceEditModeTests.cs
+++ b/client/Assets/Tests/EditMode/ClientSettingsPersistenceEditModeTests.cs
@@ -1,0 +1,135 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using System.IO;
+using BlocksBeyondTheStars.Client;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace BlocksBeyondTheStars.Client.Tests.EditMode
+{
+    /// <summary>
+    /// Pins the settings-persistence hardening from issue #410: a corrupt <c>client_settings.json</c> must
+    /// never destroy the name-claim <see cref="ClientSettings.PlayerToken"/> (which would permanently lock
+    /// the player out of their own multiplayer name). Saves are atomic (temp + rename) and keep a .bak;
+    /// loads recover from the .bak, then from the separate token backup, and preserve the corrupt file.
+    /// All tests run against a scratch directory via <see cref="ClientSettings.StorageDirOverride"/> so the
+    /// developer's real settings are never touched.
+    /// </summary>
+    public sealed class ClientSettingsPersistenceEditModeTests
+    {
+        private string _dir;
+
+        private static string SettingsPath(string dir) => Path.Combine(dir, "client_settings.json");
+        private static string BackupPath(string dir) => Path.Combine(dir, "client_settings.json.bak");
+        private static string CorruptPath(string dir) => Path.Combine(dir, "client_settings.json.corrupt");
+        private static string TokenPath(string dir) => Path.Combine(dir, "player_token.txt");
+
+        [SetUp]
+        public void SetUp()
+        {
+            _dir = Path.Combine(Path.GetTempPath(), "bbts_settings_tests_" + System.Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_dir);
+            ClientSettings.StorageDirOverride = _dir;
+            ClientSettings.LoadNoticeKey = "";
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            ClientSettings.StorageDirOverride = null;
+            ClientSettings.LoadNoticeKey = "";
+            try { Directory.Delete(_dir, recursive: true); } catch (IOException) { }
+        }
+
+        [Test]
+        public void SaveThenLoad_RoundTripsAndWritesTokenBackup()
+        {
+            var settings = new ClientSettings { PlayerName = "Justus", PlayerToken = "token-one", MouseSensitivity = 3.5f };
+            settings.Save();
+
+            var loaded = ClientSettings.Load();
+
+            Assert.AreEqual("Justus", loaded.PlayerName);
+            Assert.AreEqual("token-one", loaded.PlayerToken);
+            Assert.AreEqual(3.5f, loaded.MouseSensitivity);
+            Assert.IsTrue(File.Exists(TokenPath(_dir)), "Save must mirror the token into its own backup file");
+            Assert.AreEqual("token-one", File.ReadAllText(TokenPath(_dir)).Trim());
+            Assert.IsFalse(File.Exists(SettingsPath(_dir) + ".tmp"), "the atomic-write temp file must not linger");
+            Assert.AreEqual("", ClientSettings.LoadNoticeKey, "a clean load must not raise a recovery notice");
+        }
+
+        [Test]
+        public void Save_KeepsThePreviousFileAsBackup()
+        {
+            var settings = new ClientSettings { PlayerName = "First", PlayerToken = "token-one" };
+            settings.Save();
+            settings.PlayerName = "Second";
+            settings.Save();
+
+            Assert.IsTrue(File.Exists(BackupPath(_dir)), "the second save must keep the previous file as .bak");
+            var backup = JsonUtility.FromJson<ClientSettings>(File.ReadAllText(BackupPath(_dir)));
+            Assert.AreEqual("First", backup.PlayerName);
+            var main = JsonUtility.FromJson<ClientSettings>(File.ReadAllText(SettingsPath(_dir)));
+            Assert.AreEqual("Second", main.PlayerName);
+        }
+
+        [Test]
+        public void Load_WithCorruptFile_RecoversFromBackupAndPreservesTheEvidence()
+        {
+            var settings = new ClientSettings { PlayerName = "Pilot", PlayerToken = "token-one" };
+            settings.Save();
+            settings.Save(); // second save stamps the good state into .bak
+            File.WriteAllText(SettingsPath(_dir), "{\"PlayerName\":\"Pilo"); // truncated mid-write
+
+            var loaded = ClientSettings.Load();
+
+            Assert.AreEqual("Pilot", loaded.PlayerName, "settings must come back from the .bak");
+            Assert.AreEqual("token-one", loaded.PlayerToken, "the name-claim token must survive the corruption");
+            Assert.AreEqual("ui.settings.recovered_backup", ClientSettings.LoadNoticeKey);
+            Assert.IsTrue(File.Exists(CorruptPath(_dir)), "the corrupt file must be preserved, not clobbered");
+            var rewritten = JsonUtility.FromJson<ClientSettings>(File.ReadAllText(SettingsPath(_dir)));
+            Assert.AreEqual("token-one", rewritten.PlayerToken, "the recovered state must be persisted again");
+        }
+
+        [Test]
+        public void Load_WithCorruptFileAndNoBackup_StillRestoresTheTokenFromItsOwnBackup()
+        {
+            // First save ever (no .bak yet), then the only settings file gets corrupted: the worst case
+            // from #410. Settings reset to defaults, but the token backup must save the name claim.
+            new ClientSettings { PlayerName = "Pilot", PlayerToken = "token-one" }.Save();
+            File.WriteAllText(SettingsPath(_dir), "not json at all");
+
+            var loaded = ClientSettings.Load();
+
+            Assert.AreEqual("", loaded.PlayerName, "settings fall back to defaults without a .bak");
+            Assert.AreEqual("token-one", loaded.PlayerToken, "the token must be restored from player_token.txt");
+            Assert.AreEqual("ui.settings.reset_defaults", ClientSettings.LoadNoticeKey);
+            Assert.IsTrue(File.Exists(CorruptPath(_dir)));
+        }
+
+        [Test]
+        public void Load_OnFreshInstall_GeneratesAndBacksUpAToken()
+        {
+            var loaded = ClientSettings.Load();
+
+            Assert.IsNotEmpty(loaded.PlayerToken);
+            Assert.IsTrue(File.Exists(SettingsPath(_dir)), "the minted token must be persisted immediately");
+            Assert.AreEqual(loaded.PlayerToken, File.ReadAllText(TokenPath(_dir)).Trim());
+            Assert.AreEqual("", ClientSettings.LoadNoticeKey, "a fresh install is not a recovery");
+        }
+
+        [Test]
+        public void Load_HealsAMissingTokenBackup_WithoutRewritingSettings()
+        {
+            new ClientSettings { PlayerToken = "token-one" }.Save();
+            File.Delete(TokenPath(_dir));
+
+            var loaded = ClientSettings.Load();
+
+            Assert.AreEqual("token-one", loaded.PlayerToken);
+            Assert.AreEqual("token-one", File.ReadAllText(TokenPath(_dir)).Trim(),
+                "an install that predates the token backup must gain one on the next load");
+        }
+    }
+}

--- a/client/Assets/Tests/EditMode/ClientSettingsPersistenceEditModeTests.cs.meta
+++ b/client/Assets/Tests/EditMode/ClientSettingsPersistenceEditModeTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 96ccc1cbf63865b4a85abbf43acada8c

--- a/data/locales/de.json
+++ b/data/locales/de.json
@@ -1016,6 +1016,8 @@
   "ui.glitch.arcade_failed": "Die Arcade-Welt konnte gerade nicht betreten werden - bitte versuch es gleich noch einmal.",
   "ui.glitch.access_revoked": "Dein Arcade-Zugang wurde gesperrt.",
   "ui.sp.browser_failed": "Die Welt konnte in diesem Browser nicht gestartet werden - bitte lade die Seite neu und versuch es noch einmal.",
+  "ui.settings.recovered_backup": "Deine Einstellungsdatei war beschaedigt - die letzte gute Sicherung wurde automatisch wiederhergestellt.",
+  "ui.settings.reset_defaults": "Deine Einstellungsdatei war beschaedigt und wurde zurueckgesetzt - bitte pruefe deinen Namen und deine Optionen in den Einstellungen.",
   "ui.host.title": "WELT HOSTEN",
   "ui.host.subtitle": "Eine Welt für Freunde hosten: eine gespeicherte Welt wählen oder neu erstellen, dann die im Spiel angezeigte Adresse teilen.",
   "ui.host.max_players": "Max. Spieler",

--- a/data/locales/en.json
+++ b/data/locales/en.json
@@ -1015,6 +1015,8 @@
   "ui.glitch.arcade_failed": "Could not join the arcade world right now - please try again in a moment.",
   "ui.glitch.access_revoked": "Your arcade access has been revoked.",
   "ui.sp.browser_failed": "The world could not be started in this browser - please reload the page and try again.",
+  "ui.settings.recovered_backup": "Your settings file was damaged - the last good backup was restored automatically.",
+  "ui.settings.reset_defaults": "Your settings file was damaged and has been reset to defaults - please check your name and options in Settings.",
   "ui.host.title": "HOST A WORLD",
   "ui.host.subtitle": "Host a world for friends: pick any saved world or create a new one, then share the address shown in-game.",
   "ui.host.max_players": "Max players",


### PR DESCRIPTION
## Summary

A corrupt/truncated `client_settings.json` used to silently reset all settings **and** overwrite the only copy of the name-claim `PlayerToken` — under name verification the player was then permanently rejected on every server under their own established name (issue #410, audit finding M1, upgraded to Critical).

## Changes

- **Atomic saves**: `ClientSettings.Save()` writes to a `.tmp` file and swaps it in via `File.Replace` (with a copy+move fallback), so a crash mid-write can only ever corrupt the temp file, never the live settings.
- **Rolling backup**: every save keeps the previous file as `client_settings.json.bak` — the recovery source for `Load()`.
- **Never clobber evidence**: an unreadable settings file is moved aside to `client_settings.json.corrupt` (latest incident kept) instead of being overwritten.
- **Separate token backup**: the token is mirrored into `player_token.txt`, which settings rewrites never touch. It restores the name claim even when the settings file *and* its `.bak` are both lost; installs that predate the file gain it on the next launch.
- **One-shot menu notice** (DE+EN): the main menu tells the player whether their settings were restored from backup or reset to defaults (`ui.settings.recovered_backup` / `ui.settings.reset_defaults`).

## Recovery ladder on load

1. parse `client_settings.json` → ok: as before
2. corrupt → preserve as `.corrupt`, load `client_settings.json.bak` (full recovery incl. token, notice shown)
3. no usable `.bak` → defaults, but token restored from `player_token.txt` (name claim survives, notice shown)
4. nothing at all → genuine fresh install, mint a new token and persist it + its backup immediately

## Testing

- New EditMode suite `ClientSettingsPersistenceEditModeTests` (6 tests) against a scratch directory (`StorageDirOverride` seam): round-trip, `.bak` rotation, backup recovery, token-only recovery, fresh-install minting, token-backup healing — UnityEdit suite green (18/18).
- .NET suites green: 1047 server + 129 client (incl. locale parity for the two new keys).
- Local clean Unity Windows build: success, no compiler warnings.

**Note:** this is client-side — it reaches players only with the next client release (Velopack).

Closes #410

🤖 Generated with [Claude Code](https://claude.com/claude-code)