### PR TITLE
fix(server): wake-lock the reaper/archive sweep; WS accept loop survives request faults (#415, #416, #417)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -100,6 +100,26 @@ Per-item detail lives in the dated work log below.
 
 ---
 
+### ★ WorldHost background passes take the wake lock; WS gateway accept loop survives request faults (#415/#416/#417, 2026-07-19, branch fix/415-417-worldhost-hardening)
+Three audit findings (S3/S4/S5), one theme: fleet background work racing live joins. **(#415)** The
+reaper read a world row, spent seconds in `docker inspect`, then wrote `Stopped/""` **without the
+per-world wake lock** — a join waking the world in that window got its fresh registry row clobbered,
+and the *next* join's `docker rm -f bbs-world-<id>` SIGKILLed the live container (players dropped,
+progress since the last autosave lost). `Reap()` now takes each world's wake lock non-blocking
+(`Wait(0)`; a held lock means a join is waking it — skip this pass) and re-reads the row under the
+lock before deciding. **(#416)** Same class in the hourly `ArchiveSweep`: its live-container guard
+inspected the **stale** candidate row whose container id is always `""`, so it could move `world.db`
+out from under a world being woken. The sweep now also takes the wake lock per world and re-checks
+the FRESH row (status still Stopped, no recent start, fresh container id not running) right before
+moving files. **(#417)** The browser WS gateway's accept loop only guarded `GetContextAsync`; the
+response writes for `/`, `/healthz`, `/status`, `/announce` ran bare, so a client resetting the
+connection mid-write (or a faulting status provider) exited the `while (_running)` loop — no browser
+client could connect until process restart, a silent partial outage since native clients keep
+working. Per-request handling (HTTP branches + WS upgrade) is now wrapped so one bad request can
+never end the loop. Regression tests: blocked-health-probe harness proves reap/sweep skip a mid-wake
+world (reap test fails pre-fix), and a throwing `/status` provider proves the gateway answers the
+next request (fails pre-fix). Server-only (WorldHost image + bundled server gateway).
+
 ### ★ WorldHost rate limits no longer spoofable via X-Forwarded-For; per-account login backoff (#418, 2026-07-19, branch fix/418-xff-ratelimit)
 The ForwardedHeaders middleware had `KnownIPNetworks`/`KnownProxies` **cleared**, which in ASP.NET
 means "trust any peer": whoever reached the bind directly could rotate a fabricated `X-Forwarded-For`

--- a/src/BlocksBeyondTheStars.Networking/Transport/WebSocketServerTransport.cs
+++ b/src/BlocksBeyondTheStars.Networking/Transport/WebSocketServerTransport.cs
@@ -84,47 +84,65 @@ public sealed class WebSocketServerTransport : IServerTransport
                 break; // listener stopped
             }
 
-            if (!ctx.Request.IsWebSocketRequest)
+            // One request must never take down the accept loop (#417): a client resetting the connection
+            // mid-response write faults right here, and /status is polled continuously — an unhandled
+            // fault would end the while loop and close the gateway to every future browser client.
+            try
             {
-                if (ctx.Request.HttpMethod == "GET"
-                    && (ctx.Request.Url?.AbsolutePath is "/" or "/healthz"))
+                if (ctx.Request.IsWebSocketRequest)
                 {
-                    byte[] body = System.Text.Encoding.UTF8.GetBytes("Blocks Beyond the Stars WebSocket gateway\n");
-                    ctx.Response.StatusCode = 200;
-                    ctx.Response.ContentType = "text/plain; charset=utf-8";
-                    ctx.Response.ContentLength64 = body.Length;
-                    await ctx.Response.OutputStream.WriteAsync(body, 0, body.Length).ConfigureAwait(false);
-                    ctx.Response.Close();
-                }
-                else if (ctx.Request.HttpMethod == "GET"
-                    && ctx.Request.Url?.AbsolutePath == "/status"
-                    && StatusJsonProvider is { } statusProvider)
-                {
-                    byte[] body = System.Text.Encoding.UTF8.GetBytes(statusProvider());
-                    ctx.Response.StatusCode = 200;
-                    ctx.Response.ContentType = "application/json; charset=utf-8";
-                    ctx.Response.ContentLength64 = body.Length;
-                    await ctx.Response.OutputStream.WriteAsync(body, 0, body.Length).ConfigureAwait(false);
-                    ctx.Response.Close();
-                }
-                else if (ctx.Request.HttpMethod == "POST"
-                    && ctx.Request.Url?.AbsolutePath == "/announce"
-                    && AnnounceReceiver is { } announceReceiver
-                    && !string.IsNullOrEmpty(AnnounceToken))
-                {
-                    ctx.Response.StatusCode = await HandleAnnounceAsync(ctx, announceReceiver).ConfigureAwait(false);
-                    ctx.Response.Close();
+                    _ = HandleClientAsync(ctx);
                 }
                 else
                 {
-                    ctx.Response.StatusCode = 400;
-                    ctx.Response.Close();
+                    await HandleHttpRequestAsync(ctx).ConfigureAwait(false);
                 }
-
-                continue;
             }
+            catch
+            {
+                try { ctx.Response.Abort(); } catch { }
+            }
+        }
+    }
 
-            _ = HandleClientAsync(ctx);
+    /// <summary>Serves the plain-HTTP routes (landing page/healthz, /status, /announce). Runs on the
+    /// accept loop; any exception — aborted connection mid-write, faulting status provider — is
+    /// contained by the caller.</summary>
+    private async Task HandleHttpRequestAsync(HttpListenerContext ctx)
+    {
+        if (ctx.Request.HttpMethod == "GET"
+            && (ctx.Request.Url?.AbsolutePath is "/" or "/healthz"))
+        {
+            byte[] body = System.Text.Encoding.UTF8.GetBytes("Blocks Beyond the Stars WebSocket gateway\n");
+            ctx.Response.StatusCode = 200;
+            ctx.Response.ContentType = "text/plain; charset=utf-8";
+            ctx.Response.ContentLength64 = body.Length;
+            await ctx.Response.OutputStream.WriteAsync(body, 0, body.Length).ConfigureAwait(false);
+            ctx.Response.Close();
+        }
+        else if (ctx.Request.HttpMethod == "GET"
+            && ctx.Request.Url?.AbsolutePath == "/status"
+            && StatusJsonProvider is { } statusProvider)
+        {
+            byte[] body = System.Text.Encoding.UTF8.GetBytes(statusProvider());
+            ctx.Response.StatusCode = 200;
+            ctx.Response.ContentType = "application/json; charset=utf-8";
+            ctx.Response.ContentLength64 = body.Length;
+            await ctx.Response.OutputStream.WriteAsync(body, 0, body.Length).ConfigureAwait(false);
+            ctx.Response.Close();
+        }
+        else if (ctx.Request.HttpMethod == "POST"
+            && ctx.Request.Url?.AbsolutePath == "/announce"
+            && AnnounceReceiver is { } announceReceiver
+            && !string.IsNullOrEmpty(AnnounceToken))
+        {
+            ctx.Response.StatusCode = await HandleAnnounceAsync(ctx, announceReceiver).ConfigureAwait(false);
+            ctx.Response.Close();
+        }
+        else
+        {
+            ctx.Response.StatusCode = 400;
+            ctx.Response.Close();
         }
     }
 
@@ -187,8 +205,16 @@ public sealed class WebSocketServerTransport : IServerTransport
         }
         catch
         {
-            ctx.Response.StatusCode = 500;
-            ctx.Response.Close();
+            try
+            {
+                ctx.Response.StatusCode = 500;
+                ctx.Response.Close();
+            }
+            catch
+            {
+                // the connection is already gone — nothing left to answer
+            }
+
             return;
         }
 

--- a/src/BlocksBeyondTheStars.WorldHost/WorldOrchestrator.cs
+++ b/src/BlocksBeyondTheStars.WorldHost/WorldOrchestrator.cs
@@ -336,17 +336,40 @@ public sealed class WorldOrchestrator
 
     /// <summary>Reconciles registry state with reality: a world marked active whose container has exited
     /// (idle shutdown is the normal case) is marked stopped, so joins wake it cleanly and world lists tell
-    /// the truth. Called periodically by the host's background loop.</summary>
+    /// the truth. Called periodically by the host's background loop. Each world is reconciled under its
+    /// wake lock (#415): the container probe takes seconds, and writing a stale Stopped/"" over a wake
+    /// that happened in that window would make the next join `docker rm -f` the freshly started container.
+    /// A held lock means a join is waking or probing the world right now — skip it this pass.</summary>
     public int Reap()
     {
         int reaped = 0;
         foreach (var world in _registry.ListActiveWorlds())
         {
-            if (!_launcher.IsRunning(world.ContainerId))
+            var gate = _wakeLocks.GetOrAdd(world.Id, _ => new SemaphoreSlim(1, 1));
+            if (!gate.Wait(0))
             {
-                _registry.SetWorldStatus(world.Id, WorldStatus.Stopped, string.Empty);
-                _registry.TouchWorldActive(world.Id); // it WAS just running — inactivity starts now
-                reaped++;
+                continue;
+            }
+
+            try
+            {
+                // Re-read under the lock: the listed row may predate a wake that has since run.
+                if (_registry.GetWorld(world.Id) is not { } fresh
+                    || fresh.Status is not (WorldStatus.Running or WorldStatus.Starting))
+                {
+                    continue;
+                }
+
+                if (!_launcher.IsRunning(fresh.ContainerId))
+                {
+                    _registry.SetWorldStatus(fresh.Id, WorldStatus.Stopped, string.Empty);
+                    _registry.TouchWorldActive(fresh.Id); // it WAS just running — inactivity starts now
+                    reaped++;
+                }
+            }
+            finally
+            {
+                gate.Release();
             }
         }
 
@@ -368,14 +391,34 @@ public sealed class WorldOrchestrator
         int archived = 0;
         foreach (var world in _registry.ListArchiveCandidates(cutoff))
         {
-            if (_launcher.IsRunning(world.ContainerId))
+            var gate = _wakeLocks.GetOrAdd(world.Id, _ => new SemaphoreSlim(1, 1));
+            if (!gate.Wait(0))
             {
-                continue; // belt and braces — never archive under a live container
+                continue; // a join is waking this world right now — clearly not archive material
             }
 
-            SavePaths.MoveToArchive(_config, world.Id);
-            _registry.SetWorldStatus(world.Id, WorldStatus.Archived, string.Empty);
-            archived++;
+            try
+            {
+                // Re-read under the lock (#416): the candidate row may predate a wake. A woken world is
+                // no longer Stopped; one that woke and idle-stopped again since the listing shows a fresh
+                // last-start. Both must be spared, and the live-container guard must use the FRESH
+                // container id — the stale candidate row always carries "", so IsRunning("") proves nothing.
+                if (_registry.GetWorld(world.Id) is not { } fresh
+                    || fresh.Status != WorldStatus.Stopped
+                    || fresh.LastStartedUnix >= cutoff
+                    || _launcher.IsRunning(fresh.ContainerId))
+                {
+                    continue;
+                }
+
+                SavePaths.MoveToArchive(_config, world.Id);
+                _registry.SetWorldStatus(world.Id, WorldStatus.Archived, string.Empty);
+                archived++;
+            }
+            finally
+            {
+                gate.Release();
+            }
         }
 
         _metrics.Archived(archived);

--- a/tests/BlocksBeyondTheStars.Tests/WebSocketTransportTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/WebSocketTransportTests.cs
@@ -108,6 +108,31 @@ public sealed class WebSocketTransportTests : IDisposable
         Assert.Null(NetCodec.Decode(payload));
     }
 
+    [Fact]
+    public async Task Gateway_AcceptLoop_SurvivesAFaultingRequestAsync()
+    {
+        int port = FreeTcpPort();
+        using var transport = new WebSocketServerTransport("127.0.0.1");
+        // A throwing status provider faults request handling exactly where a client resetting the
+        // connection mid-response write would — one bad /status poll must never end the accept loop (#417).
+        transport.StatusJsonProvider = () => throw new InvalidOperationException("status snapshot failed (simulated)");
+        transport.Start(port);
+
+        using var http = new System.Net.Http.HttpClient { Timeout = TimeSpan.FromSeconds(5) };
+        try
+        {
+            (await http.GetAsync($"http://127.0.0.1:{port}/status")).Dispose();
+        }
+        catch (System.Net.Http.HttpRequestException)
+        {
+            // the faulted request may tear down its own connection — that is fine
+        }
+
+        // The accept loop must still be alive: the next client gets a normal answer.
+        using var ok = await http.GetAsync($"http://127.0.0.1:{port}/healthz");
+        Assert.Equal(HttpStatusCode.OK, ok.StatusCode);
+    }
+
     private static async Task ReceiveLoopAsync(ClientWebSocket ws, ConcurrentQueue<byte[]> received, CancellationToken token)
     {
         var buffer = new byte[16 * 1024];

--- a/tests/BlocksBeyondTheStars.Tests/WorldHostPhase3Tests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/WorldHostPhase3Tests.cs
@@ -3,6 +3,7 @@
 // This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using BlocksBeyondTheStars.WorldHost;
 using Xunit;
@@ -237,6 +238,86 @@ public sealed class WorldHostPhase3Tests : IDisposable
         long fiveMonthsLater = DateTimeOffset.UtcNow.ToUnixTimeSeconds() + 5L * 30 * 86400;
         Assert.Equal(0, orchestrator.ArchiveSweep(fiveMonthsLater));
         Assert.Equal(WorldStatus.Stopped, registry.GetWorld(world.Id)!.Status);
+    }
+
+    // ---------------- Reaper/sweep vs. wake races (#415/#416) ----------------
+
+    /// <summary>Builds an orchestrator whose health probe blocks: it signals <paramref name="probeEntered"/>
+    /// on entry (the wake now holds the per-world lock) and waits for <paramref name="probeGate"/> before
+    /// answering — the deterministic stand-in for "a wake is in flight while a background pass runs".</summary>
+    private static WorldOrchestrator NewBlockingProbeOrchestrator(
+        HostRegistry registry, FakeLauncher launcher, WorldHostConfig config,
+        SemaphoreSlim probeEntered, SemaphoreSlim probeGate)
+        => new(config, registry, launcher, async w =>
+        {
+            probeEntered.Release();
+            await probeGate.WaitAsync();
+            return launcher.IsRunning(w.ContainerId);
+        });
+
+    [Fact]
+    public async Task Reap_SkipsAWorld_WhoseWakeIsInFlightAsync()
+    {
+        var config = new WorldHostConfig { WakeTimeoutSeconds = 5 };
+        var registry = NewRegistry(config);
+        var launcher = new FakeLauncher();
+        using var probeEntered = new SemaphoreSlim(0);
+        using var probeGate = new SemaphoreSlim(0);
+        var orchestrator = NewBlockingProbeOrchestrator(registry, launcher, config, probeEntered, probeGate);
+        var (accountId, account) = NewAccount(registry);
+        var world = registry.CreateWorld(accountId, "Waking World").World!;
+
+        var joinTask = orchestrator.JoinAsync(world.Id, account, "Pilot");
+        Assert.True(await probeEntered.WaitAsync(TimeSpan.FromSeconds(10)));
+
+        // The reaper's container probe races the wake: simulate it observing "not running" for the
+        // container the wake just started. It must NOT write a stale Stopped/"" over the in-flight wake —
+        // that row would make the next join `docker rm -f` the live container (#415).
+        string containerId = registry.GetWorld(world.Id)!.ContainerId;
+        launcher.Running.Clear();
+        Assert.Equal(0, orchestrator.Reap());
+        Assert.Equal(WorldStatus.Starting, registry.GetWorld(world.Id)!.Status);
+
+        launcher.Running.Add(containerId);
+        probeGate.Release();
+        Assert.NotNull((await joinTask).Grant);
+        Assert.Equal(WorldStatus.Running, registry.GetWorld(world.Id)!.Status);
+    }
+
+    [Fact]
+    public async Task ArchiveSweep_SparesAWorld_WhoseWakeIsInFlightAsync()
+    {
+        var config = new WorldHostConfig
+        {
+            WakeTimeoutSeconds = 5,
+            ArchiveAfterMonths = 6,
+            WorldsDir = System.IO.Path.Combine(_root, "worlds-waking"),
+        };
+        var registry = NewRegistry(config);
+        var launcher = new FakeLauncher();
+        using var probeEntered = new SemaphoreSlim(0);
+        using var probeGate = new SemaphoreSlim(0);
+        var orchestrator = NewBlockingProbeOrchestrator(registry, launcher, config, probeEntered, probeGate);
+        var (accountId, account) = NewAccount(registry);
+        var world = registry.CreateWorld(accountId, "Night Owl World").World!;
+
+        string dbPath = SavePaths.WorldDbPath(config, world.Id);
+        System.IO.Directory.CreateDirectory(System.IO.Path.GetDirectoryName(dbPath)!);
+        System.IO.File.WriteAllText(dbPath, "save-bytes");
+
+        // The hourly sweep fires while the world is mid-wake (wake lock held, probe pending). It must
+        // not move the saves out from under the starting container (#416) — even with a cutoff that
+        // would have archived the world a moment earlier.
+        var joinTask = orchestrator.JoinAsync(world.Id, account, "Pilot");
+        Assert.True(await probeEntered.WaitAsync(TimeSpan.FromSeconds(10)));
+        long sevenMonthsLater = DateTimeOffset.UtcNow.ToUnixTimeSeconds() + 7L * 30 * 86400;
+        Assert.Equal(0, orchestrator.ArchiveSweep(sevenMonthsLater));
+        Assert.True(System.IO.File.Exists(dbPath));
+
+        probeGate.Release();
+        Assert.NotNull((await joinTask).Grant);
+        Assert.Equal(WorldStatus.Running, registry.GetWorld(world.Id)!.Status);
+        Assert.True(System.IO.File.Exists(dbPath));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

One PR for audit findings S3/S4/S5 (#415/#416/#417) — all three are server-side resilience fixes in the hosted-worlds fleet path, same theme: background work racing live joins.

- **#415 — reaper vs. wake race**: `Reap()` used to read a world row, spend seconds in `docker inspect`, then write `Stopped/""` without the per-world wake lock. A join waking the world in that window got its row clobbered, and the next join's `docker rm -f` SIGKILLed the live container. The reaper now takes each world's wake lock non-blocking (`Wait(0)` — a held lock means a join is waking it, skip this pass) and re-reads the row under the lock before deciding.
- **#416 — archive sweep vs. wake race**: same class in the hourly `ArchiveSweep`. Its live-container guard inspected the stale candidate row, whose container id is always `""` for stopped worlds (`IsRunning("")` proves nothing), so it could move `world.db` out from under a world being woken. The sweep now also takes the wake lock and re-checks the fresh row (still Stopped, no recent start, fresh container id not running) immediately before moving files.
- **#417 — WS gateway accept loop**: only `GetContextAsync` was guarded; the response writes for `/`, `/healthz`, `/status`, `/announce` ran bare. A client resetting the connection mid-write (or a faulting status provider) exited the accept loop — no browser client could connect until process restart (silent partial outage, native clients unaffected). Per-request handling (plain-HTTP branches + WS upgrade) is now wrapped so one bad request can never end the loop.

## Tests

- New blocked-health-probe harness proves `Reap()`/`ArchiveSweep()` skip a mid-wake world (the reap test fails pre-fix: the stale `Stopped` write happened).
- New gateway test: a throwing `/status` provider faults one request; the next `/healthz` must still answer 200 (fails pre-fix: accept loop dead, request times out).
- Full suite: 1080/1080 green locally, build clean under `-warnaserror`.

Server-only (WorldHost image + bundled server gateway) — no client release needed.

closes #415
closes #416
closes #417

🤖 Generated with [Claude Code](https://claude.com/claude-code)