### PR TITLE
fix(client): free procedural atlas/material/mesh assets per menu↔world cycle (#423)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -100,6 +100,26 @@ Per-item detail lives in the dated work log below.
 
 ---
 
+### ★ Client no longer leaks ~20 MB+ of procedural assets per menu↔world cycle (#423, 2026-07-19, branch fix/423-client-memory-leaks)
+Unity never garbage-collects assets created via `new` (Texture2D/Material/Mesh), this is a
+single-scene game, and `Resources.UnloadUnusedAssets` was never called — so every enter-world /
+return-to-menu cycle permanently leaked both 1024² atlas textures + chunk materials, a full second
+atlas from the recreated MenuBackground, and every sky/starfield/chunk mesh (audit findings M11/N7/
+N9/N8; on WebGL's fixed heap this is an OOM tab crash after repeated world-hopping). Fixes, layered:
+**(M11)** `GameBootstrap.OnDestroy` + a new `MenuBackground.OnDestroy` destroy their atlas textures
+(`BlockTextureAtlas.Destroy()`) and chunk materials; `AppShell.ReturnToMenu` then runs a one-frame-
+deferred `Resources.UnloadUnusedAssets()` sweep that collects everything else the dead world left
+behind. **(N7)** The static `IconResolver`/`ShapeIconFactory` caches and the static
+`HeldItem.BlockTileResolver` delegate are cleared first in `GameBootstrap.OnDestroy` — they wrapped
+the old world's atlas (stale tiles on content-differing servers) and pinned the whole GameBootstrap
+graph, which would have blanked icons / defeated the sweep. **(N9)** Display-only ship/speeder
+meshers now destroy the cooked collider mesh they always discarded, free empty meshes on the
+skip path, and attach a new `OwnedProceduralMesh` component so every preview/transit/recolor rebuild
+frees its render mesh with its GameObject (previously one leaked Mesh per chunk per build).
+**(N8)** `GlitchCloudSaves.Attach` subscribes once per persistent host instead of stacking one
+anonymous `BlobPersisted` handler per browser-SP session (stale duplicate re-uploads). Client-only;
+reaches players with the next release.
+
 ### ★ Wrecked ships stay wrecked across a restart — Downed flag persisted (#419, 2026-07-19, branch fix/419-downed-not-persisted)
 Under `KeepShipOnDeath=false` a ship lost in combat is downed (hull 0, grounded until repaired) — but
 `ShipSnapshot` never carried the `Downed` flag, and `RecomputeShipCombatStats` clamps a hull ≤ 0 back

--- a/client/Assets/BlocksBeyondTheStars/Scripts/AppShell.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/AppShell.cs
@@ -766,6 +766,19 @@ namespace BlocksBeyondTheStars.Client
             }
 
             Phase = ShellPhase.MainMenu; // leaving the game returns to the main menu
+            StartCoroutine(UnloadDestroyedWorldAssets());
+        }
+
+        /// <summary>Sweeps the destroyed world's procedural assets (sky/starfield meshes+materials, chunk
+        /// render meshes, icon sprites, the previous MenuBackground's leftovers). This is a single-scene game,
+        /// so nothing else ever frees them — without this pass every menu↔world cycle leaks ~20 MB+, enough
+        /// to OOM a WebGL tab after repeated world-hopping (#423). Deferred one frame so the
+        /// <see cref="UnityEngine.Object.Destroy"/> calls above (end-of-frame) have actually released their
+        /// references; GameBootstrap.OnDestroy clears the static caches that would otherwise pin the atlas.</summary>
+        private IEnumerator UnloadDestroyedWorldAssets()
+        {
+            yield return null;
+            Resources.UnloadUnusedAssets();
         }
 
         private bool _confirmQuit; // showing the "quit to menu?" confirmation over the game

--- a/client/Assets/BlocksBeyondTheStars/Scripts/BlockTextureAtlas.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/BlockTextureAtlas.cs
@@ -31,6 +31,23 @@ namespace BlocksBeyondTheStars.Client
         /// diffuse for texture-scale depth.</summary>
         public Texture2D NormalTexture { get; private set; }
 
+        /// <summary>Frees the atlas textures. Unity never garbage-collects <c>Texture2D</c>s created via
+        /// <c>new</c>, so the owner (GameBootstrap / MenuBackground) must call this when it is destroyed —
+        /// otherwise every menu↔world cycle permanently leaks both full atlases (#423).</summary>
+        public void Destroy()
+        {
+            if (Texture != null)
+            {
+                UnityEngine.Object.Destroy(Texture);
+            }
+
+            if (NormalTexture != null)
+            {
+                UnityEngine.Object.Destroy(NormalTexture);
+                NormalTexture = null;
+            }
+        }
+
         public BlockTextureAtlas(GameContent content)
         {
             Texture = new Texture2D(Cols * Tile, Rows * Tile, TextureFormat.RGBA32, mipChain: true)

--- a/client/Assets/BlocksBeyondTheStars/Scripts/GameBootstrap.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/GameBootstrap.cs
@@ -943,6 +943,7 @@ namespace BlocksBeyondTheStars.Client
             }
             else
             {
+                Atlas.Destroy(); // free the just-built textures — nothing will ever sample them
                 Atlas = null; // no atlas shader → fall back to the flat palette + vertex-colour material
             }
 
@@ -2016,6 +2017,33 @@ namespace BlocksBeyondTheStars.Client
             return dx * dx + dy * dy + dz * dz;
         }
 
-        private void OnDestroy() => Network?.Dispose();
+        /// <summary>Frees the session's procedural assets alongside the network. Unity never garbage-collects
+        /// assets created via <c>new</c> (Texture2D/Material/Mesh), so without this every menu↔world cycle
+        /// leaks both atlas textures + the chunk materials (#423). The static icon caches and the
+        /// <see cref="HeldItem.BlockTileResolver"/> delegate MUST be cleared first — they wrap/pin this
+        /// session's atlas (and the whole GameBootstrap object graph) across sessions. Everything else the
+        /// world created (sky/starfield meshes+materials, chunk render meshes, icon sprites) becomes
+        /// unreferenced with the world root and is swept by AppShell.ReturnToMenu's
+        /// <c>Resources.UnloadUnusedAssets</c> pass.</summary>
+        private void OnDestroy()
+        {
+            Network?.Dispose();
+
+            IconResolver.ClearCache();
+            ShapeIconFactory.ClearCache();
+            HeldItem.BlockTileResolver = null;
+
+            if (ChunkMaterial != null)
+            {
+                Destroy(ChunkMaterial);
+            }
+
+            if (ChunkMaterialTransparent != null)
+            {
+                Destroy(ChunkMaterialTransparent);
+            }
+
+            Atlas?.Destroy();
+        }
     }
 }

--- a/client/Assets/BlocksBeyondTheStars/Scripts/GlitchCloudSaves.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/GlitchCloudSaves.cs
@@ -30,6 +30,7 @@ namespace BlocksBeyondTheStars.Client
         private static bool _uploadInFlight;
         private static float _lastUploadTime = float.NegativeInfinity;
         private static byte[] _pending;
+        private static BrowserLocalServer _attachedHost; // the persistent host we already subscribed to (#423)
 
         /// <summary>True when this build can sync: served by Glitch (install id present) with a portal baked in.</summary>
         public static bool Enabled
@@ -133,14 +134,17 @@ namespace BlocksBeyondTheStars.Client
         }
 
         /// <summary>Hooks the host's durable saves: every persisted blob is queued for upload (throttled;
-        /// silently off for guests/non-Glitch hosts).</summary>
+        /// silently off for guests/non-Glitch hosts). The host is a DontDestroyOnLoad singleton but Attach is
+        /// called on EVERY menu → browser-SP boot — subscribe once per host, or after N sessions each save
+        /// fires N stacked handlers and a stale duplicate blob can be re-uploaded (#423).</summary>
         public static void Attach(AppShell shell, BrowserLocalServer host)
         {
-            if (!Enabled)
+            if (!Enabled || host == _attachedHost)
             {
                 return;
             }
 
+            _attachedHost = host;
             host.BlobPersisted += blob =>
             {
                 if (_blocked)

--- a/client/Assets/BlocksBeyondTheStars/Scripts/IconResolver.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/IconResolver.cs
@@ -19,6 +19,17 @@ namespace BlocksBeyondTheStars.Client
         private static readonly Dictionary<string, Sprite> _sprites = new Dictionary<string, Sprite>();
         private static readonly Dictionary<string, Texture2D> _itemTex = new Dictionary<string, Texture2D>();
 
+        /// <summary>Drops every cached sprite/texture. Called from <see cref="GameBootstrap"/>'s teardown:
+        /// the sprites wrap THAT session's atlas texture, so keeping them across sessions would pin the
+        /// destroyed atlas (stale tiles on a server with different content) and blank the icons once the
+        /// atlas is freed (#423). The unreferenced sprites are then swept by the return-to-menu
+        /// <c>Resources.UnloadUnusedAssets</c> pass.</summary>
+        public static void ClearCache()
+        {
+            _sprites.Clear();
+            _itemTex.Clear();
+        }
+
         /// <summary>The best icon sprite for an item / ship-module / blueprint key, or null if none.</summary>
         public static Sprite Resolve(string key, GameBootstrap game)
         {

--- a/client/Assets/BlocksBeyondTheStars/Scripts/MenuBackground.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/MenuBackground.cs
@@ -198,6 +198,25 @@ namespace BlocksBeyondTheStars.Client
             Shader.SetGlobalVector("_Sc_Fog", new Vector4(0f, 1f, 0f, 0f)); // distance haze off
         }
 
+        /// <summary>Frees the menu's own procedural atlas + chunk materials — the backdrop is recreated on
+        /// every return to the menu, so without this each cycle leaks a full second atlas (#423). The sun
+        /// glow materials and other per-build assets become unreferenced with this GameObject and are swept
+        /// by the return-to-menu <c>Resources.UnloadUnusedAssets</c> pass.</summary>
+        private void OnDestroy()
+        {
+            if (_chunkMat != null)
+            {
+                Destroy(_chunkMat);
+            }
+
+            if (_chunkMatT != null)
+            {
+                Destroy(_chunkMatT);
+            }
+
+            _atlas?.Destroy();
+        }
+
         /// <summary>Builds the block texture atlas + chunk materials once for the menu (same recipe as
         /// GameBootstrap), so the real voxel ship can be meshed. No-op without content or the atlas shader.</summary>
         private void BuildRenderContext()

--- a/client/Assets/BlocksBeyondTheStars/Scripts/ShapeIconFactory.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/ShapeIconFactory.cs
@@ -20,6 +20,12 @@ namespace BlocksBeyondTheStars.Client
     {
         private static readonly Dictionary<int, Texture2D> _cache = new Dictionary<int, Texture2D>();
 
+        /// <summary>Drops every cached icon texture. Called from <see cref="GameBootstrap"/>'s teardown —
+        /// the icons are built from THAT session's atlas, and the (tile id, shape) key would serve stale art
+        /// for a different world's content (#423). The unreferenced textures are then swept by the
+        /// return-to-menu <c>Resources.UnloadUnusedAssets</c> pass.</summary>
+        public static void ClearCache() => _cache.Clear();
+
         /// <summary>The shape-masked icon texture for a block tile + shape, or null for cube / when the atlas
         /// is not ready or not CPU-readable.</summary>
         public static Texture2D ForBlock(BlockTextureAtlas atlas, ushort tileId, int shape)

--- a/client/Assets/BlocksBeyondTheStars/Scripts/ShipMeshBuilder.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/ShipMeshBuilder.cs
@@ -144,9 +144,15 @@ namespace BlocksBeyondTheStars.Client
                     }
                 }
 
-                var (mesh, _) = ChunkMesher.Build(chunk, content, WorldBlock, atlas, paintTint: paint);
+                var (mesh, collider) = ChunkMesher.Build(chunk, content, WorldBlock, atlas, paintTint: paint);
+                if (collider != null)
+                {
+                    Object.Destroy(collider); // display-only build — the cooked collider mesh is never used (#423)
+                }
+
                 if (mesh.vertexCount == 0)
                 {
+                    Object.Destroy(mesh); // all-air chunk cell — free the empty mesh instead of orphaning it
                     continue;
                 }
 
@@ -155,6 +161,24 @@ namespace BlocksBeyondTheStars.Client
                 go.transform.localPosition = new Vector3(origin.X, origin.Y, origin.Z) - centre;
                 go.AddComponent<MeshFilter>().sharedMesh = mesh;
                 go.AddComponent<MeshRenderer>().sharedMaterials = mats;
+                go.AddComponent<OwnedProceduralMesh>(); // the mesh dies with the chunk object (paint re-mesh, transit end, …)
+            }
+        }
+    }
+
+    /// <summary>Destroys the <see cref="MeshFilter"/>'s procedural mesh together with its GameObject. Unity
+    /// never garbage-collects Mesh assets, so display meshers (ship previews, transits, speeder hulls) attach
+    /// this to every object whose mesh they own — teardown paths only destroy GameObjects, which would leak
+    /// one mesh per rebuild otherwise (#423). Attach ONLY where the mesh is exclusive to this object — never
+    /// on primitives, whose sharedMesh is the shared built-in asset.</summary>
+    public sealed class OwnedProceduralMesh : MonoBehaviour
+    {
+        private void OnDestroy()
+        {
+            var filter = GetComponent<MeshFilter>();
+            if (filter != null && filter.sharedMesh != null)
+            {
+                Destroy(filter.sharedMesh);
             }
         }
     }

--- a/client/Assets/BlocksBeyondTheStars/Scripts/SpeederView.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/SpeederView.cs
@@ -210,7 +210,12 @@ namespace BlocksBeyondTheStars.Client
                 chunk.Set(kv.Key.X, kv.Key.Y, kv.Key.Z, kv.Value);
             }
 
-            var (mesh, _) = ChunkMesher.Build(chunk, Game.Content, CellAt, Game.Atlas, paintTint: paint);
+            var (mesh, collider) = ChunkMesher.Build(chunk, Game.Content, CellAt, Game.Atlas, paintTint: paint);
+            if (collider != null)
+            {
+                Destroy(collider); // render-only hull — the cooked collider mesh is never used (#423)
+            }
+
             if (mesh.vertexCount > 0)
             {
                 var go = new GameObject("SpeederHull");
@@ -218,6 +223,11 @@ namespace BlocksBeyondTheStars.Client
                 go.transform.localPosition = MeshOffset;
                 go.AddComponent<MeshFilter>().sharedMesh = mesh;
                 go.AddComponent<MeshRenderer>().sharedMaterials = mats;
+                go.AddComponent<OwnedProceduralMesh>(); // freed by the child teardown on the next recolor/rebuild
+            }
+            else
+            {
+                Destroy(mesh); // empty grid — free the mesh instead of orphaning it
             }
 
             // Engine glow at the rear (design z=0 → root-local z = -2 after centring).


### PR DESCRIPTION
## Summary

Fixes the client memory leaks from the 2026-07-19 audit (findings M11, N7, N9, N8): Unity never garbage-collects assets created via `new` (Texture2D/Material/Mesh), this is a single-scene game, and `Resources.UnloadUnusedAssets` was never called — so every enter-world/return-to-menu cycle permanently leaked ~20 MB+ (possible OOM tab crash on WebGL after repeated world-hopping).

- **M11** — `GameBootstrap.OnDestroy` + a new `MenuBackground.OnDestroy` destroy their atlas textures (new `BlockTextureAtlas.Destroy()`) and chunk materials; `AppShell.ReturnToMenu` then runs a one-frame-deferred `Resources.UnloadUnusedAssets()` sweep that collects everything else the dead world left behind (sky/starfield meshes+materials, chunk render meshes, icon sprites).
- **N7** — the static `IconResolver`/`ShapeIconFactory` caches and the static `HeldItem.BlockTileResolver` delegate are cleared first in `GameBootstrap.OnDestroy`: they wrapped the old world's atlas (stale tiles on a content-differing server) and pinned the whole GameBootstrap object graph — and would have blanked cached icons once the atlas is freed (the reason the audit requires fixing N7 together with M11).
- **N9** — display-only ship/speeder meshers (`ShipMeshBuilder.BuildVoxChunks`, `SpeederView.BuildMesh`) destroy the cooked collider mesh they always discarded, free empty meshes on the skip path, and attach a new `OwnedProceduralMesh` component so every preview/transit/recolor rebuild frees its render mesh together with its GameObject (previously one leaked Mesh per chunk per build).
- **N8** — `GlitchCloudSaves.Attach` subscribes once per persistent host instead of stacking one anonymous `BlobPersisted` handler per browser-SP boot (N handlers after N sessions; stale duplicate blob re-uploads).

Bonus: the WorldRig fallback chunk material (also `new Material(...)` per world) is now freed by the same `OnDestroy`, and the shader-missing path frees the just-built atlas instead of nulling it.

Closes #423

## Verification

- Full test suite green locally (Dotnet + ClientCore, 129 client-core tests).
- Local Unity Windows build from this branch succeeds (fresh `BlocksBeyondTheStars.Client.dll`).
- Leak magnitudes in the audit are computed, not measured — a profiler session over a menu↔world cycle (especially WebGL heaps) remains a good follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)