### PR TITLE
fix(client): single cursor/menu-input arbiter replaces per-panel MenuOpen writes (#413)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -100,6 +100,26 @@ Per-item detail lives in the dated work log below.
 
 ---
 
+### ★ Cursor/menu/input ownership rebuilt on a single arbiter (#413, 2026-07-19, branch fix/413-cursor-input-ownership)
+~12 panels each wrote the shared `GameBootstrap.MenuOpen` bool AND forced `Cursor.lockState` on their
+own open/close, each assuming it was the only open UI — last-writer-wins produced a whole family of
+locked-cursor-under-live-UI / free-cursor-over-live-gameplay states (audit M2; #407 was the worst
+instance). `MenuOpen` is now a **property derived from an owner set** (`SetMenuOwner`), with a second
+cursor-only owner set (`SetCursorOwner`) for overlays that free the cursor without pausing gameplay
+(landing-pad chooser, respawn prompt, maintenance notice); `GameBootstrap.LateUpdate` **recomputes the
+cursor lock every frame** from all owners — no panel touches `Cursor.*` in-game anymore. That per-frame
+re-assert also fixes M3 (pause "Resume" never re-locked) and N2 (Alt-Tab skips re-lock in flight;
+the old `OnApplicationFocus` special-casing is gone). Instance fixes riding along: M15 (`SpaceView.Exit`
+now tears down a still-open pad chooser — ship destroyed while choosing left a dead 760×540 map with
+live click-to-land buttons over the on-foot world), N1 (Esc closing trade/feedback/beacon/beam-pad/pad-
+chooser marks the press consumed so it can't also pop the quit prompt), N3 (settle/teleport freeze now
+sends jetpack-off; the server kept draining suit energy), N4 (opening a menu while driving a speeder
+held on-foot gravity — now holds the hover), N5 (Esc/Tab while typing in a menu text field or the
+save-select world name only leaves the field, via `UiKit.TextFieldFocused` + a prev-frame latch),
+N6 (planet map closes on Esc; M gated on the death prompt), and Tab can no longer stack the crafting
+menu over an open modal. PlayerInteractions' #407 level-trigger + menu-deference special case collapsed
+into one idempotent per-frame owner registration. Client-only; reaches players with the next release.
+
 ### ★ Ghost entities/players/doors no longer persist across world transitions (#412, 2026-07-19, branch fix/412-ghost-entities-world-transitions)
 Three audit findings (M5/M6/S12), one failure shape: a world change left stale state rendering and
 interacting. **(M5)** `GameBootstrap.OnWorldReset` now clears every world-scoped entity list

--- a/client/Assets/BlocksBeyondTheStars/Scripts/AppShell.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/AppShell.cs
@@ -716,28 +716,10 @@ namespace BlocksBeyondTheStars.Client
             Phase = ShellPhase.InGame;
         }
 
-        /// <summary>Windows/desktop Unity releases a locked cursor when the window loses focus (Alt-Tab), and
-        /// nothing re-locked it on return — so the mouse stayed free and could wander or click out of the game
-        /// during normal on-foot play (Severin playtest). Re-lock on focus regain, but only when we're actually
-        /// in on-foot play with nothing that intentionally frees the cursor: a menu, chat, any of the
-        /// map/trade/dock/beacon/feedback modals (all via <see cref="GameBootstrap.MenuOpen"/>), the space view,
-        /// the respawn prompt, or the quit dialog. Editors/settings are separate shell phases, so already excluded.</summary>
-        private void OnApplicationFocus(bool hasFocus)
-        {
-            if (!hasFocus || Phase != ShellPhase.InGame || _confirmQuit)
-            {
-                return;
-            }
-
-            var boot = Boot();
-            if (boot == null || boot.MenuOpen || boot.ChatTyping || boot.SpaceViewActive || boot.AwaitingRespawnConfirm)
-            {
-                return;
-            }
-
-            Cursor.lockState = CursorLockMode.Locked;
-            Cursor.visible = false;
-        }
+        // NOTE (#413 N2): Alt-Tab cursor re-lock used to live in an OnApplicationFocus handler here — with
+        // hand-rolled "is anyone else holding the cursor?" checks that missed space flight. The arbiter in
+        // GameBootstrap.LateUpdate now re-asserts the lock every frame from the owner set, which covers
+        // focus regain in every mode with no special-casing.
 
         /// <summary>Tears down the in-game world, stops the local server, and returns to the menu.</summary>
         public void ReturnToMenu()
@@ -783,6 +765,7 @@ namespace BlocksBeyondTheStars.Client
 
         private bool _confirmQuit; // showing the "quit to menu?" confirmation over the game
         private bool _chatTypingPrev; // chat focus last frame (so closing chat with Esc doesn't pop quit)
+        private bool _fieldTypingPrev; // text field focused last frame (an Esc that unfocuses it clears isFocused the same frame)
         private GameObject _quitDialog;
 
         private GameBootstrap Boot() => _gameRoot != null ? _gameRoot.GetComponentInChildren<GameBootstrap>() : null;
@@ -791,11 +774,10 @@ namespace BlocksBeyondTheStars.Client
         {
             _confirmQuit = false;
             ShowQuitDialog(false);
-            var boot = Boot();
-            if (boot != null)
-            {
-                boot.MenuOpen = false; // hands control back to the player (re-locks the cursor)
-            }
+            // Release our ownership — the arbiter re-locks the cursor this frame unless another panel is
+            // still open. Before #413 this path only cleared the shared MenuOpen bool and never re-locked,
+            // so "Resume" left a live, visible OS cursor over the game (M3).
+            Boot()?.SetMenuOwner(this, false);
         }
 
         private GameObject _uiMenu;
@@ -1108,6 +1090,13 @@ namespace BlocksBeyondTheStars.Client
                 return;
             }
 
+            // Esc while typing in a text field (e.g. the world name on save-select) must only leave the
+            // field, not tear the whole screen down (#413 N5). The InputField may process the same Esc
+            // first and clear isFocused before we run, so remember the previous frame's focus too.
+            bool fieldTyping = UiKit.TextFieldFocused();
+            bool fieldTypingRecent = fieldTyping || _fieldTypingPrev;
+            _fieldTypingPrev = fieldTyping;
+
             if (Input.GetKeyDown(KeyCode.Escape))
             {
                 if (Phase == ShellPhase.InGame)
@@ -1121,22 +1110,18 @@ namespace BlocksBeyondTheStars.Client
                     {
                         CancelQuit(); // Esc again dismisses the confirmation
                     }
-                    else if (boot != null && (boot.MenuOpen || boot.MenuInputHandledThisFrame))
+                    else if (boot != null && (boot.MenuOpen || boot.MenuInputHandledThisFrame || boot.AwaitingRespawnConfirm))
                     {
-                        // The in-game menu or one of its browser screens owns this Esc press.
+                        // The in-game menu / a modal owns this Esc press — or the death prompt is up
+                        // (#413: the quit dialog would open invisibly BEHIND its backdrop, sortingOrder
+                        // 60 vs 85; only its "Weiter" button proceeds).
                     }
                     else
                     {
                         // Ask before leaving the game (rather than quitting instantly).
                         _confirmQuit = true;
                         ShowQuitDialog(true);
-                        if (boot != null)
-                        {
-                            boot.MenuOpen = true; // freezes player control + frees the cursor for the buttons
-                        }
-
-                        Cursor.lockState = CursorLockMode.None;
-                        Cursor.visible = true;
+                        boot?.SetMenuOwner(this, true); // freezes player control + frees the cursor for the buttons (#413)
                     }
                 }
                 else if (Phase == ShellPhase.Settings)
@@ -1153,7 +1138,10 @@ namespace BlocksBeyondTheStars.Client
                 }
                 else if (Phase == ShellPhase.SaveSelect)
                 {
-                    Phase = ShellPhase.MainMenu;
+                    if (!fieldTypingRecent)
+                    {
+                        Phase = ShellPhase.MainMenu;
+                    }
                 }
                 else if (Phase == ShellPhase.ShipEditor)
                 {

--- a/client/Assets/BlocksBeyondTheStars/Scripts/BeaconLabelUi.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/BeaconLabelUi.cs
@@ -54,13 +54,7 @@ namespace BlocksBeyondTheStars.Client
             _openFrame = Time.frameCount;
             _canvas.gameObject.SetActive(true);
 
-            if (Game != null)
-            {
-                Game.MenuOpen = true; // freezes player control + frees the cursor (modal, like trade/dock)
-            }
-
-            Cursor.lockState = CursorLockMode.None;
-            Cursor.visible = true;
+            Game?.SetMenuOwner(this, true); // freezes player control + frees the cursor via the arbiter (#413)
             _input.ActivateInputField();
             _input.Select();
         }
@@ -84,6 +78,7 @@ namespace BlocksBeyondTheStars.Client
 
             if (Input.GetKeyDown(KeyCode.Escape))
             {
+                Game?.MarkMenuInputHandled(); // this Esc is consumed — don't also pop the quit prompt (#413 N1)
                 Close(); // cancel — no callback, nothing placed/renamed
             }
         }
@@ -97,13 +92,7 @@ namespace BlocksBeyondTheStars.Client
                 _canvas.gameObject.SetActive(false);
             }
 
-            if (Game != null)
-            {
-                Game.MenuOpen = false;
-            }
-
-            Cursor.lockState = CursorLockMode.Locked;
-            Cursor.visible = false;
+            Game?.SetMenuOwner(this, false); // arbiter re-locks only once NO other panel is open (#413)
         }
 
         private void EnsureBuilt()

--- a/client/Assets/BlocksBeyondTheStars/Scripts/BeamPadUi.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/BeamPadUi.cs
@@ -47,9 +47,7 @@ namespace BlocksBeyondTheStars.Client
             _canvas.gameObject.SetActive(true);
             RebuildList();
 
-            if (Game != null) Game.MenuOpen = true;
-            Cursor.lockState = CursorLockMode.None;
-            Cursor.visible = true;
+            Game?.SetMenuOwner(this, true); // freezes player control + frees the cursor via the arbiter (#413)
         }
 
         private void Update()
@@ -58,6 +56,7 @@ namespace BlocksBeyondTheStars.Client
 
             if (Time.frameCount != _openFrame && Input.GetKeyDown(KeyCode.Escape))
             {
+                Game?.MarkMenuInputHandled(); // this Esc is consumed — don't also pop the quit prompt (#413 N1)
                 Close();
             }
         }
@@ -66,9 +65,7 @@ namespace BlocksBeyondTheStars.Client
         {
             _open = false;
             if (_canvas != null) _canvas.gameObject.SetActive(false);
-            if (Game != null) Game.MenuOpen = false;
-            Cursor.lockState = CursorLockMode.Locked;
-            Cursor.visible = false;
+            Game?.SetMenuOwner(this, false); // arbiter re-locks only once NO other panel is open (#413)
         }
 
         private NetBeam Find(int id)

--- a/client/Assets/BlocksBeyondTheStars/Scripts/DisconnectScreen.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/DisconnectScreen.cs
@@ -52,11 +52,6 @@ namespace BlocksBeyondTheStars.Client
                 Show();
             }
 
-            if (_shown)
-            {
-                Cursor.lockState = CursorLockMode.None;
-                Cursor.visible = true;
-            }
         }
 
         private void OnDisconnected()
@@ -72,10 +67,7 @@ namespace BlocksBeyondTheStars.Client
             _detail.text = Tr(maintenance ? "ui.disconnect.maint_detail" : "ui.disconnect.detail");
             _panel.SetActive(true);
             _shown = true;
-            if (Game != null)
-            {
-                Game.MenuOpen = true; // freeze player control under the panel
-            }
+            Game?.SetMenuOwner(this, true); // freeze player control + free the cursor under the panel (#413)
         }
 
         private void OnBackToMenu()

--- a/client/Assets/BlocksBeyondTheStars/Scripts/FeedbackUi.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/FeedbackUi.cs
@@ -56,7 +56,6 @@ namespace BlocksBeyondTheStars.Client
 
         private bool _open;
         private bool _sending;
-        private bool _cursorWasLocked = true; // cursor state before the dialog opened, restored on close
         private byte[] _shotJpg;                 // screenshot captured when the dialog opened
         private Task<FeedbackUploadResult> _uploadTask;
 
@@ -102,6 +101,7 @@ namespace BlocksBeyondTheStars.Client
 
             if (_open && !_sending && Input.GetKeyDown(KeyCode.Escape))
             {
+                Game.MarkMenuInputHandled(); // this Esc is consumed — don't also pop the quit prompt (#413 N1)
                 Close();
             }
 
@@ -144,12 +144,10 @@ namespace BlocksBeyondTheStars.Client
             _dialog.SetActive(true);
 
             // Modal: free the cursor + pause player/flight control (mirrors GameMenu / BeamPadUi; SpaceView
-            // holds position while MenuOpen). Remember the cursor state so closing restores it — in flight
-            // sub-screens like the landing-pad chooser the cursor was already free, not locked.
-            _cursorWasLocked = Cursor.lockState == CursorLockMode.Locked;
-            Game.MenuOpen = true;
-            Cursor.lockState = CursorLockMode.None;
-            Cursor.visible = true;
+            // holds position while MenuOpen). The arbiter recomputes on close, so a flight sub-screen the
+            // dialog opened over (e.g. the landing-pad chooser) keeps its free cursor without us having to
+            // save/restore the prior state by hand (#413).
+            Game.SetMenuOwner(this, true);
         }
 
         private void Close()
@@ -160,12 +158,7 @@ namespace BlocksBeyondTheStars.Client
             _shotJpg = null;
             if (_dialog != null) _dialog.SetActive(false);
 
-            if (Game != null)
-            {
-                Game.MenuOpen = false;
-                Cursor.lockState = _cursorWasLocked ? CursorLockMode.Locked : CursorLockMode.None;
-                Cursor.visible = !_cursorWasLocked;
-            }
+            Game?.SetMenuOwner(this, false); // arbiter re-locks only once NO other owner is open (#413)
         }
 
         private void ResetFields()

--- a/client/Assets/BlocksBeyondTheStars/Scripts/GameBootstrap.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/GameBootstrap.cs
@@ -713,8 +713,70 @@ namespace BlocksBeyondTheStars.Client
         /// <summary>Hotbar slot the player has selected (written by the player controller).</summary>
         public int SelectedHotbarSlot;
 
-        /// <summary>True while an in-game UI panel is open; the player controller pauses look/move.</summary>
-        public bool MenuOpen;
+        /// <summary>True while an in-game UI panel is open; the player controller pauses look/move.
+        /// Derived from the menu-owner set — panels register via <see cref="SetMenuOwner"/> instead of
+        /// writing a shared bool, so overlapping panels can no longer clobber each other's state (#413).</summary>
+        public bool MenuOpen => _menuOwners.Count > 0;
+
+        // The cursor/menu arbiter (#413): every open panel registers itself as an owner, and the cursor
+        // lock state is recomputed each frame in LateUpdate from ALL owners — no panel writes
+        // Cursor.lockState directly anymore, so "last close wins" can't strand a locked cursor under a
+        // still-open UI (or an unlocked one over live gameplay).
+        private readonly System.Collections.Generic.HashSet<object> _menuOwners = new();
+        private readonly System.Collections.Generic.HashSet<object> _cursorOwners = new();
+
+        /// <summary>Registers/unregisters <paramref name="owner"/> as an open menu-style panel: frees the
+        /// cursor AND pauses player/flight control (via <see cref="MenuOpen"/>). Idempotent per owner.</summary>
+        public void SetMenuOwner(object owner, bool open)
+        {
+            if (owner == null)
+            {
+                return;
+            }
+
+            if (open)
+            {
+                _menuOwners.Add(owner);
+            }
+            else
+            {
+                _menuOwners.Remove(owner);
+            }
+        }
+
+        /// <summary>Registers/unregisters <paramref name="owner"/> as a cursor-only owner: frees the cursor
+        /// WITHOUT pausing gameplay (e.g. the landing-pad chooser, the respawn prompt, a maintenance
+        /// notice — their systems hold position through their own flags). Idempotent per owner.</summary>
+        public void SetCursorOwner(object owner, bool open)
+        {
+            if (owner == null)
+            {
+                return;
+            }
+
+            if (open)
+            {
+                _cursorOwners.Add(owner);
+            }
+            else
+            {
+                _cursorOwners.Remove(owner);
+            }
+        }
+
+        /// <summary>True while anything wants the OS cursor free (any menu panel or cursor-only owner).</summary>
+        public bool CursorFreeWanted => _menuOwners.Count > 0 || _cursorOwners.Count > 0;
+
+        /// <summary>The single place the in-game cursor lock is decided (#413): recomputed every frame from
+        /// all open-UI owners, after every panel's Update has run. Assigned unconditionally — Windows drops
+        /// a hardware cursor lock on Alt-Tab without telling us, so re-asserting each frame also re-locks
+        /// on focus regain (in flight and on foot alike) with no special focus handling.</summary>
+        private void LateUpdate()
+        {
+            bool free = CursorFreeWanted;
+            Cursor.lockState = free ? CursorLockMode.None : CursorLockMode.Locked;
+            Cursor.visible = free;
+        }
 
         /// <summary>True while the chat input is focused; the player controller pauses look/move.</summary>
         public bool ChatTyping;

--- a/client/Assets/BlocksBeyondTheStars/Scripts/GameMenu.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/GameMenu.cs
@@ -29,6 +29,7 @@ namespace BlocksBeyondTheStars.Client
         private bool _open;
         private bool _wasInSpaceView;
         private bool _hyperjumpHooked;
+        private bool _typingPrev; // text field focused last frame (an Esc that unfocuses it clears isFocused the same frame)
 
         private void Update()
         {
@@ -50,9 +51,17 @@ namespace BlocksBeyondTheStars.Client
 
                 _wasInSpaceView = Game.SpaceViewActive;
 
+                // Esc/Tab while typing in a menu text field (crafting search, alliance picker …) must only
+                // leave the field, not close the whole menu (#413 N5). The InputField may process the same
+                // Esc first and clear isFocused before we run, so remember the previous frame's focus too
+                // (same trick AppShell uses for the chat input).
+                bool typing = UiKit.TextFieldFocused();
+                bool typingRecent = typing || _typingPrev;
+                _typingPrev = typing;
+
                 // Full-screen menu/browser panes must be escapable before the app shell sees Esc
                 // as "leave game", otherwise the player can get trapped behind overlapping modals.
-                if (_open && Input.GetKeyDown(KeyCode.Escape) && !Game.ChatTyping)
+                if (_open && Input.GetKeyDown(KeyCode.Escape) && !Game.ChatTyping && !typingRecent)
                 {
                     Game.MarkMenuInputHandled();
                     SetOpen(false);
@@ -60,10 +69,13 @@ namespace BlocksBeyondTheStars.Client
                 }
 
                 // Don't let Tab open the menu while the death / ship-destruction prompt is up — only its
-                // "Weiter" button proceeds.
+                // "Weiter" button proceeds. Also not while another modal owns the input (trade, beacon
+                // naming, dock request …): stacking the crafting menu on top of those was the root of a
+                // family of cursor-fights (#413) — the modal's own Esc/Tab handling closes it instead.
                 // Tab (keyboard) or Start (gamepad button 7) toggles the menu.
                 if ((Input.GetKeyDown(KeyCode.Tab) || Input.GetKeyDown(KeyCode.JoystickButton7))
-                    && !Game.AwaitingRespawnConfirm && !Game.ChatTyping)
+                    && !Game.AwaitingRespawnConfirm && !Game.ChatTyping && !typingRecent
+                    && !Game.MenuInputHandledThisFrame && (_open || !Game.MenuOpen))
                 {
                     Game.MarkMenuInputHandled();
                     SetOpen(!_open);
@@ -114,10 +126,6 @@ namespace BlocksBeyondTheStars.Client
         /// as the Tab key does (at the current tab), so a marketing shot can show the Tab menu over the cockpit.</summary>
         public void SetMenuOpen(bool open) => SetOpen(open);
 
-        /// <summary>Whether the Tab menu is currently open — read by <see cref="PlayerInteractions"/> to
-        /// decide who owns the cursor when its dock/trade modal closes (#407).</summary>
-        public bool IsOpen => _open;
-
         /// <summary>Opens the in-game Wiki ("Codex") screen — an always-available menu point.</summary>
         public void OpenWiki() { _browser = BrowserScreen.Wiki; SetOpen(true); }
 
@@ -165,9 +173,7 @@ namespace BlocksBeyondTheStars.Client
             }
 
             _open = open;
-            Game.MenuOpen = _open;
-            Cursor.lockState = _open ? CursorLockMode.None : CursorLockMode.Locked;
-            Cursor.visible = _open;
+            Game.SetMenuOwner(this, _open); // the cursor arbiter frees/locks from the owner set (#413)
             if (_open)
             {
                 UiNav.Enable(gameObject); // gamepad can drive the menu (covers every tab; inert on KB/mouse)

--- a/client/Assets/BlocksBeyondTheStars/Scripts/MaintenanceUi.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/MaintenanceUi.cs
@@ -68,10 +68,6 @@ namespace BlocksBeyondTheStars.Client
                     }
                 }
 
-                // Keep the cursor usable for the OK button while the modal is up (cheap per-frame insurance,
-                // same as RespawnPrompt — gameplay systems would otherwise re-lock it).
-                Cursor.lockState = CursorLockMode.None;
-                Cursor.visible = true;
             }
 
             if (_lingerRemaining > 0f)
@@ -131,6 +127,9 @@ namespace BlocksBeyondTheStars.Client
             }
 
             _modal?.SetActive(true);
+            // Cursor-only owner (#413): the OK button needs a free cursor, but gameplay is not paused
+            // (a maintenance notice can arrive mid-flight; the countdown plays out regardless).
+            Game?.SetCursorOwner(this, true);
         }
 
         private void OnInfoAck()
@@ -142,12 +141,7 @@ namespace BlocksBeyondTheStars.Client
                 _lingerRemaining = InfoBannerLinger;
             }
 
-            // Hand the cursor back to gameplay unless a menu holds it open.
-            if (Game != null && !Game.MenuOpen)
-            {
-                Cursor.lockState = CursorLockMode.Locked;
-                Cursor.visible = false;
-            }
+            Game?.SetCursorOwner(this, false); // arbiter re-locks only once NO other owner is open (#413)
         }
 
         private void RefreshBanner()

--- a/client/Assets/BlocksBeyondTheStars/Scripts/PlayerController.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/PlayerController.cs
@@ -198,6 +198,10 @@ namespace BlocksBeyondTheStars.Client
             // after a fall let a far teleport (boarding a station, travel) drop through while chunks loaded.
             if (_settling && Game != null)
             {
+                // The settle freeze was the one early-return that skipped this: jetpack-thrusting onto a
+                // beam pad froze the player with the jetpack still "on" server-side, draining suit energy
+                // the whole wait (#413 N3).
+                UpdateJetpack(false);
                 transform.position = _spawnPos;
                 _verticalVelocity = 0f;
 
@@ -263,11 +267,17 @@ namespace BlocksBeyondTheStars.Client
                 return;
             }
 
-            // A UI panel or the chat input is open: don't steer/interact, just settle by gravity.
+            // A UI panel or the chat input is open: don't steer/interact, just settle by gravity — unless
+            // we're driving a speeder: on-foot gravity would drag the player out of hover under the menu
+            // and yank them back up on close (#413 N4). Hold the hover position instead.
             if (Game != null && (Game.MenuOpen || Game.ChatTyping))
             {
                 UpdateJetpack(false);
-                ApplyGravityOnly();
+                if (string.IsNullOrEmpty(Game.InSpeeder))
+                {
+                    ApplyGravityOnly();
+                }
+
                 return;
             }
 

--- a/client/Assets/BlocksBeyondTheStars/Scripts/PlayerInteractions.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/PlayerInteractions.cs
@@ -20,11 +20,8 @@ namespace BlocksBeyondTheStars.Client
     {
         public GameBootstrap Game;
         public RemotePlayers Remotes;
-        public GameMenu Menu; // Tab menu — cursor-ownership arbitration on modal close (#407)
 
         public float InteractRange = 6f;
-
-        private bool _managedCursor;
 
         private void Update()
         {
@@ -34,31 +31,12 @@ namespace BlocksBeyondTheStars.Client
             }
 
             // Our windows are modal: while one is up, free the cursor and pause on-foot control.
-            // Level-triggered (like RespawnPrompt), not edge-triggered: a dock/trade request can
-            // arrive while the Tab menu is open, and GameMenu re-locks the cursor unconditionally
-            // on close — re-asserting every frame keeps the modal clickable instead of leaving the
-            // session with a permanently locked cursor (#407).
+            // Level-triggered on the server-driven state (a dock/trade request can arrive or resolve
+            // remotely at any time, even under the Tab menu). The per-owner registration is idempotent,
+            // and the arbiter keeps the cursor free while ANY owner — us or the menu above us — is still
+            // open, so a remote resolve can no longer strand a locked cursor (#407 → #413).
             bool modal = Game.TradeActive || !string.IsNullOrEmpty(Game.PendingDockFrom);
-            if (modal)
-            {
-                Game.MenuOpen = true;
-                Cursor.lockState = CursorLockMode.None;
-                Cursor.visible = true;
-                _managedCursor = true;
-            }
-            else if (_managedCursor)
-            {
-                _managedCursor = false;
-                // Hand the cursor back to gameplay — unless the Tab menu is still open above us
-                // (the modal resolved remotely under it); then the menu keeps cursor ownership
-                // and re-locks on its own close.
-                if (Menu == null || !Menu.IsOpen)
-                {
-                    Game.MenuOpen = false;
-                    Cursor.lockState = CursorLockMode.Locked;
-                    Cursor.visible = false;
-                }
-            }
+            Game.SetMenuOwner(this, modal);
 
             if (modal || Game.MenuOpen || Game.SpaceViewActive || Game.ChatTyping)
             {

--- a/client/Assets/BlocksBeyondTheStars/Scripts/RespawnPrompt.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/RespawnPrompt.cs
@@ -74,10 +74,6 @@ namespace BlocksBeyondTheStars.Client
                     }
                 }
 
-                // Keep the cursor free for the button every frame — other systems (flight, settle) won't
-                // re-lock it while we're up, but this is cheap insurance against a one-frame fight.
-                Cursor.lockState = CursorLockMode.None;
-                Cursor.visible = true;
             }
         }
 
@@ -126,6 +122,9 @@ namespace BlocksBeyondTheStars.Client
 
             _panel?.SetActive(true);
             _shown = true;
+            // Cursor-only owner (#413): the button needs a free cursor, but gameplay holds through
+            // AwaitingRespawnConfirm, not MenuOpen — the arbiter keeps the two axes separate.
+            Game?.SetCursorOwner(this, true);
             _fade = 0f;
             if (_backdrop != null)
             {
@@ -143,11 +142,8 @@ namespace BlocksBeyondTheStars.Client
             if (Game != null)
             {
                 Game.AwaitingRespawnConfirm = false; // release: world reveals / ship recovers from here
+                Game.SetCursorOwner(this, false);    // arbiter re-locks only once NO other owner is open (#413)
             }
-
-            // Hand the cursor back to gameplay (on-foot look / flight re-lock it as before).
-            Cursor.lockState = CursorLockMode.Locked;
-            Cursor.visible = false;
         }
 
         private void EnsureUi()

--- a/client/Assets/BlocksBeyondTheStars/Scripts/SpaceView.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/SpaceView.cs
@@ -970,6 +970,7 @@ namespace BlocksBeyondTheStars.Client
             {
                 if (Input.GetKeyDown(KeyCode.Escape))
                 {
+                    Game.MarkMenuInputHandled(); // this Esc is consumed — don't also pop the quit prompt (#413 N1)
                     CancelLandChooser();
                     return;
                 }
@@ -1270,8 +1271,9 @@ namespace BlocksBeyondTheStars.Client
             EnsureUi();
 
             var loc = Game.Localizer;
-            Cursor.lockState = CursorLockMode.None;
-            Cursor.visible = true;
+            // Cursor-only owner (#413): the pad map needs a free cursor for its click-to-land buttons,
+            // but flight holds through _confirmLand, not MenuOpen.
+            Game.SetCursorOwner(this, true);
 
             // Centre panel in the 1536×864 HUD space (equirect map strip + button rows below).
             const float pw = 760f, ph = 540f;
@@ -1422,7 +1424,8 @@ namespace BlocksBeyondTheStars.Client
             return null;
         }
 
-        /// <summary>Tears down the landing-pad map + re-locks the cursor for flight.</summary>
+        /// <summary>Tears down the landing-pad map + releases its cursor ownership (the arbiter re-locks
+        /// for flight only once no other panel is open, #413).</summary>
         private void HideLandMap()
         {
             if (_landMapGo != null)
@@ -1432,11 +1435,7 @@ namespace BlocksBeyondTheStars.Client
             }
 
             _landMapBody = null;
-            if (Game != null && Game.SpaceViewActive)
-            {
-                Cursor.lockState = CursorLockMode.Locked;
-                Cursor.visible = false;
-            }
+            Game?.SetCursorOwner(this, false);
         }
 
         /// <summary>Rebuilds the quick-bar of ship systems from the active ship's fitted modules (a weapon
@@ -2304,6 +2303,10 @@ namespace BlocksBeyondTheStars.Client
 
         private void Exit()
         {
+            // The pad chooser can still be up when space closes under us (ship destroyed while choosing,
+            // #413 M15): its map lives on the persistent _ui canvas and would survive Exit as a dead
+            // overlay with live click-to-land raycast targets. Tear it down with the view.
+            CancelLandChooser();
             _landDestBody = null; // descent finished — don't let a stale target steer a later recovery landing
             Camera.transform.SetParent(_camPrevParent, false);
             Camera.transform.localPosition = _camPrevLocalPos;

--- a/client/Assets/BlocksBeyondTheStars/Scripts/UiKit.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/UiKit.cs
@@ -25,6 +25,20 @@ namespace BlocksBeyondTheStars.Client
         public static readonly Color Warn = new Color(1.00f, 0.72f, 0.28f); // amber — caution / developer-tool labels
         public static readonly Color TabLocked = new Color(0.30f, 0.34f, 0.42f, 0.85f); // dimmed tab whose context isn't met (stays clickable)
 
+        /// <summary>True while a uGUI text field has keyboard focus — Esc/Tab hotkey handlers must then
+        /// leave the keystroke to the field (unfocus/advance) instead of closing their screen (#413 N5).</summary>
+        public static bool TextFieldFocused()
+        {
+            var selected = EventSystem.current != null ? EventSystem.current.currentSelectedGameObject : null;
+            if (selected == null)
+            {
+                return false;
+            }
+
+            var field = selected.GetComponent<InputField>();
+            return field != null && field.isFocused;
+        }
+
         private static Font _font;
         private static Sprite _panelSprite;
         private static Sprite _buttonSprite;

--- a/client/Assets/BlocksBeyondTheStars/Scripts/VendorTradeUI.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/VendorTradeUI.cs
@@ -40,13 +40,7 @@ namespace BlocksBeyondTheStars.Client
             _open = true;
             _openedFrame = Time.frameCount; // so the same E press that opened it doesn't close it this frame
             _canvas.enabled = true;
-            if (Game != null)
-            {
-                Game.MenuOpen = true;
-            }
-
-            Cursor.lockState = CursorLockMode.None;
-            Cursor.visible = true;
+            Game?.SetMenuOwner(this, true); // the cursor arbiter frees/locks from the owner set (#413)
             Rebuild();
         }
 
@@ -63,13 +57,7 @@ namespace BlocksBeyondTheStars.Client
                 _canvas.enabled = false;
             }
 
-            if (Game != null)
-            {
-                Game.MenuOpen = false;
-            }
-
-            Cursor.lockState = CursorLockMode.Locked;
-            Cursor.visible = false;
+            Game?.SetMenuOwner(this, false); // arbiter re-locks only once NO other panel is open (#413)
         }
 
         private void Update()
@@ -86,6 +74,7 @@ namespace BlocksBeyondTheStars.Client
             if (_open && Time.frameCount > _openedFrame
                 && (Input.GetKeyDown(KeyCode.Escape) || Input.GetKeyDown(KeyCode.Tab)))
             {
+                Game?.MarkMenuInputHandled(); // this Esc/Tab is consumed — no quit prompt / menu toggle on top (#413 N1)
                 Close();
             }
         }

--- a/client/Assets/BlocksBeyondTheStars/Scripts/WorldMap.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/WorldMap.cs
@@ -31,7 +31,17 @@ namespace BlocksBeyondTheStars.Client
                 return;
             }
 
-            if (Input.GetKeyDown(KeyCode.M) && !Game.ChatTyping)
+            // Esc closes the map like every other panel — before this, the map set MenuOpen (so the app
+            // shell left Esc alone) but had no handler of its own, leaving Esc swallowed-but-dead (#413 N6).
+            if (_open && Input.GetKeyDown(KeyCode.Escape) && !Game.ChatTyping)
+            {
+                Game.MarkMenuInputHandled(); // consumed — don't also pop the quit prompt
+                Close();
+            }
+
+            // Not while the death/ship-destruction prompt is up — confirming it would otherwise reveal a
+            // still-open map (#413 N6).
+            if (Input.GetKeyDown(KeyCode.M) && !Game.ChatTyping && !Game.AwaitingRespawnConfirm)
             {
                 if (_open)
                 {
@@ -61,18 +71,14 @@ namespace BlocksBeyondTheStars.Client
         private void Open()
         {
             _open = true;
-            Game.MenuOpen = true;
-            Cursor.lockState = CursorLockMode.None;
-            Cursor.visible = true;
+            Game.SetMenuOwner(this, true); // the cursor arbiter frees/locks from the owner set (#413)
             Build();
         }
 
         private void Close()
         {
             _open = false;
-            Game.MenuOpen = false;
-            Cursor.lockState = CursorLockMode.Locked;
-            Cursor.visible = false;
+            Game.SetMenuOwner(this, false); // arbiter re-locks only once NO other panel is open (#413)
             if (_canvas != null)
             {
                 Destroy(_canvas.gameObject);

--- a/client/Assets/BlocksBeyondTheStars/Scripts/WorldMinimap.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/WorldMinimap.cs
@@ -49,7 +49,9 @@ namespace BlocksBeyondTheStars.Client
             }
 
             var gen = new WorldGenerator(worldSeed, content);
-            gen.SetCircumference(circumference);
+            // Local preview generator: only the wrap size matters here (no cratering, no pad flattening —
+            // same as before the individual setters became the atomic SetWorldMode, #424 S13).
+            gen.SetWorldMode(circumference, cratered: false, landingPads: null);
             int latPeriod = WorldConstants.LatitudePeriodFor(circumference);
             int sea = gen.SeaLevel(planet);
 

--- a/client/Assets/BlocksBeyondTheStars/Scripts/WorldRig.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/WorldRig.cs
@@ -259,7 +259,6 @@ namespace BlocksBeyondTheStars.Client
             var interactions = root.AddComponent<PlayerInteractions>();
             interactions.Game = boot;
             interactions.Remotes = remotes;
-            interactions.Menu = menu;
 
             // Render planet enemies (M25).
             var entities = root.AddComponent<WorldEntities>();


### PR DESCRIPTION
## Summary

Root fix for the systemic cursor/menu/input-ownership breakage from the static bug-hunt audit (**M2**, issue #413): ~12 panels each wrote the shared `GameBootstrap.MenuOpen` bool **and** forced `Cursor.lockState` on their own open/close, each assuming it was the only open UI. Last-writer-wins produced a family of locked-cursor-under-live-UI / free-cursor-over-live-gameplay states (#407 was the worst instance).

**The arbiter (M2):**
- `MenuOpen` is now a **property derived from an owner set** — panels register via `SetMenuOwner(this, open)` (idempotent per owner) instead of writing a bool.
- A second cursor-only set (`SetCursorOwner`) covers overlays that free the cursor **without** pausing gameplay: landing-pad chooser, respawn prompt, maintenance notice.
- `GameBootstrap.LateUpdate` **recomputes the cursor lock every frame** from all owners; no panel touches `Cursor.*` in-game anymore. The per-frame re-assert also covers Alt-Tab focus regain in every mode, so the old hand-rolled `AppShell.OnApplicationFocus` special-casing is deleted.
- All ~25 `MenuOpen` readers are untouched (it stayed a bool-valued member).
- `PlayerInteractions`' #407 level-trigger + menu-deference special case collapses into one per-frame owner registration; `FeedbackUi`'s manual cursor save/restore is gone too.

**Audit instances fixed on top (checklist from #413):**
- **M3** — pause "Resume" re-locks the cursor (owner release + per-frame recompute).
- **M15** — `SpaceView.Exit()` tears down a still-open landing-pad chooser (ship destroyed while choosing left a dead 760×540 map with live click-to-land raycast targets over the on-foot world).
- **N1** — Esc/Tab that closes trade/feedback/beacon/beam-pad/pad-chooser (and the new WorldMap Esc) calls `MarkMenuInputHandled()` so the same press can't also pop the quit prompt.
- **N2** — Alt-Tab re-lock now works during flight too (arbiter re-asserts every frame; skips only while a modal genuinely owns the cursor).
- **N3** — the settle/teleport freeze calls `UpdateJetpack(false)` so the server stops draining suit energy while the player is frozen.
- **N4** — opening a menu while driving a speeder holds the hover position instead of applying on-foot gravity (no more drop + snap-back).
- **N5** — Esc/Tab while typing in a menu text field (crafting search, …) or the save-select world name only leaves the field (`UiKit.TextFieldFocused()` + a previous-frame latch, same trick as the chat-Esc handling).
- **N6** — the planet map (M) closes on Esc and won't open during the death prompt.
- GameMenu's Tab is gated on open modals — the crafting menu can no longer stack over trade/beacon/dock dialogs (M2's stacking scenarios).

Esc during the death gate no longer opens the pause dialog invisibly behind the respawn backdrop (stacking scenario (c)).

Closes #413

## Verification

- `dotnet build` — 0 warnings / 0 errors (warnaserror-clean)
- .NET suites: **1077 server + 129 client** tests passed
- Unity EditMode **18/18**, PlayMode **2/2** passed (re-ran EditMode after the rebase onto latest main)
- Local Windows client build (`scripts/build-client.ps1`) succeeds end-to-end
- Rebased onto latest `origin/main` (post #435/#436/#438)

🤖 Generated with [Claude Code](https://claude.com/claude-code)