### PR TITLE
fix(server): protocol/join/transport hardening — S8–S14 (#424)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -120,6 +120,31 @@ frees its render mesh with its GameObject (previously one leaked Mesh per chunk 
 anonymous `BlobPersisted` handler per browser-SP session (stale duplicate re-uploads). Client-only;
 reaches players with the next release.
 
+### ★ Protocol/join/transport hardening — join flood gate, untrusted MessagePack, slow-loris, docker timeout, timing leaks (#424, 2026-07-19, branch fix-424-protocol-hardening)
+Six audit findings (S8–S14), one theme: the server's untrusted edges. **(S8)** `JoinRequest` was handled
+BEFORE the per-session token-bucket flood gate and `HandleJoin` never checked for an existing joined
+session — an already-connected client looping joins forced a DB load + world load + ~40 outbound
+messages per cheap packet (asymmetric amplifier) and rolled its own progress back to the last autosave.
+Joins now have their own per-connection token bucket (1/s, burst 5, cleared on disconnect) and a re-join
+on a live connection is dropped without a reply. **(S10)** `NetCodec` decoded attacker-controlled
+MessagePack with the default `TrustedData` security level; decode options now set `UntrustedData`
+(depth limits + hash-collision-resistant map handling; empirically the 1M-deep-nesting skip vector was
+already benign in MessagePack 2.5.302, so this is belt-and-suspenders). **(S9)** The browser WS gateway
+accepted unlimited connections and waited forever for a first message — a slow-loris fleet of idle
+sockets held buffers + receive tasks without ever counting against `MaxPlayers`. Now: connection cap
+(default 64, scaled `MaxPlayers*4`, 503 past it) + a 15 s first-message handshake window after which an
+idle connection is dropped. **(S11)** `DockerCliLauncher.Run`'s blocking `ReadToEnd()` had no timeout —
+a hung docker daemon wedged the join path AND the reaper; streams now drain async (large stderr can no
+longer deadlock either) and on the 120 s expiry the CLI process tree is killed. **(S14)** WorldHost's
+`X-Admin-Token`, ReportHost's read/write keys and the game `ServerPassword` were compared with ordinal
+equality (timing leak); all now fixed-time (`BasicAuth.TokenEquals` / shared `SecretCompare`).
+**(S13)** The shared `WorldGenerator`'s per-world mode state was set asymmetrically (one path set
+circumference+pads, another circumference+cratered) — correct only while a single world generates. The
+three setters are replaced by one all-or-nothing `SetWorldMode(circumference, cratered, pads)`;
+`ServerWorld` carries its `Cratered` flag and fully re-configures the generator before every chunk
+generation. Server-only; regression tests for each finding in `ProtocolHardeningTests` + WS transport
+cap/timeout tests.
+
 ### ★ Wrecked ships stay wrecked across a restart — Downed flag persisted (#419, 2026-07-19, branch fix/419-downed-not-persisted)
 Under `KeepShipOnDeath=false` a ship lost in combat is downed (hull 0, grounded until repaired) — but
 `ShipSnapshot` never carried the `Downed` flag, and `RecomputeShipCombatStats` clamps a hull ≤ 0 back

--- a/src/BlocksBeyondTheStars.GameServer/GameServer.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServer.cs
@@ -412,12 +412,14 @@ public sealed partial class GameServer
 
         var world = _worlds.GetOrCreate(planet, locationId, circumference, out bool isNew);
         world.SizeClass = sizeClass; // remembered for the per-world gravity band seeded in InitWeather
-        _generator.SetCircumference(world.World.Circumference); // active world's size for direct gen queries
         // Airless MOONS get cratered regolith too (item 33) — even when their planet type normally has air on a
         // full planet. The asteroid type carries Cratered in data, so it's handled by the planet type itself.
         bool airlessMoon = worldBody?.Kind == CelestialKind.Moon
             && string.Equals(planet.Atmosphere, "none", System.StringComparison.OrdinalIgnoreCase);
-        _generator.SetCratered(airlessMoon);
+        world.World.Cratered = airlessMoon; // stamped on the world so chunk gen re-configures fully (#424 S13)
+        // Configure the shared generator for this body's direct gen queries (size, cratering, pads —
+        // LandingPadFlats is still empty for a brand-new world; BuildLandingPads below refills it).
+        _generator.SetWorldMode(world.World.Circumference, airlessMoon, world.World.LandingPadFlats);
         if (!isNew)
         {
             return world; // already resident — keep its fauna/structures/edits
@@ -1662,6 +1664,7 @@ public sealed partial class GameServer
 
     private void OnClientDisconnected(int connectionId)
     {
+        _joinGates.Remove(connectionId); // transport connection ids may be reused — a new connection starts fresh
         if (_sessions.TryGetValue(connectionId, out var session) && session.Joined)
         {
             ClearDocking(session.State.PlayerId);
@@ -1708,6 +1711,24 @@ public sealed partial class GameServer
 
         if (message is JoinRequest join)
         {
+            // Re-join guard (#424 S8): a joined connection re-sending JoinRequest would reload the player
+            // from the DB (rolling back progress since the last autosave) and re-run the full ~40-message
+            // join burst — an asymmetric amplifier. A legitimate client never re-joins on a live
+            // connection, so drop it without a reply (an answer would feed the amplifier).
+            if (_sessions.TryGetValue(connectionId, out var existing) && existing.Joined)
+            {
+                _log.Warn($"Connection {connectionId} sent a JoinRequest while already joined — dropped.");
+                return;
+            }
+
+            // Flood gate for the join path (#424 S8): joins arrive before a session (and its token bucket)
+            // exists, so they get their own per-connection bucket. Even a rejected join does DB/crypto work,
+            // and an accepted one is the most expensive message the server has.
+            if (!AllowJoinAttempt(connectionId))
+            {
+                return;
+            }
+
             HandleJoin(connectionId, join);
             return;
         }
@@ -1748,6 +1769,47 @@ public sealed partial class GameServer
     // with a 400-token burst never throttles real play but caps a scripted flood cheaply.
     private const double MsgRatePerSecond = 200.0;
     private const double MsgBurst = 400.0;
+
+    // Join-attempt gate (#424 S8): a client joins once per connection; retries after a rejection are
+    // human-paced. 1/s with a burst of 5 never throttles a real client but caps a scripted join flood.
+    private const double JoinRatePerSecond = 1.0;
+    private const double JoinBurst = 5.0;
+
+    private sealed class JoinGate
+    {
+        public double Budget = JoinBurst;
+        public int LastRefillTick;
+    }
+
+    // Per-connection pre-join token buckets; entries are dropped when the connection closes.
+    private readonly Dictionary<int, JoinGate> _joinGates = new();
+
+    /// <summary>Same token-bucket scheme as <see cref="AllowMessage"/> but for pre-session join attempts,
+    /// keyed by connection id. Returns false when the connection's join budget is exhausted (drop it).</summary>
+    private bool AllowJoinAttempt(int connectionId)
+    {
+        if (!_joinGates.TryGetValue(connectionId, out var gate))
+        {
+            _joinGates[connectionId] = gate = new JoinGate { LastRefillTick = Environment.TickCount };
+        }
+
+        int now = Environment.TickCount;
+        int elapsedMs = unchecked(now - gate.LastRefillTick);
+        if (elapsedMs is < 0 or > 60_000)
+        {
+            elapsedMs = 0; // clock wrap or a long gap — just don't over-refill
+        }
+
+        gate.LastRefillTick = now;
+        gate.Budget = System.Math.Min(JoinBurst, gate.Budget + (elapsedMs / 1000.0 * JoinRatePerSecond));
+        if (gate.Budget < 1.0)
+        {
+            return false;
+        }
+
+        gate.Budget -= 1.0;
+        return true;
+    }
 
     /// <summary>Refills the session's token bucket by elapsed wall time and consumes one token. Returns
     /// false when the bucket is empty (drop the message).</summary>
@@ -1896,7 +1958,8 @@ public sealed partial class GameServer
             return;
         }
 
-        if (!string.IsNullOrEmpty(_config.ServerPassword) && join.Password != _config.ServerPassword)
+        if (!string.IsNullOrEmpty(_config.ServerPassword)
+            && !Shared.Security.SecretCompare.FixedTimeEquals(join.Password, _config.ServerPassword))
         {
             SendTo(connectionId, new JoinRejected { Reason = "Invalid server password." });
             return;

--- a/src/BlocksBeyondTheStars.GameServer/GameServerSpace.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerSpace.cs
@@ -109,10 +109,12 @@ public sealed partial class GameServer
     {
         int savedCirc = _generator.Circumference;
         bool savedCratered = _generator.Cratered;
-        _generator.SetCircumference(circ);
+        var savedPads = _generator.LandingPads;
         bool airlessMoon = kind == CelestialKind.Moon
             && string.Equals(planet.Atmosphere, "none", System.StringComparison.OrdinalIgnoreCase);
-        _generator.SetCratered(airlessMoon);
+        // Full mode swap for the target body (#424 S13) — no pads: this computes WHERE the pads go, so
+        // flattening must not apply, and the active world's pads must not leak into the noise queries.
+        _generator.SetWorldMode(circ, airlessMoon, null);
 
         try
         {
@@ -155,8 +157,7 @@ public sealed partial class GameServer
         }
         finally
         {
-            _generator.SetCircumference(savedCirc);
-            _generator.SetCratered(savedCratered);
+            _generator.SetWorldMode(savedCirc, savedCratered, savedPads);
         }
     }
 

--- a/src/BlocksBeyondTheStars.GameServer/Program.cs
+++ b/src/BlocksBeyondTheStars.GameServer/Program.cs
@@ -67,7 +67,12 @@ logger.Info($"Persistence backend: {WorldRepositoryFactory.DisplayName(config)}.
 // Native UDP for the Windows client; optionally also WebSocket for browser clients
 // (same protocol, same authoritative server). Both share the gameplay port number.
 var native = new LiteNetLibServerTransport(config.MaxPlayers);
-var webSocket = config.EnableWebSocket ? new WebSocketServerTransport(config.WebSocketBindAddress) : null;
+// Connection cap (#424 S9): scaled off MaxPlayers with generous headroom for handshakes/reconnects,
+// but never below the default — a small world still tolerates a burst of browser tabs.
+var webSocket = config.EnableWebSocket
+    ? new WebSocketServerTransport(config.WebSocketBindAddress,
+        maxConnections: Math.Max(WebSocketServerTransport.DefaultMaxConnections, config.MaxPlayers * 4))
+    : null;
 using IServerTransport transport = webSocket != null
     ? new CompositeServerTransport(native, webSocket)
     : native;

--- a/src/BlocksBeyondTheStars.GameServer/ServerWorld.cs
+++ b/src/BlocksBeyondTheStars.GameServer/ServerWorld.cs
@@ -43,6 +43,10 @@ public sealed class ServerWorld
     /// any pad-area chunk generates — and re-applied to the shared generator per chunk generation.</summary>
     public List<LandingPadFlatten> LandingPadFlats { get; } = new();
 
+    /// <summary>Whether this body generates with airless-moon cratering (item 33). Stamped by the server
+    /// at world-load so every chunk generation can fully re-configure the shared generator (#424 S13).</summary>
+    public bool Cratered { get; set; }
+
     public ServerWorld(GameContent content, WorldGenerator generator, IWorldRepository repo, PlanetType planet, string locationId, int circumference)
     {
         _content = content;
@@ -71,8 +75,10 @@ public sealed class ServerWorld
             return cached;
         }
 
-        _generator.SetCircumference(Circumference); // generate this world at its own size
-        _generator.SetLandingPads(LandingPadFlats); // level this world's planned pads (ship-as-object)
+        // Fully re-configure the SHARED generator for THIS world before generating (#424 S13): size,
+        // airless-moon cratering and pad flattening together — a partial set here previously left the
+        // cratered flag of whatever world was configured last (wrong terrain once several worlds are hot).
+        _generator.SetWorldMode(Circumference, Cratered, LandingPadFlats);
         var chunk = _generator.Generate(Planet, coord);
         foreach (var edit in _repo.LoadChunkEdits(LocationId, coord))
         {

--- a/src/BlocksBeyondTheStars.Networking/NetCodec.cs
+++ b/src/BlocksBeyondTheStars.Networking/NetCodec.cs
@@ -26,8 +26,13 @@ public static class NetCodec
     public const int MaxPacketBytes = 1024 * 1024;
     private const int MaxJsonDepth = 64;
 
+    // UntrustedData (#424 S10): every decoded payload is attacker-controlled, so deserialization must be
+    // depth-limited (a ~5-byte header can declare an absurdly nested/huge structure inside the 1 MB cap)
+    // and allocation-clamped. Security options only affect reading — the encode path is unchanged.
     private static readonly MessagePackSerializerOptions Options =
-        MessagePackSerializerOptions.Standard.WithResolver(ContractlessStandardResolver.Instance);
+        MessagePackSerializerOptions.Standard
+            .WithResolver(ContractlessStandardResolver.Instance)
+            .WithSecurity(MessagePackSecurity.UntrustedData);
 
     private static readonly JsonSerializerOptions JsonOptions = new()
     {

--- a/src/BlocksBeyondTheStars.Networking/Transport/WebSocketServerTransport.cs
+++ b/src/BlocksBeyondTheStars.Networking/Transport/WebSocketServerTransport.cs
@@ -20,6 +20,16 @@ public sealed class WebSocketServerTransport : IServerTransport
 {
     private const int MaxReceiveFrameBytes = NetCodec.MaxJsonPayloadBytes;
 
+    /// <summary>Default cap on concurrent WebSocket connections (#424 S9). Unlike the native transport
+    /// (LiteNetLib rejects past maxConnections), an uncapped WS gateway would hold a socket + buffers +
+    /// a receive task for every idler that never joins — MaxPlayers only counts JOINED sessions.</summary>
+    public const int DefaultMaxConnections = 64;
+
+    /// <summary>Default window a fresh connection gets to send its first complete message (the join
+    /// handshake, #424 S9). A real client sends JoinRequest immediately; a slow-loris connection that
+    /// just idles is dropped when the window expires.</summary>
+    public static readonly TimeSpan DefaultHandshakeTimeout = TimeSpan.FromSeconds(15);
+
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA1001:Types that own disposable fields should be disposable",
         Justification = "Per-connection holder; the socket is torn down when the receive loop ends or the listener stops, and SendLock is used only for WaitAsync/Release (no WaitHandle is ever allocated), so there is nothing requiring deterministic disposal.")]
     private sealed class Client
@@ -59,8 +69,18 @@ public sealed class WebSocketServerTransport : IServerTransport
     /// <summary>Shared secret required by <c>POST /announce</c>; empty disables the endpoint.</summary>
     public string AnnounceToken { get; set; } = string.Empty;
 
+    private readonly int _maxConnections;
+    private readonly TimeSpan _handshakeTimeout;
+
     /// <param name="bindHost">Host for the HTTP prefix; "localhost" for dev/LAN, "+" for all interfaces (may need elevation on Windows).</param>
-    public WebSocketServerTransport(string bindHost = "localhost") => _bindHost = bindHost;
+    /// <param name="maxConnections">Cap on concurrent WebSocket connections; further upgrades are answered 503.</param>
+    /// <param name="handshakeTimeout">How long a fresh connection may idle before its first complete message.</param>
+    public WebSocketServerTransport(string bindHost = "localhost", int maxConnections = DefaultMaxConnections, TimeSpan? handshakeTimeout = null)
+    {
+        _bindHost = bindHost;
+        _maxConnections = maxConnections;
+        _handshakeTimeout = handshakeTimeout ?? DefaultHandshakeTimeout;
+    }
 
     public void Start(int port)
     {
@@ -198,6 +218,24 @@ public sealed class WebSocketServerTransport : IServerTransport
 
     private async Task HandleClientAsync(HttpListenerContext ctx)
     {
+        // Connection cap (#424 S9): reject BEFORE the upgrade so an idler flood can't pile up sockets,
+        // receive tasks and buffers. Racing handshakes may overshoot by a few — the bound still holds.
+        if (_clients.Count >= _maxConnections)
+        {
+            LogWarning($"Rejected browser WebSocket connection: {_clients.Count}/{_maxConnections} connections in use.");
+            try
+            {
+                ctx.Response.StatusCode = 503;
+                ctx.Response.Close();
+            }
+            catch
+            {
+                // the connection is already gone — nothing left to answer
+            }
+
+            return;
+        }
+
         WebSocketContext wsCtx;
         try
         {
@@ -225,6 +263,13 @@ public sealed class WebSocketServerTransport : IServerTransport
 
         var buffer = new byte[8192];
         using var ms = new System.IO.MemoryStream();
+
+        // Handshake window (#424 S9): until the FIRST complete message arrives (a real client's
+        // JoinRequest, sent immediately), receives run under a deadline — a connection that only idles
+        // (slow-loris) is dropped instead of holding its socket + receive task forever. After the first
+        // message the connection is the session layer's to manage and receives wait indefinitely again.
+        var handshakeClock = System.Diagnostics.Stopwatch.StartNew(); // netstandard2.1: no Environment.TickCount64
+        bool firstMessageReceived = false;
         try
         {
             while (client.Socket.State == WebSocketState.Open && !_cts.IsCancellationRequested)
@@ -233,7 +278,35 @@ public sealed class WebSocketServerTransport : IServerTransport
                 WebSocketReceiveResult result;
                 do
                 {
-                    result = await client.Socket.ReceiveAsync(new ArraySegment<byte>(buffer), _cts.Token).ConfigureAwait(false);
+                    if (!firstMessageReceived)
+                    {
+                        long remainingMs = (long)(_handshakeTimeout - handshakeClock.Elapsed).TotalMilliseconds;
+                        if (remainingMs <= 0)
+                        {
+                            LogWarning($"Dropped browser WebSocket connection {id}: no message within the handshake window.");
+                            await client.Socket.CloseAsync(WebSocketCloseStatus.PolicyViolation, "Handshake timeout", CancellationToken.None)
+                                .ConfigureAwait(false);
+                            return;
+                        }
+
+                        using var handshakeCts = CancellationTokenSource.CreateLinkedTokenSource(_cts.Token);
+                        handshakeCts.CancelAfter((int)System.Math.Min(remainingMs, int.MaxValue));
+                        try
+                        {
+                            result = await client.Socket.ReceiveAsync(new ArraySegment<byte>(buffer), handshakeCts.Token).ConfigureAwait(false);
+                        }
+                        catch (OperationCanceledException) when (!_cts.IsCancellationRequested)
+                        {
+                            LogWarning($"Dropped browser WebSocket connection {id}: no message within the handshake window.");
+                            client.Socket.Abort(); // the pending receive was cancelled — a graceful close can't complete
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        result = await client.Socket.ReceiveAsync(new ArraySegment<byte>(buffer), _cts.Token).ConfigureAwait(false);
+                    }
+
                     if (result.MessageType == WebSocketMessageType.Close)
                     {
                         break;
@@ -259,6 +332,7 @@ public sealed class WebSocketServerTransport : IServerTransport
                 }
 
                 _events.Enqueue((EventKind.Payload, id, ms.ToArray()));
+                firstMessageReceived = true;
             }
         }
         catch

--- a/src/BlocksBeyondTheStars.ReportHost/BasicAuth.cs
+++ b/src/BlocksBeyondTheStars.ReportHost/BasicAuth.cs
@@ -45,4 +45,21 @@ public static class BasicAuth
         bool equal = CryptographicOperations.FixedTimeEquals(presented, sameLength ? expected : presented);
         return sameLength && equal;
     }
+
+    /// <summary>Fixed-time compare of a request-supplied secret (header value) against a configured one
+    /// (#424 S14 — an ordinal <c>string.Equals</c> leaks secret length/prefix via response timing). An
+    /// empty configured secret never matches, so an unconfigured gate stays closed.</summary>
+    public static bool TokenEquals(string? presented, string configured)
+    {
+        if (string.IsNullOrEmpty(configured))
+        {
+            return false;
+        }
+
+        byte[] presentedBytes = Encoding.UTF8.GetBytes(presented ?? string.Empty);
+        byte[] configuredBytes = Encoding.UTF8.GetBytes(configured);
+        bool sameLength = presentedBytes.Length == configuredBytes.Length;
+        bool equal = CryptographicOperations.FixedTimeEquals(presentedBytes, sameLength ? configuredBytes : presentedBytes);
+        return sameLength && equal;
+    }
 }

--- a/src/BlocksBeyondTheStars.ReportHost/Program.cs
+++ b/src/BlocksBeyondTheStars.ReportHost/Program.cs
@@ -60,7 +60,7 @@ IResult? GuardReadKey(HttpContext ctx)
         return Results.Json(new { error = "read_api_disabled" }, statusCode: StatusCodes.Status503ServiceUnavailable);
     }
 
-    return string.Equals(ctx.Request.Headers["x-report-read-key"].ToString(), config.ReadKey, StringComparison.Ordinal)
+    return BasicAuth.TokenEquals(ctx.Request.Headers["x-report-read-key"].ToString(), config.ReadKey)
         ? null
         : Results.Json(new { error = "forbidden" }, statusCode: StatusCodes.Status403Forbidden);
 }
@@ -155,7 +155,7 @@ app.MapPost("/api/bugreport", async (HttpContext ctx) =>
         return Results.Json(new { error = "ingest_not_configured" }, statusCode: StatusCodes.Status503ServiceUnavailable);
     }
 
-    if (!string.Equals(ctx.Request.Headers["x-bugreport-key"].ToString(), config.WriteKey, StringComparison.Ordinal))
+    if (!BasicAuth.TokenEquals(ctx.Request.Headers["x-bugreport-key"].ToString(), config.WriteKey))
     {
         return Results.Json(new { error = "forbidden" }, statusCode: StatusCodes.Status403Forbidden);
     }

--- a/src/BlocksBeyondTheStars.Shared/Security/SecretCompare.cs
+++ b/src/BlocksBeyondTheStars.Shared/Security/SecretCompare.cs
@@ -1,0 +1,34 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+namespace BlocksBeyondTheStars.Shared.Security;
+
+/// <summary>
+/// Fixed-time secret comparison for protocol-level checks (#424 S14). Length-then-XOR-accumulate like
+/// <see cref="HostedJoinToken"/>'s signature check — netstandard2.1 (Unity profile) has no
+/// <c>CryptographicOperations.FixedTimeEquals</c>, so this hand-rolled variant is shared instead.
+/// A length mismatch still returns early: secret length is far less sensitive than a byte-by-byte
+/// match prefix, and padding to a fixed width would change no caller's behavior.
+/// </summary>
+public static class SecretCompare
+{
+    /// <summary>Whether two secrets match, without leaking a match prefix through timing. Null is
+    /// treated as empty; two empties match (callers gate "no secret configured" themselves).</summary>
+    public static bool FixedTimeEquals(string? a, string? b)
+    {
+        a ??= string.Empty;
+        b ??= string.Empty;
+        if (a.Length != b.Length)
+        {
+            return false;
+        }
+
+        int diff = 0;
+        for (int i = 0; i < a.Length; i++)
+        {
+            diff |= a[i] ^ b[i];
+        }
+
+        return diff == 0;
+    }
+}

--- a/src/BlocksBeyondTheStars.WorldGeneration/WorldGenerator.cs
+++ b/src/BlocksBeyondTheStars.WorldGeneration/WorldGenerator.cs
@@ -34,30 +34,38 @@ public sealed class WorldGenerator
     /// <summary>The circumference this generator is currently producing terrain for.</summary>
     public int Circumference => _circumference;
 
-    /// <summary>Sets the world circumference for subsequent generation/queries (the server calls this when the
-    /// active world changes, so terrain, surface-height and flora all wrap at the right size).</summary>
-    public void SetCircumference(int circumference) => _circumference = circumference;
-
     // True when the active body is an airless moon (item 33): its terrain is cratered even though its planet
     // TYPE may carry an atmosphere on a full-size planet. The asteroid type carries Cratered in data instead,
-    // so it craters everywhere (incl. standalone queries). Set beside SetCircumference at world-load.
+    // so it craters everywhere (incl. standalone queries). Set via SetWorldMode at world-load.
     private bool _crateredWorld;
-
-    /// <summary>Marks the active world as cratered regardless of its planet type (used for airless moons).</summary>
-    public void SetCratered(bool cratered) => _crateredWorld = cratered;
 
     /// <summary>The current cratered-world flag (so a caller can save/restore it around a transient query
     /// for a different body, e.g. computing another body's landing pads).</summary>
     public bool Cratered => _crateredWorld;
 
     // The active world's planned landing pads. Pad terrain is FLATTENED at generation time (the landed
-    // ship is a placed structure object, not stamped blocks — it needs level, clear ground). Set beside
-    // SetCircumference whenever the active world changes; empty = no flattening (void worlds, tests).
+    // ship is a placed structure object, not stamped blocks — it needs level, clear ground). Set via
+    // SetWorldMode whenever the active world changes; empty = no flattening (void worlds, tests).
     private IReadOnlyList<LandingPadFlatten> _landingPads = System.Array.Empty<LandingPadFlatten>();
 
-    /// <summary>Sets the active world's landing pads so <see cref="Generate"/> levels their terrain.</summary>
-    public void SetLandingPads(IReadOnlyList<LandingPadFlatten> pads)
-        => _landingPads = pads ?? System.Array.Empty<LandingPadFlatten>();
+    /// <summary>The active world's landing pads (so a caller can save/restore them like <see cref="Cratered"/>).</summary>
+    public IReadOnlyList<LandingPadFlatten> LandingPads => _landingPads;
+
+    /// <summary>
+    /// Configures ALL per-world mode state (circumference, airless-moon cratering, landing-pad flattening)
+    /// in one call. This generator instance is shared across every resident world, and #424 S13 showed the
+    /// old individual setters invited asymmetric configuration — one path set circumference + pads but not
+    /// cratered, another circumference + cratered but not pads, so correctness rested entirely on the
+    /// single-active-world invariant. One all-or-nothing setter makes a full re-configure the only option.
+    /// Callers re-apply it before every generate/query batch for a body (chunk gen itself stays on the
+    /// single tick thread — this method is about complete state, not thread-safety).
+    /// </summary>
+    public void SetWorldMode(int circumference, bool cratered, IReadOnlyList<LandingPadFlatten>? landingPads)
+    {
+        _circumference = circumference;
+        _crateredWorld = cratered;
+        _landingPads = landingPads ?? System.Array.Empty<LandingPadFlatten>();
+    }
 
     /// <summary>The flattened pad surface height for a column, or null when it is not on a pad.</summary>
     private int? PadSurfaceAt(int worldX, int worldZ)

--- a/src/BlocksBeyondTheStars.WorldHost/BasicAuth.cs
+++ b/src/BlocksBeyondTheStars.WorldHost/BasicAuth.cs
@@ -45,4 +45,21 @@ public static class BasicAuth
         bool equal = CryptographicOperations.FixedTimeEquals(presented, sameLength ? expected : presented);
         return sameLength && equal;
     }
+
+    /// <summary>Fixed-time compare of a request-supplied secret (header value) against a configured one
+    /// (#424 S14 — an ordinal <c>string.Equals</c> leaks secret length/prefix via response timing). An
+    /// empty configured secret never matches, so an unconfigured gate stays closed.</summary>
+    public static bool TokenEquals(string? presented, string configured)
+    {
+        if (string.IsNullOrEmpty(configured))
+        {
+            return false;
+        }
+
+        byte[] presentedBytes = Encoding.UTF8.GetBytes(presented ?? string.Empty);
+        byte[] configuredBytes = Encoding.UTF8.GetBytes(configured);
+        bool sameLength = presentedBytes.Length == configuredBytes.Length;
+        bool equal = CryptographicOperations.FixedTimeEquals(presentedBytes, sameLength ? configuredBytes : presentedBytes);
+        return sameLength && equal;
+    }
 }

--- a/src/BlocksBeyondTheStars.WorldHost/InstanceLauncher.cs
+++ b/src/BlocksBeyondTheStars.WorldHost/InstanceLauncher.cs
@@ -183,9 +183,20 @@ public sealed class DockerCliLauncher : IInstanceLauncher
         return exitCode == 0 ? HostStats.ParseDockerStats(stdout) : Array.Empty<ContainerStat>();
     }
 
+    private const int CliTimeoutMs = 120_000;
+
     private static (int ExitCode, string Stdout, string Stderr) Run(List<string> args)
+        => RunProcess("docker", args, CliTimeoutMs);
+
+    /// <summary>Runs a CLI process with a hard timeout (#424 S11). The old blocking
+    /// <c>StandardOutput.ReadToEnd()</c> had none — a hung docker daemon (CLI that never exits or never
+    /// closes its pipes) wedged the caller forever, and this runs on the join path AND the reaper loop.
+    /// Both streams drain concurrently (a large stderr can no longer deadlock the stdout read either);
+    /// on expiry the CLI process tree is killed and the call reports failure (exit -1).
+    /// Public (like <see cref="BuildRunArgs"/>) so the timeout/kill behavior is unit-testable without Docker.</summary>
+    public static (int ExitCode, string Stdout, string Stderr) RunProcess(string fileName, List<string> args, int timeoutMs)
     {
-        var psi = new ProcessStartInfo("docker")
+        var psi = new ProcessStartInfo(fileName)
         {
             RedirectStandardOutput = true,
             RedirectStandardError = true,
@@ -196,10 +207,41 @@ public sealed class DockerCliLauncher : IInstanceLauncher
             psi.ArgumentList.Add(a);
         }
 
-        using var proc = Process.Start(psi) ?? throw new InvalidOperationException("Failed to start docker CLI.");
-        string stdout = proc.StandardOutput.ReadToEnd();
-        string stderr = proc.StandardError.ReadToEnd();
-        proc.WaitForExit(120_000);
-        return (proc.HasExited ? proc.ExitCode : -1, stdout, stderr);
+        using var proc = Process.Start(psi) ?? throw new InvalidOperationException($"Failed to start {fileName} CLI.");
+        var stdoutTask = proc.StandardOutput.ReadToEndAsync();
+        var stderrTask = proc.StandardError.ReadToEndAsync();
+        if (!proc.WaitForExit(timeoutMs))
+        {
+            try
+            {
+                proc.Kill(entireProcessTree: true);
+            }
+            catch
+            {
+                // already exited in the race, or access denied — either way we stop waiting on it
+            }
+
+            proc.WaitForExit(5_000);
+            return (-1, DrainOrEmpty(stdoutTask), DrainOrEmpty(stderrTask));
+        }
+
+        // Exited: the pipes are closed (or close imminently), so the reads complete promptly.
+        return (proc.ExitCode, DrainOrEmpty(stdoutTask), DrainOrEmpty(stderrTask));
+    }
+
+    /// <summary>Best-effort result of a stream drain; empty when it cannot finish in bounded time
+    /// (a killed process may leave a pipe held open by an orphaned grandchild).</summary>
+    private static string DrainOrEmpty(Task<string> read)
+    {
+#pragma warning disable VSTHRD002 // Bounded wait on a background pipe drain in a deliberately synchronous CLI wrapper (no SynchronizationContext) — cannot deadlock.
+        try
+        {
+            return read.Wait(5_000) ? read.Result : string.Empty;
+        }
+        catch (AggregateException)
+        {
+            return string.Empty;
+        }
+#pragma warning restore VSTHRD002
     }
 }

--- a/src/BlocksBeyondTheStars.WorldHost/Program.cs
+++ b/src/BlocksBeyondTheStars.WorldHost/Program.cs
@@ -157,8 +157,7 @@ IResult? GuardAccount(AccountRecord account)
 }
 
 bool IsAdmin(HttpContext ctx)
-    => !string.IsNullOrEmpty(config.AdminToken)
-       && string.Equals(ctx.Request.Headers["X-Admin-Token"].ToString(), config.AdminToken, StringComparison.Ordinal);
+    => BasicAuth.TokenEquals(ctx.Request.Headers["X-Admin-Token"].ToString(), config.AdminToken);
 
 // Browser admin UI gate (Basic Auth — browsers can't send X-Admin-Token). Returns the 401 challenge
 // to send, or null when authorized. Off until BBS_WH_ADMIN_USER + _PASSWORD are configured.

--- a/tests/BlocksBeyondTheStars.Tests/MaintenanceAnnounceTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/MaintenanceAnnounceTests.cs
@@ -146,6 +146,12 @@ public sealed class MaintenanceAnnounceTests : IDisposable
         server.EnqueueMaintenance(MaintenanceNotice.KindRestartCountdown, "Heads up", 300);
         TickAndPoll(server, client, 1.0, times: 5);
 
+        // The creator leaves before the latecomer joins: the loopback link has a single connection id,
+        // and a JoinRequest on an already-joined connection is dropped since #424 S8 (re-join guard) —
+        // the countdown itself is server-global and survives the world being empty.
+        client.Disconnect();
+        server.Tick(0.1);
+
         var (_, lateNotices) = JoinAndListen(server, link, "Latecomer");
 
         var notice = Assert.Single(lateNotices);
@@ -184,6 +190,12 @@ public sealed class MaintenanceAnnounceTests : IDisposable
     {
         var (server, link, client, _) = Start("maint_guard");
         TickAndPoll(server, client, 0.1);
+
+        // The admin creator leaves, then a guest joins on the freed loopback connection (a second
+        // JoinRequest on a live joined connection is dropped since #424 S8). The creator's WorldAdmin
+        // role is persisted on THEIR player record — the guest joins as a plain player.
+        client.Disconnect();
+        server.Tick(0.1);
 
         ActionRejected? rejected = null;
         var guest = new LoopbackClientTransport(link);

--- a/tests/BlocksBeyondTheStars.Tests/ProtocolHardeningTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/ProtocolHardeningTests.cs
@@ -1,0 +1,268 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using BlocksBeyondTheStars.Networking;
+using BlocksBeyondTheStars.Networking.Messages;
+using BlocksBeyondTheStars.Networking.Transport;
+using BlocksBeyondTheStars.Persistence;
+using BlocksBeyondTheStars.Shared.Configuration;
+using BlocksBeyondTheStars.Shared.Content;
+using BlocksBeyondTheStars.Shared.Security;
+using BlocksBeyondTheStars.Shared.World;
+using BlocksBeyondTheStars.WorldGeneration;
+using BlocksBeyondTheStars.WorldHost;
+using Xunit;
+using SvGameServer = BlocksBeyondTheStars.GameServer.GameServer;
+
+namespace BlocksBeyondTheStars.Tests;
+
+/// <summary>
+/// Protocol/join/transport hardening (#424, audit findings S8–S14): the join path is flood-gated and
+/// re-join-proof, untrusted MessagePack is decoded with security limits, the docker CLI wrapper cannot
+/// hang forever, secret compares are fixed-time, and the shared world generator's per-world mode state
+/// is always configured completely.
+/// </summary>
+public sealed class ProtocolHardeningTests : IDisposable
+{
+    private readonly string _root;
+    private readonly GameContent _content;
+
+    public ProtocolHardeningTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "bbts_hardening_" + Guid.NewGuid().ToString("N"));
+        _content = ContentLoader.LoadFromDirectory(TestPaths.DataDir());
+    }
+
+    /// <summary>A transport the test drives directly: it raises connect/payload/disconnect into the server
+    /// and records every message the server sends back, per connection.</summary>
+    private sealed class DrivenTransport : IServerTransport
+    {
+        public event Action<int>? ClientConnected;
+        public event Action<int>? ClientDisconnected;
+        public event Action<int, byte[]>? PayloadReceived;
+
+        public readonly List<(int Conn, object Msg)> Sent = new();
+
+        public void Connect(int id) => ClientConnected?.Invoke(id);
+        public void Disconnect(int id) => ClientDisconnected?.Invoke(id);
+        public void Receive(int id, object message) => PayloadReceived?.Invoke(id, NetCodec.Encode(message));
+
+        public void Start(int port) { }
+        public void Send(int connectionId, byte[] payload, DeliveryMode mode)
+        {
+            if (NetCodec.Decode(payload) is { } m) Sent.Add((connectionId, m));
+        }
+        public void Broadcast(byte[] payload, DeliveryMode mode)
+        {
+            if (NetCodec.Decode(payload) is { } m) Sent.Add((int.MinValue, m));
+        }
+        public void Poll() { }
+        public void Stop() { }
+        public void Dispose() { }
+    }
+
+    private SvGameServer NewServer(string name, DrivenTransport transport)
+    {
+        var repo = new SqliteWorldRepository(new SaveGamePaths(_root, name));
+        _repos.Add(repo);
+        var config = new ServerConfig
+        {
+            WorldName = name,
+            Seed = 1,
+            StartPlanet = "rocky",
+            AutoSaveIntervalMinutes = 9999,
+            PlaceStarterShip = false,
+        };
+        var server = new SvGameServer(config, _content, transport, repo);
+        server.Start();
+        return server;
+    }
+
+    private readonly List<SqliteWorldRepository> _repos = new();
+
+    // ---------------- S8 — join re-join guard + flood gate ----------------
+
+    [Fact]
+    public void Join_OnAlreadyJoinedConnection_IsDroppedWithoutReply()
+    {
+        var transport = new DrivenTransport();
+        var server = NewServer("s8_rejoin", transport);
+
+        transport.Connect(1);
+        transport.Receive(1, new JoinRequest { ProtocolVersion = Protocol.Version, PlayerName = "Pilot" });
+        Assert.Single(transport.Sent.Where(x => x.Msg is JoinAccepted));
+
+        // The re-join must neither re-run the join burst (amplifier) nor answer at all (an answer feeds it).
+        transport.Sent.Clear();
+        transport.Receive(1, new JoinRequest { ProtocolVersion = Protocol.Version, PlayerName = "Pilot" });
+        Assert.Empty(transport.Sent);
+
+        server.Stop();
+    }
+
+    [Fact]
+    public void Join_Flood_IsRateLimitedPerConnection()
+    {
+        var transport = new DrivenTransport();
+        var server = NewServer("s8_flood", transport);
+
+        // 20 protocol-mismatch joins in one burst: only the join budget's worth may even be processed
+        // (each would otherwise do rejection work; a valid flood would do DB + world work).
+        transport.Connect(2);
+        for (int i = 0; i < 20; i++)
+        {
+            transport.Receive(2, new JoinRequest { ProtocolVersion = Protocol.Version + 999, PlayerName = "Flood" });
+        }
+
+        int rejected = transport.Sent.Count(x => x.Conn == 2 && x.Msg is JoinRejected);
+        Assert.True(rejected is > 0 and <= 5, $"expected 1..5 processed join attempts, got {rejected}");
+
+        // A reconnect starts with a fresh budget — a legitimate client retrying after a rejection
+        // (new connection) is never locked out.
+        transport.Disconnect(2);
+        transport.Connect(2);
+        transport.Sent.Clear();
+        transport.Receive(2, new JoinRequest { ProtocolVersion = Protocol.Version + 999, PlayerName = "Flood" });
+        Assert.Single(transport.Sent.Where(x => x.Conn == 2 && x.Msg is JoinRejected));
+
+        server.Stop();
+    }
+
+    // ---------------- S10 — untrusted MessagePack decoding ----------------
+
+    [Fact]
+    public void Decode_DeeplyNestedMaliciousPayload_IsHandledBenignly()
+    {
+        // A JoinRequest body that is a map with one unknown key whose value is a million nested arrays
+        // (one byte per level — maximal nesting inside the packet cap): the contractless formatter must
+        // Skip it. Whatever the library does with it (skip, or reject via the UntrustedData limits this
+        // codebase now sets — #424 S10), the contract here is: no exception escapes Decode, no crash, no
+        // hang; the result is either dropped or a plain default-shaped message.
+        const int Depth = 1_000_000;
+        var body = new List<byte> { 0x81, 0xA1, (byte)'x' }; // fixmap(1) { "x": ... }
+        for (int i = 0; i < Depth; i++)
+        {
+            body.Add(0x91); // fixarray(1) — one more nesting level
+        }
+
+        body.Add(0xC0); // nil terminator at the bottom
+
+        var payload = new byte[body.Count + 1];
+        payload[0] = 1; // JoinRequest tag
+        body.CopyTo(payload, 1);
+
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        object? decoded = NetCodec.Decode(payload);
+        sw.Stop();
+
+        Assert.True(decoded is null or JoinRequest, $"unexpected decode result: {decoded?.GetType().Name}");
+        Assert.True(sw.Elapsed < TimeSpan.FromSeconds(10), $"decoding a hostile payload must stay cheap (took {sw.Elapsed})");
+    }
+
+    [Fact]
+    public void Decode_NormalJoinRequest_StillRoundTrips()
+    {
+        // Regression guard: the security limits must not reject legitimate traffic.
+        var encoded = NetCodec.Encode(new JoinRequest { ProtocolVersion = Protocol.Version, PlayerName = "Pilot" });
+        var decoded = Assert.IsType<JoinRequest>(NetCodec.Decode(encoded));
+        Assert.Equal("Pilot", decoded.PlayerName);
+    }
+
+    // ---------------- S11 — docker CLI wrapper timeout ----------------
+
+    [Fact]
+    public void RunProcess_KillsAHungCliOnTimeout()
+    {
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        var (exitCode, _, _) = OperatingSystem.IsWindows()
+            ? DockerCliLauncher.RunProcess("cmd", new List<string> { "/c", "ping -n 60 127.0.0.1 > nul" }, 1_500)
+            : DockerCliLauncher.RunProcess("/bin/sh", new List<string> { "-c", "sleep 60" }, 1_500);
+        sw.Stop();
+
+        Assert.Equal(-1, exitCode);
+        Assert.True(sw.Elapsed < TimeSpan.FromSeconds(30),
+            $"a hung CLI must be killed at the timeout, not waited out (took {sw.Elapsed})");
+    }
+
+    [Fact]
+    public void RunProcess_CapturesOutputOfAWellBehavedCli()
+    {
+        var (exitCode, stdout, _) = OperatingSystem.IsWindows()
+            ? DockerCliLauncher.RunProcess("cmd", new List<string> { "/c", "echo hello" }, 30_000)
+            : DockerCliLauncher.RunProcess("/bin/sh", new List<string> { "-c", "echo hello" }, 30_000);
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal("hello", stdout.Trim());
+    }
+
+    // ---------------- S14 — fixed-time secret compares ----------------
+
+    [Fact]
+    public void TokenEquals_MatchesOnlyTheExactSecret()
+    {
+        Assert.True(BasicAuth.TokenEquals("s3cret", "s3cret"));
+        Assert.False(BasicAuth.TokenEquals("s3crex", "s3cret"));
+        Assert.False(BasicAuth.TokenEquals("s3cret-longer", "s3cret"));
+        Assert.False(BasicAuth.TokenEquals(null, "s3cret"));
+        Assert.False(BasicAuth.TokenEquals(string.Empty, "s3cret"));
+
+        // An unconfigured secret must never match anything — the gate stays closed, not open.
+        Assert.False(BasicAuth.TokenEquals(string.Empty, string.Empty));
+        Assert.False(BasicAuth.TokenEquals("anything", string.Empty));
+    }
+
+    [Fact]
+    public void SecretCompare_FixedTimeEquals_Basics()
+    {
+        Assert.True(SecretCompare.FixedTimeEquals("pass", "pass"));
+        Assert.False(SecretCompare.FixedTimeEquals("pass", "pasS"));
+        Assert.False(SecretCompare.FixedTimeEquals("pass", "password"));
+        Assert.True(SecretCompare.FixedTimeEquals(null, string.Empty)); // callers gate empty-config themselves
+    }
+
+    // ---------------- S13 — shared generator mode state ----------------
+
+    [Fact]
+    public void SharedGenerator_InterleavedWorlds_StayDeterministic()
+    {
+        var planet = _content.GetPlanet("rocky");
+        Assert.NotNull(planet);
+        var coord = new ChunkCoord(0, 3, 0);
+
+        // One shared generator, alternating between a small cratered moon and a full-size world — like
+        // two resident worlds generating on demand. The moon's chunk must be identical to what a fresh,
+        // single-world generator produces (no mode bleed-through from the other world).
+        var shared = new WorldGenerator(worldSeed: 42, _content);
+        shared.SetWorldMode(1008, cratered: true, landingPads: null);
+        _ = shared.Generate(planet!, coord);
+        shared.SetWorldMode(WorldConstants.Circumference, cratered: false, landingPads: null);
+        _ = shared.Generate(planet!, coord);
+        shared.SetWorldMode(1008, cratered: true, landingPads: null);
+        var interleaved = shared.Generate(planet!, coord);
+
+        var fresh = new WorldGenerator(worldSeed: 42, _content);
+        fresh.SetWorldMode(1008, cratered: true, landingPads: null);
+        var baseline = fresh.Generate(planet!, coord);
+
+        int cs = WorldConstants.ChunkSize;
+        for (int x = 0; x < cs; x++)
+            for (int y = 0; y < cs; y++)
+                for (int z = 0; z < cs; z++)
+                {
+                    Assert.Equal(baseline.Get(x, y, z), interleaved.Get(x, y, z));
+                }
+    }
+
+    public void Dispose()
+    {
+        foreach (var repo in _repos)
+        {
+            repo.Dispose();
+        }
+
+        try { Directory.Delete(_root, recursive: true); } catch { }
+    }
+}

--- a/tests/BlocksBeyondTheStars.Tests/WebSocketTransportTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/WebSocketTransportTests.cs
@@ -133,6 +133,56 @@ public sealed class WebSocketTransportTests : IDisposable
         Assert.Equal(HttpStatusCode.OK, ok.StatusCode);
     }
 
+    [Fact]
+    public async Task Gateway_RejectsConnectionsBeyondTheCapAsync()
+    {
+        int port = FreeTcpPort();
+        using var transport = new WebSocketServerTransport("127.0.0.1", maxConnections: 2);
+        transport.Start(port);
+
+        using var ws1 = new ClientWebSocket();
+        using var ws2 = new ClientWebSocket();
+        await ws1.ConnectAsync(new Uri($"ws://127.0.0.1:{port}/"), CancellationToken.None);
+        await ws2.ConnectAsync(new Uri($"ws://127.0.0.1:{port}/"), CancellationToken.None);
+
+        // #424 S9: connection 3 must be refused BEFORE the upgrade — an idler flood would otherwise hold
+        // a socket + receive task + buffers each without ever counting against MaxPlayers.
+        using var ws3 = new ClientWebSocket();
+        await Assert.ThrowsAsync<WebSocketException>(
+            () => ws3.ConnectAsync(new Uri($"ws://127.0.0.1:{port}/"), CancellationToken.None));
+
+        ws1.Abort();
+        ws2.Abort();
+    }
+
+    [Fact]
+    public async Task Gateway_DropsAConnectionThatNeverSendsAsync()
+    {
+        int port = FreeTcpPort();
+        using var transport = new WebSocketServerTransport("127.0.0.1", handshakeTimeout: TimeSpan.FromMilliseconds(500));
+        transport.Start(port);
+
+        // A slow-loris connection: upgrade completes but no message ever follows. The server must close
+        // it once the handshake window expires (#424 S9) instead of parking a receive task forever.
+        using var ws = new ClientWebSocket();
+        await ws.ConnectAsync(new Uri($"ws://127.0.0.1:{port}/"), CancellationToken.None);
+
+        var buffer = new byte[256];
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        bool closedByServer;
+        try
+        {
+            var result = await ws.ReceiveAsync(new ArraySegment<byte>(buffer), cts.Token);
+            closedByServer = result.MessageType == WebSocketMessageType.Close;
+        }
+        catch (WebSocketException)
+        {
+            closedByServer = true; // an abortive teardown counts too — the connection is gone either way
+        }
+
+        Assert.True(closedByServer, "an idle pre-join connection must be dropped after the handshake window");
+    }
+
     private static async Task ReceiveLoopAsync(ClientWebSocket ws, ConcurrentQueue<byte[]> received, CancellationToken token)
     {
         var buffer = new byte[16 * 1024];


### PR DESCRIPTION
Fixes the six server hardening findings from the 2026-07-19 static bug-hunt audit bundled in #424 (`bugreports/bughunt.md` §8–§11).

## Changes

### S8 — `JoinRequest` flood gate + re-join guard (`GameServer.cs`)
- A `JoinRequest` on an **already-joined connection is dropped without a reply** — previously it reloaded the player from the DB (rolling back progress since the last autosave) and re-ran the full ~40-message join burst per cheap inbound packet (asymmetric amplifier against the single-threaded tick).
- Joins now pass a **per-connection token bucket** (1/s, burst 5, cleared on disconnect) — the session flood gate could not cover them because joins arrive before a session exists.

### S10 — untrusted MessagePack (`NetCodec.cs`)
- Decode options now set `MessagePackSecurity.UntrustedData` (depth limits + hash-collision-resistant map handling). Empirical probe: the 1M-deep-nesting skip vector was already benign in MessagePack 2.5.302, so this is belt-and-suspenders — matching the audit's own reachability caveat.

### S9 — WS slow-loris (`WebSocketServerTransport.cs`)
- **Connection cap** (rejects with 503 *before* the upgrade; default 64, wired to `MaxPlayers*4` in `Program.cs`) — idlers never counted against `MaxPlayers`, which only tracks joined sessions.
- **15 s first-message handshake window**: a connection that never sends anything is dropped instead of holding a socket + 8 KB buffer + receive task forever.

### S11 — docker CLI timeout (`InstanceLauncher.cs`)
- `Run` drains stdout/stderr **async** (large stderr can no longer deadlock the stdout read) and **kills the CLI process tree** when the 120 s timeout expires — a hung docker daemon no longer wedges the join path and the reaper loop.

### S14 — fixed-time secret compares
- WorldHost `X-Admin-Token`, ReportHost read/write keys → new `BasicAuth.TokenEquals` (fixed-time; empty configured secret never matches).
- Game `ServerPassword` → new shared `SecretCompare.FixedTimeEquals` (netstandard2.1-compatible, like `HostedJoinToken`'s).
- (Api admin password was already fixed-time via `AdminAuth`, #411.)

### S13 — shared `WorldGenerator` mode state
- The three individual setters (`SetCircumference`/`SetCratered`/`SetLandingPads`) are replaced by one all-or-nothing **`SetWorldMode(circumference, cratered, pads)`** — the old API invited the asymmetric configuration the audit found (one path set circumference+pads, another circumference+cratered).
- `ServerWorld` now carries its `Cratered` flag and fully re-configures the generator before **every** chunk generation; `ComputeLandingPads` save/restores all three fields. Thread-safety stays guarded by the single-tick-thread invariant (documented).

## Tests
- New `ProtocolHardeningTests`: re-join drop, join-flood cap + fresh-budget-after-reconnect, hostile deep-nesting decode, docker-CLI hang kill + happy path, fixed-time compare basics, interleaved-worlds generator determinism.
- `WebSocketTransportTests`: connection-cap rejection + idle-connection drop.
- `MaintenanceAnnounceTests` joined a second player by re-sending `JoinRequest` on the already-joined loopback connection — exactly the session overwrite S8 removes; they now disconnect the first client before the second joins.

Server-only; ships with the next image/release. Full fast-tier suite green locally (1056 server + 122 client tests).

Closes #424

🤖 Generated with [Claude Code](https://claude.com/claude-code)