### PR TITLE
fix(client+server): touch path for naming modal, content-load recovery, teleport snap channel (#408, #422, #414)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -100,6 +100,29 @@ Per-item detail lives in the dated work log below.
 
 ---
 
+### ★ Touch naming modal, content-load dead-ends, teleport snap channel (#408/#422/#414, 2026-07-19, branch fix/audit-408-422-414)
+Three community-facing audit issues in one pass. **(#408, critical)** The beacon/beam naming modal
+could only be closed with a physical Enter/Esc — and while it is open every on-screen touch control
+is hidden, so tablet/touch-browser players (play.glitch.fun) were soft-locked until a page reload.
+The modal now builds on-screen Confirm/Cancel buttons (deliberately NO `onEndEdit` auto-confirm: on
+touch it fires on the pointer-down that deselects the field, i.e. also when tapping Cancel — it
+would commit the name before the Cancel click lands). **(#422 M8)** One malformed data file in
+`StreamingAssets/data` threw out of `ContentLoader.LoadFromDirectory` before `_splash`/`_studio`/
+`_loading` existed → per-frame NRE storm, frozen shell, zero explanation. All three call sites are
+now guarded: `AppShell.LoadLocalizer` catches and (cold start) raises a blocking DE/EN error overlay
+with a Retry button — hardcoded texts, the locale files themselves are the content that failed —
+while a mid-session re-load failure keeps the working in-memory snapshot; `GameBootstrap.Start`
+routes the failure through the existing `ConnectFailedReason` bail-out (menu + localized notice, new
+key `ui.content.load_failed`); `AppShell.Update` also null-guards the screens. **(#422 M9)** A failed
+WebGL content download left a dead menu with raw `ui.*` keys forever; the same overlay now offers
+Retry, which re-runs the (re-entrant) `StreamingAssetsCache.EnsureReady` download. **(#414 M7/N17)**
+Every server-side position set that rode a plain `PlayerStateUpdate` was discarded by the client and
+then reverted by its client-authoritative move stream: admin `teleport_to_location`/`teleport_to_player`
+and the suit teleporter now send a `RespawnNotice` snap (`Died=false` → no death flash, same channel
+as the void-fall rescue), and the craftable `suit_teleporter` finally got its client trigger —
+right-click the held item recalls to the ship (server validates device/energy/cooldown). New tests:
+admin-teleport + suit-teleport RespawnNotice snaps (position, `Died=false`).
+
 ### ★ Server infra hardening & polish — bounded caches, WS teardown, docking gates, atomic crash-writer init (#426, 2026-07-19, branch fix/421-terrain-hole-webgl-telemetry)
 Four audit findings (S15–S18). **(S15)** `RateLimiter._windows` and the GlitchGateway `_validateCache`
 grew one entry per unique visitor until process restart; the limiter now amortizes a sweep (≥ 2 idle

--- a/client/Assets/BlocksBeyondTheStars/Scripts/AppShell.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/AppShell.cs
@@ -91,6 +91,10 @@ namespace BlocksBeyondTheStars.Client
 
         public bool ContentReady { get; private set; }
 
+        /// <summary>Non-empty after a failed content load (malformed local file) or a failed WebGL content
+        /// download — drives the blocking error+retry overlay instead of a dead shell (#422 M8/M9).</summary>
+        public string ContentLoadError { get; private set; } = "";
+
         private bool _splashSoundDone;
         private bool _autoJoinWhenReady;
 
@@ -231,7 +235,11 @@ namespace BlocksBeyondTheStars.Client
             yield return StreamingAssetsCache.EnsureReady(ex => failure = ex);
             if (failure != null)
             {
+                // One failed download of the ~20 data files (CDN hiccup, flaky mobile network) must not
+                // leave a dead menu with raw ui.* keys forever — surface it with a Retry instead (#422 M9).
+                // EnsureReady is re-entrant, so RetryContentLoad can simply run this coroutine again.
                 Debug.LogError($"Content startup failed: {failure.Message}");
+                ContentLoadError = failure.Message;
                 yield break;
             }
 
@@ -374,7 +382,28 @@ namespace BlocksBeyondTheStars.Client
             }
 
             string dataDir = StreamingAssetsCache.DataDir;
-            Content = ContentLoader.LoadFromDirectory(dataDir);
+            GameContent loaded;
+            try
+            {
+                loaded = ContentLoader.LoadFromDirectory(dataDir);
+            }
+            catch (System.Exception e)
+            {
+                // One malformed data file (corrupted install, interrupted patch, AV lock) must not escape
+                // Awake and brick the shell with per-frame NREs (#422 M8). With content already loaded
+                // (e.g. a re-load via Settings→CloseSettings) keep the working in-memory snapshot; on a
+                // cold start the error+retry overlay takes over.
+                Debug.LogError($"Content load from '{dataDir}' failed: {e}");
+                if (!ContentReady)
+                {
+                    ContentLoadError = e.Message;
+                }
+
+                return;
+            }
+
+            Content = loaded;
+            ContentLoadError = "";
             Debug.Log($"Content loaded from '{dataDir}' ({Content.Blocks.Count} blocks, {Content.Items.Count} items, {Content.Recipes.Count} recipes, {Content.Planets.Count} planet types).");
             var locale = Settings.Language == "de" ? GameLocale.German : GameLocale.English;
             Localizer = Content.CreateLocalizer(locale);
@@ -404,6 +433,25 @@ namespace BlocksBeyondTheStars.Client
             {
                 Destroy(_uiLoading);
                 _uiLoading = null;
+            }
+        }
+
+        /// <summary>Retries a failed content load: re-runs the WebGL download when the remote cache never
+        /// became ready, else re-reads the local data directory. Wired to the error overlay's button (#422).</summary>
+        public void RetryContentLoad()
+        {
+            ContentLoadError = "";
+            if (StreamingAssetsCache.UsesRemoteStreamingAssets && !StreamingAssetsCache.IsReady)
+            {
+                StartCoroutine(LoadContentForStartup());
+            }
+            else
+            {
+                LoadLocalizer();
+                if (ContentReady)
+                {
+                    EnsureMenuBackground();
+                }
             }
         }
 
@@ -786,6 +834,41 @@ namespace BlocksBeyondTheStars.Client
         private GameObject _uiCredits;
         private GameObject _uiEditors;
         private GameObject _uiSaveSelect;
+        private GameObject _uiContentError;
+
+        /// <summary>Blocking "content failed to load" overlay with a Retry button (#422 M8/M9). Texts are
+        /// hardcoded DE/EN pairs — the locale files themselves are part of the content that failed.</summary>
+        private GameObject BuildContentErrorUi()
+        {
+            bool de = Settings?.Language == "de";
+            var canvas = UiKit.CreateCanvas("ContentErrorUI");
+            canvas.sortingOrder = 90; // above every shell screen — the shell is unusable without content
+            var root = canvas.transform;
+
+            UiKit.AddPanel(root, 0, 0, 1920, 1080, new Color(0f, 0f, 0f, 0.75f));
+            const float w = 720f, h = 320f;
+            float x = (1920f - w) * 0.5f, y = (1080f - h) * 0.5f;
+            UiKit.AddPanel(root, x, y, w, h, UiKit.Panel);
+
+            var title = UiKit.AddText(root, x + 32, y + 28, w - 64, 34,
+                de ? "Inhalte konnten nicht geladen werden" : "Content failed to load",
+                26, UiKit.TextCol, TextAnchor.MiddleLeft);
+            title.fontStyle = FontStyle.Bold;
+
+            UiKit.AddText(root, x + 32, y + 80, w - 64, 84,
+                de
+                    ? "Das Laden der Spieldaten ist fehlgeschlagen. Prüfe deine Internetverbindung bzw. die Installation und versuche es dann erneut."
+                    : "Loading the game data failed. Check your internet connection or the install, then try again.",
+                18, UiKit.TextCol, TextAnchor.UpperLeft);
+
+            UiKit.AddText(root, x + 32, y + 168, w - 64, 60, ContentLoadError ?? string.Empty,
+                14, UiKit.CyanDim, TextAnchor.UpperLeft);
+
+            UiKit.AddButton(root, x + (w - 280f) * 0.5f, y + h - 82, 280, 56,
+                de ? "Erneut versuchen" : "Retry", RetryContentLoad);
+
+            return canvas.gameObject;
+        }
         private GameObject _editorRoot;
 
         /// <summary>Opens the standalone ship-type editor (build a ship design + save it).</summary>
@@ -918,6 +1001,26 @@ namespace BlocksBeyondTheStars.Client
 
         private void Update()
         {
+            // A failed content load/download shows the blocking retry overlay (#422) — handled before
+            // anything else so it appears no matter which shell phase the failure hit.
+            bool contentError = !ContentReady && !string.IsNullOrEmpty(ContentLoadError);
+            if (contentError && _uiContentError == null)
+            {
+                _uiContentError = BuildContentErrorUi();
+            }
+            else if (!contentError && _uiContentError != null)
+            {
+                Destroy(_uiContentError);
+                _uiContentError = null;
+            }
+
+            // Belt-and-braces (#422 M8): should Awake ever abort before these exist, a per-frame NRE
+            // storm would freeze the shell with zero explanation — skip instead.
+            if (_studio == null || _splash == null || _loading == null)
+            {
+                return;
+            }
+
             _studio.Update();
             _splash.Update();
             _loading.Update();

--- a/client/Assets/BlocksBeyondTheStars/Scripts/BeaconLabelUi.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/BeaconLabelUi.cs
@@ -69,10 +69,7 @@ namespace BlocksBeyondTheStars.Client
             if (Time.frameCount != _openFrame &&
                 (Input.GetKeyDown(KeyCode.Return) || Input.GetKeyDown(KeyCode.KeypadEnter)))
             {
-                string label = _input.text?.Trim() ?? string.Empty;
-                var cb = _onConfirm;
-                Close();
-                cb?.Invoke(label);
+                Confirm();
                 return;
             }
 
@@ -81,6 +78,19 @@ namespace BlocksBeyondTheStars.Client
                 Game?.MarkMenuInputHandled(); // this Esc is consumed — don't also pop the quit prompt (#413 N1)
                 Close(); // cancel — no callback, nothing placed/renamed
             }
+        }
+
+        private void Confirm()
+        {
+            if (!_open)
+            {
+                return; // Enter + onEndEdit can both fire for the same submit — first one wins
+            }
+
+            string label = _input.text?.Trim() ?? string.Empty;
+            var cb = _onConfirm;
+            Close();
+            cb?.Invoke(label);
         }
 
         private void Close()
@@ -110,7 +120,7 @@ namespace BlocksBeyondTheStars.Client
             UiKit.AddPanel(root, 0, 0, 1920, 1080, new Color(0f, 0f, 0f, 0.45f));
 
             // Centred card.
-            const float w = 460f, h = 190f;
+            const float w = 460f, h = 236f;
             float x = (1920f - w) * 0.5f, y = (1080f - h) * 0.5f;
             UiKit.AddPanel(root, x, y, w, h, UiKit.Panel);
 
@@ -121,8 +131,20 @@ namespace BlocksBeyondTheStars.Client
             _input.characterLimit = 24;
             _input.lineType = InputField.LineType.SingleLine;
 
-            UiKit.AddText(root, x + 24, y + 128, w - 48, 26, L("ui.beacon.confirm") + " — Enter   ·   " + L("ui.beacon.cancel") + " — Esc",
+            // Deliberately NO auto-confirm on onEndEdit: on touch it fires on the pointer-DOWN that
+            // deselects the field — i.e. also when tapping the Cancel button — which would commit the
+            // name before the Cancel click lands. The on-screen buttons below are the touch path (#408).
+            UiKit.AddText(root, x + 24, y + 122, w - 48, 24, L("ui.beacon.confirm") + " — Enter   ·   " + L("ui.beacon.cancel") + " — Esc",
                 18, UiKit.CyanDim, TextAnchor.MiddleLeft);
+
+            // On-screen Confirm/Cancel: the only way to close the modal without a physical keyboard —
+            // while it is open every touch control is hidden, so it must be self-sufficient (#408).
+            UiKit.AddButton(root, x + 24, y + 158, (w - 60f) * 0.5f, 52, L("ui.beacon.confirm"), Confirm);
+            UiKit.AddButton(root, x + 36 + (w - 60f) * 0.5f, y + 158, (w - 60f) * 0.5f, 52, L("ui.beacon.cancel"), () =>
+            {
+                Game?.MarkMenuInputHandled();
+                Close();
+            });
 
             _canvas.gameObject.SetActive(false);
             _built = true;

--- a/client/Assets/BlocksBeyondTheStars/Scripts/GameBootstrap.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/GameBootstrap.cs
@@ -990,7 +990,25 @@ namespace BlocksBeyondTheStars.Client
             }
 
             string dataDir = StreamingAssetsCache.DataDir;
-            Content = ContentLoader.LoadFromDirectory(dataDir);
+            try
+            {
+                Content = ContentLoader.LoadFromDirectory(dataDir);
+            }
+            catch (System.Exception e)
+            {
+                // A malformed data file must not strand the player in a half-built world (#422 M8):
+                // surface it through the same bail-out AppShell already watches for failed connects —
+                // back to the menu with a reason. The shell's own content snapshot is still in memory,
+                // so its localizer is available for the message.
+                Debug.LogError($"Content re-load on world entry failed from '{dataDir}': {e}");
+                var shell = FindAnyObjectByType<AppShell>();
+                ConnectFailedReason = shell != null && shell.Localizer != null
+                    ? shell.L("ui.content.load_failed")
+                    : "Game content failed to load — the install may be damaged.";
+                enabled = false;
+                return;
+            }
+
             Localizer = Content.CreateLocalizer(German ? GameLocale.German : GameLocale.English);
             World = new ClientWorld();
             // Index dedicated light blocks (+ placed glow blocks) as coloured light sources for the mesher.

--- a/client/Assets/BlocksBeyondTheStars/Scripts/PlayerController.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/PlayerController.cs
@@ -1873,6 +1873,15 @@ namespace BlocksBeyondTheStars.Client
                     return;
                 }
 
+                // Right-click the held suit teleporter → recall to the ship. The item was craftable but
+                // had no client-side trigger at all (#414 N17); the server validates ownership, suit
+                // energy and the cooldown, and answers with a RespawnNotice snap (or a reject toast).
+                if (held == "suit_teleporter")
+                {
+                    Game.Network?.SendTeleportToShip();
+                    return;
+                }
+
                 // Right-click the camera → photograph the current view (HUD-free), saved to disk locally.
                 // Handled entirely on the client (no server round-trip), so it's intercepted before the
                 // generic gadget path below.

--- a/data/locales/de.json
+++ b/data/locales/de.json
@@ -1020,6 +1020,7 @@
   "ui.settings.reset_defaults": "Deine Einstellungsdatei war beschaedigt und wurde zurueckgesetzt - bitte pruefe deinen Namen und deine Optionen in den Einstellungen.",
   "ui.sp.server_failed": "Der Welt-Server konnte nicht gestartet werden - vielleicht wurde er vom Virenschutz blockiert oder ein anderes Programm benutzt seinen Port. Bitte versuch es noch einmal oder starte das Spiel neu, wenn es wieder passiert.",
   "ui.connect.failed": "Keine Verbindung zum Server moeglich - bitte pruefe Adresse und Port und versuch es noch einmal.",
+  "ui.content.load_failed": "Die Spielinhalte konnten nicht geladen werden - die Installation ist vielleicht beschaedigt. Bitte versuch es noch einmal oder installiere das Spiel neu, wenn es wieder passiert.",
   "ui.host.title": "WELT HOSTEN",
   "ui.host.subtitle": "Eine Welt für Freunde hosten: eine gespeicherte Welt wählen oder neu erstellen, dann die im Spiel angezeigte Adresse teilen.",
   "ui.host.max_players": "Max. Spieler",

--- a/data/locales/en.json
+++ b/data/locales/en.json
@@ -1019,6 +1019,7 @@
   "ui.settings.reset_defaults": "Your settings file was damaged and has been reset to defaults - please check your name and options in Settings.",
   "ui.sp.server_failed": "The world server could not be started - it may have been blocked by your antivirus or another program is using its port. Please try again, or restart the game if it keeps happening.",
   "ui.connect.failed": "Could not connect to the server - please check the address and port and try again.",
+  "ui.content.load_failed": "The game content could not be loaded - the install may be damaged. Please try again, or reinstall the game if it keeps happening.",
   "ui.host.title": "HOST A WORLD",
   "ui.host.subtitle": "Host a world for friends: pick any saved world or create a new one, then share the address shown in-game.",
   "ui.host.max_players": "Max players",

--- a/src/BlocksBeyondTheStars.GameServer/GameServer.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServer.cs
@@ -3320,6 +3320,10 @@ public sealed partial class GameServer
 
             case "teleport_to_location":
                 p.Position = new Vector3f(cmd.X, cmd.Y, cmd.Z);
+                // A plain PlayerStateUpdate position is ignored by the client and then reverted by its
+                // client-authoritative move stream — every server-side teleport must go through the
+                // RespawnNotice snap channel or it silently does nothing (#414 M7).
+                Send(session, new RespawnNotice { X = p.Position.X, Y = p.Position.Y, Z = p.Position.Z, Reason = "Teleported." });
                 SendPlayerState(session);
                 CheatLog(p, $"teleported to ({cmd.X:0.#}, {cmd.Y:0.#}, {cmd.Z:0.#})");
                 break;
@@ -3334,6 +3338,8 @@ public sealed partial class GameServer
                     }
 
                     p.Position = target.State.Position;
+                    // Same snap-channel rule as teleport_to_location (#414 M7).
+                    Send(session, new RespawnNotice { X = p.Position.X, Y = p.Position.Y, Z = p.Position.Z, Reason = $"Teleported to {target.State.Name}." });
                     SendPlayerState(session);
                     CheatLog(p, $"teleported to player {target.State.Name}");
                     break;

--- a/src/BlocksBeyondTheStars.GameServer/GameServerTeleport.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerTeleport.cs
@@ -58,8 +58,18 @@ public sealed partial class GameServer
         p.AboardShip = true;
         _teleportCooldown[playerId] = TeleportCooldownSeconds;
 
+        // The snap must ride the RespawnNotice channel (Died=false → no death feedback): a plain
+        // PlayerStateUpdate position is discarded by the client, whose next MoveIntent would then
+        // revert this teleport server-side — "aboard" per server, still standing outside per client
+        // (#414 N17). Same pattern as the void-fall rescue in GameServerSpawnSafety.
+        Send(session, new RespawnNotice
+        {
+            X = p.RespawnPoint.X,
+            Y = p.RespawnPoint.Y,
+            Z = p.RespawnPoint.Z,
+            Reason = "Teleported back to your ship.",
+        });
         SendPlayerState(session);
-        Send(session, new ServerMessage { Text = "Teleported back to your ship." });
     }
 
     /// <summary>Counts down a player's teleporter cooldown (called from the environment tick).</summary>

--- a/tests/BlocksBeyondTheStars.Tests/AdminCheatTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/AdminCheatTests.cs
@@ -111,6 +111,52 @@ public sealed class AdminCheatTests : IDisposable
     }
 
     [Fact]
+    public void Teleport_ToLocation_SendsRespawnSnap()
+    {
+        var rules = new GameRules { AdminCheats = true, AllowCheatsInSurvival = true };
+        var (server, client) = Start(rules, "tpsnap");
+
+        // Without the RespawnNotice snap the client discards the new position and its next MoveIntent
+        // reverts the teleport server-side — /tp silently does nothing (#414 M7).
+        RespawnNotice? snap = null;
+        client.PayloadReceived += pl => { if (NetCodec.Decode(pl) is RespawnNotice r) snap = r; };
+
+        client.Send(NetCodec.Encode(new AdminCommandIntent { Command = "teleport_to_location", X = 100, Y = 70, Z = -50 }),
+            DeliveryMode.ReliableOrdered);
+        server.Tick(0.1);
+        client.Poll();
+
+        Assert.NotNull(snap);
+        Assert.Equal(100f, snap!.X);
+        Assert.Equal(70f, snap.Y);
+        Assert.Equal(-50f, snap.Z);
+        Assert.False(snap.Died); // a relocation, not a death — must not trigger the death flash/prompt
+    }
+
+    [Fact]
+    public void Teleport_ToPlayer_SendsRespawnSnap()
+    {
+        var rules = new GameRules { AdminCheats = true, AllowCheatsInSurvival = true };
+        var (server, client) = Start(rules, "tpplayer");
+
+        var target = server.AddLocalPlayer("Target");
+        target.State.Position = new Shared.Geometry.Vector3f(321, 70, 123);
+
+        RespawnNotice? snap = null;
+        client.PayloadReceived += pl => { if (NetCodec.Decode(pl) is RespawnNotice r) snap = r; };
+
+        client.Send(NetCodec.Encode(new AdminCommandIntent { Command = "teleport_to_player", TargetPlayer = "Target" }),
+            DeliveryMode.ReliableOrdered);
+        server.Tick(0.1);
+        client.Poll();
+
+        Assert.NotNull(snap);
+        Assert.Equal(321f, snap!.X);
+        Assert.Equal(123f, snap.Z);
+        Assert.False(snap.Died);
+    }
+
+    [Fact]
     public void GodMode_PreventsDeath()
     {
         var rules = new GameRules { AdminCheats = true, AllowCheatsInSurvival = true };

--- a/tests/BlocksBeyondTheStars.Tests/TeleportTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/TeleportTests.cs
@@ -1,6 +1,8 @@
 // Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using BlocksBeyondTheStars.Networking;
+using BlocksBeyondTheStars.Networking.Messages;
 using BlocksBeyondTheStars.Networking.Transport;
 using BlocksBeyondTheStars.Persistence;
 using BlocksBeyondTheStars.Shared.Configuration;
@@ -72,6 +74,44 @@ public sealed class TeleportTests : IDisposable
             server.TeleportToShip("Spacer");
 
             Assert.Equal(200f, p.State.Position.X); // unchanged
+        }
+    }
+
+    [Fact]
+    public void Teleport_SendsRespawnSnap_NotJustAStateUpdate()
+    {
+        // The recall must ride the RespawnNotice snap channel: a plain PlayerStateUpdate position is
+        // discarded by the client, whose next MoveIntent then reverts the teleport server-side (#414 N17).
+        var repo = new SqliteWorldRepository(new SaveGamePaths(_root, "tpsnap"));
+        using (repo)
+        {
+            var link = new LoopbackLink();
+            var st = new LoopbackServerTransport(link);
+            var client = new LoopbackClientTransport(link);
+            var config = new ServerConfig { WorldName = "tpsnap", Seed = 1, AutoSaveIntervalMinutes = 9999, PlaceStarterShip = false };
+            var server = new SvGameServer(config, _content, st, repo);
+            server.Start();
+            client.Connect("loopback", 0);
+            client.Send(NetCodec.Encode(new JoinRequest { PlayerName = "Spacer" }), DeliveryMode.ReliableOrdered);
+            server.Tick(0.1);
+
+            var p = server.Sessions[1];
+            p.State.RespawnPoint = new Vector3f(5, 70, 5);
+            p.State.Position = new Vector3f(200, 64, 200);
+            p.State.AboardShip = false;
+            p.State.SuitEnergy = 100f;
+            p.State.Inventory.Add("suit_teleporter", 1, 1);
+
+            RespawnNotice? snap = null;
+            client.PayloadReceived += pl => { if (NetCodec.Decode(pl) is RespawnNotice r) snap = r; };
+
+            server.TeleportToShip(p.State.PlayerId);
+            client.Poll();
+
+            Assert.NotNull(snap);
+            Assert.Equal(5f, snap!.X);
+            Assert.Equal(70f, snap.Y);
+            Assert.False(snap.Died); // a recall, not a death — no death feedback on the client
         }
     }
 


### PR DESCRIPTION
## Summary

Three community-facing audit issues in one pass — the touch soft-lock, both content-load dead-ends, and the silently-reverted server teleports.

### #408 — Beacon/beam naming modal soft-locked touch players (critical)
The modal closed only on a physical Enter/Esc while every on-screen touch control is hidden behind it (`Game.MenuOpen`), so tablet/touch-browser players (play.glitch.fun) were stuck until a page reload. `BeaconLabelUi` now builds on-screen **Confirm/Cancel buttons** (reusing the existing `ui.beacon.confirm/cancel` keys). Deliberately **no `onEndEdit` auto-confirm**: on touch it fires on the pointer-*down* that deselects the field — i.e. also when tapping Cancel — and would commit the name before the Cancel click lands.

### #422 — Content-load dead-ends (M8 + M9)
- **M8:** a malformed data file threw out of `ContentLoader.LoadFromDirectory` before `_splash`/`_studio`/`_loading` existed → per-frame NRE storm, frozen shell, zero explanation. All three call sites are guarded now: `AppShell.LoadLocalizer` catches and (cold start) raises a blocking DE/EN **error overlay with Retry** — texts hardcoded, because the locale files are part of the content that failed — while a mid-session re-load failure keeps the working in-memory snapshot. `GameBootstrap.Start` routes its failure through the existing `ConnectFailedReason` bail-out (menu + localized notice, new key `ui.content.load_failed` DE+EN). `AppShell.Update` additionally null-guards the shell screens as a backstop.
- **M9:** a failed WebGL content download left a dead menu with raw `ui.*` keys forever. The same overlay now offers **Retry**, which re-runs the re-entrant `StreamingAssetsCache.EnsureReady` download.

### #414 — Server position-sets silently reverted (M7 + N17)
Any position change delivered as a plain `PlayerStateUpdate` is discarded by the client and then reverted server-side by the client-authoritative move stream. Admin `teleport_to_location`/`teleport_to_player` and `TeleportToShip` now send a **`RespawnNotice` snap** (`Died=false` → no death flash/prompt; same channel as the void-fall rescue in `GameServerSpawnSafety`). The craftable `suit_teleporter` also got its missing client trigger: **right-click the held item** recalls to the ship (server validates device, energy, cooldown; rejects surface as toasts).

## Verification
- `dotnet build -warnaserror`: 0 warnings, 0 errors
- `dotnet test`: **1225/1225 green** (129 client + 1096 server), incl. 3 new tests asserting the `RespawnNotice` snap (position + `Died=false`) for both admin teleports and the suit teleporter
- Local Unity Windows batch build: **succeeded** (worktree, PackageCache + Velopack libs synced)
- TODO.md updated

closes #408
closes #414
closes #422

🤖 Generated with [Claude Code](https://claude.com/claude-code)