### PR TITLE
fix(client): plug see-through ship holes + washed-out greebles (#420)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -6168,6 +6168,21 @@ is **pre-approved** (keys in `tools/ai-assets/.env`, run via `uv`).
 
 ---
 
+## ✅ Done (2026-07-21): ship render fixes — see-through hull holes + washed-out greebles (#420)
+
+Two static-audit findings in the client mesher (M12, M13). **M12 — see-through holes:** the chunk mesher
+only rescues a cube face bordering a shaped (slab/ramp/stairs/sphere) neighbour when handed the optional
+`worldShape` delegate; the planet streamer passed one but all ship display paths omitted it, so a full hull
+cube next to a shaped cell got its face culled while the shaped geometry didn't fill the cell — a
+see-through hole into the interior (flight view, landed ships, paint preview, remote ships). Fixed by
+passing a `worldShape` delegate reading each path's own shapes dict at the three shaped-hull call sites
+(`ShipMeshBuilder`, `SpaceView`, `LandedShipView`); the speeder hull has no shaped cells so it's documented
+as N/A. **M13 — washed-out greebles:** `AddGreeblePanel` gave all four corners of a raised panel the same
+`uv.center`, a zero-area UV footprint that on the mipmapped, gutter-less atlas sampled a coarse cross-tile
+average resolving to near-white (same defect fixed for bevels in #382). Fixed by projecting each inset
+corner across the tile like `EmitBevel.Push`, so the plate samples the hull's own texel and reads as
+slightly darker plating. Client-side — reaches players with the next Velopack release.
+
 ## ✅ Done (2026-07-19): editor palettes usable + fully localized (ship / station / settlement editors)
 
 The build-material list in the ship, station and settlement editors was a flat, ~150-row list sorted by

--- a/client/Assets/BlocksBeyondTheStars/Scripts/ChunkMesher.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/ChunkMesher.cs
@@ -1000,12 +1000,26 @@ namespace BlocksBeyondTheStars.Client
             Vector3 tan3 = (p3 - p0).sqrMagnitude > 1e-8f ? (p3 - p0).normalized : (p1 - p0).normalized;
             float hand = Vector3.Dot(Vector3.Cross(nrm, tan3), p1 - p0) < 0f ? -1f : 1f;
             var tan = new Vector4(tan3.x, tan3.y, tan3.z, hand);
-            Vector2 uvC = uv.center;
-            for (int i = 0; i < 4; i++)
+
+            // Per-vertex UVs projected across the tile like EmitBevel.Push: a single shared uv.center gave all
+            // four corners a zero-area UV footprint, which on the mipmapped, gutter-less atlas sampled a coarse
+            // cross-tile average that resolved to near-white — the washed-out greeble bug (#420 M13, the same
+            // defect fixed for bevels in #382). The inset corners keep a real footprint so the plate samples the
+            // hull's own texel and reads as slightly darker plating instead of a white blotch.
+            Vector3 nAbs = new Vector3(Mathf.Abs(nrm.x), Mathf.Abs(nrm.y), Mathf.Abs(nrm.z));
+            int domAxis = nAbs.x >= nAbs.y && nAbs.x >= nAbs.z ? 0 : (nAbs.y >= nAbs.z ? 1 : 2);
+            int uAxis = domAxis == 0 ? 1 : 0;
+            int vAxis = domAxis == 2 ? 1 : 2;
+            void PushGreeble(Vector3 p) // verts were already appended above; this adds only the matching attributes
             {
-                colors.Add(col); uvs.Add(uvC); tangents.Add(tan);
+                Vector3 loc = p - cell;
+                var uvv = new Vector2(uv.xMin + Mathf.Clamp01(loc[uAxis]) * uv.width,
+                                      uv.yMin + Mathf.Clamp01(loc[vAxis]) * uv.height);
+                colors.Add(col); uvs.Add(uvv); tangents.Add(tan);
                 skyUv.Add(new Vector2(sky, tintMode)); leafUv.Add(leaf); blockLight.Add(bl); blockLightDir.Add(blDir);
             }
+
+            PushGreeble(p0); PushGreeble(p1); PushGreeble(p2); PushGreeble(p3);
 
             tris.Add(baseIdx); tris.Add(baseIdx + 1); tris.Add(baseIdx + 2);
             tris.Add(baseIdx); tris.Add(baseIdx + 2); tris.Add(baseIdx + 3);

--- a/client/Assets/BlocksBeyondTheStars/Scripts/LandedShipView.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/LandedShipView.cs
@@ -192,6 +192,10 @@ namespace BlocksBeyondTheStars.Client
             }
 
             BlockId CellAt(int x, int y, int z) => m.Get(new Vector3i(x, y, z));
+            // Hand the mesher this ship's shapes so a hull cube next to a slab/ramp/sphere doesn't cull the face
+            // the shaped cell leaves uncovered — that gap is a see-through hole into the parked ship (#420 M12).
+            System.Func<int, int, int, int> WorldShape = m.Shapes == null ? null
+                : (x, y, z) => m.Shapes.TryGetValue(new Vector3i(x, y, z), out var s) ? s : 0;
 
             int cs = WorldConstants.ChunkSize;
             int FloorDiv(int a, int b) => (a >= 0 ? a : a - (b - 1)) / b;
@@ -215,7 +219,7 @@ namespace BlocksBeyondTheStars.Client
                     }
                 }
 
-                var (mesh, collider) = ChunkMesher.Build(chunk, Game.Content, CellAt, Game.Atlas, paintTint: paint);
+                var (mesh, collider) = ChunkMesher.Build(chunk, Game.Content, CellAt, Game.Atlas, paintTint: paint, worldShape: WorldShape);
                 if (mesh.vertexCount == 0)
                 {
                     continue;

--- a/client/Assets/BlocksBeyondTheStars/Scripts/ShipMeshBuilder.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/ShipMeshBuilder.cs
@@ -117,6 +117,11 @@ namespace BlocksBeyondTheStars.Client
             }
 
             BlockId WorldBlock(int x, int y, int z) => cells.TryGetValue(new Vector3i(x, y, z), out var b) ? b : BlockId.Air;
+            // A cube face bordering a shaped (slab/ramp/…) neighbour must not be culled — the shaped cell doesn't
+            // fill its volume, so culling leaves a see-through hole into the hull (#420 M12). The mesher rescues
+            // that face only when handed a worldShape delegate reading the same shapes dict the planet uses.
+            System.Func<int, int, int, int> WorldShape = shapes == null ? null
+                : (x, y, z) => shapes.TryGetValue(new Vector3i(x, y, z), out var s) ? s : 0;
 
             int cs = WorldConstants.ChunkSize;
             int FloorDiv(int a, int b) => (a >= 0 ? a : a - (b - 1)) / b;
@@ -144,7 +149,7 @@ namespace BlocksBeyondTheStars.Client
                     }
                 }
 
-                var (mesh, collider) = ChunkMesher.Build(chunk, content, WorldBlock, atlas, paintTint: paint);
+                var (mesh, collider) = ChunkMesher.Build(chunk, content, WorldBlock, atlas, paintTint: paint, worldShape: WorldShape);
                 if (collider != null)
                 {
                     Object.Destroy(collider); // display-only build — the cooked collider mesh is never used (#423)

--- a/client/Assets/BlocksBeyondTheStars/Scripts/SpaceView.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/SpaceView.cs
@@ -2975,6 +2975,10 @@ namespace BlocksBeyondTheStars.Client
             }
 
             BlockId WorldBlock(int x, int y, int z) => cells.TryGetValue(new Vector3i(x, y, z), out var b) ? b : BlockId.Air;
+            // Feed the mesher the hull's shapes so a full cube next to a slab/ramp/sphere keeps the face the
+            // shaped cell doesn't cover — otherwise it's culled and you see through the hull into the ship (#420 M12).
+            System.Func<int, int, int, int> WorldShape = shapes == null ? null
+                : (x, y, z) => shapes.TryGetValue(new Vector3i(x, y, z), out var s) ? s : 0;
 
             int cs = WorldConstants.ChunkSize;
             int FloorDiv(int a, int b) => (a >= 0 ? a : a - (b - 1)) / b;
@@ -3002,7 +3006,7 @@ namespace BlocksBeyondTheStars.Client
                     }
                 }
 
-                var (mesh, collider) = ChunkMesher.Build(chunk, Game.Content, WorldBlock, Game.Atlas, paintTint: paint);
+                var (mesh, collider) = ChunkMesher.Build(chunk, Game.Content, WorldBlock, Game.Atlas, paintTint: paint, worldShape: WorldShape);
                 if (mesh.vertexCount == 0)
                 {
                     continue;

--- a/client/Assets/BlocksBeyondTheStars/Scripts/SpeederView.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/SpeederView.cs
@@ -210,6 +210,9 @@ namespace BlocksBeyondTheStars.Client
                 chunk.Set(kv.Key.X, kv.Key.Y, kv.Key.Z, kv.Value);
             }
 
+            // No worldShape delegate (unlike the ship paths in #420 M12): the speeder hull is a fixed procedural
+            // cube grid built by SpeederCells() with no shaped (slab/ramp/…) cells, so no cube face can border a
+            // shaped neighbour and there are no see-through holes to rescue.
             var (mesh, collider) = ChunkMesher.Build(chunk, Game.Content, CellAt, Game.Atlas, paintTint: paint);
             if (collider != null)
             {


### PR DESCRIPTION
Fixes the two client meshing defects reported in #420 (static-audit findings **M12**, **M13**).

## M12 — see-through holes in ship hulls next to shaped blocks
The chunk mesher only rescues a cube face bordering a non-cube neighbour when handed the optional `worldShape` delegate (`ChunkMesher.cs:531`). The planet streamer passes one, but all ship display paths omitted it — so a full hull cube adjacent to a slab/ramp/stairs/sphere cell got its face culled (neighbour id is opaque non-air) while the shaped geometry didn't fill the cell → a **see-through hole into the ship interior**. Visible in the flight view, on landed ships, in the paint preview and on remote ships. The editor renders correctly (`EditorVoxelChunkView.Occludes` returns false for shaped cells), so builders only discovered the holes after launch.

**Fix:** pass a `worldShape` delegate reading each path's own shapes dict at the three shaped-hull call sites:
- [ShipMeshBuilder.cs](../blob/fix/420-ship-render-defects/client/Assets/BlocksBeyondTheStars/Scripts/ShipMeshBuilder.cs) (paint preview / remote ships)
- [SpaceView.cs](../blob/fix/420-ship-render-defects/client/Assets/BlocksBeyondTheStars/Scripts/SpaceView.cs) (flight ship)
- [LandedShipView.cs](../blob/fix/420-ship-render-defects/client/Assets/BlocksBeyondTheStars/Scripts/LandedShipView.cs) (parked ships)

The **speeder** (`SpeederView.cs`) is a fixed procedural cube grid with no shaped cells, so no cube face can border a shaped neighbour — documented at its call site rather than wired to a non-existent shapes dict.

## M13 — greeble hull panels render washed-out / near-white
`AddGreeblePanel` gave all four corners of a raised panel the identical `uv.center` — a zero-area UV footprint. On the mipmapped, gutter-less atlas that samples a coarse cross-tile average which resolves to near-white. This is exactly the defect fixed for bevels in #382 (`EmitBevel`, with real projected UVs); the T2 greeble panels were added later and never got the same treatment.

**Fix:** give each inset corner a real UV footprint projected across the tile like `EmitBevel.Push`, so the plate samples the hull's own texel and reads as slightly darker plating instead of a washed-out blotch.

## Verification
- Local Windows player build (`scripts/build-client.ps1`): **clean compile, 0 errors**, full 337 MB player produced.
- Changes are client-render-only; they reach players with the next Velopack release.

closes #420

🤖 Generated with [Claude Code](https://claude.com/claude-code)