### PR TITLE
fix(client): atomic crash-report publish + Arcade "content broken" state (#425)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -100,6 +100,18 @@ Per-item detail lives in the dated work log below.
 
 ---
 
+### ★ Truncated crash upload + Arcade "content broken" empty-state (#425, 2026-07-21, branch fix/425-crash-arcade)
+Two bounded client audit fixes (N13/N14). **(N14)** `CrashReportSpool.Write` did a plain
+`File.WriteAllText` into the live spool, so startup's `FlushPending` — running while the background log
+callback writes — could read a half-written report and POST truncated JSON. It now writes the body to a
+`.json.tmp` sibling (excluded from the `crash_*.json` scans) and `File.Move`s it into place, so readers
+only ever see complete files; the temp file is cleaned up if the rename fails. New test asserts no `.tmp`
+lingers and the report round-trips whole. **(N13)** A minigame catalogue that failed to load left `Games`
+empty, which made the Arcade show "no data fragments yet" — factually wrong for a player who owns data
+cubes and masking that the content is broken. `MinigameCatalog` now exposes a `Broken` flag (true when the
+catalogue parses to zero games), and the Arcade shows a distinct "Games couldn't be loaded" screen
+(new locale keys `ui.arcade.broken_title`/`ui.arcade.broken_body`, DE+EN) instead of the empty state.
+
 ### ★ Touch naming modal, content-load dead-ends, teleport snap channel (#408/#422/#414, 2026-07-19, branch fix/audit-408-422-414)
 Three community-facing audit issues in one pass. **(#408, critical)** The beacon/beam naming modal
 could only be closed with a physical Enter/Esc — and while it is open every on-screen touch control

--- a/client/Assets/BlocksBeyondTheStars/Scripts/ArcadeUI.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/ArcadeUI.cs
@@ -28,6 +28,7 @@ namespace BlocksBeyondTheStars.Client
         private RectTransform _rail;
         private GameObject _placeholder;
         private GameObject _emptyState;
+        private GameObject _brokenState;
         private MinigameCatalog _catalog;
         private MinigameHostUI _native;
         private bool _built;
@@ -55,6 +56,7 @@ namespace BlocksBeyondTheStars.Client
             UiKit.AddPanel(_root, RegionX, RegionY, RegionW, RegionH, new Color(0.03f, 0.06f, 0.11f, 0.96f));
             _placeholder = BuildText("ArcadePlaceholder", L("ui.browser.unavailable_title"), L("ui.browser.unavailable_body"));
             _emptyState = BuildText("ArcadeEmpty", L("ui.arcade.empty_title"), L("ui.arcade.empty_body"));
+            _brokenState = BuildText("ArcadeBroken", L("ui.arcade.broken_title"), L("ui.arcade.broken_body"));
             _canvas.enabled = false; // first Show() enables it + runs OnOpen()
             _built = true;
         }
@@ -167,11 +169,16 @@ namespace BlocksBeyondTheStars.Client
             if (owned.Count == 0)
             {
                 _placeholder.SetActive(false);
-                _emptyState.SetActive(true);
+                // A broken catalogue also yields zero owned games, but the cause — and the fix the player needs
+                // — is different: "content failed to load" (retry/reinstall), not "go find data cubes" (#425 N13).
+                bool broken = _catalog == null || _catalog.Broken;
+                _emptyState.SetActive(!broken);
+                _brokenState.SetActive(broken);
                 return;
             }
 
             _emptyState.SetActive(false);
+            _brokenState.SetActive(false);
             PlayGame(owned[0].key); // open the first owned game by default
         }
 
@@ -209,6 +216,7 @@ namespace BlocksBeyondTheStars.Client
             EnsureNative();
             _placeholder.SetActive(false);
             _emptyState.SetActive(false);
+            _brokenState.SetActive(false);
             _native.Play(MinigameRegistry.Create(key), Settings != null ? Settings.GetMinigameBest(key) : 0, Game != null && Game.German);
         }
 

--- a/client/Assets/BlocksBeyondTheStars/Scripts/MinigameCatalog.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/MinigameCatalog.cs
@@ -41,6 +41,12 @@ namespace BlocksBeyondTheStars.Client
 
         public List<Entry> Games { get; } = new List<Entry>();
 
+        /// <summary>True when the catalogue could not be loaded into a usable state (file missing, malformed
+        /// JSON, or no games parsed). Lets the Arcade tell "content is broken" apart from "player owns nothing"
+        /// (#425 N13): a broken catalogue resolves every data cube's seed to null via <see cref="GameForSeed"/>,
+        /// so a player who actually owns cubes would otherwise see a misleading "nothing unlocked" screen.</summary>
+        public bool Broken { get; private set; }
+
         public static MinigameCatalog Instance { get; private set; }
 
         /// <summary>Loads (once) the catalogue from bundled content. Returns the cached instance on repeat calls.</summary>
@@ -75,6 +81,10 @@ namespace BlocksBeyondTheStars.Client
             {
                 Debug.LogWarning($"[MinigameCatalog] failed to load: {e.Message}");
             }
+
+            // A healthy bundled catalogue always parses at least one game; an empty list means the load failed
+            // (missing file, parse error, or an empty array) — flag it so the Arcade can say so plainly.
+            cat.Broken = cat.Games.Count == 0;
 
             Instance = cat;
             return cat;

--- a/data/locales/de.json
+++ b/data/locales/de.json
@@ -533,6 +533,8 @@
   "ui.arcade.collection": "Gesammelte Fragmente",
   "ui.arcade.empty_title": "Noch keine Datenfragmente",
   "ui.arcade.empty_body": "Finde leuchtende Datenwürfel auf Planeten und drücke E, um ihre Datenfragmente zu bergen.",
+  "ui.arcade.broken_title": "Spiele konnten nicht geladen werden",
+  "ui.arcade.broken_body": "Die Minispiel-Inhalte fehlen oder sind beschädigt, deshalb lassen sich deine Datenfragmente nicht öffnen. Starte das Spiel neu oder installiere es neu.",
   "ui.arcade.downloaded": "Datenfragment geborgen!",
   "ui.browser.unavailable_title": "Browser-Komponente nicht installiert",
   "ui.browser.unavailable_body": "Der eingebettete Browser (UnityWebBrowser) ist in diesem Build nicht vorhanden. Siehe docs/developer/MINIGAMES_AND_WIKI.md zum Aktivieren.",

--- a/data/locales/en.json
+++ b/data/locales/en.json
@@ -532,6 +532,8 @@
   "ui.arcade.collection": "Collected fragments",
   "ui.arcade.empty_title": "No data fragments yet",
   "ui.arcade.empty_body": "Find glowing data cubes out on planets and press E to extract their data fragments.",
+  "ui.arcade.broken_title": "Games couldn't be loaded",
+  "ui.arcade.broken_body": "The minigame content is missing or damaged, so your data fragments can't be opened. Try restarting the game or reinstalling.",
   "ui.arcade.downloaded": "Data fragment recovered!",
   "ui.browser.unavailable_title": "Browser component not installed",
   "ui.browser.unavailable_body": "The embedded browser (UnityWebBrowser) is not present in this build. See docs/developer/MINIGAMES_AND_WIKI.md to enable it.",

--- a/src/BlocksBeyondTheStars.Client.Core/Feedback/CrashReportSpool.cs
+++ b/src/BlocksBeyondTheStars.Client.Core/Feedback/CrashReportSpool.cs
@@ -65,7 +65,24 @@ namespace BlocksBeyondTheStars.Client.Feedback
 
                 string stem = $"{FilePrefix}{Sanitize(timestampStem)}_{n:D3}";
                 string file = Path.Combine(_directory, stem + ".json");
-                File.WriteAllText(file, json);
+
+                // Publish atomically: the log callback runs on a background thread while startup's FlushPending
+                // enumerates the spool, so a reader must never observe a half-written body (#425 N14). We write
+                // the full JSON to a sibling temp file — its ".tmp" tail is excluded from the "crash_*.json"
+                // scans, so ListPending/Prune ignore it — then rename it into place, which is atomic on every
+                // supported filesystem. Readers therefore only ever see a complete file.
+                string temp = Path.Combine(_directory, stem + ".json.tmp");
+                File.WriteAllText(temp, json);
+                try
+                {
+                    File.Move(temp, file);
+                }
+                catch
+                {
+                    try { File.Delete(temp); } catch { /* best-effort */ }
+                    throw;
+                }
+
                 Prune(_directory, MaxPending); // file names lead with the UTC timestamp → oldest sorts first
                 return file;
             }

--- a/tests/BlocksBeyondTheStars.Client.Tests/CrashReportSpoolTests.cs
+++ b/tests/BlocksBeyondTheStars.Client.Tests/CrashReportSpoolTests.cs
@@ -84,6 +84,23 @@ public sealed class CrashReportSpoolTests : IDisposable
     }
 
     [Fact]
+    public void Write_PublishesAtomically_LeavesNoTempAndReadsBackWhole()
+    {
+        // The body is written to a ".tmp" sibling and renamed into place (#425 N14) so a concurrent
+        // FlushPending reader never observes a half-written file. After a successful Write the spool must
+        // hold only the finished report — the temp name must neither linger nor leak into the pending scan.
+        var spool = new CrashReportSpool(_dir);
+        string body = "{\"kind\":\"crash\",\"payload\":\"" + new string('x', 4096) + "\"}";
+
+        string? path = spool.Write(body, "20260721_120000");
+        Assert.NotNull(path);
+        Assert.EndsWith(".json", path);
+        Assert.Empty(Directory.GetFiles(_dir, "*.tmp"));          // no leftover temp file
+        Assert.Single(spool.ListPending());                       // scan sees exactly the complete report...
+        Assert.Equal(body, spool.Read(path!));                    // ...and it round-trips whole
+    }
+
+    [Fact]
     public void EmptyDirectory_DisablesSpool_NeverThrows()
     {
         var spool = new CrashReportSpool(string.Empty);


### PR DESCRIPTION
Two bounded client audit fixes from the static bug-hunt (finding IDs N13/N14), closes #425.

## N14 — truncated crash upload
`CrashReportSpool.Write` wrote report bodies straight into the live spool with `File.WriteAllText`. The threaded log callback runs while startup's `FlushPending` enumerates the spool, so a reader could observe a half-written file and POST truncated JSON — wasted, or stored by a lenient backend.

**Fix:** write the body to a `.json.tmp` sibling (excluded from the `crash_*.json` scans, so `ListPending`/`Prune` ignore it) and `File.Move` it into place — an atomic publish. Readers only ever see complete files. The temp file is deleted if the rename fails.

- Regression test asserts no `.tmp` lingers after a write and the report round-trips whole.

## N13 — corrupt catalogue masquerades as "nothing unlocked"
If the minigame catalogue fails to load, `Games` ends up empty, every data cube stops resolving, and the Arcade shows the "no data fragments yet" empty state — factually wrong for a player who owns cubes, and it hides that the content is broken.

**Fix:** `MinigameCatalog` now exposes a `Broken` flag (true when the catalogue parses to zero games). The Arcade shows a distinct "Games couldn't be loaded" screen (new locale keys `ui.arcade.broken_title` / `ui.arcade.broken_body`, DE+EN) instead of the empty state.

## Verification
- `CrashReportSpoolTests` — 7/7 pass (6 existing + 1 new).
- `ContentTests` (locale parity/validity) — 16/16 pass.
- Unity-side changes (ArcadeUI/MinigameCatalog) build in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
