### PR TITLE
ci(lint): pin ruff to 0.15.4 — unpinned "latest" broke every PR overnight

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,6 +23,9 @@ jobs:
 
   # Python AI backend — ruff is both the linter and the syntax checker. Config (if any) is read from
   # ai-backend/pyproject.toml; today it runs ruff's default rule set, which the tree already passes.
+  # The ruff version is pinned: ai-backend/pyproject.toml declares no ruff dependency, so the action
+  # would otherwise fetch "latest" — 0.16.0's new default rules (S110/BLE001/UP037) turned every PR
+  # red overnight without any code change. Bump deliberately, running the new version locally first.
   ruff:
     name: ruff (Python ai-backend)
     needs: changes
@@ -34,6 +37,7 @@ jobs:
         with:
           args: "check"
           src: "ai-backend"
+          version: "0.15.4"
 
   # Workflow YAML correctness. ShellCheck is disabled (-shellcheck=) so this stays a workflow-syntax check
   # and does not flag shell style in the existing run: scripts. Pinned for reproducibility.


### PR DESCRIPTION
## What

Pins the `astral-sh/ruff-action` ruff version to **0.15.4** in the Lint workflow.

## Why

`ai-backend/pyproject.toml` declares no ruff dependency, so the action falls back to **latest**. ruff **0.16.0** (released after the last green main run on 2026-07-22) enables new default rules (`S110`, `BLE001`, `UP037`) that flag the existing `ai-backend/app/llm.py` — every PR turned red overnight without any code change (first seen on #458, which touches no Python at all).

0.15.4 verified locally: `uvx ruff@0.15.4 check ai-backend` passes.

Future ruff bumps become a deliberate one-line change, tested locally first. (Alternative follow-up if desired: adopt 0.16 and fix/ignore the new findings in `llm.py` — the blind `except` fallbacks there are deliberate template-fallback paths.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)