### PR TITLE
feat(fleet): delete worlds from the admin panel, portal links to the game website

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,24 @@ the richer, screenshot-laden versions live there. `(#123)` references the pull r
 
 ## [Unreleased]
 
+### 🛰️ Fleet operations
+- **The fleet admin panel can delete worlds.** Every row on `/admin` gets a folded-away `delete…`
+  control: type the world's name (checked on the server — there is no undo), then either `delete`,
+  which stops the instance and drops it from the registry but leaves its saves recoverable on disk,
+  or `purge saves`, which erases them including the archived copy. Both now also remove the world's
+  container object — instances run without `--rm`, and a deleted world never wakes again to clean up
+  its own leftovers, so until today every deleted world left one behind for good. Arcade worlds show
+  `reset…` instead, because the glitch.fun pool refills itself (and its replacement worlds are now
+  numbered from the highest name in use, so a reset can no longer produce two "Glitch Arcade 3").
+  Scriptable twin for bulk cleanup: `DELETE /api/admin/worlds/{id}[?purge=true]`.
+
+### 🌍 Worlds portal
+- **The portal links to the game's website.** The shared footer carries a "Game website ↗" link on
+  every page of play.blocksbeyondthestars.de, and the landing page repeats it in a line under the
+  headline where first-time visitors actually look — German pages to the German site, English pages
+  to `/en`. Self-hosters can point both elsewhere or drop the link entirely
+  (`BBS_WH_WEBSITE_URL` / `_EN`, `-` = off).
+
 ## [0.8.7] — 2026-07-25
 
 The homestead release: player bases and space stations get their first real life support. A new heal tank block heals, feeds and recharges everyone nearby, doubles as a settable home spawn point, and dying now lets you choose whether to wake up at your ship or at your base — plus the ship's console and lab stations finally do something, and glitch.fun visitors see Singleplayer first.

--- a/TODO.md
+++ b/TODO.md
@@ -7,7 +7,7 @@ plans live under [docs/](docs/) (committed); the long-range direction is the str
 keep it current when controls/features change. Last consolidated 2026-06-04.
 
 **Build:** `scripts/build-client.ps1` (Windows) or `scripts/build-client.sh` (Linux) — publishes shared libs + bundled server + Unity player.
-**Test:** `./scripts/run-tests.sh` — currently **1123 server + 132 client passing** (2026-07-26). Locale parity (en/de) is enforced by a test.
+**Test:** `./scripts/run-tests.sh` — currently **1134 server + 132 client passing** (2026-07-26). Locale parity (en/de) is enforced by a test.
 CI runs two tiers: PRs skip the tests marked `[Trait("Category", "Slow")]`; pushes to `main` and the release workflow run the full suite. CI builds/runs
 tests in Release, and a per-test duration guardrail (`scripts/check-test-durations.py`, PRs only) fails the gate when a non-Slow test exceeds 120 s.
 **Conventions:** English docs/comments; in-game text bilingual DE+EN; commit to `main` with the
@@ -99,6 +99,33 @@ Per-item detail lives in the dated work log below.
   single-source-of-truth working end-to-end (validated: published the initial Windows zip).
 
 ---
+
+### ★ Fleet admin: delete worlds + the portal links to the game website (2026-07-26, branch feat/worldhost-admin-delete-and-site-link)
+Two small WorldHost additions, both analysed first (`analysis/fleet-admin-world-delete.md`,
+`analysis/portal-website-link.md`).
+
+**World deletion on `/admin`.** The primitives existed twice already (the owner's `DELETE
+/api/worlds/{id}` keeps the saves; account self-deletion purges them) — the operator panel simply had
+no entry point. Each instance row now carries a folded `delete…` disclosure with a **server-checked
+name confirmation** and two submit buttons sharing it: `delete` (registry row goes, saves stay) and
+`purge saves` (also erases live + `_archive`). Both run through the new
+`WorldOrchestrator.DeleteWorld(world, purgeSaves)`, which stops the instance FIRST, then removes the
+**container object** via the new `IInstanceLauncher.Remove(worldId)` — instances run without `--rm`
+and a deleted world never wakes again, so every deletion so far (owner's and DSGVO path included)
+left a `bbs-world-<id>` object with its writable layer and logs on the host forever. Port and
+per-account quota free themselves (both derived from the `world` table); open reports keep an
+orphaned `world_id` (no FK) by design. Arcade rows say `reset…` and warn that the pool refills —
+and `GlitchGateway.EnsurePool` now numbers replacements from the **highest suffix in use** instead of
+from the count, which would otherwise mint a second "Glitch Arcade 3". Scriptable twin:
+`DELETE /api/admin/worlds/{id}[?purge=true]` (`X-Admin-Token`).
+
+**Portal → website link.** `WorldHostPortalPages.Shell` (shared by every portal page *and* the admin
+panel) gained a language-aware footer link, plus a line under the landing headline where first-time
+visitors look: DE → `www.blocksbeyondthestars.com/`, EN → `…/en`, new tab with
+`rel='noopener noreferrer'` so a signed-in session is never navigated away. URLs live in
+`WorldHostConfig.WebsiteUrl` / `WebsiteUrlEn` with the production values as **code defaults**
+(`BBS_WH_WEBSITE_URL(_EN)` override, `-` = off) — no deploy change needed, and a self-hoster does not
+advertise someone else's site; the link label is derived from the configured host.
 
 ### ★ In-game UI readability: VEGA + scan panel sized up, a real UI-scale setting, localized scan results (#482–#484, 2026-07-26, branch feat/ui-readability)
 Three connected fixes to "the HUD is too small", all measured first in `analysis/ingame-ui-readability.md`.

--- a/deploy/worldhost/.env.example
+++ b/deploy/worldhost/.env.example
@@ -16,6 +16,12 @@ BBS_WH_PUBLIC_HOST=play.blocksbeyondthestars.de
 # redeploy worldhost to roll the fleet — running worlds keep the old image until their idle stop.
 BBS_WH_SERVER_IMAGE=ghcr.io/marceld23/blocks-beyond-the-stars-server:0.6.2
 
+# Game website the portal links to (footer + landing page), per language. The defaults built into
+# WorldHost are the project's own site, so these only need setting to point somewhere else — or to
+# "-", which drops the link entirely (a self-hoster does not advertise someone else's website).
+#BBS_WH_WEBSITE_URL=https://www.blocksbeyondthestars.com/
+#BBS_WH_WEBSITE_URL_EN=https://www.blocksbeyondthestars.com/en
+
 # SECRETS — generate long random values (e.g. `openssl rand -hex 24`); keep them only in this file.
 # Claim code developers present once at signup to register a reserved name (empty = unclaimable).
 BBS_WH_RESERVED_CLAIM_CODE=

--- a/deploy/worldhost/docker-compose.yml
+++ b/deploy/worldhost/docker-compose.yml
@@ -49,6 +49,10 @@ services:
       # bounds cold-worldgen bursts so one player's fresh join/fast-flight can't stall the world's tick for
       # everyone else. Default 25 (generous headroom under the ~66 ms tick); 0 = off (unbounded).
       BBS_WH_CHUNK_STREAM_BUDGET_MS: ${BBS_WH_CHUNK_STREAM_BUDGET_MS:-25}
+      # Portal → game website link (footer + landing page). Unset keeps WorldHost's built-in default
+      # (the project's own site); "-" drops the link, which is what a self-hoster wants.
+      BBS_WH_WEBSITE_URL: ${BBS_WH_WEBSITE_URL:-}
+      BBS_WH_WEBSITE_URL_EN: ${BBS_WH_WEBSITE_URL_EN:-}
       # Legal pages (Impressum/Datenschutz); empty = "not configured" notice on those pages.
       BBS_WH_LEGAL_NAME: ${BBS_WH_LEGAL_NAME:-}
       BBS_WH_LEGAL_ADDRESS: ${BBS_WH_LEGAL_ADDRESS:-}

--- a/docs/developer/HOSTED_WORLDS.md
+++ b/docs/developer/HOSTED_WORLDS.md
@@ -192,8 +192,9 @@ The SP↔hosted round-trip. Instances bind-mount `<BBS_WH_WORLDS_DIR>/<worldId>/
   (no name-exists oracle). Lost password = lost account for now — recovery UX is a Phase-2 concern.
 - Join tokens live 120 s and name one world + one player; the per-world secret never leaves the
   host (it is injected into the instance's env).
-- Deleting a world stops the container and removes the registry row but **keeps the saves volume**
-  (operator-recoverable); automated retention/archival is Phase 3.
+- Deleting a world stops the container, removes its container object and drops the registry row but
+  **keeps the saves volume** (operator-recoverable); automated retention/archival is Phase 3. Only
+  the operator's `purge saves` on `/admin` and account self-deletion erase the files themselves.
 
 ## Operations quick reference
 
@@ -214,6 +215,8 @@ docker network create bbs-hosted
 BBS_WH_BASE_DOMAIN=play.blocksbeyondthestars.de
 BBS_WH_PUBLIC_HOST=play.blocksbeyondthestars.de
 BBS_WH_SERVER_IMAGE=ghcr.io/marceld23/blocks-beyond-the-stars-server:0.6.2   # fleet version pin (WP14)
+# portal → game website link (defaults are the project's own site; set to "-" to drop the link):
+#   BBS_WH_WEBSITE_URL=https://www.blocksbeyondthestars.com/, BBS_WH_WEBSITE_URL_EN=…/en
 # quotas (operator policy): BBS_WH_MAX_WORLDS_PER_ACCOUNT=2, BBS_WH_MAX_PLAYERS=12, BBS_WH_IDLE_MINUTES=20
 # glitch.fun arcade (optional, off without credentials): BBS_WH_GLITCH_ENABLED, BBS_WH_GLITCH_TITLE_ID,
 #   BBS_WH_GLITCH_TITLE_TOKEN, BBS_WH_GLITCH_WORLDS=2, BBS_WH_GLITCH_MAX_PLAYERS=8,
@@ -262,9 +265,21 @@ on their next wake.
 
 `/admin` on the portal domain (Basic Auth via `BBS_WH_ADMIN_USER`/`_PASSWORD`; off when unset — the
 `X-Admin-Token` API for scripts is separate and unchanged): fleet instance overview (status, owner,
-live player counts via `/status`, stop/wake), the open player-report queue (close as
+live player counts via `/status`, stop/wake/restart/**delete**), the open player-report queue (close as
 reviewed/dismissed, reported names link to account lookup) and ban/unban with reason. The
 bug-report inbox has its own `/admin` (ReportHost) including a filtered JSON bulk export.
+
+**Deleting a world** (per row, folded into a `delete…` disclosure so it cannot be hit while aiming
+for stop/wake): the world's **name must be typed** into the box, checked server-side — there is no
+undo. Two buttons share that box: `delete` stops the instance and drops the registry row but leaves
+the saves in the worlds directory, `purge saves` also erases them including the archive copy. Both
+remove the container OBJECT as well (instances run without `--rm`, and a deleted world never wakes
+again to clean up its own leftovers). Deleting a *running* world is allowed and blocks while
+`docker stop` drains it, exactly like the stop button. Its port and the owner's world-quota slot
+return to the pool automatically; open reports naming the world keep their (now orphaned) world id.
+Arcade worlds show `reset…` instead: the glitch pool refills itself, so the world comes back empty
+under a fresh id and the next free `Glitch Arcade <n>` name. Scriptable twin for bulk cleanup:
+`DELETE /api/admin/worlds/{id}[?purge=true]` (`X-Admin-Token`).
 
 **Server health card** (top of `/admin`): host load/RAM/disk plus per-container CPU/memory and the
 fleet aggregates, filled asynchronously from `GET /admin/stats.json` (same Basic-Auth gate) because

--- a/src/BlocksBeyondTheStars.WorldHost/GlitchGateway.cs
+++ b/src/BlocksBeyondTheStars.WorldHost/GlitchGateway.cs
@@ -42,6 +42,9 @@ public sealed class GlitchGateway
 {
     private const string GuestAccountPrefix = "glitch:";
     private const string FallbackName = "Explorer";
+
+    /// <summary>Display-name stem of the arcade pool; the numeric suffix after it identifies a pool slot.</summary>
+    private const string PoolNamePrefix = "Glitch Arcade ";
     private const int ValidateCacheSeconds = 300;
 
     /// <summary>Heartbeats arrive once a minute per install; this only blunts scripted hammering.</summary>
@@ -510,10 +513,24 @@ public sealed class GlitchGateway
 
         lock (_poolGate)
         {
-            int existing = _registry.ListWorldsByChannel(WorldChannel.Glitch).Count;
-            for (int i = existing + 1; i <= _config.GlitchWorldCount; i++)
+            var pool = _registry.ListWorldsByChannel(WorldChannel.Glitch);
+
+            // Number from the highest suffix in use, not from the count: an operator can delete a single
+            // arcade world on /admin to reset it, and counting would then hand the replacement a name that
+            // is already on another world ("Glitch Arcade 3" twice).
+            int next = 0;
+            foreach (var world in pool)
             {
-                _registry.CreateGlitchWorld($"Glitch Arcade {i}");
+                if (world.DisplayName.StartsWith(PoolNamePrefix, StringComparison.Ordinal)
+                    && int.TryParse(world.DisplayName.AsSpan(PoolNamePrefix.Length), out int suffix))
+                {
+                    next = Math.Max(next, suffix);
+                }
+            }
+
+            for (int i = pool.Count; i < _config.GlitchWorldCount; i++)
+            {
+                _registry.CreateGlitchWorld($"{PoolNamePrefix}{++next}");
             }
         }
     }

--- a/src/BlocksBeyondTheStars.WorldHost/InstanceLauncher.cs
+++ b/src/BlocksBeyondTheStars.WorldHost/InstanceLauncher.cs
@@ -17,6 +17,12 @@ public interface IInstanceLauncher
     /// <summary>Stops the container (triggering the server's clean drain+save via SIGTERM). Idempotent.</summary>
     void Stop(string containerId);
 
+    /// <summary>Removes a world's container OBJECT (not just stops it). Instances deliberately run
+    /// without <c>--rm</c> so a sleeping world's logs stay inspectable, and the stale object is normally
+    /// cleaned by the next wake — a DELETED world never wakes again, so its object (writable layer +
+    /// logs) would linger forever. Idempotent; "no such container" is fine.</summary>
+    void Remove(string worldId);
+
     /// <summary>Whether the container is still running — false once an idle shutdown has exited it.</summary>
     bool IsRunning(string containerId);
 
@@ -164,6 +170,18 @@ public sealed class DockerCliLauncher : IInstanceLauncher
         }
 
         Run(new List<string> { "stop", containerId }); // best effort; "no such container" is fine
+    }
+
+    public void Remove(string worldId)
+    {
+        if (string.IsNullOrEmpty(worldId))
+        {
+            return;
+        }
+
+        // By NAME, not container id: the registry row is about to disappear, and the name is the one
+        // handle that survives a crashed/replaced container (Start() removes stale ones the same way).
+        Run(new List<string> { "rm", "-f", $"bbs-world-{worldId}" });
     }
 
     public bool IsRunning(string containerId)

--- a/src/BlocksBeyondTheStars.WorldHost/Program.cs
+++ b/src/BlocksBeyondTheStars.WorldHost/Program.cs
@@ -222,7 +222,8 @@ async Task<IResult> RenderAdminAsync(HttpContext ctx)
     return Results.Content(WorldHostAdminPages.Index(
         config, rows, registry.ListOpenReports(), registry.ListBannedAccounts(),
         lookupQuery is null ? null : registry.FindAccountByName(lookupQuery), lookupQuery,
-        registry.ListGlitchGuests(), registry.ListGlitchBans()),
+        registry.ListGlitchGuests(), registry.ListGlitchBans(),
+        ctx.Request.Query["notice"].ToString()),
         "text/html; charset=utf-8");
 }
 
@@ -556,9 +557,7 @@ app.MapDelete("/api/account", (HttpContext ctx) =>
 
     foreach (var world in registry.ListWorlds(account.Id))
     {
-        orchestrator.StopWorld(world);
-        SavePaths.DeleteWorldData(config, world.Id);
-        registry.DeleteWorld(world.Id);
+        orchestrator.DeleteWorld(world, purgeSaves: true);
     }
 
     registry.DeleteAccount(account.Id);
@@ -641,6 +640,29 @@ app.MapPost("/api/admin/announce", async (HttpContext ctx, AnnounceRequest req) 
     log.LogInformation("Admin API: announce kind {Kind} to {Target} — reached {Reached}/{Targets}.",
         req.Kind, req.WorldId is null ? "fleet" : LogSafe(req.WorldId), reached, targets);
     return Results.Json(new { reached, targets });
+});
+
+// Operator world deletion, scriptable twin of the /admin buttons below — the lever for bulk cleanup of
+// dead worlds. `purge=true` also erases the saves (live + archive); without it they stay on disk exactly
+// like an owner's own delete. Unlike the owner route this is NOT ownership-scoped: it deletes any world,
+// including the account-less glitch.fun arcade pool (which the gateway then re-creates empty).
+app.MapDelete("/api/admin/worlds/{id}", (HttpContext ctx, string id) =>
+{
+    if (!IsAdmin(ctx))
+    {
+        return Results.Unauthorized();
+    }
+
+    if (!HostRegistry.IsValidWorldId(id) || registry.GetWorld(id) is not { } world)
+    {
+        return ApiError("World not found.", StatusCodes.Status404NotFound);
+    }
+
+    bool purge = ctx.Request.Query["purge"].ToString() == "true";
+    orchestrator.DeleteWorld(world, purge);
+    log.LogInformation("Admin API: world '{Name}' ({Id}) deleted — saves {Fate}.",
+        LogSafe(world.DisplayName), world.Id, purge ? "PURGED" : "retained");
+    return Results.Ok();
 });
 
 // ---------------- Operator admin UI (Basic Auth; the browser front-end to the API above) ----------------
@@ -841,6 +863,37 @@ app.MapPost("/admin/worlds/{id}/wake", async (HttpContext ctx, string id) =>
     return Results.Redirect("/admin");
 });
 
+// Delete a world from the fleet overview. Guarded by a typed confirmation (the world's display name)
+// checked HERE rather than in the browser — the delete button sits next to `stop` in a narrow table cell
+// and there is no undo. `purge=true` erases the saves as well; the plain delete keeps them on disk.
+// Deleting a RUNNING world is allowed and blocks while `docker stop` drains it, exactly like the stop
+// button. On a mismatch nothing happens and the page says so.
+app.MapPost("/admin/worlds/{id}/delete", async (HttpContext ctx, string id) =>
+{
+    if (GuardAdminUi(ctx) is { } denied)
+    {
+        return denied;
+    }
+
+    var form = await ctx.Request.ReadFormAsync();
+    if (!HostRegistry.IsValidWorldId(id) || registry.GetWorld(id) is not { } world)
+    {
+        return Results.Redirect("/admin");
+    }
+
+    if (!string.Equals(form["confirm"].ToString().Trim(), world.DisplayName.Trim(), StringComparison.OrdinalIgnoreCase))
+    {
+        log.LogInformation("Admin UI: delete of world {Id} refused — confirmation name did not match.", world.Id);
+        return Results.Redirect("/admin?notice=confirm");
+    }
+
+    bool purge = form["purge"].ToString() == "true";
+    orchestrator.DeleteWorld(world, purge);
+    log.LogInformation("Admin UI: world '{Name}' ({Id}) deleted — saves {Fate}.",
+        LogSafe(world.DisplayName), world.Id, purge ? "PURGED" : "retained");
+    return Results.Redirect($"/admin?notice={(purge ? "purged" : "deleted")}");
+});
+
 // ---------------- Worlds ----------------
 
 app.MapGet("/api/worlds", (HttpContext ctx) =>
@@ -1022,10 +1075,9 @@ app.MapDelete("/api/worlds/{id}", (HttpContext ctx, string id) =>
         return Results.Forbid();
     }
 
-    // Stop first so no orphan container keeps running under a deleted registry row. The saves directory
-    // is intentionally NOT removed — an operator can still recover/export it; automated retention is Phase 3.
-    orchestrator.StopWorld(world);
-    registry.DeleteWorld(world.Id);
+    // The saves directory is intentionally NOT removed — an operator can still recover/export it (and
+    // purge it from /admin); automated retention is Phase 3.
+    orchestrator.DeleteWorld(world, purgeSaves: false);
     log.LogInformation("World '{Name}' ({Id}) deleted by {Account} (saves directory retained).", LogSafe(world.DisplayName), world.Id, LogSafe(account.Name));
     return Results.Ok();
 });

--- a/src/BlocksBeyondTheStars.WorldHost/WorldHostAdminPages.cs
+++ b/src/BlocksBeyondTheStars.WorldHost/WorldHostAdminPages.cs
@@ -23,6 +23,26 @@ public static class WorldHostAdminPages
         $"<form method='post' action='/admin/reports/{reportId}/close' style='display:inline'><input type='hidden' name='status' value='reviewed'><button>reviewed</button></form>" +
         $"<form method='post' action='/admin/reports/{reportId}/close' style='display:inline'><input type='hidden' name='status' value='dismissed'><button>dismiss</button></form>";
 
+    /// <summary>
+    /// The per-row delete control, folded into a <c>&lt;details&gt;</c> so it never competes with stop/wake
+    /// for a mis-click. Deleting needs the world's name typed into the box — checked server-side, because
+    /// this is the one action on the page with no undo. Two submit buttons share the one input: the second
+    /// carries <c>purge=true</c> and erases the saves as well.
+    /// </summary>
+    private static string DeleteForm(WorldRecord world)
+    {
+        // Arcade worlds have no owner and the gateway tops the pool back up, so deleting one is really a
+        // RESET — say so instead of pretending the world is gone for good.
+        bool glitch = world.Channel == WorldChannel.Glitch;
+        return $"<details><summary class='del'>{(glitch ? "reset" : "delete")}…</summary>" +
+               $"<form method='post' action='/admin/worlds/{world.Id}/delete'>" +
+               $"<input name='confirm' size='14' placeholder='type: {E(world.DisplayName)}' aria-label='confirm world name'>" +
+               "<button class='danger' title='stop the world, drop it from the registry, keep its saves on disk'>delete</button>" +
+               "<button class='danger' name='purge' value='true' title='the same, but also erase the saves (live + archive) — unrecoverable'>purge saves</button>" +
+               (glitch ? "<p class='hint'>The arcade pool refills itself — this world comes back empty.</p>" : string.Empty) +
+               "</form></details>";
+    }
+
     private static string Ago(long unix)
     {
         if (unix <= 0)
@@ -44,7 +64,8 @@ public static class WorldHostAdminPages
         AccountRecord? lookedUp,
         string? lookupQuery,
         IReadOnlyList<GlitchGuestRecord>? glitchGuests = null,
-        IReadOnlyList<GlitchBanRecord>? glitchBans = null)
+        IReadOnlyList<GlitchBanRecord>? glitchBans = null,
+        string? notice = null)
     {
         glitchGuests ??= Array.Empty<GlitchGuestRecord>();
         glitchBans ??= Array.Empty<GlitchBanRecord>();
@@ -56,6 +77,20 @@ public static class WorldHostAdminPages
         sb.Append($"<h1>Fleet <span class='o'>admin</span> <span class='sub'>· {E(config.BaseDomain)}</span></h1>");
         sb.Append($"<p class='hint'>{worlds.Count} worlds · <b>{active}</b>/{(config.MaxActiveInstances > 0 ? config.MaxActiveInstances.ToString() : "∞")} instances awake · " +
                   $"{playerReports.Count} open report(s) · {feedback.Count} open feedback · {banned.Count} banned account(s)</p>");
+
+        // Outcome of the last destructive action (redirect carries ?notice=…) — the page has no other
+        // channel back to the operator.
+        string? noticeText = notice switch
+        {
+            "confirm" => "Nothing deleted — the typed name did not match the world's name.",
+            "deleted" => "World deleted. Its saves are still on disk.",
+            "purged" => "World deleted and its saves erased.",
+            _ => null,
+        };
+        if (noticeText is { })
+        {
+            sb.Append($"<p class='beta'>{E(noticeText)}</p>");
+        }
 
         // ---- Server health (filled by JS from /admin/stats.json AFTER the page renders — the
         // docker-stats sample behind it takes ~1-2 s and must not stall the page) ----
@@ -84,10 +119,14 @@ public static class WorldHostAdminPages
                     : $"<form method='post' action='/admin/worlds/{w.Id}/wake'><button>wake</button></form>";
                 sb.Append($"<tr><td><b>{E(w.DisplayName)}</b>{badge}<br><code>{w.Id}</code></td><td>{E(row.OwnerName)}</td>" +
                           $"<td><span class='st {E(w.Status)}'>{E(w.Status)}</span></td><td>{players}</td>" +
-                          $"<td>{w.HostPort}</td><td>{Ago(w.LastStartedUnix)}</td><td>{action}</td></tr>");
+                          $"<td>{w.HostPort}</td><td>{Ago(w.LastStartedUnix)}</td><td>{action}{DeleteForm(w)}</td></tr>");
             }
 
             sb.Append("</table>");
+            sb.Append("<p class='hint'>Deleting stops the instance and drops the world from the registry. " +
+                      "<b>delete</b> leaves its saves in the worlds directory (recoverable by hand), " +
+                      "<b>purge saves</b> erases them including the archive copy. Both need the world's " +
+                      "name typed into the box first.</p>");
         }
 
         sb.Append("</div>");
@@ -245,7 +284,8 @@ public static class WorldHostAdminPages
         }
 
         sb.Append("<p><a href='/'>← Portal</a></p>");
-        sb.Append("<style>table{width:100%;border-collapse:collapse} th,td{padding:6px 8px;text-align:left;border-bottom:1px solid var(--line);vertical-align:top} form{margin:0}</style>");
+        sb.Append("<style>table{width:100%;border-collapse:collapse} th,td{padding:6px 8px;text-align:left;border-bottom:1px solid var(--line);vertical-align:top} form{margin:0}" +
+                  "summary.del{color:#e05c5c} td details{margin:4px 0} td details input{display:inline-block;width:auto;margin:4px 4px 0 0}</style>");
 
         // Server-health card renderer. Thresholds mirror the ops alerting levels (<70 % green,
         // <85 % amber, else red). Values interpolated into innerHTML are numbers plus docker container
@@ -287,6 +327,6 @@ public static class WorldHostAdminPages
 })();
 </script>");
 
-        return WorldHostPortalPages.Shell("Fleet admin — Blocks Beyond the Stars", sb.ToString());
+        return WorldHostPortalPages.Shell("Fleet admin — Blocks Beyond the Stars", sb.ToString(), "de", config);
     }
 }

--- a/src/BlocksBeyondTheStars.WorldHost/WorldHostConfig.cs
+++ b/src/BlocksBeyondTheStars.WorldHost/WorldHostConfig.cs
@@ -25,6 +25,16 @@ public sealed class WorldHostConfig
     /// per-world subdomain + Caddy; native UDP bypasses the proxy and needs the machine itself.</summary>
     public string PublicHost { get; set; } = "localhost";
 
+    /// <summary>Game website the portal links out to (footer + landing page). Defaults to the project's
+    /// own site; a self-hoster who does not want to advertise it sets the variable empty, which drops the
+    /// link entirely.</summary>
+    public string WebsiteUrl { get; set; } = "https://www.blocksbeyondthestars.com/";
+
+    /// <summary>English entry point of <see cref="WebsiteUrl"/> — a separate value rather than a
+    /// "+ /en" rule, because that suffix is a property of OUR site, not of websites in general. Empty
+    /// falls back to <see cref="WebsiteUrl"/>.</summary>
+    public string WebsiteUrlEn { get; set; } = "https://www.blocksbeyondthestars.com/en";
+
     /// <summary>Dedicated-server image each world instance runs (one container per world).</summary>
     public string ServerImage { get; set; } = "blocks-beyond-the-stars-server:local";
 
@@ -340,6 +350,12 @@ public sealed class WorldHostConfig
         if (Env("BBS_WH_PORT") is { } portStr && int.TryParse(portStr, out var port)) { c.Port = port; }
         if (Env("BBS_WH_BASE_DOMAIN") is { } domain) { c.BaseDomain = domain; }
         if (Env("BBS_WH_PUBLIC_HOST") is { } publicHost) { c.PublicHost = publicHost; }
+
+        // "-" turns the website link off. An UNSET (or empty) variable deliberately keeps the built-in
+        // default instead: the fleet compose forwards these unconditionally, and an operator who never
+        // filled them in must not silently lose the link.
+        if (Env("BBS_WH_WEBSITE_URL") is { } site) { c.WebsiteUrl = site.Trim() == "-" ? string.Empty : site.Trim(); }
+        if (Env("BBS_WH_WEBSITE_URL_EN") is { } siteEn) { c.WebsiteUrlEn = siteEn.Trim() == "-" ? string.Empty : siteEn.Trim(); }
         if (Env("BBS_WH_SERVER_IMAGE") is { } image) { c.ServerImage = image; }
         if (Env("BBS_WH_DOCKER_NETWORK") is { } network) { c.DockerNetwork = network; }
         if (Env("BBS_WH_PORT_RANGE_START") is { } rsStr && int.TryParse(rsStr, out var rs)) { c.PortRangeStart = rs; }

--- a/src/BlocksBeyondTheStars.WorldHost/WorldHostPortalPages.cs
+++ b/src/BlocksBeyondTheStars.WorldHost/WorldHostPortalPages.cs
@@ -27,6 +27,33 @@ public static class WorldHostPortalPages
     /// deliberate choice (URL parameter or the cookie the switcher set).</summary>
     public static string NormalizeLang(string? lang) => lang == "en" ? "en" : "de";
 
+    /// <summary>The game website's entry point for a language (empty when the operator turned the link
+    /// off). English falls back to the main URL when no separate EN entry point is configured.</summary>
+    internal static string WebsiteUrl(WorldHostConfig? config, string lang)
+    {
+        if (config is null || string.IsNullOrWhiteSpace(config.WebsiteUrl))
+        {
+            return string.Empty;
+        }
+
+        return lang == "en" && !string.IsNullOrWhiteSpace(config.WebsiteUrlEn)
+            ? config.WebsiteUrlEn.Trim()
+            : config.WebsiteUrl.Trim();
+    }
+
+    /// <summary>Bare host of a website URL for use as link text ("www." dropped) — so a self-hoster's
+    /// own URL shows their domain rather than a hardcoded one. Falls back to the raw value.</summary>
+    private static string WebsiteLabel(string url)
+    {
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
+        {
+            return url;
+        }
+
+        string host = uri.Host;
+        return host.StartsWith("www.", StringComparison.OrdinalIgnoreCase) ? host[4..] : host;
+    }
+
     /// <summary>First-visit language from the browser's <c>Accept-Language</c> header: the first
     /// supported primary tag wins (browsers list tags in preference order, so full q-value parsing
     /// would only complicate this), anything else stays German. Only consulted when neither
@@ -62,9 +89,17 @@ public static class WorldHostPortalPages
         lang = NormalizeLang(lang);
         string T(string de, string en) => lang == "en" ? en : de;
 
+        // The footer carries the same link on every page, but a first-time visitor lands HERE and would
+        // never scroll for it — the site is where the game itself, the downloads and the devblog live.
+        string websiteLine = WebsiteUrl(config, lang) is { Length: > 0 } siteUrl
+            ? $@"<p class='sub'>{T("Alles über das Spiel, Downloads und Devblog:", "Everything about the game, downloads and devblog:")}
+ <a href='{System.Net.WebUtility.HtmlEncode(siteUrl)}' target='_blank' rel='noopener noreferrer'>{System.Net.WebUtility.HtmlEncode(WebsiteLabel(siteUrl))} ↗</a></p>"
+            : string.Empty;
+
         string body = $@"
 <h1>Blocks Beyond the Stars — <span class='o'>{T("Welten", "Worlds")}</span></h1>
 <p class='sub'>{T("Eigene Multiplayer-Welt erstellen und mit Freunden spielen.", "Create your own multiplayer world and play with friends.")}</p>
+{websiteLine}
 <div class='card how'>
  <h2>{T("So funktioniert's", "How it works")}</h2>
  <ol>
@@ -121,7 +156,7 @@ public static class WorldHostPortalPages
             }, ScriptJson))
             .Replace("__LQ__", lang == "en" ? "?lang=en" : string.Empty);
 
-        return Shell($"Blocks Beyond the Stars — {T("Welten", "Worlds")}", body, lang);
+        return Shell($"Blocks Beyond the Stars — {T("Welten", "Worlds")}", body, lang, config);
     }
 
     // Plain (non-interpolated) verbatim script: single braces stay single, localized strings arrive
@@ -287,7 +322,7 @@ function v(id){return document.getElementById(id).value.trim();}
                 },
             }, ScriptJson));
 
-        return Shell($"{T("Meine Welten", "My Worlds")} — Blocks Beyond the Stars", body, lang);
+        return Shell($"{T("Meine Welten", "My Worlds")} — Blocks Beyond the Stars", body, lang, config);
     }
 
     private const string WorldsScript = @"
@@ -491,7 +526,7 @@ loadPublic();
         return Shell($"{T("Community-Regeln", "Community Rules")} — Blocks Beyond the Stars", $@"
 <h1>Community-<span class='o'>{T("Regeln", "Rules")}</span> <span class='sub'>(v{config.TermsVersion})</span></h1>
 {card}
-<p><a href='/{(lang == "en" ? "?lang=en" : "")}'>{T("Zurück", "Back")}</a></p>", lang);
+<p><a href='/{(lang == "en" ? "?lang=en" : "")}'>{T("Zurück", "Back")}</a></p>", lang, config);
     }
 
     /// <summary>Impressum (§5 DDG). Operator data comes from config so a SELF-HOSTED WorldHost never
@@ -543,7 +578,7 @@ loadPublic();
         "Dieses Welten-Portal ist ein kostenloses Hobby- und Familienprojekt im Beta-Stadium. Es besteht kein Anspruch auf Verfügbarkeit oder Datenerhalt — Welten und Spielstände können jederzeit verloren gehen (nutze die Sicherungs-Funktion!).",
         "This worlds portal is a free hobby and family project in beta. There is no entitlement to availability or data retention — worlds and saves can be lost at any time (use the backup feature!).")}</p>
 </div>
-<p><a href='/{(lang == "en" ? "?lang=en" : "")}'>{T("Zurück", "Back")}</a></p>", lang);
+<p><a href='/{(lang == "en" ? "?lang=en" : "")}'>{T("Zurück", "Back")}</a></p>", lang, config);
     }
 
     /// <summary>Datenschutzerklärung (DSGVO) — the German text is the legally authoritative one; with
@@ -641,7 +676,7 @@ loadPublic();
         return Shell("Datenschutz — Blocks Beyond the Stars", $@"
 <h1>Datenschutz<span class='o'>erklärung</span> <span class='sub'>· Privacy policy</span></h1>
 {(lang == "en" ? englishSummary + germanBody : germanBody + englishSummary)}
-<p><a href='/{(lang == "en" ? "?lang=en" : "")}'>{T("Zurück", "Back")}</a></p>", lang);
+<p><a href='/{(lang == "en" ? "?lang=en" : "")}'>{T("Zurück", "Back")}</a></p>", lang, config);
     }
 
     /// <summary>The game logo as a compact self-contained inline SVG (mini block cluster + orbit ring,
@@ -658,10 +693,17 @@ loadPublic();
     /// <summary>Shared page chrome, styled after the per-instance portal (dark starfield, cyan/orange):
     /// game-logo header, localized footer with the DE/EN switcher, and the shared error localization.
     /// Internal so the operator admin pages (<see cref="WorldHostAdminPages"/>) share the same look.</summary>
-    internal static string Shell(string title, string body, string lang = "de")
+    internal static string Shell(string title, string body, string lang = "de", WorldHostConfig? config = null)
     {
         lang = NormalizeLang(lang);
         string T(string de, string en) => lang == "en" ? en : de;
+
+        // Outbound link to the game's own website, per language. Opens in a new tab: leaving the portal
+        // mid-session (signed in, a world possibly waking) would be the worse trade. Omitted when the
+        // operator cleared the URLs — a self-hoster must not advertise someone else's site.
+        string websiteLink = WebsiteUrl(config, lang) is { Length: > 0 } url
+            ? $"<a href='{System.Net.WebUtility.HtmlEncode(url)}' target='_blank' rel='noopener noreferrer'>{T("Spiel-Website", "Game website")} ↗</a> ·\n"
+            : string.Empty;
 
         return $@"<!DOCTYPE html>
 <html lang='{lang}'>
@@ -759,7 +801,7 @@ window.bbsErr = function(j, fallback) {{
         : "<span class='cur'>DE</span><a href='?lang=en' lang='en'>EN</a>")}</nav></header>
 <main>{body}</main>
 <footer>
-<a href='/rules{(lang == "en" ? "?lang=en" : "")}'>{T("Regeln", "Rules")}</a> ·
+{websiteLink}<a href='/rules{(lang == "en" ? "?lang=en" : "")}'>{T("Regeln", "Rules")}</a> ·
 <a href='/impressum{(lang == "en" ? "?lang=en" : "")}'>{T("Impressum", "Legal notice")}</a> ·
 <a href='/datenschutz{(lang == "en" ? "?lang=en" : "")}'>{T("Datenschutz", "Privacy")}</a>
 <span class='lang'> · {(lang == "en"

--- a/src/BlocksBeyondTheStars.WorldHost/WorldOrchestrator.cs
+++ b/src/BlocksBeyondTheStars.WorldHost/WorldOrchestrator.cs
@@ -287,6 +287,25 @@ public sealed class WorldOrchestrator
         _registry.SetWorldStatus(world.Id, WorldStatus.Stopped, string.Empty);
     }
 
+    /// <summary>
+    /// Removes a world for good: stop the instance first (so no container keeps running under a deleted
+    /// registry row), drop the now-unreachable container object, optionally erase the saves, then delete
+    /// the registry row last — a crash mid-way leaves a stopped world, never an orphan container.
+    /// <paramref name="purgeSaves"/> false keeps <c>&lt;WorldsDir&gt;/&lt;id&gt;</c> (and the archive copy)
+    /// on disk for manual recovery, matching the owner-facing delete; true erases both.
+    /// </summary>
+    public void DeleteWorld(WorldRecord world, bool purgeSaves)
+    {
+        StopWorld(world);
+        _launcher.Remove(world.Id);
+        if (purgeSaves)
+        {
+            SavePaths.DeleteWorldData(_config, world.Id);
+        }
+
+        _registry.DeleteWorld(world.Id);
+    }
+
     /// <summary>Pushes a maintenance announcement (#249) into one running instance via its token-gated
     /// POST /announce. Kind: 0 = info, 1 = restart countdown of <paramref name="seconds"/>, 2 = cancel.
     /// False when announcements are unconfigured or the instance did not accept.</summary>

--- a/tests/BlocksBeyondTheStars.Tests/GlitchGatewayTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/GlitchGatewayTests.cs
@@ -61,6 +61,10 @@ public sealed class GlitchGatewayTests : IDisposable
 
         public void Stop(string containerId) => Running.Remove(containerId);
 
+        public void Remove(string worldId) => Removed.Add(worldId);
+
+        public readonly List<string> Removed = new();
+
         public bool IsRunning(string containerId) => containerId != null && Running.Contains(containerId);
 
         public IReadOnlyList<ContainerStat> ContainerStats() => Array.Empty<ContainerStat>();
@@ -159,6 +163,25 @@ public sealed class GlitchGatewayTests : IDisposable
         // The validate call went out with the server-side title token; the guest is on the ban-target list.
         Assert.Contains(api.Requests, r => r.Url.Contains("/validate") && r.Auth == "Bearer token-1");
         Assert.Equal(Install, Assert.Single(registry.ListGlitchGuests()).InstallId);
+    }
+
+    [Fact]
+    public void EnsurePool_NumbersReplacementsFromTheHighestSuffix_NotTheCount()
+    {
+        // An operator can delete a single arcade world on /admin to reset it; the pool then refills.
+        // Numbering by COUNT would hand the replacement a name another world already carries.
+        var (gateway, registry, _, _) = NewGateway();
+        gateway.EnsurePool();
+        var pool = registry.ListWorldsByChannel(WorldChannel.Glitch);
+        Assert.Equal(2, pool.Count);
+
+        registry.DeleteWorld(pool[0].Id); // reset the first arcade world
+        gateway.EnsurePool();
+
+        var refilled = registry.ListWorldsByChannel(WorldChannel.Glitch);
+        Assert.Equal(2, refilled.Count);
+        Assert.Equal(refilled.Select(w => w.DisplayName).Distinct().Count(), refilled.Count);
+        Assert.Contains(refilled, w => w.DisplayName == "Glitch Arcade 3");
     }
 
     [Fact]

--- a/tests/BlocksBeyondTheStars.Tests/WebSocketTransportTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/WebSocketTransportTests.cs
@@ -119,6 +119,13 @@ public sealed class WebSocketTransportTests : IDisposable
         transport.Start(port);
 
         using var http = new System.Net.Http.HttpClient { Timeout = TimeSpan.FromSeconds(5) };
+
+        // No keep-alive: on Linux (managed HttpListener) an idle connection is only reaped after the
+        // listener's 2-minute idle timeout, and Dispose() below waits for that drain — the test body
+        // takes milliseconds, but the CI runs measured it at ~126 s and it blew the fast-tier duration
+        // budget on every PR. Windows (http.sys) never showed it. Closing each connection keeps the
+        // shutdown immediate without changing what this test covers.
+        http.DefaultRequestHeaders.ConnectionClose = true;
         try
         {
             (await http.GetAsync($"http://127.0.0.1:{port}/status")).Dispose();

--- a/tests/BlocksBeyondTheStars.Tests/WorldHostPhase3Tests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/WorldHostPhase3Tests.cs
@@ -47,6 +47,10 @@ public sealed class WorldHostPhase3Tests : IDisposable
 
         public void Stop(string containerId) => Running.Remove(containerId);
 
+        public void Remove(string worldId) => Removed.Add(worldId);
+
+        public readonly List<string> Removed = new();
+
         public bool IsRunning(string containerId) => containerId != null && Running.Contains(containerId);
 
         public IReadOnlyList<ContainerStat> ContainerStats() => Array.Empty<ContainerStat>();

--- a/tests/BlocksBeyondTheStars.Tests/WorldHostPortalPagesTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/WorldHostPortalPagesTests.cs
@@ -226,6 +226,108 @@ public sealed class WorldHostPortalPagesTests
         Assert.True(reportsCard < feedbackCard && feedbackCard < feedbackRow);
     }
 
+    // ---------------- Fleet admin: world deletion ----------------
+
+    private static AdminWorldRow AdminRow(string name, string status = WorldStatus.Stopped, string channel = WorldChannel.Portal)
+        => new(new WorldRecord("aabbccddee11", "acct1", name, "secret", 32000, status, "", 0, 0, "", false, channel), "Owner", null);
+
+    [Fact]
+    public void AdminPage_DeleteNeedsTheWorldNameTyped_AndOffersAPurgeVariant()
+    {
+        string html = WorldHostAdminPages.Index(
+            Config, new[] { AdminRow("Justus' Welt") }, Array.Empty<ReportRecord>(),
+            Array.Empty<AccountRecord>(), null, null);
+
+        Assert.Contains("action='/admin/worlds/aabbccddee11/delete'", html);
+        Assert.Contains("name='confirm'", html);
+        Assert.Contains("name='purge' value='true'", html);
+
+        // The world name reaches the placeholder HTML-encoded (apostrophes would break the attribute).
+        Assert.Contains("placeholder='type: Justus&#39; Welt'", html);
+
+        // Folded away so it cannot be hit while aiming for stop/wake.
+        int deleteForm = html.IndexOf("/delete'", StringComparison.Ordinal);
+        Assert.True(html.LastIndexOf("<details>", deleteForm, StringComparison.Ordinal)
+            > html.LastIndexOf("</details>", deleteForm, StringComparison.Ordinal),
+            "the delete form must sit inside its own collapsed <details>");
+    }
+
+    [Fact]
+    public void AdminPage_LabelsArcadeWorldDeletionAsAReset()
+    {
+        string glitch = WorldHostAdminPages.Index(
+            Config, new[] { AdminRow("Glitch Arcade 1", channel: WorldChannel.Glitch) },
+            Array.Empty<ReportRecord>(), Array.Empty<AccountRecord>(), null, null);
+        Assert.Contains(">reset…</summary>", glitch);
+        Assert.Contains("arcade pool refills itself", glitch);
+
+        string portal = WorldHostAdminPages.Index(
+            Config, new[] { AdminRow("Justus Welt") }, Array.Empty<ReportRecord>(),
+            Array.Empty<AccountRecord>(), null, null);
+        Assert.Contains(">delete…</summary>", portal);
+        Assert.DoesNotContain("arcade pool refills itself", portal);
+    }
+
+    [Theory]
+    [InlineData("confirm", "did not match")]
+    [InlineData("deleted", "still on disk")]
+    [InlineData("purged", "saves erased")]
+    public void AdminPage_ReportsTheOutcomeOfTheLastDelete(string notice, string expected)
+    {
+        string html = WorldHostAdminPages.Index(
+            Config, Array.Empty<AdminWorldRow>(), Array.Empty<ReportRecord>(),
+            Array.Empty<AccountRecord>(), null, null, null, null, notice);
+        Assert.Contains(expected, html);
+    }
+
+    // ---------------- Link out to the game website ----------------
+
+    [Fact]
+    public void Portal_LinksToTheGameWebsite_PerLanguage()
+    {
+        string de = WorldHostPortalPages.Landing(Config);
+        Assert.Contains("https://www.blocksbeyondthestars.com/'", de); // footer + landing line
+        Assert.Contains("Spiel-Website", de);
+        Assert.Contains("Alles über das Spiel", de);
+        Assert.DoesNotContain("blocksbeyondthestars.com/en", de);
+
+        string en = WorldHostPortalPages.Landing(Config, "en");
+        Assert.Contains("https://www.blocksbeyondthestars.com/en'", en);
+        Assert.Contains("Game website", en);
+        Assert.Contains("Everything about the game", en);
+
+        // New tab, and never a referrer/opener handle into the portal session.
+        Assert.Contains("rel='noopener noreferrer'", de);
+
+        // The shared shell carries it, so every portal page has it — not just the landing page.
+        Assert.Contains("Spiel-Website", WorldHostPortalPages.Worlds(Config));
+        Assert.Contains("Game website", WorldHostPortalPages.Rules(Config, "en"));
+    }
+
+    [Fact]
+    public void Portal_OmitsTheWebsiteLink_WhenTheOperatorClearedIt()
+    {
+        var noSite = new WorldHostConfig { WebsiteUrl = string.Empty, WebsiteUrlEn = string.Empty };
+        foreach (string html in new[] { WorldHostPortalPages.Landing(noSite), WorldHostPortalPages.Landing(noSite, "en") })
+        {
+            Assert.DoesNotContain("blocksbeyondthestars.com", html);
+            Assert.DoesNotContain("Spiel-Website", html);
+            Assert.DoesNotContain("Game website", html);
+        }
+    }
+
+    [Fact]
+    public void Portal_WebsiteLink_UsesTheOperatorsOwnDomainAsLabel()
+    {
+        var own = new WorldHostConfig { WebsiteUrl = "https://www.example.org/spiel", WebsiteUrlEn = string.Empty };
+        string de = WorldHostPortalPages.Landing(own);
+        Assert.Contains("https://www.example.org/spiel", de);
+        Assert.Contains(">example.org ↗<", de); // label without the "www."
+
+        // No EN entry point configured — English falls back to the one URL rather than dropping the link.
+        Assert.Contains("https://www.example.org/spiel", WorldHostPortalPages.Landing(own, "en"));
+    }
+
     // ---------------- Play button: deep-link + grant rendering order (#252) ----------------
 
     [Fact]

--- a/tests/BlocksBeyondTheStars.Tests/WorldHostTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/WorldHostTests.cs
@@ -59,6 +59,11 @@ public sealed class WorldHostTests : IDisposable
 
         public void Stop(string containerId) => Running.Remove(containerId);
 
+        /// <summary>World ids whose container object was removed (`docker rm -f bbs-world-&lt;id&gt;`).</summary>
+        public readonly List<string> Removed = new();
+
+        public void Remove(string worldId) => Removed.Add(worldId);
+
         public bool IsRunning(string containerId) => containerId != null && Running.Contains(containerId);
 
         public IReadOnlyList<ContainerStat> ContainerStats() => Array.Empty<ContainerStat>();
@@ -138,6 +143,54 @@ public sealed class WorldHostTests : IDisposable
         var w4 = registry.CreateWorld(accountId, "Replacement");
         Assert.True(w4.Ok);
         Assert.Equal(32000, w4.World!.HostPort);
+    }
+
+    [Fact]
+    public async Task DeleteWorld_StopsTheInstance_DropsTheContainerObject_AndKeepsTheSavesAsync()
+    {
+        var config = new WorldHostConfig { WorldsDir = System.IO.Path.Combine(_root, "worlds") };
+        var registry = NewRegistry(config);
+        var launcher = new FakeLauncher();
+        var orchestrator = NewOrchestrator(registry, launcher, config);
+        var (_, _, accountId, _) = registry.CreateAccount("Owner", "super-secret-1", acceptedTermsVersion: Terms);
+        var world = registry.CreateWorld(accountId, "Doomed").World!;
+
+        var (running, _) = await orchestrator.EnsureRunningAsync(world.Id);
+        Assert.NotNull(running);
+        string savesDir = SavePaths.HostSavesDir(config, world.Id);
+        System.IO.Directory.CreateDirectory(savesDir);
+
+        orchestrator.DeleteWorld(registry.GetWorld(world.Id)!, purgeSaves: false);
+
+        Assert.Empty(launcher.Running);                                   // instance stopped, not orphaned
+        Assert.Equal(new[] { world.Id }, launcher.Removed);               // …and its container object dropped:
+        Assert.Null(registry.GetWorld(world.Id));                         // nothing will ever wake it again
+        Assert.True(System.IO.Directory.Exists(savesDir), "a plain delete must leave the saves recoverable");
+    }
+
+    [Fact]
+    public void DeleteWorld_Purge_ErasesLiveAndArchivedSaves()
+    {
+        var config = new WorldHostConfig { WorldsDir = System.IO.Path.Combine(_root, "worlds") };
+        var registry = NewRegistry(config);
+        var launcher = new FakeLauncher();
+        var orchestrator = NewOrchestrator(registry, launcher, config);
+        var (_, _, accountId, _) = registry.CreateAccount("Owner", "super-secret-1", acceptedTermsVersion: Terms);
+        var world = registry.CreateWorld(accountId, "Doomed").World!;
+
+        // Both halves of a world's on-disk life: the live saves and an archived copy from an earlier sweep.
+        string live = SavePaths.HostSavesDir(config, world.Id);
+        string archived = SavePaths.ArchivedSavesDir(config, world.Id);
+        System.IO.Directory.CreateDirectory(live);
+        System.IO.Directory.CreateDirectory(archived);
+        System.IO.File.WriteAllText(System.IO.Path.Combine(live, "world.db"), "x");
+        System.IO.File.WriteAllText(System.IO.Path.Combine(archived, "world.db"), "x");
+
+        orchestrator.DeleteWorld(world, purgeSaves: true);
+
+        Assert.False(System.IO.Directory.Exists(live));
+        Assert.False(System.IO.Directory.Exists(archived));
+        Assert.Null(registry.GetWorld(world.Id));
     }
 
     [Fact]

--- a/tests/BlocksBeyondTheStars.Tests/WorldPasswordTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/WorldPasswordTests.cs
@@ -58,6 +58,10 @@ public sealed class WorldPasswordTests : IDisposable
 
         public void Stop(string containerId) => Running.Remove(containerId);
 
+        public void Remove(string worldId) => Removed.Add(worldId);
+
+        public readonly List<string> Removed = new();
+
         public bool IsRunning(string containerId) => containerId != null && Running.Contains(containerId);
 
         public IReadOnlyList<ContainerStat> ContainerStats() => Array.Empty<ContainerStat>();


### PR DESCRIPTION
Two small WorldHost additions, both analysed before implementing.

## 1. Delete worlds from `/admin`

The deletion primitives existed **twice** already — the owner-facing `DELETE /api/worlds/{id}` (keeps the saves) and account self-deletion (purges them). The operator panel simply had no entry point.

Each instance row now carries a folded-away `delete…` disclosure, so it cannot be hit while aiming for `stop`/`wake`:

- the world's **name must be typed** into the box — checked **server-side**, because there is no undo
- `delete` → stop the instance, drop the registry row, **leave the saves** in the worlds directory
- `purge saves` → the same, but also erase them including the `_archive` copy
- the page reports the outcome (deleted / purged / name mismatch) after the redirect

### The bug this uncovered

Both paths now run through the new `WorldOrchestrator.DeleteWorld(world, purgeSaves)`, which stops the instance **first** and then removes the container **object** via the new `IInstanceLauncher.Remove(worldId)`. Instances deliberately run without `--rm` (a sleeping world's logs stay inspectable) and the stale object is normally cleaned by the *next wake* — a deleted world never wakes again, so **every deletion so far left a `bbs-world-<id>` object with its writable layer and logs on the host forever**. The owner delete and the DSGVO account deletion inherit the fix.

Port and per-account quota free themselves (both derived from the `world` table). Open reports keep an orphaned `world_id` (no FK) by design.

### Arcade worlds

Rows on the glitch.fun channel say `reset…` and warn that the pool refills itself. `GlitchGateway.EnsurePool` now numbers replacements from the **highest suffix in use** instead of from the count — otherwise a reset would mint a second "Glitch Arcade 3".

### Scriptable twin

`DELETE /api/admin/worlds/{id}[?purge=true]` behind `X-Admin-Token`, for bulk cleanup.

## 2. The portal links to the game website

`WorldHostPortalPages.Shell` — shared by every portal page *and* the admin panel — gained a language-aware footer link, plus a line under the landing headline where first-time visitors actually look:

- DE → `https://www.blocksbeyondthestars.com/`, EN → `…/en`
- new tab, `rel="noopener noreferrer"` — leaving the portal mid-session (signed in, a world possibly waking) would be the worse trade

URLs live in `WorldHostConfig.WebsiteUrl` / `WebsiteUrlEn` with the production values as **code defaults** (`BBS_WH_WEBSITE_URL(_EN)` override, `-` = off): no deploy change needed, and a self-hoster does not advertise a site that is not theirs. The link label is derived from the configured host.

## Verification

- `dotnet build BlocksBeyondTheStars.CI.slnf -c Release` — 0 warnings, 0 errors
- full server suite: **1134 passed** (11 new: delete stops/removes/keeps-vs-purges saves, arcade pool naming, admin form + confirmation + notices, website link per language, link off when cleared, own-domain label)
- no client/Unity code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)
