### PR TITLE
Fleet admin reaches private and password-protected worlds (child-safety oversight)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -6337,6 +6337,26 @@ Docs updated (WORLD_GENERATION.md, FLUID_ROUTING.md, stale comments). Tests upda
 (spawn distribution, pooled-column water, layered overrides). NOT yet merged to main — local Unity build
 for the user's own playtest first.
 
+## ✅ Done (2026-07-26): fleet admin reaches private + password-protected worlds (#495)
+
+Follow-up to #487: observer mode existed but the JOIN path still treated the operator like a player — the
+world browser only listed "mine + public", and only a world's *owner* bypassed its password. So the invisible
+observer could only reach public, password-free worlds — while kids play mostly on private, password-shared
+ones, and their oversight is the whole point.
+
+**Access model (double-locked).** The operator gate is `account.IsDeveloper && fleet-admin join name`:
+developer accounts are only claimable with the secret `BBS_WH_RESERVED_CLAIM_CODE`, and config load now
+**auto-adds every fleet-admin name to `ReservedNames`**, so the name carrying the power can never be
+registered or played by anyone else. A developer account under a normal name gets no bypass (family member
+playing), and a normal account can't even join under the fleet-admin name (reserved). Name matching is now
+case-insensitive on both the WorldHost and the game server — the token check already was, and a silent
+`marcel` ≠ `Marcel` mismatch would deny the elevation with no error anywhere.
+
+**Plumbing.** `WorldOrchestrator.JoinAsync` gains the operator bypass next to the existing owner bypass
+(ban/terms checks untouched); new `GET /api/worlds/all` (developer accounts only, 403 otherwise) lists every
+world incl. owner names; the client's Official Worlds screen probes it and renders an "All worlds (operator)"
+section — invisible to normal accounts by construction, with `[PW]`/`[PRIV]`/owner flags per row. DE+EN.
+
 ## ✅ Done (2026-07-26): fleet-admin observer mode + admin world inspection (#487–#490)
 
 Analysis: `analysis/admin-spectator-access.md` (all decisions in §0). The operator can now walk any hosted

--- a/client/Assets/BlocksBeyondTheStars/Scripts/UiMainMenu.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/UiMainMenu.cs
@@ -337,6 +337,7 @@ namespace BlocksBeyondTheStars.Client
             var oContent = UiKit.AddPanel(odlg, 0f, 150f, 1100f, 440f, new Color(0f, 0f, 0f, 0f)).transform;
             var oWorlds = new List<PortalWorldInfo>();  // the signed-in account's own worlds
             var oPublic = new List<PortalWorldInfo>();  // public worlds shared by OTHERS (own ones filtered out)
+            var oOperator = new List<PortalWorldInfo>(); // fleet-operator view: EVERY world (#495); empty for normal accounts
 
             string PortalBase() => string.IsNullOrWhiteSpace(shell.Settings.PortalUrl)
                 ? PortalClient.DefaultPortalUrl
@@ -387,6 +388,11 @@ namespace BlocksBeyondTheStars.Client
                 var pub = await Task.Run(() => portal.ListPublicWorlds(session));
                 if (official == null) { return; }
 
+                // Operator probe (#495): only developer accounts get an answer here — a 403 simply means
+                // "not an operator" and the section stays hidden, so this costs normal players nothing.
+                var all = await Task.Run(() => portal.ListAllWorldsOperator(session));
+                if (official == null) { return; }
+
                 oStatus.text = "";
                 oWorlds.Clear();
                 oWorlds.AddRange(r.Worlds);
@@ -399,6 +405,19 @@ namespace BlocksBeyondTheStars.Client
                         if (!oWorlds.Exists(o => o.Id == p.Id))
                         {
                             oPublic.Add(p);
+                        }
+                    }
+                }
+
+                oOperator.Clear();
+                if (all.Ok)
+                {
+                    // The operator list shows OTHER people's worlds — own ones sit in "My worlds" already.
+                    foreach (var w in all.Worlds)
+                    {
+                        if (!oWorlds.Exists(o => o.Id == w.Id))
+                        {
+                            oOperator.Add(w);
                         }
                     }
                 }
@@ -1246,6 +1265,33 @@ namespace BlocksBeyondTheStars.Client
                 EmptyHint(shell.L("ui.portal.public_intro"));
                 if (oPublic.Count == 0) { EmptyHint(shell.L("ui.portal.no_public")); }
                 else { foreach (var world in oPublic) { WorldRow(world, owned: false); } }
+
+                // Section 3 — fleet operator only (#495): every world on the fleet, private and
+                // password-protected ones included. The list is simply empty for normal accounts (the
+                // server answers 403 to the probe), so nothing here ever renders for players. Joining
+                // bypasses the world password server-side; the owner name is shown because moderation
+                // starts with "whose world is this".
+                if (oOperator.Count > 0)
+                {
+                    ry += 12f;
+                    UiKit.AddImage(list, 30f, ry, 1016f, 2f, UiKit.SolidSprite, new Color(UiKit.Warn.r, UiKit.Warn.g, UiKit.Warn.b, 0.35f));
+                    ry += 18f;
+                    SectionHeader(shell.L("ui.portal.operator_title"));
+                    EmptyHint(shell.L("ui.portal.operator_intro"));
+                    foreach (var world in oOperator)
+                    {
+                        var w = world;
+                        UiKit.AddText(list, 30f, ry + 8f, 380f, 26f, w.Name, 17, UiKit.TextCol, TextAnchor.MiddleLeft, FontStyle.Bold);
+                        string flags = w.Status
+                            + (w.HasPassword ? " [PW]" : "")
+                            + (w.IsPublic ? " [PUB]" : " [PRIV]")
+                            + (string.IsNullOrEmpty(w.Owner) ? "" : " · " + w.Owner);
+                        var st = UiKit.AddText(list, 420f, ry + 8f, 230f, 26f, flags, 13, UiKit.CyanDim, TextAnchor.MiddleLeft);
+                        st.horizontalOverflow = HorizontalWrapMode.Wrap;
+                        UiKit.AddButton(list, col[3], ry, colW, 44f, shell.L("ui.portal.play"), () => DoJoinWorld(w.Id), "btn_join");
+                        ry += 52f;
+                    }
+                }
 
                 list.sizeDelta = new Vector2(0f, Mathf.Max(322f, ry + 8f));
                 UiKit.AddVerticalScrollbar(oContent, scroll, 1080f, 108f, 14f, 322f);

--- a/data/locales/de.json
+++ b/data/locales/de.json
@@ -849,6 +849,8 @@
   "ui.portal.my_worlds": "Meine Welten",
   "ui.portal.public_browse_title": "ÖFFENTLICHE WELTEN",
   "ui.portal.public_intro": "Von anderen Spielern geteilte Welten. Zum Beitreten brauchst du das Passwort des Erstellers.",
+  "ui.portal.operator_title": "ALLE WELTEN (OPERATOR)",
+  "ui.portal.operator_intro": "Flotten-Operator-Ansicht: jede Welt auf diesem Server, auch private. Beitritt umgeht das Welt-Passwort. Mit /spectate unsichtbar beobachten.",
   "ui.portal.no_public": "Gerade keine öffentlichen Welten. Sei die/der Erste — teile eine deiner Welten!",
   "ui.portal.public_title": "Öffentlich listen",
   "ui.portal.public_hint": "Diese Welt im öffentlichen Browser listen, damit Freunde sie finden. Jede/r mit dem Passwort kann beitreten.",

--- a/data/locales/en.json
+++ b/data/locales/en.json
@@ -848,6 +848,8 @@
   "ui.portal.my_worlds": "My worlds",
   "ui.portal.public_browse_title": "PUBLIC WORLDS",
   "ui.portal.public_intro": "Worlds shared by other players. You need the creator's password to join.",
+  "ui.portal.operator_title": "ALL WORLDS (OPERATOR)",
+  "ui.portal.operator_intro": "Fleet operator view: every world on this server, private ones included. Joining skips the world password. Use /spectate to observe without being seen.",
   "ui.portal.no_public": "No public worlds right now. Be the first — list one of yours!",
   "ui.portal.public_title": "Public listing",
   "ui.portal.public_hint": "List this world in the public browser so friends can find it. Anyone who has the password can join.",

--- a/deploy/worldhost/docker-compose.yml
+++ b/deploy/worldhost/docker-compose.yml
@@ -40,6 +40,10 @@ services:
       # Maintenance announcements (#249): shared secret forwarded to each world as BBS_ANNOUNCE_TOKEN;
       # worlds only pick it up on their next wake. Empty = announcements off.
       BBS_WH_ANNOUNCE_TOKEN: ${BBS_WH_ANNOUNCE_TOKEN:-}
+      # Fleet admins (#487/#495): operator player names, forwarded to each world as BBS_FLEET_ADMINS
+      # (picked up on the next wake). Grants the invisible observer mode + all-worlds access; the names
+      # are auto-reserved so nobody else can register or play them. Empty = observer mode off fleet-wide.
+      BBS_WH_FLEET_ADMINS: ${BBS_WH_FLEET_ADMINS:-}
       # Server crash reports (#363): the ReportHost write key, forwarded to each world as
       # BBS_CRASH_REPORT_KEY (picked up on the next wake). Empty = crash upload off. The endpoint
       # override is only for fleets with their own ReportHost — the server default is the official inbox.

--- a/docs/developer/SELF_HOSTING.md
+++ b/docs/developer/SELF_HOSTING.md
@@ -108,6 +108,13 @@ people own. Two deliberate properties:
 On a hosted fleet, set `fleetAdmins` on the WorldHost (`BBS_WH_FLEET_ADMINS`) — it forwards the list to every
 world container as `BBS_FLEET_ADMINS`. Left empty (the default), observer mode is off for the entire fleet.
 
+Reaching **any** world (issue #495): a fleet admin signed in with a **developer account** (one registered with
+the secret `BBS_WH_RESERVED_CLAIM_CODE`) sees an extra "All worlds (operator)" section in the client's
+Official Worlds screen — every world on the fleet, private ones included — and joins password-protected worlds
+without the password. The gate is double-locked: developer account **and** fleet-admin join name. Config load
+auto-adds every fleet-admin name to `ReservedNames`, so the name that carries this power can never be
+registered or played by anyone else. Name matching is case-insensitive on both sides.
+
 `BBS_FREE_FLIGHT=true` is useful for hosted WebGL realms where every player should be allowed to launch and fly
 manually right away. It also upgrades older world metadata that was saved before free flight became the default,
 while leaving the rest of that world's saved rules intact.

--- a/docs/user/USER_MANUAL.md
+++ b/docs/user/USER_MANUAL.md
@@ -599,6 +599,11 @@ and that option is off by default on hosted worlds.
 Reserved for the operator of the installation (`BBS_FLEET_ADMINS`, see
 [SELF_HOSTING.md](../developer/SELF_HOSTING.md)). The owner of an individual world does **not** get it.
 
+To reach a world: sign in on the Official Worlds screen with a **developer account** (registered with the
+secret claim code) — an extra **"All worlds (operator)"** section then lists every world on the fleet,
+private and password-protected ones included, each with a Play button. Joining as the fleet-admin player name
+skips the world password (child-safety oversight, issue #495); once in, `/spectate on` observes invisibly.
+
 | Command | Effect |
 |---|---|
 | `/spectate [on\|off]` | Enter/leave observer mode: invisible to players, creatures and NPCs, invulnerable, free flight through walls, no ship, no landing pad, no player slot |

--- a/src/BlocksBeyondTheStars.Client.Core/Portal/PortalClient.cs
+++ b/src/BlocksBeyondTheStars.Client.Core/Portal/PortalClient.cs
@@ -36,6 +36,10 @@ namespace BlocksBeyondTheStars.Client.Portal
         /// <summary>The owner listed this world in the public browser (opt-in; requires a password). Only
         /// meaningful for the caller's own worlds — the public listing returns only listed worlds.</summary>
         public bool IsPublic { get; set; }
+
+        /// <summary>Owner display name — only filled by the operator listing (issue #495), which may name
+        /// owners because the operator moderates; the public listing never carries it.</summary>
+        public string Owner { get; set; } = string.Empty;
     }
 
     public sealed class PortalWorldsResult
@@ -152,6 +156,15 @@ namespace BlocksBeyondTheStars.Client.Portal
         public PortalWorldsResult ListPublicWorlds(string session)
         {
             var (status, body) = Get("/api/worlds/public", session);
+            return ParseWorlds(status, body);
+        }
+
+        /// <summary>Operator listing (issue #495): every world on the fleet, private ones included, with
+        /// owner names. Developer accounts only — everyone else gets 403, so the caller treats a failed
+        /// answer as "not an operator" and hides the section rather than showing an error.</summary>
+        public PortalWorldsResult ListAllWorldsOperator(string session)
+        {
+            var (status, body) = Get("/api/worlds/all", session);
             return ParseWorlds(status, body);
         }
 
@@ -296,6 +309,7 @@ namespace BlocksBeyondTheStars.Client.Portal
                             Status = GetString(w, "status"),
                             HasPassword = w.TryGetProperty("hasPassword", out var hp) && hp.ValueKind == JsonValueKind.True,
                             IsPublic = w.TryGetProperty("isPublic", out var ip) && ip.ValueKind == JsonValueKind.True,
+                            Owner = GetString(w, "owner"), // only the operator listing fills this (#495)
                         });
                     }
                 }

--- a/src/BlocksBeyondTheStars.GameServer/GameServer.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServer.cs
@@ -2149,8 +2149,10 @@ public sealed partial class GameServer
         }
 
         // Fleet admin (issue #487): the operator of this installation, config-only and never persisted —
-        // see ServerConfig.FleetAdminPlayers for why this must not become a PlayerRole.
-        bool fleetAdmin = _config.FleetAdminPlayers.Contains(name);
+        // see ServerConfig.FleetAdminPlayers for why this must not become a PlayerRole. Case-insensitive
+        // (#495): the hosted token check above compares names OrdinalIgnoreCase too, and a silent
+        // `marcel` ≠ `Marcel` mismatch would grant nothing with no error anywhere.
+        bool fleetAdmin = IsFleetAdminName(name);
 
         // A fleet admin gets a reserved slot on top of MaxPlayers: they come to observe a world, and a full
         // world is exactly when moderation is most likely to be needed. Their observer session also does not
@@ -2469,7 +2471,7 @@ public sealed partial class GameServer
             Joined = true,
             CurrentLocationId = joinBody,
             Locale = NormalizeLocale(locale),
-            IsFleetAdmin = _config.FleetAdminPlayers.Contains(name), // config-only, like the network join path
+            IsFleetAdmin = IsFleetAdminName(name), // config-only, like the network join path
         };
         _sessions[connectionId] = session;
         state.LastSeenUtc = UtcNowIso();

--- a/src/BlocksBeyondTheStars.GameServer/GameServerObserver.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerObserver.cs
@@ -42,6 +42,12 @@ public sealed partial class GameServer
     /// <summary>ISO-8601 UTC "now", the format <see cref="PlayerState.LastSeenUtc"/> stores.</summary>
     private static string UtcNowIso() => DateTime.UtcNow.ToString("o", CultureInfo.InvariantCulture);
 
+    /// <summary>Whether <paramref name="name"/> is a configured fleet-admin name. Case-insensitive (#495),
+    /// matching how the hosted join token compares names — a silent case mismatch would deny the elevation
+    /// with no error anywhere to see.</summary>
+    private bool IsFleetAdminName(string name)
+        => _config.FleetAdminPlayers.Any(a => string.Equals(a, name, StringComparison.OrdinalIgnoreCase));
+
     /// <summary>True when this session's client is German — server-authored text is written in the player's
     /// language (the game is bilingual DE/EN).</summary>
     private static bool De(PlayerSession session) => session.Locale == "de";

--- a/src/BlocksBeyondTheStars.WorldHost/Program.cs
+++ b/src/BlocksBeyondTheStars.WorldHost/Program.cs
@@ -945,6 +945,36 @@ app.MapGet("/api/worlds/public", (HttpContext ctx) =>
     return Results.Json(new { worlds });
 });
 
+// Operator world browser (issue #495): EVERY world on the fleet, including private ones — the reach the
+// invisible observer needs, since kids mostly play on private/password worlds. Developer accounts only
+// (claimable solely with the secret ReservedClaimCode), and unlike /api/worlds/public this one may name the
+// owner: the operator moderates, and "whose world is this" is the first question moderation asks. Regular
+// accounts get 403 — the client probes this endpoint and simply hides the operator section on failure.
+app.MapGet("/api/worlds/all", (HttpContext ctx) =>
+{
+    if (Caller(ctx) is not { } account)
+    {
+        return Results.Unauthorized();
+    }
+
+    if (!account.IsDeveloper)
+    {
+        return Results.StatusCode(StatusCodes.Status403Forbidden);
+    }
+
+    var worlds = registry.ListAllWorldsAdmin()
+        .Select(e => new
+        {
+            id = e.World.Id,
+            name = e.World.DisplayName,
+            status = e.World.Status,
+            owner = e.OwnerName,
+            isPublic = e.World.IsPublic,
+            hasPassword = e.World.HasPassword,
+        });
+    return Results.Json(new { worlds });
+});
+
 app.MapPost("/api/worlds", (HttpContext ctx, CreateWorldRequest req) =>
 {
     if (Caller(ctx) is not { } account)

--- a/src/BlocksBeyondTheStars.WorldHost/WorldHostConfig.cs
+++ b/src/BlocksBeyondTheStars.WorldHost/WorldHostConfig.cs
@@ -433,6 +433,52 @@ public sealed class WorldHostConfig
         if (Env("BBS_WH_GLITCH_SAVES_PER_HOUR") is { } gsvStr && int.TryParse(gsvStr, out var gsv)) { c.GlitchSavesPerHourPerInstall = gsv; }
         if (Env("BBS_WH_GLITCH_KEEP_AWAKE") is { } gkaStr && bool.TryParse(gkaStr, out var gka)) { c.GlitchKeepAwake = gka; }
 
+        c.ReserveFleetAdminNames();
         return c;
+    }
+
+    /// <summary>True when <paramref name="playerName"/> is one of the configured fleet-admin names.
+    /// Case-insensitive on purpose: the game server matches the name the same way, and a silent
+    /// `marcel` ≠ `Marcel` mismatch would grant nothing without any error anywhere.</summary>
+    public bool IsFleetAdminName(string? playerName)
+    {
+        if (string.IsNullOrWhiteSpace(playerName) || string.IsNullOrWhiteSpace(FleetAdmins))
+        {
+            return false;
+        }
+
+        string wanted = playerName.Trim();
+        foreach (var name in FleetAdmins.Split(','))
+        {
+            if (string.Equals(name.Trim(), wanted, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>Adds every fleet-admin name to <see cref="ReservedNames"/> (child-safety hardening,
+    /// issue #495): fleet-admin power is granted by player NAME, so the name itself must be unclaimable
+    /// by anyone but a developer account. Without this, an operator who sets <c>BBS_WH_FLEET_ADMINS</c>
+    /// to a name outside the default reserved list would leave that name — and with it invisible-observer
+    /// access — open for any kid to register. Called at config load; idempotent.</summary>
+    public void ReserveFleetAdminNames()
+    {
+        if (string.IsNullOrWhiteSpace(FleetAdmins))
+        {
+            return;
+        }
+
+        foreach (var name in FleetAdmins.Split(','))
+        {
+            string trimmed = name.Trim();
+            if (trimmed.Length > 0
+                && !ReservedNames.Any(r => string.Equals(r, trimmed, StringComparison.OrdinalIgnoreCase)))
+            {
+                ReservedNames.Add(trimmed);
+            }
+        }
     }
 }

--- a/src/BlocksBeyondTheStars.WorldHost/WorldOrchestrator.cs
+++ b/src/BlocksBeyondTheStars.WorldHost/WorldOrchestrator.cs
@@ -137,12 +137,21 @@ public sealed class WorldOrchestrator
             return (null, "The community rules have changed — please accept them on the portal first.");
         }
 
+        // Fleet operator (issue #495): the operator must be able to enter ANY world on the fleet — private,
+        // password-protected, whatever — because oversight of worlds where kids play is the point of observer
+        // mode, and those are rarely the public password-free ones. The gate is deliberately double-locked:
+        // the account must be a developer account (only claimable with the secret ReservedClaimCode at
+        // signup) AND the join name must be a configured fleet-admin name (which config load auto-reserves,
+        // so nobody else can hold it). A stolen password alone gets neither.
+        bool fleetOperator = account.IsDeveloper && _config.IsFleetAdminName(playerName);
+
         // World password gate (#250/#251) — enforced BEFORE the wake, at token issuance (the one choke
         // point every hosted join passes), so an unauthorized join can neither enter nor wake the world.
-        // The owner always bypasses their own world's password.
+        // The owner always bypasses their own world's password; so does the fleet operator (above).
         if (_registry.GetWorld(worldId) is { } gated
             && !string.IsNullOrEmpty(gated.PasswordHash)
-            && gated.OwnerAccountId != account.Id)
+            && gated.OwnerAccountId != account.Id
+            && !fleetOperator)
         {
             string attemptKey = account.Id + "|" + gated.Id;
             if (_passwordAttempts.IsExhausted(attemptKey))

--- a/tests/BlocksBeyondTheStars.Tests/AdminObserverTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/AdminObserverTests.cs
@@ -117,6 +117,17 @@ public sealed class AdminObserverTests : IDisposable
         Assert.DoesNotContain("FleetAdmin", Enum.GetNames<PlayerRole>());
     }
 
+    [Fact]
+    public void FleetAdmin_NameMatch_IsCaseInsensitive()
+    {
+        // #495: the hosted join token already compares names OrdinalIgnoreCase — a case-sensitive config
+        // match here would deny the elevation silently, with no error anywhere to see.
+        var transport = new RecordingTransport();
+        var server = NewServer("fleet_case", transport, "operator");
+
+        Assert.True(server.AddLocalPlayer("Operator").IsFleetAdmin);
+    }
+
     // ---------------- Invisibility (issue #487) ----------------
 
     [Fact]

--- a/tests/BlocksBeyondTheStars.Tests/FleetOperatorAccessTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/FleetOperatorAccessTests.cs
@@ -1,0 +1,217 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using BlocksBeyondTheStars.WorldHost;
+using Xunit;
+
+namespace BlocksBeyondTheStars.Tests;
+
+/// <summary>
+/// Fleet-operator access to any world (issue #495): the operator must be able to enter private and
+/// password-protected worlds — that is where kids actually play, and oversight is the point of observer
+/// mode. What these tests pin down is the SECURITY BOUNDARY around that power: it must require the
+/// developer account (claimable only with the secret code) AND a configured fleet-admin name, and the
+/// name itself must be unclaimable by anyone else.
+/// </summary>
+public sealed class FleetOperatorAccessTests : IDisposable
+{
+    private const int Terms = 1;
+    private const string ClaimCode = "family-secret";
+
+    private readonly string _root;
+    private readonly List<HostRegistry> _registries = new();
+
+    public FleetOperatorAccessTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "bbts_fleetop_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    /// <summary>A config with "Operator" as the fleet admin, the claim code set, and the fleet-admin
+    /// names reserved — exactly what <see cref="WorldHostConfig.FromEnvironment"/> produces in production.</summary>
+    private static WorldHostConfig NewConfig()
+    {
+        var config = new WorldHostConfig
+        {
+            FleetAdmins = "Operator",
+            ReservedClaimCode = ClaimCode,
+            TermsVersion = Terms,
+        };
+        config.ReserveFleetAdminNames();
+        return config;
+    }
+
+    private HostRegistry NewRegistry(WorldHostConfig config)
+    {
+        var registry = new HostRegistry(config, Path.Combine(_root, Guid.NewGuid().ToString("N") + ".db"));
+        _registries.Add(registry);
+        return registry;
+    }
+
+    private sealed class FakeLauncher : IInstanceLauncher
+    {
+        private int _startCount;
+        private readonly HashSet<string> _running = new(StringComparer.Ordinal);
+
+        public string Start(WorldRecord world)
+        {
+            string id = "container-" + ++_startCount;
+            _running.Add(id);
+            return id;
+        }
+
+        public void Stop(string containerId) => _running.Remove(containerId);
+        public void Remove(string worldId) { }
+        public bool IsRunning(string containerId) => containerId != null && _running.Contains(containerId);
+        public IReadOnlyList<ContainerStat> ContainerStats() => Array.Empty<ContainerStat>();
+    }
+
+    private static WorldOrchestrator NewOrchestrator(HostRegistry registry, WorldHostConfig config)
+    {
+        var launcher = new FakeLauncher();
+        return new(config, registry, launcher, w => Task.FromResult(launcher.IsRunning(w.ContainerId)));
+    }
+
+    private static AccountRecord NewAccount(HostRegistry registry, string name, string? claimCode = null)
+    {
+        var (ok, error, _, session) = registry.CreateAccount(name, "super-secret-1", claimCode, Terms);
+        Assert.True(ok, error);
+        return registry.ResolveSession(session)!;
+    }
+
+    // ---------------- The password bypass ----------------
+
+    [Fact]
+    public async Task Operator_EntersPasswordProtectedWorld_WithoutThePasswordAsync()
+    {
+        var config = NewConfig();
+        var registry = NewRegistry(config);
+        var orchestrator = NewOrchestrator(registry, config);
+
+        var owner = NewAccount(registry, "KidOwner");
+        var world = registry.CreateWorld(owner.Id, "Kids World", "geheim").World!;
+
+        // The operator: a developer account (claimed with the secret code) joining under the fleet-admin name.
+        var op = NewAccount(registry, "Operator", ClaimCode);
+        Assert.True(op.IsDeveloper);
+
+        var (grant, error) = await orchestrator.JoinAsync(world.Id, op, "Operator");
+        Assert.Null(error.Length == 0 ? null : error); // surface the reason on failure
+        Assert.NotNull(grant);
+    }
+
+    [Fact]
+    public async Task DeveloperAccount_UnderANormalName_StillNeedsThePasswordAsync()
+    {
+        // Both halves of the gate are required: a developer account joining under a non-fleet-admin name
+        // is a family member playing normally, not the operator observing — no bypass.
+        var config = NewConfig();
+        var registry = NewRegistry(config);
+        var orchestrator = NewOrchestrator(registry, config);
+
+        var owner = NewAccount(registry, "KidOwner");
+        var world = registry.CreateWorld(owner.Id, "Kids World", "geheim").World!;
+        var dev = NewAccount(registry, "Operator", ClaimCode);
+
+        var (grant, error) = await orchestrator.JoinAsync(world.Id, dev, "JustPlaying");
+        Assert.Null(grant);
+        Assert.Contains("password", error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task NormalAccount_CannotUseTheFleetAdminName_AtAllAsync()
+    {
+        // The other half: without the developer flag the fleet-admin name is a RESERVED name (auto-added
+        // by config load), so a regular account cannot even join under it — let alone bypass a password.
+        var config = NewConfig();
+        var registry = NewRegistry(config);
+        var orchestrator = NewOrchestrator(registry, config);
+
+        var owner = NewAccount(registry, "KidOwner");
+        var world = registry.CreateWorld(owner.Id, "Kids World", "geheim").World!;
+        var kid = NewAccount(registry, "SomeKid");
+
+        var (grant, error) = await orchestrator.JoinAsync(world.Id, kid, "Operator");
+        Assert.Null(grant);
+        Assert.Contains("reserved", error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Operator_EntersPrivateWorlds_TheSameWayAsync()
+    {
+        // Private = never made public, no password. The join API itself has no visibility gate (players
+        // just cannot SEE unlisted worlds); the operator finds them via /api/worlds/all and joins by id.
+        var config = NewConfig();
+        var registry = NewRegistry(config);
+        var orchestrator = NewOrchestrator(registry, config);
+
+        var owner = NewAccount(registry, "KidOwner");
+        var world = registry.CreateWorld(owner.Id, "Private World").World!;
+        Assert.False(world.IsPublic);
+
+        var op = NewAccount(registry, "Operator", ClaimCode);
+        Assert.NotNull((await orchestrator.JoinAsync(world.Id, op, "Operator")).Grant);
+    }
+
+    // ---------------- The name lock (child-safety hardening) ----------------
+
+    [Fact]
+    public void ConfigLoad_AutoReservesFleetAdminNames()
+    {
+        var config = new WorldHostConfig { FleetAdmins = "Operator, Aufsicht" };
+        Assert.DoesNotContain(config.ReservedNames, r => r == "Aufsicht");
+
+        config.ReserveFleetAdminNames();
+
+        Assert.Contains(config.ReservedNames, r => r == "Operator");
+        Assert.Contains(config.ReservedNames, r => r == "Aufsicht");
+
+        // Idempotent — a second load must not stack duplicates.
+        int count = config.ReservedNames.Count;
+        config.ReserveFleetAdminNames();
+        Assert.Equal(count, config.ReservedNames.Count);
+    }
+
+    [Fact]
+    public void AutoReservedName_CannotBeRegistered_WithoutTheClaimCode()
+    {
+        var config = NewConfig();
+        var registry = NewRegistry(config);
+
+        var (ok, error, _, _) = registry.CreateAccount("Operator", "super-secret-1", null, Terms);
+
+        Assert.False(ok);
+        Assert.Contains("reserved", error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void FleetAdminNameMatch_IsCaseInsensitive()
+    {
+        var config = new WorldHostConfig { FleetAdmins = "Marcel" };
+
+        Assert.True(config.IsFleetAdminName("Marcel"));
+        Assert.True(config.IsFleetAdminName("marcel"));
+        Assert.True(config.IsFleetAdminName(" MARCEL "));
+        Assert.False(config.IsFleetAdminName("Marcel2"));
+        Assert.False(config.IsFleetAdminName(""));
+    }
+
+    public void Dispose()
+    {
+        foreach (var registry in _registries)
+        {
+            registry.Dispose();
+        }
+
+        try
+        {
+            if (Directory.Exists(_root))
+            {
+                Directory.Delete(_root, recursive: true);
+            }
+        }
+        catch (IOException)
+        {
+        }
+    }
+}


### PR DESCRIPTION
Follow-up to #487/PR #491. Observer mode existed, but the join path still treated the operator like a player:
the world browser listed only "mine + public", and only a world's *owner* bypassed its password. So the
invisible observer could reach exactly the worlds least worth watching — public, password-free ones — while
kids play mostly on private, password-shared worlds.

## Access model (double-locked)

> `account.IsDeveloper && playerName ∈ FleetAdmins`

- **Developer account** — claimable only by presenting the secret `BBS_WH_RESERVED_CLAIM_CODE` at signup.
- **Fleet-admin join name** — and config load now **auto-adds every fleet-admin name to `ReservedNames`**, so
  the name that carries the power can never be registered or played by anyone else.
- A developer account under a normal name gets **no** bypass (family member playing, not the operator
  observing). A normal account cannot even join under the fleet-admin name (reserved). Both are pinned by
  tests.
- Name matching is now `OrdinalIgnoreCase` on the WorldHost **and** the game server — the hosted token check
  already was, and a silent `marcel` ≠ `Marcel` mismatch denied the elevation with no error anywhere.

## Changes

- `WorldOrchestrator.JoinAsync`: operator bypass for the world-password gate, next to the existing owner
  bypass. Ban/terms checks untouched.
- `GET /api/worlds/all` (developer accounts only, 403 otherwise): every world on the fleet with owner names —
  the operator moderates, and "whose world is this" is the first question moderation asks.
- Client: the Official Worlds screen probes the endpoint and renders an **"All worlds (operator)"** section —
  every world with `[PW]`/`[PRIV]`/owner flags and a Play button. Normal accounts never see it (the probe
   403s). DE+EN.
- Deploy: **`BBS_WH_FLEET_ADMINS` was missing from `deploy/worldhost/docker-compose.yml`** — without that
  line the observer feature from #491 never reached a deployed fleet at all.

## Verification

- 7 new `FleetOperatorAccessTests` (password bypass, private-world join, both negative gates, auto-reserve,
  claim-code lock, case-insensitivity) + 1 new case-insensitivity test in `AdminObserverTests` — all green.
- Full `dotnet build` of the CI solution filter clean, no warnings.
- Local Unity Windows player build.

closes #495

🤖 Generated with [Claude Code](https://claude.com/claude-code)