### PR TITLE
fix(client): space view — planets and satellites keep a visible gap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ the richer, screenshot-laden versions live there. `(#123)` references the pull r
 
 ## [Unreleased]
 
+### 🪐 Room to fly between the worlds
+- **Planets and their moons no longer huddle together in space.** Out in the flight view, every moon
+  used to sit glued to the surface of its planet, and the odd pair of planets came out nearly
+  touching — the view kept a flat 8-unit gap between any two bodies, whether they were pebbles or gas
+  giants, and that gap is less than the distance the ship itself is held at. The gap now grows with
+  the bodies, so a moon rides at a real altitude above its planet and neighbouring worlds read as
+  separate places you fly *between*. Measured across 2 400 generated systems the typical clear space
+  between two bodies went from 8 to 21 units, and moon-to-planet from 8 to 22 — while the time to
+  cruise out to the system's farthest body is unchanged. A moon of the world you launched from could
+  also end up stuck *inside* it; it can't any more (#493).
+
 ### 🛰️ Fleet operations
 - **The fleet admin panel can delete worlds.** Every row on `/admin` gets a folded-away `delete…`
   control: type the world's name (checked on the server — there is no undo), then either `delete`,

--- a/TODO.md
+++ b/TODO.md
@@ -100,6 +100,37 @@ Per-item detail lives in the dated work log below.
 
 ---
 
+### ★ Space view: planets and satellites keep a visible gap (#493, 2026-07-26, branch fix/space-view-body-spacing)
+Analysed and measured first (`analysis/space-view-body-spacing.md`): a probe replayed
+`SpaceView.BuildSystem`'s layout math over real `UniverseGenerator` output across **2 400 systems /
+26 951 bodies**.
+
+**Root cause: two independent size models.** `UniverseGenerator` places bodies with hand-picked
+constants (`MoonOrbit` 90, `OrbitStep` 520, `BodyClearance` 470/290/215) while `SpaceView` derives a
+body's *rendered* radius from its real walkable circumference — 11…27 view units for a planet, i.e.
+**69…169 system units**. So a moon's star-map orbit (90 → 14 view units) is always *inside* its own
+planet once drawn: the `minClear` clamp fired for **13 882/13 882 moons = 100 %** and pinned each at
+the flat `BodyGap = 8f`, *below* the ship's own 10-unit keep-out shell. The moon's seeded *angle*
+survived; its seeded *distance* was discarded entirely, making `MoonStep` dead code. Planets were
+fine on average (median 185) but the tail near-touched (p10 54, min 8.0) because `pAngle` is a free
+random draw. The relax pass displaced 17 % of bodies and was the de-facto layout.
+
+**Fix (client only, deliberately):** the gap rule + relaxation moved to
+`Shared/World/SystemBodyLayout.cs`, beside `WorldConstants.CircumferenceFor` (the size source both
+stages must agree on), and the flat gap became `max(14, (rA+rB) · 0.55)` for both the moon clamp and
+the relax pass. Home is now passed in as a **fixed obstacle** — it never moves, but its own moons are
+laid out in *its* plane and nothing stopped the pass from shoving one back into it (measured overlaps
+up to 16 units). Measured after: nearest-neighbour gap median **8.0 → 21.4**, p10 **8.0 → 14.0**,
+moon→parent median **8.0 → 22.2**, home-moon→home min **−16.1 → 39.1**, cruise to the outermost body
+28 s → 29 s. `SystemBodyLayoutTests` asserts the guarantee over 320 real generated systems.
+
+`SystemX`/`SystemZ` are untouched, so the surface sky view, star map, radar and travel distances are
+unaffected. **Not done, and why:** deriving moon orbits from the parent's real size is the deeper fix,
+but `SkyBodiesView` sizes sky bodies from real system-space distance, so it would shrink the parent
+planet seen from its moon from 47 → 9-12 and stretch cruise to 43 s — it needs its own parent/child-aware
+companion change. Two further findings left open: landable asteroids are the only body kind with **no**
+generator separation pass, and `MoonStep` remains inert.
+
 ### ★ Fleet admin: delete worlds + the portal links to the game website (2026-07-26, branch feat/worldhost-admin-delete-and-site-link)
 Two small WorldHost additions, both analysed first (`analysis/fleet-admin-world-delete.md`,
 `analysis/portal-website-link.md`).

--- a/client/Assets/BlocksBeyondTheStars/Scripts/SpaceView.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/SpaceView.cs
@@ -2516,11 +2516,10 @@ namespace BlocksBeyondTheStars.Client
             // The system's other planets/moons at their (scaled) orbit coords — all real, all landable.
             if (current != null && system != null)
             {
-                // Clear space between two bodies' surfaces comes from SystemBodyLayout: proportional to how
-                // big the two bodies are, because a flat gap made every moon hug its planet (#493).
-
                 // Plan every body first (positions + radii), then nudge any overlaps apart, THEN spawn — so no
-                // two planets/moons ever clip into each other at the compact view scale.
+                // two planets/moons ever clip into each other at the compact view scale. How much clear space
+                // "apart" means comes from SystemBodyLayout: proportional to the two bodies, because a flat gap
+                // left every moon hugging its planet (#493).
                 var ids = new List<string>();
                 var names = new List<string>();
                 var locKeys = new List<string>(); // "System · Body" — the key the body's WORLD seeds flora hues with

--- a/client/Assets/BlocksBeyondTheStars/Scripts/SpaceView.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/SpaceView.cs
@@ -2516,7 +2516,8 @@ namespace BlocksBeyondTheStars.Client
             // The system's other planets/moons at their (scaled) orbit coords — all real, all landable.
             if (current != null && system != null)
             {
-                const float BodyGap = 8f; // clear space kept between two bodies' surfaces
+                // Clear space between two bodies' surfaces comes from SystemBodyLayout: proportional to how
+                // big the two bodies are, because a flat gap made every moon hug its planet (#493).
 
                 // Plan every body first (positions + radii), then nudge any overlaps apart, THEN spawn — so no
                 // two planets/moons ever clip into each other at the compact view scale.
@@ -2527,6 +2528,7 @@ namespace BlocksBeyondTheStars.Client
                 var radii = new List<float>();
                 var bodyTypes = new List<string>();
                 var kinds = new List<string>(); // star-map Kind — keys each body's true circumference
+                var homeMoons = new List<int>(); // planned in home's plane → must also clear home itself
 
                 void Plan(string id, string name, string kind, Vector3 pos, float diameter, string type)
                 {
@@ -2565,18 +2567,23 @@ namespace BlocksBeyondTheStars.Client
                     }
 
                     string type = string.IsNullOrEmpty(b.PlanetType) ? homeType : b.PlanetType;
-                    var parent = planets[0];
+                    int parentIndex = 0;
                     float bestSq = float.MaxValue;
-                    foreach (var p in planets)
+                    for (int p = 0; p < planets.Count; p++)
                     {
-                        float dx = b.SystemX - p.Sx, dz = b.SystemZ - p.Sz;
+                        float dx = b.SystemX - planets[p].Sx, dz = b.SystemZ - planets[p].Sz;
                         float dsq = dx * dx + dz * dz;
-                        if (dsq < bestSq) { bestSq = dsq; parent = p; }
+                        if (dsq < bestSq) { bestSq = dsq; parentIndex = p; }
                     }
+
+                    var parent = planets[parentIndex];
 
                     var rel = new Vector3((b.SystemX - parent.Sx) * SystemViewScale, 0f, (b.SystemZ - parent.Sz) * SystemViewScale);
                     float moonDia = OrbitDiameterFor(b.Id, b.Kind, b.PlanetType);
-                    float minClear = parent.Radius + moonDia * 0.5f + BodyGap; // outside the planet's surface
+                    // Outside the planet's surface, with room to spare. This clamp fires for essentially every
+                    // moon — the star map's moon orbit (90 system units ≈ 14 view units) is smaller than any
+                    // planet's rendered radius — so the gap it leaves IS the moon's visible altitude (#493).
+                    float minClear = SystemBodyLayout.MinOrbitFor(parent.Radius, moonDia * 0.5f);
                     if (rel.magnitude < minClear)
                     {
                         Vector3 dir = rel.sqrMagnitude > 0.0001f ? rel.normalized : Vector3.right;
@@ -2584,6 +2591,12 @@ namespace BlocksBeyondTheStars.Client
                     }
 
                     Plan(b.Id, b.Name, b.Kind, parent.Render + rel, moonDia, type);
+                    if (parentIndex == 0)
+                    {
+                        // A moon of the body you launched from: planned in HOME'S plane (far below the flight
+                        // plane), so it is the one case where the relax pass can shove a body back into home.
+                        homeMoons.Add(positions.Count - 1);
+                    }
                 }
 
                 // Pass 3: large landable asteroids — scattered like planets; you fly up + press E to land on
@@ -2602,35 +2615,25 @@ namespace BlocksBeyondTheStars.Client
                     Plan(b.Id, b.Name, b.Kind, pos, diameter, type);
                 }
 
-                // Separation pass: relax any overlapping pair apart in the x-z plane until every body has a
-                // clear gap to every other. (Home is excluded — it sits far "below" you and never overlaps.)
-                for (int iter = 0; iter < 24; iter++)
+                // Separation pass: nudge any overlapping pair apart in the x-z plane until every body has
+                // its clear gap (SystemBodyLayout — shared with the tests that assert the guarantee).
+                // Home is passed as the fixed body: it never moves (the scene is centred on it) and its
+                // own moons are the ones laid out in its plane, so they are the ones it has to push out.
+                var flatX = new float[positions.Count];
+                var flatZ = new float[positions.Count];
+                for (int k = 0; k < positions.Count; k++)
                 {
-                    bool moved = false;
-                    for (int a = 0; a < positions.Count; a++)
-                    {
-                        for (int c = a + 1; c < positions.Count; c++)
-                        {
-                            Vector3 d = positions[a] - positions[c];
-                            d.y = 0f;
-                            float dist = d.magnitude;
-                            float need = radii[a] + radii[c] + BodyGap;
-                            if (dist < need)
-                            {
-                                Vector3 dir = dist > 0.0001f ? d / dist
-                                    : new Vector3(Mathf.Cos(a * 2.39996f), 0f, Mathf.Sin(a * 2.39996f)); // co-located → spread by a golden angle
-                                float push = (need - dist) * 0.5f;
-                                positions[a] += dir * push;
-                                positions[c] -= dir * push;
-                                moved = true;
-                            }
-                        }
-                    }
+                    flatX[k] = positions[k].x;
+                    flatZ[k] = positions[k].z;
+                }
 
-                    if (!moved)
-                    {
-                        break;
-                    }
+                SystemBodyLayout.SeparateXZ(
+                    flatX, flatZ, radii.ToArray(),
+                    homePos.x, homePos.z, homeDiameter * 0.5f, homeMoons.ToArray());
+
+                for (int k = 0; k < positions.Count; k++)
+                {
+                    positions[k] = new Vector3(flatX[k], positions[k].y, flatZ[k]);
                 }
 
                 // Spawn the separated bodies + register them as landable / keep-out.

--- a/src/BlocksBeyondTheStars.Shared/World/SystemBodyLayout.cs
+++ b/src/BlocksBeyondTheStars.Shared/World/SystemBodyLayout.cs
@@ -1,0 +1,123 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+namespace BlocksBeyondTheStars.Shared.World;
+
+/// <summary>
+/// How far apart celestial bodies must sit in the space-flight view, and the relaxation that
+/// enforces it. Pure math, no Unity — the client's space view is the only caller, but keeping it
+/// here (next to <see cref="WorldConstants.CircumferenceFor"/>, the single source of body size)
+/// makes the spacing testable and keeps the size model in one place.
+/// <para>Why a separation pass is needed at all: the star map lays bodies out in system units with
+/// fixed constants (a moon orbits its planet at 90 of them), while a body's RENDERED size comes
+/// from its real walkable circumference — a planet's radius alone is 69…169 system units. A moon's
+/// star-map orbit is therefore always *inside* its own planet once drawn, so the view has to decide
+/// the spacing itself (#493).</para>
+/// </summary>
+public static class SystemBodyLayout
+{
+    /// <summary>Smallest clear space between two bodies' surfaces, in flight-view units. Deliberately
+    /// above the ship's keep-out margin (10) so there is always a gap the ship can fly through.</summary>
+    public const float MinBodyGap = 14f;
+
+    /// <summary>…and the gap grows with the two bodies, so big worlds stay visibly apart instead of
+    /// being separated by the same hairline as two small rocks. A flat gap made every moon hug its
+    /// planet: the clamp fires for essentially every moon, so the gap it leaves *is* the moon's
+    /// visible altitude.</summary>
+    public const float BodyGapFraction = 0.55f;
+
+    /// <summary>Clear space to keep between the surfaces of two bodies of these radii.</summary>
+    public static float ClearGapFor(float radiusA, float radiusB)
+        => System.MathF.Max(MinBodyGap, (radiusA + radiusB) * BodyGapFraction);
+
+    /// <summary>Centre distance at which a body of <paramref name="bodyRadius"/> clears the surface of
+    /// its parent — the minimum orbit a moon is drawn at.</summary>
+    public static float MinOrbitFor(float parentRadius, float bodyRadius)
+        => parentRadius + bodyRadius + ClearGapFor(parentRadius, bodyRadius);
+
+    /// <summary>
+    /// Relaxes overlapping bodies apart in the x-z plane until every pair has its
+    /// <see cref="ClearGapFor"/> of clear space, nudging both halves of a pair by half the deficit.
+    /// <para>The body the player launched from is passed separately: it never moves (the scene is
+    /// centred on it) and hangs far below the flight plane, so it only pushes the bodies listed in
+    /// <paramref name="boundToFixed"/> — its own moons, which are laid out in *its* plane. Without
+    /// that, nothing stopped the pass from shoving one of those back into it.</para>
+    /// </summary>
+    /// <param name="x">Body x coordinates, updated in place.</param>
+    /// <param name="z">Body z coordinates, updated in place.</param>
+    /// <param name="radius">Body radii, parallel to <paramref name="x"/>/<paramref name="z"/>.</param>
+    /// <param name="fixedX">x of the body that never moves.</param>
+    /// <param name="fixedZ">z of the body that never moves.</param>
+    /// <param name="fixedRadius">Radius of the body that never moves.</param>
+    /// <param name="boundToFixed">Indices laid out in the fixed body's plane, which must clear it.</param>
+    /// <param name="iterations">Relaxation budget. Runs once per launch, never per frame.</param>
+    public static void SeparateXZ(
+        System.Span<float> x,
+        System.Span<float> z,
+        System.ReadOnlySpan<float> radius,
+        float fixedX,
+        float fixedZ,
+        float fixedRadius,
+        System.ReadOnlySpan<int> boundToFixed,
+        int iterations = 24)
+    {
+        int count = radius.Length;
+        for (int iter = 0; iter < iterations; iter++)
+        {
+            bool moved = false;
+
+            for (int a = 0; a < count; a++)
+            {
+                for (int c = a + 1; c < count; c++)
+                {
+                    float dx = x[a] - x[c], dz = z[a] - z[c];
+                    float dist = System.MathF.Sqrt(dx * dx + dz * dz);
+                    float need = radius[a] + radius[c] + ClearGapFor(radius[a], radius[c]);
+                    if (dist >= need)
+                    {
+                        continue;
+                    }
+
+                    float nx, nz;
+                    if (dist > 0.0001f)
+                    {
+                        nx = dx / dist; nz = dz / dist;
+                    }
+                    else
+                    {
+                        // Co-located → spread by a golden angle, so a pile-up fans out instead of
+                        // picking one arbitrary direction for every body in it.
+                        nx = System.MathF.Cos(a * 2.39996f); nz = System.MathF.Sin(a * 2.39996f);
+                    }
+
+                    float push = (need - dist) * 0.5f;
+                    x[a] += nx * push; z[a] += nz * push;
+                    x[c] -= nx * push; z[c] -= nz * push;
+                    moved = true;
+                }
+            }
+
+            foreach (int a in boundToFixed)
+            {
+                float dx = x[a] - fixedX, dz = z[a] - fixedZ;
+                float dist = System.MathF.Sqrt(dx * dx + dz * dz);
+                float need = radius[a] + fixedRadius + ClearGapFor(radius[a], fixedRadius);
+                if (dist >= need)
+                {
+                    continue;
+                }
+
+                float nx = dist > 0.0001f ? dx / dist : System.MathF.Cos(a * 2.39996f);
+                float nz = dist > 0.0001f ? dz / dist : System.MathF.Sin(a * 2.39996f);
+                x[a] = fixedX + nx * need; // the fixed body never gives way
+                z[a] = fixedZ + nz * need;
+                moved = true;
+            }
+
+            if (!moved)
+            {
+                break;
+            }
+        }
+    }
+}

--- a/tests/BlocksBeyondTheStars.Client.Tests/SystemBodyLayoutTests.cs
+++ b/tests/BlocksBeyondTheStars.Client.Tests/SystemBodyLayoutTests.cs
@@ -1,0 +1,203 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using BlocksBeyondTheStars.Shared.Content;
+using BlocksBeyondTheStars.Shared.World;
+using BlocksBeyondTheStars.WorldGeneration;
+using Xunit;
+
+namespace BlocksBeyondTheStars.Client.Tests;
+
+/// <summary>
+/// The spacing guarantee for the space-flight view (#493): planets and their satellites must end up
+/// visibly apart, not hairline-close. The layout stage under test is
+/// <see cref="SystemBodyLayout"/>; the geometry is fed from the REAL <see cref="UniverseGenerator"/>
+/// through the same conversion the space view uses, so a regression in either the gap rule or the
+/// relaxation shows up here rather than only on screen.
+/// </summary>
+public sealed class SystemBodyLayoutTests
+{
+    // Mirrors SpaceView: system units → flight-view units, and body diameter from real circumference.
+    private const float SystemViewScale = 0.16f;
+    private const float KeepOutMargin = 10f; // the shell the ship is held at, from SpaceView
+    private const float Tolerance = 0.01f;
+
+    private static float RadiusOf(string id, CelestialKind kind, string? planetType)
+    {
+        var cls = WorldConstants.SizeClassFor(kind, planetType ?? string.Empty);
+        return (8f + WorldConstants.CircumferenceFor(id, cls) / 220f) * 0.5f;
+    }
+
+    [Fact]
+    public void ClearGap_NeverDropsBelowTheShipsOwnKeepOutMargin()
+    {
+        // Two of the smallest bodies in the game still have to leave a gap the ship fits through,
+        // otherwise "fly between those two rocks" is impossible and they read as one clump.
+        float smallest = RadiusOf("sys0-a0", CelestialKind.AsteroidField, "asteroid");
+        Assert.True(
+            SystemBodyLayout.ClearGapFor(smallest, smallest) > KeepOutMargin,
+            $"gap {SystemBodyLayout.ClearGapFor(smallest, smallest)} must exceed the keep-out margin {KeepOutMargin}");
+    }
+
+    [Fact]
+    public void ClearGap_GrowsWithTheBodies()
+    {
+        // The bug was a FLAT gap: two gas giants got the same hairline as two pebbles.
+        float small = SystemBodyLayout.ClearGapFor(6f, 6f);
+        float large = SystemBodyLayout.ClearGapFor(31f, 31f);
+        Assert.True(large > small * 2f, $"large-body gap {large} should dwarf small-body gap {small}");
+    }
+
+    [Fact]
+    public void MinOrbit_PutsAMoonClearOfItsParentsSurface()
+    {
+        const float planetRadius = 27f, moonRadius = 11.5f;
+        float orbit = SystemBodyLayout.MinOrbitFor(planetRadius, moonRadius);
+        Assert.True(
+            orbit - planetRadius - moonRadius >= SystemBodyLayout.MinBodyGap - Tolerance,
+            $"orbit {orbit} leaves only {orbit - planetRadius - moonRadius} of clear space");
+    }
+
+    [Fact]
+    public void EveryBodyKeepsItsClearGap_AcrossRealGeneratedSystems()
+    {
+        var content = ContentLoader.LoadFromDirectory(ClientTestPaths.DataDir());
+        int systemsChecked = 0, bodiesChecked = 0;
+
+        for (long seed = 1; seed <= 40; seed++)
+        {
+            var galaxy = new UniverseGenerator(seed, new WorldDescription(), content).Generate();
+            foreach (var system in galaxy.Systems)
+            {
+                // The body you launched from: it stays put and is drawn oversized, as in the view.
+                var home = system.Bodies.FirstOrDefault(b => b.Kind == CelestialKind.Planet);
+                if (home is null)
+                {
+                    continue;
+                }
+
+                systemsChecked++;
+                float homeRadius = RadiusOf(home.Id, home.Kind, home.PlanetType) * 3.2f;
+                const float homeX = 0f, homeZ = -20f;
+
+                var xs = new List<float>();
+                var zs = new List<float>();
+                var radii = new List<float>();
+                var homeMoons = new List<int>();
+
+                // Planets, at their scaled orbit coords.
+                var parents = new List<(float Sx, float Sz, float X, float Z, float R)>
+                {
+                    (home.SystemX, home.SystemZ, homeX, homeZ, homeRadius),
+                };
+                foreach (var b in system.Bodies)
+                {
+                    if (b.Id == home.Id || b.Kind != CelestialKind.Planet)
+                    {
+                        continue;
+                    }
+
+                    float x = (b.SystemX - home.SystemX) * SystemViewScale;
+                    float z = (b.SystemZ - home.SystemZ) * SystemViewScale;
+                    float r = RadiusOf(b.Id, b.Kind, b.PlanetType);
+                    xs.Add(x); zs.Add(z); radii.Add(r);
+                    parents.Add((b.SystemX, b.SystemZ, x, z, r));
+                }
+
+                // Moons, clamped out to the minimum orbit around their nearest planet.
+                foreach (var b in system.Bodies)
+                {
+                    if (b.Id == home.Id || b.Kind != CelestialKind.Moon)
+                    {
+                        continue;
+                    }
+
+                    int best = 0;
+                    float bestSq = float.MaxValue;
+                    for (int i = 0; i < parents.Count; i++)
+                    {
+                        float ddx = b.SystemX - parents[i].Sx, ddz = b.SystemZ - parents[i].Sz;
+                        float dsq = (ddx * ddx) + (ddz * ddz);
+                        if (dsq < bestSq)
+                        {
+                            bestSq = dsq;
+                            best = i;
+                        }
+                    }
+
+                    var parent = parents[best];
+                    float relX = (b.SystemX - parent.Sx) * SystemViewScale;
+                    float relZ = (b.SystemZ - parent.Sz) * SystemViewScale;
+                    float moonRadius = RadiusOf(b.Id, b.Kind, b.PlanetType);
+                    float minClear = SystemBodyLayout.MinOrbitFor(parent.R, moonRadius);
+                    float mag = MathF.Sqrt((relX * relX) + (relZ * relZ));
+                    if (mag < minClear)
+                    {
+                        // The star map's moon orbit is inside the rendered planet, so this always fires.
+                        if (mag > 0.01f)
+                        {
+                            relX = relX / mag * minClear;
+                            relZ = relZ / mag * minClear;
+                        }
+                        else
+                        {
+                            relX = minClear;
+                            relZ = 0f;
+                        }
+                    }
+
+                    xs.Add(parent.X + relX); zs.Add(parent.Z + relZ); radii.Add(moonRadius);
+                    if (best == 0)
+                    {
+                        homeMoons.Add(xs.Count - 1);
+                    }
+                }
+
+                // Landable asteroids, straight from their disc coords.
+                foreach (var b in system.Bodies)
+                {
+                    if (b.Id == home.Id || b.Kind != CelestialKind.AsteroidField)
+                    {
+                        continue;
+                    }
+
+                    string type = string.IsNullOrEmpty(b.PlanetType) ? "asteroid" : b.PlanetType;
+                    xs.Add((b.SystemX - home.SystemX) * SystemViewScale);
+                    zs.Add((b.SystemZ - home.SystemZ) * SystemViewScale);
+                    radii.Add(RadiusOf(b.Id, b.Kind, type));
+                }
+
+                var bx = xs.ToArray();
+                var bz = zs.ToArray();
+                var br = radii.ToArray();
+                SystemBodyLayout.SeparateXZ(bx, bz, br, homeX, homeZ, homeRadius, homeMoons.ToArray());
+
+                for (int a = 0; a < bx.Length; a++)
+                {
+                    bodiesChecked++;
+                    for (int c = a + 1; c < bx.Length; c++)
+                    {
+                        float dx = bx[a] - bx[c], dz = bz[a] - bz[c];
+                        float gap = MathF.Sqrt((dx * dx) + (dz * dz)) - br[a] - br[c];
+                        Assert.True(
+                            gap >= SystemBodyLayout.ClearGapFor(br[a], br[c]) - Tolerance,
+                            $"seed {seed} {system.Id}: bodies {a}/{c} left only {gap:0.00} of clear space");
+                    }
+                }
+
+                // The moons laid out in home's plane must clear home itself — home never gives way.
+                foreach (int a in homeMoons)
+                {
+                    float dx = bx[a] - homeX, dz = bz[a] - homeZ;
+                    float gap = MathF.Sqrt((dx * dx) + (dz * dz)) - br[a] - homeRadius;
+                    Assert.True(
+                        gap >= SystemBodyLayout.ClearGapFor(br[a], homeRadius) - Tolerance,
+                        $"seed {seed} {system.Id}: a moon of the launch body left only {gap:0.00} to it");
+                }
+            }
+        }
+
+        Assert.True(systemsChecked > 300, $"expected a broad sample, got {systemsChecked} systems");
+        Assert.True(bodiesChecked > 3000, $"expected a broad sample, got {bodiesChecked} bodies");
+    }
+}


### PR DESCRIPTION
Planets and their satellites were drawn almost touching in the space-flight view — moons in
particular looked glued to the surface of their parent planet. Analysed and measured before touching
anything (`analysis/space-view-body-spacing.md`); a probe replayed `SpaceView.BuildSystem`'s layout
math over real `UniverseGenerator` output across **2 400 systems / 26 951 bodies**.

## Root cause: two independent size models

`UniverseGenerator` places bodies with hand-picked constants (`MoonOrbit` 90, `OrbitStep` 520,
`BodyClearance` 470/290/215), while `SpaceView` derives a body's **rendered** radius from its real
walkable circumference — 11…27 view units for a planet, i.e. **69…169 system units**. So a moon's
star-map orbit (90 system units ≈ 14 view units) is always *inside* its own planet once drawn. The
same file declares that a planet needs a 470-unit berth while parking that planet's own moon at 90:
the two halves disagree by ~5×.

Measured consequences:

- The `minClear` clamp fired for **13 882 / 13 882 moons = 100 %**, pinning each at the flat
  `BodyGap = 8f` — *below* the 10-unit keep-out shell the ship itself is held at. The moon's seeded
  *angle* survived; its seeded *distance* was discarded entirely, making `MoonStep` dead code.
- Median nearest-neighbour gap over **all** bodies was **8.0** — the bare minimum. The relax pass
  displaced 17 % of bodies and was the de-facto layout.
- Planets were fine on average (median 185) but the tail near-touched (p10 54, min 8.0), because
  `pAngle` is a free random draw and two adjacent orbits can come out near-co-directional.
- Moons of the body you launched from could end up **inside** it (overlaps up to **16 units**): home
  is drawn at 3.2× and excluded from the relax pass, yet its own moons are laid out in *its* plane, so
  nothing stopped the pass from shoving one back in.

## The fix

Client-only, and deliberately so: `SystemX`/`SystemZ` are **not** touched.

- The gap rule and the relaxation move to `Shared/World/SystemBodyLayout.cs`, beside
  `WorldConstants.CircumferenceFor` — the size source the two stages were disagreeing about.
- The flat gap becomes `max(14, (rA + rB) · 0.55)`, applied to both the moon clamp and the relax pass,
  so two gas giants no longer get the same hairline as two pebbles. The floor sits above the ship's
  keep-out margin, so there is always a gap you can fly through.
- Home is passed in as a **fixed obstacle**: it never gives way, but it now pushes its own moons out.

| Surface gap (flight-view units) | before | after |
| --- | --- | --- |
| nearest neighbour, all bodies — median | 8.0 | **21.4** |
| nearest neighbour, all bodies — p10 / min | 8.0 / 8.0 | **14.0 / 14.0** |
| moon → its parent planet — median / min | 8.0 / — | **22.2 / 15.9** |
| moon of the launch body → it — min | **−16.1** | **39.1** |
| planet ↔ planet — min | 8.0 | 25.6 |
| cruise, star → outermost body | 28 s | 29 s |

## Two things I measured and then *didn't* do

- **Raising the relax iteration budget.** 24, 60, 200 and 600 iterations produce byte-identical
  output, and no pair is left overlapping in any of the 2 400 systems. The "iteration cap hit" flag
  only means `moved` was still set on the last pass (two constraints trading a body back and forth).
  Dropped as a no-op rather than shipped with a comment claiming a benefit it doesn't have.
- **Pushing *all* bodies away from home.** Home's rendered radius reaches 100 units, so a blanket
  obstacle would have redistributed the whole flight-plane layout for no visual gain — home hangs 150
  units below that plane. Narrowed to exactly the bodies laid out in home's plane.

## Why not fix the generator

Deriving moon orbits from the parent's real size is the deeper fix, but `SkyBodiesView.cs:319-338`
sizes bodies in the **surface sky** from real system-space distance (`clamp(250·radius/dist, 4, 120)`).
Moving moons from 90 to ~450 system units shrinks the parent planet seen from its moon from **47 →
9-12**, destroying the documented "fills a chunk of the sky" look, and stretches cruise to the
outermost body to 43 s. One global constant can't compensate (moon orbits would grow ~5×, planet
orbits only ~1.45×), so it needs its own parent/child-aware companion change. `SystemViewScale` is not
a cheap third way either — rendered radii are independent of it, so moons would need scale ≈ 0.5 and
3× the cruise time.

Left open and noted in TODO.md: landable asteroids are still the only body kind with **no** generator
separation pass, and `MoonStep` remains inert.

## Verification

- `SystemBodyLayoutTests` (new, 4 tests) asserts every pair keeps its clear gap across **320 real
  generated systems**, plus the gap rule's floor, its growth with body size, and the moon orbit.
- Clean Release rebuild: **0 warnings, 0 errors**.
- **Local Unity build** (client/Assets changed) succeeded; `BlocksBeyondTheStars.Client.dll` rebuilt —
  `SpaceView.cs` isn't covered by `dotnet build`, so this is the compile check that matters.
- The full local suite was still running under heavy CPU contention from parallel jobs when this PR
  opened; CI is the authoritative gate.

closes #493

🤖 Generated with [Claude Code](https://claude.com/claude-code)
