### PR TITLE
feat(worldgen): frozen water on cold worlds — ice sheets and solid-frozen seas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,20 @@ the richer, screenshot-laden versions live there. `(#123)` references the pull r
   to `/en`. Self-hosters can point both elsewhere or drop the link entirely
   (`BBS_WH_WEBSITE_URL` / `_EN`, `-` = off).
 
+### ❄️ Cold worlds freeze over
+- **Water on cold worlds now generates frozen.** Below the freeze line a sea, pond or river carries
+  a solid ice sheet — one to four blocks thick, growing with the cold — and in the deep cold
+  (ice-type worlds) the whole body freezes through to the seabed. The waterline is walkable: no more
+  diving into open water on a −38 °C planet. On merely-cold worlds (tundra, high mountain lakes on
+  temperate planets) liquid water survives **under** the sheet — mine through the hand-diggable ice
+  to reach the water, the kelp and the fish below, and take an oxygen reserve: under a closed sheet
+  you dig your way back out. Mined ice stacks and crafts into water by hand (2 ice → 1 water, as
+  before), so frozen worlds feed an algae tank just fine, and ice remains placeable as a building
+  block. Ships treat thickly frozen seas as solid ground and may land on them. Freeze edges are
+  noise-dithered, so partially frozen lakes with open patches appear right at the freeze line.
+  ⚠️ *One-time world change:* existing cold worlds freeze retroactively on next load (player-built
+  blocks are untouched). (#495, closes #494)
+
 ## [0.8.7] — 2026-07-25
 
 The homestead release: player bases and space stations get their first real life support. A new heal tank block heals, feeds and recharges everyone nearby, doubles as a settable home spawn point, and dying now lets you choose whether to wake up at your ship or at your base — plus the ship's console and lab stations finally do something, and glitch.fun visitors see Singleplayer first.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ the richer, screenshot-laden versions live there. `(#123)` references the pull r
   block. Ships treat thickly frozen seas as solid ground and may land on them. Freeze edges are
   noise-dithered, so partially frozen lakes with open patches appear right at the freeze line.
   ⚠️ *One-time world change:* existing cold worlds freeze retroactively on next load (player-built
-  blocks are untouched). (#495, closes #494)
+  blocks are untouched). (#501, closes #494)
 
 ## [0.8.7] — 2026-07-25
 

--- a/TODO.md
+++ b/TODO.md
@@ -100,6 +100,25 @@ Per-item detail lives in the dated work log below.
 
 ---
 
+### ★ Cold worlds freeze over: ice sheets + solid-frozen seas (#494, 2026-07-26, branch feat/frozen-water)
+Analysed first (`analysis/frozen-water-and-ice-sheets.md`); everything item-side already existed
+(ice block mineable by hand + placeable, `water_ice` hand recipe 2→1) — the whole feature is a
+worldgen freeze pass. The climate pass used to skip every submerged column (`surfaceY > waterTop`),
+so even −38 °C ice worlds pooled liquid seas. Now `IceSheetThickness` runs at the single fluid
+write site (covers seas, ponds, rivers, waterfall columns; lava never freezes): below the snow line
+the top 1–4 water cells become solid ice (1 block per started 7 °C, dithered like the snow pass so
+freeze edges wander), below −32 °C at the waterline — or when the sheet reaches the bed (shallow
+ponds) — the column freezes through. Ice worlds (−38±6) get walkable frozen seas; tundra (−22±6)
+gets sheets with liquid + kelp + fish **below** (mine through, mind your oxygen); temperate
+mountain lakes freeze via the existing lapse rate for free. Consistency: aquatic flora stays below
+the sheet (no lilies on ice, nothing in frozen-through columns); `TryGetWaterSurface` now reports
+the topmost LIQUID cell (fauna spawns under the ice) and returns false when frozen through;
+`IsSurfaceWater` counts frozen-solid or ≥3-sheet columns as LAND (ships may land on frozen seas —
+decided), thin sheets stay "water" so pads/chests avoid breakable crust; new public
+`SurfaceIceThickness`. Server-only — no new block key (no palette shift), no client change (ice
+renders/collides already; minimap stays stylized). ⚠️ Retroactive one-time change on existing cold
+worlds (seed+delta persistence) — announced in the Unreleased changelog next to #492's note.
+
 ### ★ Fleet admin: delete worlds + the portal links to the game website (2026-07-26, branch feat/worldhost-admin-delete-and-site-link)
 Two small WorldHost additions, both analysed first (`analysis/fleet-admin-world-delete.md`,
 `analysis/portal-website-link.md`).

--- a/docs/developer/WORLD_GENERATION.md
+++ b/docs/developer/WORLD_GENERATION.md
@@ -281,9 +281,12 @@ When a chunk is generated (`WorldGenerator.Generate(planet, coord)`):
 2. Resolve per-world constants: planet seed, biomes, deep/bedrock blocks, cave threshold, ore
    richness, mantle depth, flora multiplier (all seeded).
 3. Resolve fluids: sea level + type, pond mask, river field (memoised per world).
-4. Per column: surface height → water carve (pond/river/sea precedence) → biome index → optional
-   floating islands / crater floors → vertical fill (air/fluid, bedrock, floor band, caves,
-   surface/deep blocks, ore veins, rare data caches) → surface or aquatic flora.
+4. Per column: surface height → water carve (pond/river/sea precedence) → freeze pass (#494: below
+   the snow line a water column's top 1–4 cells become solid ice — frozen through to the seabed in
+   the deep cold, so cold worlds get walkable frozen seas you can mine into) → biome index →
+   optional floating islands / crater floors → vertical fill (air/fluid, bedrock, floor band, caves,
+   surface/deep blocks, ore veins, rare data caches) → surface or aquatic flora (kept below any ice
+   sheet; nothing grows in a frozen-through column).
 5. Feature stamps with cross-chunk margins: trees, giant mushrooms, geysers, and set-dressing
    (boulders, crystal shards, dead logs, monoliths, stone circles).
 6. Landing-pad flattening where a pad is reserved.

--- a/src/BlocksBeyondTheStars.WorldGeneration/WorldGenerator.cs
+++ b/src/BlocksBeyondTheStars.WorldGeneration/WorldGenerator.cs
@@ -817,11 +817,70 @@ public sealed class WorldGenerator
     private const double TreeLineC = -4.0;  // no trees / giant mushrooms above the tree line
     private const double FloraFadeHiC = 4.0, FloraFadeLoC = -8.0; // flora density ramps to zero across this band
 
+    // Frozen water (#494): below the snow line a water body carries a floating ice sheet that thickens
+    // with the cold; below DeepFreezeC at the waterline it freezes through to the seabed. A sheet of
+    // LandableIceSheet+ blocks is treated as land by the surface-water queries (ships may land on it).
+    private const double DeepFreezeC = -32.0; // waterline temperature below which a body freezes solid
+    private const int MaxIceSheet = 4;        // thickest floating sheet on a merely-cold world (blocks)
+    private const int LandableIceSheet = 3;   // a sheet this thick counts as land, not water
+
     /// <summary>Flora density multiplier for the cold: 1 in the warm lowlands, fading to 0 toward the ice.</summary>
     private static double ColdFloraFactor(WorldCalibration c, int surfaceY)
     {
         double t = TempAt(c, surfaceY);
         return System.Math.Clamp((t - FloraFadeLoC) / (FloraFadeHiC - FloraFadeLoC), 0.0, 1.0);
+    }
+
+    /// <summary>True when this world can freeze water at all (#494) — the snow pass's gate plus the ice
+    /// block itself. A cheap whole-world precheck: if even the highest point stays warm, no column can.</summary>
+    private bool CanFreezeWater(PlanetType planet, WorldCalibration calib)
+    {
+        bool airlessBody = planet.Cratered || _crateredWorld;
+        bool hasAtmosphere = !string.Equals(planet.Atmosphere, "none", System.StringComparison.OrdinalIgnoreCase);
+        return hasAtmosphere && !airlessBody
+            && !(_content.GetBlock("snow")?.NumericId ?? BlockId.Air).IsAir
+            && !(_content.GetBlock("ice")?.NumericId ?? BlockId.Air).IsAir
+            && TempAt(calib, calib.MaxHeight) < SnowLineC + 2.0;
+    }
+
+    /// <summary>Ice-sheet thickness (blocks, 0 = open water) for a water column whose surface sits at
+    /// <paramref name="waterTop"/> (#494): 0 above the freeze line, then 1 block per started 7 °C below
+    /// it (capped at <see cref="MaxIceSheet"/>), and the full <paramref name="depth"/> below
+    /// <see cref="DeepFreezeC"/> — or whenever the sheet would reach the seabed anyway (shallow ponds
+    /// freeze through). Dithered with the snow pass's noise shape so the freeze edge wanders raggedly
+    /// instead of cutting a temperature contour.</summary>
+    private int IceSheetThickness(WorldCalibration calib, long seed, int worldX, int worldZ, int waterTop, int depth)
+    {
+        double surfT = TempAt(calib, waterTop)
+            + (FbmT(seed + 0x1CE0, worldX, worldZ, 24.0, octaves: 2) - 0.5) * 3.0;
+        if (surfT >= SnowLineC)
+        {
+            return 0;
+        }
+
+        if (surfT < DeepFreezeC)
+        {
+            return depth; // frozen through, down to the seabed
+        }
+
+        int sheet = 1 + (int)((SnowLineC - surfT) / 7.0);
+        return System.Math.Min(System.Math.Min(sheet, MaxIceSheet), depth);
+    }
+
+    /// <summary>The generated ice on the water column at (x,z): 0 for a dry/lava/warm column, the sheet
+    /// thickness on a frozen one — equal to the full water depth when the body is frozen through (#494).
+    /// Mirrors exactly what <see cref="Generate"/> fills, like the other surface-water queries.</summary>
+    public int SurfaceIceThickness(PlanetType planet, int worldX, int worldZ)
+    {
+        var calib = CalibFor(planet);
+        if (!CanFreezeWater(planet, calib)) // cheap whole-world gate first — warm worlds pay nothing
+        {
+            return 0;
+        }
+
+        return TryGetRawWaterColumn(planet, worldX, worldZ, out int waterTopY, out int seabedY)
+            ? IceSheetThickness(calib, PlanetSeed(planet), worldX, worldZ, waterTopY, waterTopY - seabedY)
+            : 0;
     }
 
     /// <summary>The world's surface sea: which fluid fills its basins and up to what world-Y level (#473 —
@@ -1032,13 +1091,28 @@ public sealed class WorldGenerator
     {
         var (seaLevel, seaFluid) = ResolveSeaFluid(planet);
         var waterId = _content.GetBlock("water")?.NumericId ?? BlockId.Air;
-        if (seaFluid == waterId && !waterId.IsAir && SurfaceHeight(planet, worldX, worldZ) + 1 <= seaLevel)
+        bool water = (seaFluid == waterId && !waterId.IsAir && SurfaceHeight(planet, worldX, worldZ) + 1 <= seaLevel)
+            || SurfacePondDepth(planet, worldX, worldZ) > 0   // inside an upland pond
+            || SurfaceRiverDepth(planet, worldX, worldZ) > 0; // …or a river channel
+        if (!water)
         {
-            return true; // beneath the global sea
+            return false;
         }
 
-        return SurfacePondDepth(planet, worldX, worldZ) > 0   // inside an upland pond
-            || SurfaceRiverDepth(planet, worldX, worldZ) > 0; // …or a river channel
+        // Frozen columns (#494): a body frozen to the seabed, or capped by a thick sheet, is walkable
+        // land — ships may land on a frozen sea. Thin sheets (1–2 blocks) still count as water so
+        // landings and chests don't sit on breakable crust.
+        var calib = CalibFor(planet);
+        if (CanFreezeWater(planet, calib) && TryGetRawWaterColumn(planet, worldX, worldZ, out int top, out int bed))
+        {
+            int ice = IceSheetThickness(calib, PlanetSeed(planet), worldX, worldZ, top, top - bed);
+            if (ice >= top - bed || ice >= LandableIceSheet)
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /// <summary>True if this surface column is under a LAVA sea — or inside a volcano's molten summit
@@ -1055,11 +1129,33 @@ public sealed class WorldGenerator
         return seaFluid == lavaId && !lavaId.IsAir && SurfaceHeight(planet, worldX, worldZ) + 1 <= seaLevel;
     }
 
-    /// <summary>The local water column at a surface (x,z): true if water actually covers it — the global sea,
-    /// an upland pond, or a river — returning the water-surface Y (topmost filled cell) and the seabed Y (last
-    /// solid cell below the water). Mirrors what <see cref="Generate"/> fills, so the server can place and keep
-    /// aquatic life in ANY water body, not just the deep global sea. False (with 0s) for dry/lava columns.</summary>
+    /// <summary>The local LIQUID water column at a surface (x,z): true if water actually covers it — the
+    /// global sea, an upland pond, or a river — returning the liquid-surface Y (topmost water cell, i.e.
+    /// beneath any ice sheet, #494) and the seabed Y (last solid cell below the water). Mirrors what
+    /// <see cref="Generate"/> fills, so the server can place and keep aquatic life in ANY water body, not
+    /// just the deep global sea. False (with 0s) for dry/lava/frozen-through columns.</summary>
     public bool TryGetWaterSurface(PlanetType planet, int worldX, int worldZ, out int waterTopY, out int seabedY)
+    {
+        if (!TryGetRawWaterColumn(planet, worldX, worldZ, out waterTopY, out seabedY))
+        {
+            return false;
+        }
+
+        var calib = CalibFor(planet);
+        if (CanFreezeWater(planet, calib))
+        {
+            // Fauna lives below the ice sheet (#494) — report the topmost LIQUID cell.
+            waterTopY -= IceSheetThickness(calib, PlanetSeed(planet), worldX, worldZ, waterTopY, waterTopY - seabedY);
+        }
+
+        return waterTopY > seabedY; // frozen through → no water body left here
+    }
+
+    /// <summary>The water column at a surface (x,z) as generated BEFORE the freeze pass (#494) — surface Y
+    /// of the topmost filled (water or ice) cell and the seabed Y. The ice-aware public queries
+    /// (<see cref="TryGetWaterSurface"/>, <see cref="IsSurfaceWater"/>, <see cref="SurfaceIceThickness"/>)
+    /// layer the sheet on top of this.</summary>
+    private bool TryGetRawWaterColumn(PlanetType planet, int worldX, int worldZ, out int waterTopY, out int seabedY)
     {
         waterTopY = 0;
         seabedY = 0;
@@ -1195,6 +1291,7 @@ public sealed class WorldGenerator
         bool hasAtmosphere = !string.Equals(planet.Atmosphere, "none", System.StringComparison.OrdinalIgnoreCase);
         bool snowPossible = hasAtmosphere && !airlessBody && !snowId.IsAir
             && TempAt(calib, calib.MaxHeight) < SnowLineC + 2.0;
+        bool freezeWater = CanFreezeWater(planet, calib); // #494: cold water columns freeze from the top
 
         // Volcanoes (#477): watery worlds may carry basalt cones with molten summit craters.
         bool volcanoWorld = HasVolcanoes(planet);
@@ -1316,6 +1413,15 @@ public sealed class WorldGenerator
                     columnFluid = riverField.FillFluid; // water on watery worlds, lava on lava/ashen worlds (L2)
                 }
 
+                // Frozen water (#494): a cold column's water freezes from the waterline down — a walkable
+                // ice sheet with liquid below on merely-cold bodies, frozen through to the seabed in the
+                // deep cold or where the sheet reaches the bed anyway. Lava columns never freeze.
+                int iceTop = 0;
+                if (freezeWater && columnFluid == seaWaterId && !seaWaterId.IsAir && waterTop > seabedY)
+                {
+                    iceTop = IceSheetThickness(calib, seed, worldX, worldZ, waterTop, waterTop - seabedY);
+                }
+
                 // Per-column biome → surface/sub-surface blocks (single-biome worlds use index 0).
                 int biomeIndex = biomes.Count <= 1 ? 0 : BiomeIndex(calib, seed, worldX, worldZ, biomes.Count, surfaceY);
                 var biome = biomes[biomeIndex];
@@ -1372,7 +1478,9 @@ public sealed class WorldGenerator
                     {
                         if (worldY <= waterTop)
                         {
-                            chunk.Set(lx, ly, lz, columnFluid); // sea fill in a basin, or an upland pond above it
+                            // Sea fill in a basin, or an upland pond above it — the top of a cold column
+                            // reads as solid ice instead of water (#494).
+                            chunk.Set(lx, ly, lz, worldY > waterTop - iceTop ? iceId : columnFluid);
                         }
                         else if (floatingIslands && worldY >= islandBottom && worldY <= islandTop)
                         {
@@ -1469,12 +1577,14 @@ public sealed class WorldGenerator
                         chunk.Set(lx, fly, lz, floraId);
                     }
                 }
-                else if (waterFlora && columnFluid == seaWaterId && seabedY + 1 <= waterTop)
+                else if (waterFlora && columnFluid == seaWaterId && seabedY + 1 <= waterTop - iceTop)
                 {
                     // Submerged WATER column — the sea or an upland pond grows seabed plants / lily pads.
                     // The column-fluid check keeps kelp out of lava rivers and volcano craters (#477).
-                    StampWaterFlora(chunk, origin, lx, lz, seed, worldX, worldZ, seabedY, waterTop,
-                        kelpId, lilyId, coralId, seagrassId, floraDensity);
+                    // Plants stay below any ice sheet, and no lily pads float on a frozen surface (#494);
+                    // frozen-through columns (guard above) grow nothing at all.
+                    StampWaterFlora(chunk, origin, lx, lz, seed, worldX, worldZ, seabedY, waterTop - iceTop,
+                        kelpId, iceTop > 0 ? BlockId.Air : lilyId, coralId, seagrassId, floraDensity);
                 }
 
                 // Sky islands grow their own surface flora on top — a floating meadow, not a bare slab.

--- a/tests/BlocksBeyondTheStars.Tests/WorldGenerationTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/WorldGenerationTests.cs
@@ -656,4 +656,143 @@ public class WorldGenerationTests
         Assert.True(CountBlock(gen, planet, lava) > 0, "A volcanic world should pool lava in its basins.");
         Assert.Equal(0, CountBlock(gen, planet, water));
     }
+
+    [Fact]
+    public void IceWorld_SeaFreezesOver_NoDivingFromTheSurface()
+    {
+        // #494: on a deep-frozen world (ice type, −38 ± 6 °C at the waterline) every sea column carries
+        // at least a 4-block ice cap — often frozen through — so the waterline is walkable solid ice and
+        // there is no open water to fall into from the surface.
+        var content = Content();
+        var planet = content.GetPlanet("ice")!;
+        var gen = new WorldGenerator(7, content);
+        int sea = gen.SeaLevel(planet);
+        Assert.True(sea > int.MinValue, "expected the icy world to pool a (frozen) sea");
+        var iceId = content.GetBlock("ice")!.NumericId;
+        int cs = WorldConstants.ChunkSize;
+
+        var chunks = new System.Collections.Generic.Dictionary<ChunkCoord, ChunkData>();
+        BlockId At(int wx, int wy, int wz)
+        {
+            var c = new ChunkCoord(wx / cs, wy / cs, wz / cs);
+            if (!chunks.TryGetValue(c, out var ch))
+            {
+                chunks[c] = ch = gen.Generate(planet, c);
+            }
+
+            return ch.Get(wx % cs, wy % cs, wz % cs);
+        }
+
+        int verified = 0;
+        for (int x = 0; x < 1024 && verified < 12; x += 5)
+            for (int z = 0; z < 512 && verified < 12; z += 5)
+            {
+                int depth = sea - gen.SurfaceHeight(planet, x, z);
+                if (depth < 4)
+                {
+                    continue; // want genuinely deep sea columns — shallows freeze through trivially
+                }
+
+                int ice = gen.SurfaceIceThickness(planet, x, z);
+                Assert.True(ice >= 4, $"deep-frozen sea column at ({x},{z}) carries only {ice} ice");
+
+                // Whatever a would-be diver touches from above is solid ice, not water.
+                Assert.Equal(iceId, At(x, sea, z));
+                Assert.Equal(iceId, At(x, sea - 3, z));
+
+                // Any liquid the helper still reports sits BELOW the cap, never at the waterline.
+                if (gen.TryGetWaterSurface(planet, x, z, out int top, out _))
+                {
+                    Assert.True(top <= sea - 4, "liquid water reported inside the ice cap");
+                }
+
+                verified++;
+            }
+
+        Assert.True(verified > 0, "expected to find deep sea columns on the icy world");
+    }
+
+    [Fact]
+    public void TundraWorld_IceSheet_KeepsLiquidWaterBelow()
+    {
+        // #494: a merely-cold world (tundra, −22 ± 6 °C) freezes a 1..4-block sheet you can mine
+        // through — with real liquid water (and the fauna the helpers place there) underneath on deep
+        // bodies. The helper trio must agree exactly with the generated blocks.
+        var content = Content();
+        var planet = content.GetPlanet("tundra")!;
+        var gen = new WorldGenerator(7, content);
+        int sea = gen.SeaLevel(planet);
+        Assert.True(sea > int.MinValue, "expected the tundra world to pool a sea");
+        var iceId = content.GetBlock("ice")!.NumericId;
+        var waterId = content.GetBlock("water")!.NumericId;
+        int cs = WorldConstants.ChunkSize;
+
+        var chunks = new System.Collections.Generic.Dictionary<ChunkCoord, ChunkData>();
+        BlockId At(int wx, int wy, int wz)
+        {
+            var c = new ChunkCoord(wx / cs, wy / cs, wz / cs);
+            if (!chunks.TryGetValue(c, out var ch))
+            {
+                chunks[c] = ch = gen.Generate(planet, c);
+            }
+
+            return ch.Get(wx % cs, wy % cs, wz % cs);
+        }
+
+        int verified = 0;
+        for (int x = 0; x < 1024 && verified < 12; x += 5)
+            for (int z = 0; z < 512 && verified < 12; z += 5)
+            {
+                int surfaceY = gen.SurfaceHeight(planet, x, z);
+                int depth = sea - surfaceY;
+                if (depth < 6)
+                {
+                    continue; // deep water — a sheet (max 4) can never freeze it through
+                }
+
+                int ice = gen.SurfaceIceThickness(planet, x, z);
+                Assert.InRange(ice, 1, depth - 1);
+
+                // The liquid column the fauna spawner sees starts right under the sheet.
+                Assert.True(gen.TryGetWaterSurface(planet, x, z, out int top, out int bed));
+                Assert.Equal(sea - ice, top);
+                Assert.Equal(surfaceY, bed);
+
+                Assert.Equal(iceId, At(x, sea, z));           // frozen waterline…
+                Assert.Equal(iceId, At(x, sea - ice + 1, z)); // …down to the sheet's underside
+                Assert.Equal(waterId, At(x, top, z));         // liquid directly below it
+                verified++;
+            }
+
+        Assert.True(verified > 0, "expected to find deep sea columns on the tundra world");
+    }
+
+    [Fact]
+    public void WarmWorld_SeaStaysLiquid_NoIceSheet()
+    {
+        // #494 guard: the freeze pass must not touch warm seas — a jungle world's waterline stays
+        // open water, and the water-surface helper still reports the sea level itself.
+        var content = Content();
+        var planet = content.GetPlanet("jungle")!;
+        var gen = new WorldGenerator(7, content);
+        int sea = gen.SeaLevel(planet);
+        Assert.True(sea > int.MinValue, "expected the jungle world to pool a sea");
+
+        int verified = 0;
+        for (int x = 0; x < 512 && verified < 50; x += 5)
+            for (int z = 0; z < 512 && verified < 50; z += 5)
+            {
+                if (sea - gen.SurfaceHeight(planet, x, z) < 2)
+                {
+                    continue;
+                }
+
+                Assert.Equal(0, gen.SurfaceIceThickness(planet, x, z));
+                Assert.True(gen.TryGetWaterSurface(planet, x, z, out int top, out _));
+                Assert.Equal(sea, top);
+                verified++;
+            }
+
+        Assert.True(verified > 0, "expected to find sea columns on the jungle world");
+    }
 }


### PR DESCRIPTION
## What

Water on cold worlds now generates **frozen** (closes #494):

- Below the snow line every generated water body (sea, pond, routed river, waterfall column) carries a **solid ice sheet**, 1–4 blocks thick, growing 1 block per started 7 °C below freezing — dithered with the snow pass's noise so freeze edges wander raggedly instead of cutting a contour.
- Below ≈ **−32 °C** at the waterline — or wherever the sheet would reach the bed (shallow ponds) — the column **freezes through to the seabed**.
- Net effect: **ice worlds** (−38 ± 6 °C) get walkable solid-frozen seas (no diving into open water); **tundra worlds** (−22 ± 6 °C) get sheets with real liquid water, kelp and fish **underneath** — mine through the hand-diggable ice to reach them; **temperate mountain lakes** freeze for free via the existing altitude lapse. Lava never freezes.
- Everything item-side already existed and is unchanged: ice is hand-mineable, placeable, and the `water_ice` hand recipe (2 ice → 1 water) feeds the algae tank on frozen worlds.

## Consistency

- Aquatic flora stays below the sheet: no lily pads on a frozen surface, kelp capped under the ice, nothing grows in frozen-through columns.
- `TryGetWaterSurface` now reports the topmost **liquid** cell (fauna spawns under the sheet) and returns false when frozen through.
- `IsSurfaceWater` counts frozen-solid or ≥3-block-sheet columns as **land** — ships may land on frozen seas (decided in review of the analysis) — while thin 1–2 block sheets still count as water so landings/chests avoid breakable crust.
- New public `SurfaceIceThickness(planet, x, z)` mirrors the generated blocks exactly.

## Scope & risk

- **Server-only**, ~60 lines in `WorldGenerator.cs` + guards. No new block key → no palette/id migration. No client changes (ice already renders, collides, has footsteps).
- ⚠️ **One-time retroactive world change**: chunks regenerate from seed on load, so existing cold worlds freeze on next visit (player-built blocks survive as deltas). Announced in the Unreleased changelog next to the #492 note.
- Analysis: `analysis/frozen-water-and-ice-sheets.md` (local, gitignored).

## Tests

- 3 new worldgen tests: ice world → ≥4-block cap at the waterline and no liquid inside it; tundra world → sheet ∈ [1, depth) with `water` directly below the ice and helper/blocks agreement; jungle world → thickness 0 everywhere, `TryGetWaterSurface` still reports sea level.
- Full non-Slow suite locally: **1116 server + 125 client passing**, Release build with **0 warnings**.
- Note for local runs: the suite serializes on the global river-field lock when xunit runs 16-wide on this box (pre-existing since #492) — `dotnet test -- xUnit.MaxParallelThreads=4` runs it in 2 m 41 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
