### PR TITLE
fix(moderation): a kick that reached nobody no longer reports success

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ the richer, screenshot-laden versions live there. `(#123)` references the pull r
 - **The operator can never be banned or kicked** — not by a world owner's ban list, not by a kick, not
   even from the admin panel. Oversight of worlds where kids play must not be something anyone can switch
   off, and an operator locked out of their own fleet would have nobody left to lift it. (#496, #497)
+- A kick now says the truth: if the player is not in the world at that moment (or the world is asleep),
+  the owner reads *"the player is not in this world right now"* instead of a "kicked ✓" that never
+  happened. The block itself always holds — it decides the next join. (#502)
 
 ### 🪐 Room to fly between the worlds
 - **Planets and their moons no longer huddle together in space.** Out in the flight view, every moon

--- a/client/Assets/BlocksBeyondTheStars/Scripts/UiMainMenu.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/UiMainMenu.cs
@@ -1185,8 +1185,12 @@ namespace BlocksBeyondTheStars.Client
                     return;
                 }
 
+                // The block always holds; the kick behind it only reaches someone who is in the world right
+                // now (#502). Saying "blocked ✓" alone would imply they were thrown out — they weren't.
                 warn.color = UiKit.Ok;
-                warn.text = shell.L("ui.portal.blocked_ok");
+                warn.text = r.Kicked
+                    ? shell.L("ui.portal.blocked_ok")
+                    : shell.L("ui.portal.blocked_ok") + " " + shell.L("ui.portal.kick_not_online");
                 done?.Invoke();
             }
 
@@ -1222,8 +1226,10 @@ namespace BlocksBeyondTheStars.Client
                     return;
                 }
 
-                warn.color = UiKit.Ok;
-                warn.text = shell.L("ui.portal.kicked_ok");
+                // A kick that reached nobody is not a success story — the player may be offline, the world
+                // asleep, or the instance still on an image without the kick endpoint (#502).
+                warn.color = r.Kicked ? UiKit.Ok : warnCol;
+                warn.text = shell.L(r.Kicked ? "ui.portal.kicked_ok" : "ui.portal.kick_not_online");
             }
 
             async void DoFeedbackSend(string message, Text warn)

--- a/data/locales/de.json
+++ b/data/locales/de.json
@@ -914,6 +914,7 @@
   "ui.portal.block_reason": "Grund (der Spieler sieht ihn)",
   "ui.portal.blocked_ok": "Gesperrt ✓",
   "ui.portal.kicked_ok": "Rausgeworfen ✓",
+  "ui.portal.kick_not_online": "Der Spieler ist gerade nicht in dieser Welt.",
   "ui.notice.title": "Nachricht vom Portal",
   "ui.notice.banned_title": "Dein Konto ist gesperrt",
   "ui.notice.banned_perm": "Die Sperre gilt, bis wir sie aufheben.",

--- a/data/locales/en.json
+++ b/data/locales/en.json
@@ -913,6 +913,7 @@
   "ui.portal.block_reason": "reason (the player sees it)",
   "ui.portal.blocked_ok": "Blocked ✓",
   "ui.portal.kicked_ok": "Kicked ✓",
+  "ui.portal.kick_not_online": "The player is not in this world right now.",
   "ui.notice.title": "Message from the portal",
   "ui.notice.banned_title": "Your account is blocked",
   "ui.notice.banned_perm": "The block stays until we lift it.",

--- a/src/BlocksBeyondTheStars.Client.Core/Portal/PortalClient.cs
+++ b/src/BlocksBeyondTheStars.Client.Core/Portal/PortalClient.cs
@@ -106,6 +106,22 @@ namespace BlocksBeyondTheStars.Client.Portal
         public long LastSeenUnix { get; set; }
     }
 
+    /// <summary>Outcome of a moderation action that also tries to end a running session (#502). The action
+    /// succeeding says nothing about whether anyone was actually thrown out: the player may be offline, the
+    /// world asleep, or the instance still on an image that predates the kick endpoint — so
+    /// <see cref="Kicked"/> is what the UI must report, not a bare HTTP 200.</summary>
+    public sealed class PortalKickResult
+    {
+        public bool Ok { get; set; }
+        public string Error { get; set; } = string.Empty;
+
+        /// <summary>Stable machine code of the error (empty on success/unknown) — the UI localizes it.</summary>
+        public string Code { get; set; } = string.Empty;
+
+        /// <summary>True only when a running instance accepted the kick for that player.</summary>
+        public bool Kicked { get; set; }
+    }
+
     /// <summary>Owner view of a world's moderation state: who is blocked, and who could be.</summary>
     public sealed class PortalWorldBansResult
     {
@@ -340,11 +356,12 @@ namespace BlocksBeyondTheStars.Client.Portal
         }
 
         /// <summary>Owner-only: bar a player from this world; <paramref name="kick"/> also ends a session
-        /// already in progress (a block alone only decides the next join).</summary>
-        public PortalSimpleResult AddWorldBan(string session, string worldId, string playerName, string accountId, string reason, bool kick = true)
+        /// already in progress (a block alone only decides the next join). The answer reports whether that
+        /// kick actually reached anyone — the block itself holds either way.</summary>
+        public PortalKickResult AddWorldBan(string session, string worldId, string playerName, string accountId, string reason, bool kick = true)
         {
             var (status, body) = Post($"/api/worlds/{worldId}/bans", new { playerName, accountId, reason, kick }, session);
-            return ParseSimple(status, body);
+            return ParseKick(status, body);
         }
 
         /// <summary>Owner-only: lift a block.</summary>
@@ -354,11 +371,13 @@ namespace BlocksBeyondTheStars.Client.Portal
             return ParseSimple(status, body);
         }
 
-        /// <summary>Owner-only: end one player's session on this world, without a lasting block.</summary>
-        public PortalSimpleResult KickFromWorld(string session, string worldId, string playerName, string? reason = null)
+        /// <summary>Owner-only: end one player's session on this world, without a lasting block. A 200 only
+        /// means the request was understood — see <see cref="PortalKickResult.Kicked"/> for whether anyone
+        /// was actually thrown out.</summary>
+        public PortalKickResult KickFromWorld(string session, string worldId, string playerName, string? reason = null)
         {
             var (status, body) = Post($"/api/worlds/{worldId}/kick", new { playerName, reason }, session);
-            return ParseSimple(status, body);
+            return ParseKick(status, body);
         }
 
         /// <summary>Deletes the account, ALL its worlds and their saves — irreversible (DSGVO Art. 17).</summary>
@@ -456,6 +475,27 @@ namespace BlocksBeyondTheStars.Client.Portal
             }
 
             return state;
+        }
+
+        public static PortalKickResult ParseKick(int status, string body)
+        {
+            var result = new PortalKickResult();
+            if (!Succeeded(status, body, out string error, out string code, out JsonDocument? doc))
+            {
+                result.Error = error;
+                result.Code = code;
+                return result;
+            }
+
+            using (doc)
+            {
+                result.Ok = true;
+                result.Kicked = doc != null
+                                && doc.RootElement.TryGetProperty("kicked", out var kicked)
+                                && kicked.ValueKind == JsonValueKind.True;
+            }
+
+            return result;
         }
 
         public static PortalWorldBansResult ParseWorldBans(int status, string body)

--- a/src/BlocksBeyondTheStars.WorldHost/WorldHostPortalPages.cs
+++ b/src/BlocksBeyondTheStars.WorldHost/WorldHostPortalPages.cs
@@ -348,6 +348,7 @@ function v(id){return document.getElementById(id).value.trim();}
                 modBlocked = T("Gesperrt.", "Blocked."),
                 modUnblocked = T("Entsperrt.", "Unblocked."),
                 modKicked = T("Rausgeworfen.", "Kicked."),
+                modNotOnline = T("Der Spieler ist gerade nicht in dieser Welt.", "The player is not in this world right now."),
                 st = new
                 {
                     stopped = T("gestoppt", "stopped"),
@@ -608,13 +609,17 @@ async function loadBans(id){
 }
 async function banPlayer(id, playerName, accountId){
   const reason = (document.getElementById('bans-reason-'+id)||{}).value || '';
-  if(await api('POST',`/api/worlds/${id}/bans`,{playerName, accountId, reason, kick:true})){ say(L.modBlocked); loadBans(id); }
+  // The block always holds; the kick behind it only reaches someone who is in the world right now (#502).
+  const j = await api('POST',`/api/worlds/${id}/bans`,{playerName, accountId, reason, kick:true});
+  if(j){ say(j.kicked ? L.modBlocked : L.modBlocked + ' ' + L.modNotOnline); loadBans(id); }
 }
 async function unbanPlayer(id, banId){
   if(await api('DELETE',`/api/worlds/${id}/bans/${banId}`)!==null){ say(L.modUnblocked); loadBans(id); }
 }
 async function kickPlayer(id, playerName){
-  if(await api('POST',`/api/worlds/${id}/kick`,{playerName})){ say(L.modKicked); }
+  // A 200 only means the request was understood — `kicked` says whether anyone was actually thrown out.
+  const j = await api('POST',`/api/worlds/${id}/kick`,{playerName});
+  if(j){ say(j.kicked ? L.modKicked : L.modNotOnline); }
 }
 function v(id){return document.getElementById(id).value.trim();}
 function esc(s){return String(s).replace(/[&<>""']/g, c=>({'&':'&amp;','<':'&lt;','>':'&gt;','""':'&quot;',""'"":'&#39;'}[c]));}

--- a/tests/BlocksBeyondTheStars.Client.Tests/PortalClientTests.cs
+++ b/tests/BlocksBeyondTheStars.Client.Tests/PortalClientTests.cs
@@ -86,6 +86,25 @@ public sealed class PortalClientTests
         Assert.Equal("Unknown report category.", bad.Error);
     }
 
+    [Fact]
+    public void ParseKick_SeparatesTheRequestFromTheOutcome()
+    {
+        // The action succeeding says nothing about whether anyone was thrown out (#502): the player may be
+        // offline, the world asleep, or the instance still on an image without the kick endpoint. The UI
+        // has to report `kicked`, not the HTTP status, or a block reads as "gone" when nothing happened.
+        Assert.True(PortalClient.ParseKick(200, "{\"kicked\":true}").Kicked);
+        var missed = PortalClient.ParseKick(200, "{\"ok\":true,\"kicked\":false}");
+        Assert.True(missed.Ok);
+        Assert.False(missed.Kicked);
+
+        // An older WorldHost that answers a bare 200 must read as "not kicked", never as success.
+        Assert.False(PortalClient.ParseKick(200, "{}").Kicked);
+
+        var denied = PortalClient.ParseKick(403, "{\"error\":\"This player name is reserved.\",\"code\":\"name_reserved\"}");
+        Assert.False(denied.Ok);
+        Assert.Equal("name_reserved", denied.Code);
+    }
+
     // ---------------- Portal parity (#268-#270) ----------------
 
     [Fact]


### PR DESCRIPTION
A world owner used to read "kicked ✓" when nothing had happened.

## Why

Both kick paths (`POST /api/worlds/{id}/kick` and the kick behind a world block) answer `{"kicked": true|false}`. It is `false` whenever the player is not in the world at that moment, the world is asleep, or — right now, until the fleet rolls to a new server image — the instance still runs a build that predates the kick endpoint. Both clients threw the flag away and reported success on any HTTP 200.

The block itself was never affected: it is enforced at the join grant and holds regardless. Only the feedback lied, and it lied in the direction that matters — an owner who believes the griefer is gone stops watching.

## What changed

- `PortalClient` surfaces the outcome (`PortalKickResult` / `ParseKick`), used by both the kick and the block-with-kick.
- The game client and the portal say *"Der Spieler ist gerade nicht in dieser Welt." / "The player is not in this world right now."* instead — and for a block, that sentence is appended to the "blocked ✓", because the block did succeed.
- A bare `200` without the flag reads as **not** kicked, so an older WorldHost degrades to the honest message rather than the flattering one.

## Verification

- 137 client-core tests green, including a new `ParseKick` test covering true / false / missing-flag / 403.
- `dotnet format --verify-no-changes` clean, local Unity Windows build clean (0 CS diagnostics).

closes #502

🤖 Generated with [Claude Code](https://claude.com/claude-code)
