### PR TITLE
fix(transport): abort the gateway listener on stop — no more 2-minute teardown tail

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -6439,6 +6439,45 @@ asteroids change type and relief — a one-time change like #492/#501, and relea
 
 ---
 
+## ✅ Done (2026-07-27): why a 183 ms test measured 120–209 s on CI — gateway teardown tail + xUnit lock convoy (#536)
+
+Analysis: `analysis/ci-test-duration-flakiness.md` (all numbers from real CI TRX artifacts plus A/B re-runs
+of the fast tier in a `--cpus=2` Linux container). The fast-tier guardrail kept tripping on
+`WebSocketTransportTests` with 118–209 s durations for tests that do 183 ms of work in isolation. It was
+**two stacked mechanisms**, not one:
+
+**1. The managed HttpListener's teardown tail (~120 s, fixed here).** TRX timelines from both failing CI
+runs show the stretched test is always the LAST of the transport class to run and spends its final
+100–190 s alone on an idle machine — a wait, not contention. On Linux, `HttpListener.Stop()/Close()` wait
+for every connection the listener still tracks, and a connection with no in-flight request is only
+reclaimed by the ~2-minute idle sweep. A/B in the container: `Stop()+Close()` 5 m 51 s suite total,
+`Abort()` **3 m 41 s** — tail gone. `WebSocketServerTransport.Stop()` now calls `_listener.Abort()`;
+correct in production too, where Dispose runs after the drain + save and an idle parked browser connection
+would otherwise delay a stopping hosted world's process exit by up to ~2 min (the quieter sibling of #519).
+
+**2. xUnit v2's limited SynchronizationContext queues async-test continuations behind CPU-bound test
+bodies.** `maxParallelThreads` (default = core count) is enforced by routing every test-body `await`
+continuation through N dedicated workers; a worldgen body that computes for 30 s without awaiting holds one
+the whole time, so socket tests' wall durations measure the queue (a 9 ms test has measured 37 s; the
+WorldStopAndKill test 123.3 s for 89 ms of work). The counter-experiment `maxParallelThreads: -1` was
+**killed after 24 min** (baseline 5 m 51 s): container load sat at ~1.0 on 2 CPUs — threads parked in the
+static worldgen-cache lock convoy (`_riverLock`/`_calibLock`), the same pathology that stalls the local
+full suite for 20+ min at 16 threads. So the Slow tags on real-socket tests stay, and the guardrail keeps
+its documented looseness.
+
+**Shipped:** the `Abort()` teardown, plus a committed `tests/BlocksBeyondTheStars.Tests/xunit.runner.json`
+pinning `maxParallelThreads: 4` — a no-op on the 4-core CI runner, but locally it replaces the
+easy-to-forget `-- xUnit.MaxParallelThreads=4` incantation (2 m 41 s vs a 20+ minute stall on a 16-core
+box). The copy-to-output is an explicit `<None>` item: xunit.core's auto-copy did not fire in container
+builds, and a runner config that silently fails to deploy reverts the suite to the stall.
+
+**Sharding across runners was evaluated and rejected with numbers:** the per-project split is 2 m 54 s vs
+4 s (#535), the full suite (~11 min, main/release only) runs off every critical path (release's WebGL leg
+is ~31.6 min), and intra-project class-bucket sharding would pay N× ~1 min fixed overhead plus a
+required-check rename to shave minutes nobody waits on.
+
+---
+
 ## ✅ Done (2026-07-27): hosted worlds were hard-killed on every operator stop — no save (#519)
 
 Analysis: `analysis/hosted-world-stop-signal.md`. Pressing **stop** in `/admin` hung the page for two minutes

--- a/src/BlocksBeyondTheStars.Networking/Transport/WebSocketServerTransport.cs
+++ b/src/BlocksBeyondTheStars.Networking/Transport/WebSocketServerTransport.cs
@@ -513,12 +513,24 @@ public sealed class WebSocketServerTransport : IServerTransport
     {
         _running = false;
         _cts.Cancel();
-        try { _listener.Stop(); } catch { }
+
+        // Abort(), not Stop()+Close() (#536): on Linux the managed HttpListener's graceful teardown waits
+        // for every connection it still tracks, and a connection with no in-flight request is only
+        // reclaimed by the listener's ~2-minute idle sweep. Measured: whichever transport test tore down
+        // last paid ~120 s alone on an idle machine (5 m 51 s → 3 m 41 s suite total with Abort), and in
+        // production an idle browser connection parked on the gateway would delay a stopping hosted
+        // world's process exit the same way. Stop() only ever runs when the transport is going away — the
+        // gameplay drain + save happened upstream — so a hard close is the correct semantic: WebSocket
+        // peers are torn down via _cts anyway, and an unserved idle socket on a dying server gets a reset
+        // instead of a silently dead keep-alive.
+        try { _listener.Abort(); } catch { }
     }
 
     public void Dispose()
     {
         Stop();
+        // No-op after the Abort() above (the listener is already torn down) — kept because CA2213 wants a
+        // Close/Dispose call on the field, and a disposed listener's Close returns immediately.
         try { _listener.Close(); } catch { }
         _cts.Dispose();
     }

--- a/tests/BlocksBeyondTheStars.Tests/BlocksBeyondTheStars.Tests.csproj
+++ b/tests/BlocksBeyondTheStars.Tests/BlocksBeyondTheStars.Tests.csproj
@@ -21,6 +21,13 @@
     <Using Include="Xunit" />
   </ItemGroup>
 
+  <!-- Explicit on purpose: xunit.core's auto-copy of xunit.runner.json did not fire in our container
+       builds, and a runner config that silently fails to deploy reverts the suite to core-count
+       parallelism — the 20-minute lock-convoy stall it exists to prevent (#536). -->
+  <ItemGroup>
+    <None Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\BlocksBeyondTheStars.Shared\BlocksBeyondTheStars.Shared.csproj" />
     <ProjectReference Include="..\..\src\BlocksBeyondTheStars.WorldGeneration\BlocksBeyondTheStars.WorldGeneration.csproj" />

--- a/tests/BlocksBeyondTheStars.Tests/WebSocketTransportTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/WebSocketTransportTests.cs
@@ -109,13 +109,13 @@ public sealed class WebSocketTransportTests : IDisposable
     }
 
     [Fact]
-    [Trait("Category", "Slow")] // 183 ms in isolation (measured on Linux in a container), but 178.8 s and
-                                // 208.9 s on two consecutive loaded PR runners on 2026-07-27 — both AFTER
-                                // #536's clean-close fix, which made this rarer without removing it. What
-                                // stretches is the runner's scheduling, not the code under test, so the
-                                // fast-tier budget cannot hold it. Same symptom and same reasoning as
-                                // Gateway_DropsAConnectionThatNeverSendsAsync below; full runs on main and
-                                // release still cover it. Real cause tracked in #536 (reopened).
+    [Trait("Category", "Slow")] // 183 ms in isolation, 118-209 s inside a loaded fast tier (#536). The
+                                // ~120 s teardown-sweep share of that is fixed (transport Stop() now
+                                // Abort()s the listener), but the second mechanism remains: xUnit v2 funnels
+                                // every await continuation through maxParallelThreads workers, and this
+                                // test's HTTP hops queue behind CPU-bound worldgen test bodies — its wall
+                                // duration measures that queue, not the gateway. Full runs on main and
+                                // release still cover it. Evidence: analysis/ci-test-duration-flakiness.md.
     public async Task Gateway_AcceptLoop_SurvivesAFaultingRequestAsync()
     {
         int port = FreeTcpPort();

--- a/tests/BlocksBeyondTheStars.Tests/WebSocketTransportTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/WebSocketTransportTests.cs
@@ -149,6 +149,12 @@ public sealed class WebSocketTransportTests : IDisposable
     }
 
     [Fact]
+    [Trait("Category", "Slow")] // 22 ms locally, 132 s on a loaded PR runner (2026-07-27) with the
+                                // teardown tail already fixed — pure continuation queueing: three
+                                // ConnectAsync hops re-queue behind CPU-bound worldgen bodies on xUnit's
+                                // maxParallelThreads workers (mechanism 2 in
+                                // analysis/ci-test-duration-flakiness.md). Same call as its two Slow
+                                // neighbours; full runs on main and release still cover the cap.
     public async Task Gateway_RejectsConnectionsBeyondTheCapAsync()
     {
         int port = FreeTcpPort();

--- a/tests/BlocksBeyondTheStars.Tests/xunit.runner.json
+++ b/tests/BlocksBeyondTheStars.Tests/xunit.runner.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "_comment": "maxParallelThreads pinned to 4 (issue #536): the suite is dominated by CPU-bound worldgen tests that all funnel through WorldGenerator's static caches (_riverLock/_calibLock). On a 16-core dev box the default (= core count) parks 16 workers in that lock convoy and the full suite stalls for 20+ minutes; at 4 it finishes in ~2m41s. The 4-core CI runner is unchanged (default was already 4). Measured 2026-07-27, analysis/ci-test-duration-flakiness.md.",
+  "maxParallelThreads": 4
+}


### PR DESCRIPTION
Root cause found and measured — it was **two stacked mechanisms**, not one. Full evidence chain in
`analysis/ci-test-duration-flakiness.md` (repo checkout); all numbers from the real CI TRX artifacts of
runs 30266565660 / 30269332359 plus A/B re-runs of the fast tier in a `dotnet/sdk:10.0` container pinned
to `--cpus=2`.

## Mechanism 1 — the managed HttpListener's ~120 s teardown tail (fixed)

TRX timelines from both failing runs show the stretched test is always the **last test of
`WebSocketTransportTests` to run**, it finishes last in the whole suite, and its overlap with other tests
ends early — it spends its final 100–190 s **alone on an idle machine**. That is a wait, not contention.
On Linux the managed `HttpListener.Stop()/Close()` wait for every connection the listener still tracks,
and a connection with no in-flight request is only reclaimed by the ~2-minute idle sweep (the first fix
here — clean 500 + `KeepAlive=false` — narrowed the leak but something still lingers at teardown).

A/B proof, fast tier, identical tree except one line:

| teardown | suite total (`--cpus=2`) |
|---|---|
| `_listener.Stop()` + `Close()` (before) | 5 m 51 s — last transport test ends ~110 s after everything else |
| `_listener.Abort()` | **3 m 41 s** — tail gone |

Production angle: `Program.cs` disposes the transport after `Run()` returns (drain + save already done),
so an idle browser connection parked on the gateway delays a stopping hosted world's process exit by up
to ~2 min on Linux — the quieter sibling of #519. `Abort()` is the correct semantic there too.

## Mechanism 2 — xUnit v2 queues async continuations behind CPU-bound test bodies (mitigated, by design)

Even with `Abort()`, the transport test showed 200 s of measured duration inside a 221 s run — it was
in flight nearly the whole suite. xUnit 2.5.3 enforces `maxParallelThreads` (default = core count) via
`MaxConcurrencySyncContext`: N dedicated workers run test bodies AND receive every `await` continuation.
A worldgen body computing 30 s without awaiting holds a worker the whole time; socket tests' wall
durations measure that queue (ci.yml's "a 9 ms test has measured 37 s"; `WorldStopAndKillTests` measured
123.3 s for 89 ms of work the same day).

Counter-experiment `maxParallelThreads: -1` (no limiter, continuations on the raw pool): **killed after
24 minutes** (baseline 5 m 51 s). Container load sat at ~1.0 on 2 CPUs — threads were parked in the
static worldgen-cache lock convoy (`WorldGenerator._riverLock`/`_calibLock`), the same pathology that
stalls the local full suite 20+ min at 16 threads. More parallelism makes this suite slower. So: the
Slow tags on real-socket tests stay, and the guardrail keeps its documented looseness.

## Shipped

1. `WebSocketServerTransport.Stop()` uses `_listener.Abort()` — kills the tail in CI and the shutdown
   delay in production.
2. Committed `tests/BlocksBeyondTheStars.Tests/xunit.runner.json` with `maxParallelThreads: 4` — no-op on
   the 4-core CI runner, but locally it replaces the easy-to-forget `-- xUnit.MaxParallelThreads=4`
   (2 m 41 s vs a 20+ min stall on a 16-core box). Explicit `<None CopyToOutputDirectory>` because
   xunit.core's auto-copy did not fire in container builds.

Sharding the suite across runners was evaluated against the same data and rejected: per-project split is
2 m 54 s vs 4 s (#535), the full suite (~11 min) runs off every critical path (release WebGL leg
~31.6 min), and class-bucket sharding pays N× ~1 min fixed overhead plus a required-check rename to save
minutes nobody waits on.

closes #536

🤖 Generated with [Claude Code](https://claude.com/claude-code)
