### PR TITLE
feat(release): switch to date-based CalVer versioning YYYY.MM.N

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,10 +146,17 @@ problems are caught locally instead of at release time:
 ## Releases & versioning
 
 Releases are built in the cloud by [.github/workflows/release.yml](.github/workflows/release.yml) — never
-build a release locally for distribution. Cut one by pushing a SemVer tag:
+build a release locally for distribution. **Versions are date-based (CalVer) since 2026-07: `vYYYY.MM.N`**
+— year, month, then the release counter within that month (July's second release is `v2026.7.2`; August
+restarts at `v2026.8.1`). No leading zeros and never a fourth part: the scheme must stay valid 3-part
+SemVer2, because Velopack (and the whole update feed) parses versions as strict SemVer — `v2026.07.1`
+or `v2026.7.27.1` would be rejected/normalized. Releases up to `v0.9.1` used SemVer; the switch is
+one-way (any `0.x`/`1.x` tag would be a downgrade for every installed client and is never offered as an
+update — see [ADR 0012](docs/developer/adr/0012-calver-date-based-versioning.md)). Cut a release by
+pushing the tag:
 
 ```bash
-git tag v0.3.0 && git push origin v0.3.0
+git tag v2026.7.2 && git push origin v2026.7.2
 ```
 
 **Before tagging: refresh the in-game "What's new?" feed (#543).** The main menu shows the devblog
@@ -192,7 +199,9 @@ value. `BuildScript` writes `version.txt`; a CI guard fails the build if the bak
 committed `bundleVersion` is `0.1.0-dev` for local/dev builds. Keep `Networking/Protocol.Version` (wire
 compatibility) separate — it is not the game version. Gotchas if you touch this: GameCI *always* overrides
 `bundleVersion` (drive it via `versioning: Custom`, don't fight it with `-buildVersion`); Velopack needs
-`packVersion >= 0.0.1` (so dev is `0.1.0-dev`, not `0.0.0-*`); after `git push` wait ~20 s before
+`packVersion >= 0.0.1` (so dev is `0.1.0-dev`, not `0.0.0-*`); the WiX MSI's ProductVersion major field
+maxes out at 255, so `publish-client-installer.ps1` maps the CalVer year down for the MSI only
+(`2026.7.1` → `26.7.1` in Apps & Features — everything else shows the full version); after `git push` wait ~20 s before
 `gh workflow run` or it dispatches the previous commit. macOS *client* installers are intentionally not
 built (out of scope for now — a native macOS client would need its own graphics (Metal/Vulkan) and
 Apple code-signing/notarization work).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,16 +147,18 @@ problems are caught locally instead of at release time:
 
 Releases are built in the cloud by [.github/workflows/release.yml](.github/workflows/release.yml) — never
 build a release locally for distribution. **Versions are date-based (CalVer) since 2026-07: `vYYYY.MM.N`**
-— year, month, then the release counter within that month (July's second release is `v2026.7.2`; August
-restarts at `v2026.8.1`). No leading zeros and never a fourth part: the scheme must stay valid 3-part
+— year, month, then the release counter within that month (a month's third release is `v2026.8.3`; the
+next month restarts at `.1`). No leading zeros and never a fourth part: the scheme must stay valid 3-part
 SemVer2, because Velopack (and the whole update feed) parses versions as strict SemVer — `v2026.07.1`
-or `v2026.7.27.1` would be rejected/normalized. Releases up to `v0.9.1` used SemVer; the switch is
+or `v2026.7.27.1` would be rejected/normalized. Releases up to `v0.9.1` used SemVer and count toward
+their month's counter — July 2026 already had 18 releases, so **the first CalVer release is
+`v2026.7.19`** (if it ships in July; in August it is `v2026.8.1`). The switch is
 one-way (any `0.x`/`1.x` tag would be a downgrade for every installed client and is never offered as an
 update — see [ADR 0012](docs/developer/adr/0012-calver-date-based-versioning.md)). Cut a release by
 pushing the tag:
 
 ```bash
-git tag v2026.7.2 && git push origin v2026.7.2
+git tag v2026.7.19 && git push origin v2026.7.19
 ```
 
 **Before tagging: refresh the in-game "What's new?" feed (#543).** The main menu shows the devblog

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,24 @@
 
 All notable changes to **Blocks Beyond the Stars** are documented here.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
-and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
-(pre-1.0: minor bumps carry features, patch bumps carry fixes and small additions).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+Versions are date-based (CalVer) `YYYY.MM.N` — year, month, release counter within the month
+(e.g. `2026.7.2`; SemVer2-valid, so no leading zeros and never a fourth part — see
+[ADR 0012](docs/developer/adr/0012-calver-date-based-versioning.md)). Releases up to
+[0.9.1] followed [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 Each release below mirrors its [GitHub release notes](https://github.com/marceld23/BlocksBeyondTheStars/releases);
 the richer, screenshot-laden versions live there. `(#123)` references the pull request or issue.
 
 ## [Unreleased]
+
+### 📅 Date-based versions
+- **The version scheme switches from SemVer to CalVer `YYYY.MM.N`** (year, month, release counter
+  within the month) — this release is the first under the new scheme; v0.9.1 was the last SemVer
+  release. The tag stays the single source of truth and the format stays SemVer2-compatible, so
+  auto-updates keep working across the switch. The machine-wide MSI shows the year mapped down
+  (`26.x.x`) in Apps & Features because Windows Installer caps its major version field at 255 —
+  all other surfaces show the full version.
 
 ### 🔔 The game finally tells you about updates (#543)
 - **Update notice on startup.** An installed client now quietly checks for a newer release while the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ the richer, screenshot-laden versions live there. `(#123)` references the pull r
   auto-updates keep working across the switch. The machine-wide MSI shows the year mapped down
   (`26.x.x`) in Apps & Features because Windows Installer caps its major version field at 255 —
   all other surfaces show the full version.
+- **The MSI install wizard's finish page now shows a copyright line** (© year JuMaVe Games).
 
 ### 🔔 The game finally tells you about updates (#543)
 - **Update notice on startup.** An installed client now quietly checks for a newer release while the

--- a/TODO.md
+++ b/TODO.md
@@ -24,7 +24,9 @@ envelope at the WebSocket edge; deterministic seed world-gen; SQLite default per
 
 Published GitHub Releases (tag = version single-source-of-truth; each tag push builds the Windows installer
 trio, pushes the dedicated-server Docker image to GHCR and mirrors the builds to itch.io). Newest first.
-Per-item detail lives in the dated work log below.
+Per-item detail lives in the dated work log below. **Since 2026-07 versions are date-based (CalVer)
+`YYYY.MM.N`** — year.month.counter, valid SemVer2, one-way switch (no `1.0` ever) — see
+[ADR 0012](docs/developer/adr/0012-calver-date-based-versioning.md); releases up to v0.9.1 used SemVer.
 
 - **v0.6.2** — 2026-06-30 — *gameplay polish, oxygen tiers & a browser-client start.* **Gameplay fixes** —
   shaped blocks (sphere/pyramid/slab) now get masked silhouette icons in the hotbar/crafting instead of plain

--- a/docs/developer/DEVELOPER.md
+++ b/docs/developer/DEVELOPER.md
@@ -221,7 +221,9 @@ Useful parameters:
 
 To package the built player locally as a Velopack installer/update feed, run
 `scripts/publish-client-installer.ps1` after a successful `build-client.ps1` (it ships the launcher exe as
-`--mainExe`). Add `-Msi` to also build the machine-wide WiX MSI. Pass `-Version <semver>` for a real release;
+`--mainExe`). Add `-Msi` to also build the machine-wide WiX MSI (its ProductVersion major maxes out at 255,
+so the script maps the CalVer year down for the MSI only: `2026.7.1` → `26.7.1`). Pass `-Version <version>`
+for a real release;
 without it the version is read from `PlayerSettings.bundleVersion` in `ProjectSettings.asset` (the version
 source of truth — see [Releases & versioning](#releases-github-actions--versioning) below). For an actual
 shipped release you normally do **not** run this by hand — push a tag and let CI do it.
@@ -262,7 +264,7 @@ Useful parameters:
 For Velopack packaging on Linux (AppImage + portable zip), use `vpk` directly:
 
 ```bash
-vpk pack --packId BlocksBeyondTheStars --packVersion <semver> \
+vpk pack --packId BlocksBeyondTheStars --packVersion <version> \
   --packDir client/Build/Linux \
   --mainExe BlocksBeyondTheStars.Launcher.Console \
   --channel linux \
@@ -335,10 +337,13 @@ Get-ChildItem client/Build/Windows/BlocksBeyondTheStars_Data/Managed/BlocksBeyon
 ## Releases (GitHub Actions) & versioning
 
 Shipped releases are built in the cloud by [`.github/workflows/release.yml`](../../.github/workflows/release.yml),
-not locally. Cut one by pushing a SemVer tag:
+not locally. Versions are **date-based (CalVer)**: `vYYYY.MM.N` — year, month, release counter within the
+month (no leading zeros, never a fourth part; the result must stay valid 3-part SemVer2 because Velopack
+parses it as strict SemVer). See [ADR 0012](adr/0012-calver-date-based-versioning.md) for the rationale
+and constraints. Cut a release by pushing the tag:
 
 ```bash
-git tag v0.3.0 && git push origin v0.3.0
+git tag v2026.7.2 && git push origin v2026.7.2
 ```
 
 The workflow builds for Windows, Linux **and** (experimentally) macOS in parallel jobs. A tiny **`version`**
@@ -395,12 +400,12 @@ Notes:
 - butler authenticates with an itch.io API key stored as the **`BUTLER_API_KEY`** repository secret (Settings →
   Secrets and variables → Actions). It is **never** committed — generate one at itch.io → *Settings → API keys*.
 - The script auto-downloads butler (win-x64) if it is not already on `PATH`, so it also works locally:
-  `$env:BUTLER_API_KEY = '…'; ./scripts/publish-itch.ps1 -Version 0.3.0` (run after `publish-client-installer.ps1`).
+  `$env:BUTLER_API_KEY = '…'; ./scripts/publish-itch.ps1 -Version 2026.7.2` (run after `publish-client-installer.ps1`).
 - The `windows` prefix in each channel name tags the upload as a Windows download on the itch.io page.
 
 ### The git tag is the single source of truth for the version
 
-The tag (e.g. `v0.3.0`) is the only place the version is set. It flows everywhere automatically:
+The tag (e.g. `v2026.7.2`) is the only place the version is set. It flows everywhere automatically:
 
 - CI passes it to GameCI **`versioning: Custom`**, which sets `PlayerSettings.bundleVersion`. So in-game,
   `AppShell.Version` — now a property **`=> Application.version`** (no longer a hardcoded const) — shows the

--- a/docs/developer/DEVELOPER.md
+++ b/docs/developer/DEVELOPER.md
@@ -343,7 +343,7 @@ parses it as strict SemVer). See [ADR 0012](adr/0012-calver-date-based-versionin
 and constraints. Cut a release by pushing the tag:
 
 ```bash
-git tag v2026.7.2 && git push origin v2026.7.2
+git tag v2026.7.19 && git push origin v2026.7.19
 ```
 
 The workflow builds for Windows, Linux **and** (experimentally) macOS in parallel jobs. A tiny **`version`**

--- a/docs/developer/adr/0012-calver-date-based-versioning.md
+++ b/docs/developer/adr/0012-calver-date-based-versioning.md
@@ -28,8 +28,11 @@ zeros away, so any zero-padded scheme guarantees a mismatch between displayed an
 
 1. **Versions are `YYYY.MM.N`** — year, month (no leading zero), release counter within that
    month, restarting at `.1` each month. Example: `2026.7.1`, `2026.7.2`, then `2026.8.1`.
-   The counter counts releases *under this scheme*: the transition month starts at `.1` even
-   though earlier SemVer releases (v0.8.4–v0.9.1) also shipped in July 2026.
+   The counter counts *every* release of the month — including, in the July 2026 transition
+   month, the 18 SemVer releases that already shipped (v0.7.0 on 2026-07-05 through v0.9.1 on
+   2026-07-27). **The first CalVer release in July 2026 is therefore `v2026.7.19`.** From the
+   following month on this special case disappears: every release is a CalVer release and the
+   counter simply restarts at `.1` (August: `v2026.8.1`).
    Tags keep the `v` prefix (`v2026.7.2`) — the release trigger glob (`v*`) and the CHANGELOG
    compare links depend on it.
 2. **The scheme must remain valid 3-part SemVer2 forever**: never a fourth part, never leading

--- a/docs/developer/adr/0012-calver-date-based-versioning.md
+++ b/docs/developer/adr/0012-calver-date-based-versioning.md
@@ -2,7 +2,8 @@
 
 - **Status:** Accepted
 - **Date:** 2026-07-27
-- **Context source:** [`analysis/versioning-scheme-calver.md`](../../../analysis/versioning-scheme-calver.md)
+- **Context source:** [#550](https://github.com/marceld23/BlocksBeyondTheStars/issues/550) (the full
+  impact analysis lives in the local, git-ignored `analysis/versioning-scheme-calver.md`)
 
 ## Context
 

--- a/docs/developer/adr/0012-calver-date-based-versioning.md
+++ b/docs/developer/adr/0012-calver-date-based-versioning.md
@@ -1,0 +1,66 @@
+# ADR 0012 — Date-based (CalVer) versioning: `YYYY.MM.N`
+
+- **Status:** Accepted
+- **Date:** 2026-07-27
+- **Context source:** [`analysis/versioning-scheme-calver.md`](../../../analysis/versioning-scheme-calver.md)
+
+## Context
+
+Releases were versioned SemVer-style (`0.9.1`), with the git tag as the single source of truth
+(ADR 0010: tag → GameCI `bundleVersion` → launcher `-p:Version` → Velopack `--packVersion`).
+The project ships frequent, small releases (six in July 2026 alone); the `0.minor.patch`
+distinction carried little information, while "when is this build from?" is the question players,
+bug reports and the website actually ask. The wish was a fully dated scheme like `2026.07.27.01`.
+
+Two hard constraints rule the wished-for format out:
+
+1. **Velopack accepts only strict 3-part SemVer2** — no 4-part versions, no leading zeros
+   (FAQ-explicit). This governs `vpk pack`, the update feed (`releases.win.json`) and the
+   client's `GithubSource` update check (#543), i.e. the entire auto-update path.
+2. **Windows Installer `ProductVersion`** allows at most `255.255.65535` — a 4-digit year
+   overflows the MSI major field regardless of the rest of the format.
+
+Additionally, every parser in the chain (Velopack, `System.Version`, MSBuild) normalizes leading
+zeros away, so any zero-padded scheme guarantees a mismatch between displayed and parsed versions.
+
+## Decision
+
+1. **Versions are `YYYY.MM.N`** — year, month (no leading zero), release counter within that
+   month, restarting at `.1` each month. Example: `2026.7.1`, `2026.7.2`, then `2026.8.1`.
+   The counter counts releases *under this scheme*: the transition month starts at `.1` even
+   though earlier SemVer releases (v0.8.4–v0.9.1) also shipped in July 2026.
+   Tags keep the `v` prefix (`v2026.7.2`) — the release trigger glob (`v*`) and the CHANGELOG
+   compare links depend on it.
+2. **The scheme must remain valid 3-part SemVer2 forever**: never a fourth part, never leading
+   zeros, `-suffix` reserved for dev/pre-release isolation (`publish-client-installer.ps1` routes
+   any `-`-version to the separate `BlocksBeyondTheStarsDev` packId).
+3. **MSI only: the year is mapped down** by `publish-client-installer.ps1` (`2026.7.1` → `26.7.1`)
+   to fit the 255 cap. The mapped form is visible solely in the MSI's Apps & Features entry;
+   Setup.exe, the portable zip, the Velopack feed and the in-game UI all show the full version.
+4. **Everything else stays unchanged by design**: the release workflow's tag validation regex,
+   the What's-new tooling (`export_whatsnew.py`, `WhatsNewContentTests`), GameCI versioning and
+   the Docker tags all accept any 3-part numeric version, and ordering across the switch is
+   monotonic (`2026.7.1 > 0.9.1`), so update detection works immediately.
+
+## Consequences
+
+- **The switch is one-way.** Once a `2026.*` release ships, every smaller version is a downgrade
+  for Velopack and will never be offered as an update — there is no path back to `0.x`/`1.x`,
+  and no "1.0" milestone version exists in this scheme. Accepted deliberately.
+- Releases self-date: the version answers "how old is this build?" without consulting the
+  changelog. The devblog and CHANGELOG remain the record of *what* changed.
+- The CHANGELOG statement "follows Semantic Versioning" is replaced by this scheme (headings
+  like `## [2026.7.2] — 2026-07-28` are slightly redundant with their date — harmless).
+- **Installing the new MSI over an old `0.x` MSI keeps working** (verified against vpk 1.2.0's
+  MSI source): the `UpgradeCode` is a deterministic hash of the packId (unchanged), the mapped
+  ProductVersion stays monotonic (`26.7.1 > 0.9.1`), file replacement is governed by the
+  binaries' FileVersion (`2026.x > 0.9.x`), and the Apps & Features entry is Velopack's own
+  registry key keyed by the packId — the newer install simply overwrites it, so no duplicate
+  entry appears. Note vpk 1.2.0's MSI has no WiX `MajorUpgrade` table at all, so MSI-over-MSI
+  behaves identically to how it already did between `0.x` versions — the scheme switch changes
+  nothing here. Still: verify once by installing the first CalVer MSI over a `0.9.1` MSI install.
+- The public website (Wix) polls the GitHub release `tag_name` verbatim and does not parse it —
+  verified safe. Anything new consuming versions must parse them as SemVer, never split on a
+  fixed part count of the *string* with padding assumptions.
+- `tools/devblog/set_dates.py` (legacy, unused since devblog entry 40) still assumes a `0.x`
+  prefix and would need widening if ever revived.

--- a/scripts/publish-client-installer.ps1
+++ b/scripts/publish-client-installer.ps1
@@ -148,9 +148,20 @@ New-Item -ItemType Directory -Force $out | Out-Null
 # we keep WiX's clean default dialogs and use the game icon as the only branding (--icon below).
 $msiArgs = @()
 if ($Msi) {
-    # MSI ProductVersion must be purely numeric (x.x.x, each part <= 65535) — strip any pre-release suffix
-    # like "-dev" so a dev build still produces a valid MSI.
+    # MSI ProductVersion must be purely numeric x.x.x with major <= 255 and minor <= 255 (build <= 65535)
+    # — strip any pre-release suffix like "-dev" so a dev build still produces a valid MSI, and map the
+    # CalVer year down into the 255 range (2026.7.1 → 26.7.1): the game version's 4-digit year overflows
+    # the MSI major field. Only the MSI's Apps & Features entry shows the mapped form; Setup.exe, the
+    # portable zip and the Velopack feed all keep the full version.
     $msiVersion = ($Version -split '-')[0]
+    $msiParts = $msiVersion -split '\.'
+    if ([int]$msiParts[0] -gt 255) {
+        $msiParts[0] = [string]([int]$msiParts[0] - 2000)
+        $msiVersion = $msiParts -join '.'
+        if ([int]$msiParts[0] -gt 255 -or [int]$msiParts[0] -lt 0) {
+            Write-Error "Cannot map version '$Version' to a valid MSI ProductVersion (major must be <= 255)."
+        }
+    }
 
     # The AGPL license shown on the wizard's License page. Velopack requires the file to end in .txt/.md/.rtf,
     # but the repo LICENSE has no extension — copy it to a .txt next to the other build artifacts (.txt keeps

--- a/scripts/publish-client-installer.ps1
+++ b/scripts/publish-client-installer.ps1
@@ -171,12 +171,23 @@ if ($Msi) {
     $licensePath = Join-Path $repo 'artifacts/LICENSE.txt'
     Copy-Item $licenseSrc $licensePath -Force
 
+    # Copyright line on the wizard's finish page (--instConclusion wants a plain-text FILE). It goes on
+    # the conclusion page, not the welcome page: --instWelcome would replace the auto-localized (DE/EN)
+    # welcome text with a fixed string, while the conclusion text is purely additive — and the © line
+    # itself is language-neutral. The year comes from the CalVer version; dev/SemVer versions (major
+    # below 2000, e.g. 0.1.0-dev) fall back to the current year.
+    $copyrightYear = [int](($Version -split '[.-]')[0])
+    if ($copyrightYear -lt 2000) { $copyrightYear = (Get-Date).Year }
+    $conclusionPath = Join-Path $repo 'artifacts/msi-conclusion.txt'
+    Set-Content -Path $conclusionPath -Value ([char]0x00A9 + " $copyrightYear JuMaVe Games") -Encoding UTF8
+
     $msiArgs = @(
         '--msi', 'true',
         '--msiVersion', $msiVersion,
-        '--instLicense', $licensePath
+        '--instLicense', $licensePath,
+        '--instConclusion', $conclusionPath
     )
-    Write-Host "MSI will be built (version $msiVersion, AGPL license page, clean WiX dialogs, game icon only)." -ForegroundColor Cyan
+    Write-Host "MSI will be built (version $msiVersion, AGPL license page, (c) $copyrightYear conclusion line, clean WiX dialogs, game icon only)." -ForegroundColor Cyan
 }
 
 # Attribution: copy the project LICENSE + the third-party NOTICES into the player folder so every pack


### PR DESCRIPTION
Closes #550

## What

Switches the version scheme from SemVer (last: v0.9.1) to **date-based CalVer `YYYY.MM.N`** — year, month, release counter within the month. The next release is tagged `v2026.7.1` (or `v2026.8.1` if it slips to August); the counter restarts at `.1` each month and, for the transition month, counts only CalVer releases.

## Why this exact shape

The originally wished `2026.07.27.01` is impossible with our stack (full analysis in the local `analysis/versioning-scheme-calver.md`, decision in **ADR 0012**):
- **Velopack accepts only strict 3-part SemVer2** — no 4-part versions, no leading zeros. This governs `vpk pack` and the whole auto-update path incl. the #545 `GithubSource` feed.
- **WiX MSI ProductVersion caps its major at 255** — any 4-digit year overflows it.

`YYYY.MM.N` is valid SemVer2, so the release workflow's tag regex, the What's-new tooling (`export_whatsnew.py` + `WhatsNewContentTests`), GameCI versioning and Docker tags all work **unchanged**, and `2026.7.1 > 0.9.1` keeps update detection monotonic across the switch.

## Changes

- `scripts/publish-client-installer.ps1` — the only code change: map the CalVer year down **for the MSI only** (`2026.7.1` → `26.7.1`); Setup.exe, portable zip, Velopack feed and in-game UI keep the full version. Mapping verified for old + new + `-dev` versions; script parse-checked.
- `docs/developer/adr/0012-calver-date-based-versioning.md` — scheme, constraints, the **one-way consequence** (no path back to 0.x/1.x, no "1.0" milestone — accepted deliberately), and proof that installing the new MSI over an old 0.x MSI keeps working (vpk 1.2.0 source: UpgradeCode is a deterministic hash of the packId; ProductVersion + FileVersion stay monotonic; the Apps & Features entry is Velopack's own packId-keyed registry key).
- `AGENTS.md` + `docs/developer/DEVELOPER.md` — release procedure now documents the scheme + MSI gotcha.
- `CHANGELOG.md` — conventions header + Unreleased note (player-visible announcement).
- `TODO.md` — released-versions section notes the switch.

## Verified

- `2026.7.1` passes the release tag regex, the whatsnew heading regex and the whatsnew content test format unchanged (checked directly against the patterns).
- MSI mapping simulated: `2026.7.1→26.7.1`, `2026.12.3→26.12.3`, `0.9.1→0.9.1` (old behavior untouched), `-dev` suffix stripped as before.
- Velopack docs confirm 3-part SemVer2-only; vpk 1.2.0 MSI template inspected for the upgrade-path question.
- No compiled code touched — no test-suite/Unity-build run needed.
- Wix website backend snippet returns `tag_name` verbatim (no parsing) — no website change needed.

## Release checklist additions (first CalVer release)

1. Tag `v2026.7.1` (after the usual whatsnew export).
2. One-time: verify the new MSI installs cleanly over a `v0.9.1` MSI install.
3. This release doubles as the GithubSource smoke test from #545 — 0.9.x users need one last manual download either way (they predate the update notice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)