### PR TITLE
feat(worldgen): star system archetypes — lone giants, swarms, hubs & pirate havens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,27 @@ the richer, screenshot-laden versions live there. `(#123)` references the pull r
 
 ## [Unreleased]
 
+### 🌌 Star systems have character now (#546–#549)
+- **Every system rolls an archetype** in newly created worlds: alongside the familiar mix there are
+  **Lone Giants** (one oversized planet with 4–8 moons), **Swarms** (many small planets, hardly any
+  moons), **Belts** (asteroid fields with barely a planet), **Hubs** (guaranteed stations and busy
+  trade lanes), **Desolate** systems (empty, silent space), **Pirate Havens** (always lawless — no
+  stations, more camps, more wrecks) and **Twin Worlds** (two like-sized planets on close orbits).
+  The home system never rolls the hostile/empty archetypes, so a fresh start stays friendly (#546).
+- **Planets genuinely differ in size now** (#549): archetypes bias the walkable circumference —
+  giants reach 16000 blocks around, swarm dwarfs go down to 4000 (the classic band is 5000–12000) —
+  and the orbit view, the sky and gravity all reflect it.
+- **The inhabitants follow the archetype** (#547): trader traffic, pirate-space flags, bandit-camp
+  odds, ambient drones/UFOs and wreck frequency all read the system's character; the previously dead
+  **Danger** world option now scales hostile encounter odds globally. The synthesised fallback
+  station only appears in the home system anymore — a Desolate system out there really has none.
+- **The space view keeps up** (#548): moons stack on their own orbit rings around their true parent
+  planet (a giant's 8 moons read as a family, not one crowded shell), and the from-the-surface sky
+  sizes bodies by their real circumference, capped at the 14 most prominent.
+- **Existing worlds are completely untouched**: variance only applies to worlds created from this
+  release on (the galaxy re-derives from the seed, so changing counts on an old save would orphan
+  visited worlds — bias 0 and the Standard archetype reproduce the old layout bit-for-bit).
+
 ### 🔔 The game finally tells you about updates (#543)
 - **Update notice on startup.** An installed client now quietly checks for a newer release while the
   splash screens play and, if one exists, offers it on the main menu: *Install now* downloads and

--- a/TODO.md
+++ b/TODO.md
@@ -7,7 +7,7 @@ plans live under [docs/](docs/) (committed); the long-range direction is the str
 keep it current when controls/features change. Last consolidated 2026-06-04.
 
 **Build:** `scripts/build-client.ps1` (Windows) or `scripts/build-client.sh` (Linux) — publishes shared libs + bundled server + Unity player.
-**Test:** `./scripts/run-tests.sh` — currently **1219 server + 145 client passing** (2026-07-27). Locale parity (en/de) is enforced by a test.
+**Test:** `./scripts/run-tests.sh` — currently **1228 server + 145 client passing** (2026-07-27). Locale parity (en/de) is enforced by a test.
 CI runs two tiers: PRs skip the tests marked `[Trait("Category", "Slow")]`; pushes to `main` and the release workflow run the full suite. CI builds/runs
 tests in Release, and a per-test duration guardrail (`scripts/check-test-durations.py`, PRs only) fails the gate when a non-Slow test exceeds 120 s.
 **Conventions:** English docs/comments; in-game text bilingual DE+EN; commit to `main` with the
@@ -6465,6 +6465,33 @@ is **pre-approved** (keys in `tools/ai-assets/.env`, run via `uv`).
    ship interior; ship interior is water-free after landing in a sea.
 
 ---
+
+## ✅ Done (2026-07-27): star system archetypes — high per-system variance (#546–#549)
+
+Full analysis in `analysis/star-system-variance.md`. Every system in a NEWLY created world rolls a
+character class (`SystemArchetypes.cs`, Hash01 salt 500): Standard 30 / Lone Giant 12 / Swarm 12 /
+Belt 10 / Hub 10 / Desolate 12 / Pirate Haven 8 / Twin Worlds 6 — shaping planet/moon/asteroid/
+station/wreck rolls in `UniverseGenerator` (#546), per-body size via `CelestialBody.SizeBias` →
+`CircumferenceFor(key, class, bias)` with an extended 4000–16000 planet band (#549), and the
+inhabitants at runtime — trader traffic, pirate flag, camp odds, drones/UFOs, plus the previously
+dead `Danger` option as a global hostility multiplier (#547). Client: moons ladder outward on their
+own orbit slots around their TRUE `ParentId` parent (the nearest-planet scan mis-parented under
+varied sizes), the sky view sizes bodies by real circumference and caps at the 14 most prominent
+(#548).
+
+Hard-won invariants to keep:
+- **`SystemVariance` defaults false on `WorldDescription`** (old saves regenerate byte-identically —
+  count changes would orphan visited worlds) **and true on `ServerConfig.World`** (new-world path).
+  The Standard archetype reproduces the legacy rng draw sequence EXACTLY — the station gate draw
+  happens even when the archetype overrides the outcome, to keep that alignment.
+- **`CircumferenceFor` with bias 0 is bit-identical** to the classic hash (existing terrain).
+  `BiasToward` inverts the mapping (Twin Worlds sizing); both live in `WorldConstants`.
+- The **fallback "Orbital Station" now only synthesises in `sys0`** (variance worlds) — onboarding
+  needs one reachable station; everywhere else Desolate/Pirate systems genuinely have none.
+- `NetBody.SizeBias` must reach EVERY client `CircumferenceFor` call (orbit spheres, sky bodies,
+  pad-map bake) — a missed one desyncs rendered vs walkable size.
+- Moons clamp: `--moons-max` now 0–8 (Lone Giant identity); planets min/max cross-normalise in
+  `ServerConfig` (Range(min>max) silently returned min before).
 
 ## ✅ Done (2026-07-27): landable asteroids — five families and per-body crater relief (#515/#518)
 

--- a/client/Assets/BlocksBeyondTheStars/Scripts/SkyBodiesView.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/SkyBodiesView.cs
@@ -252,14 +252,44 @@ namespace BlocksBeyondTheStars.Client
                 }
             }
 
+            // Collect candidates first and CAP them (#548): an archetype system can carry many moons, and
+            // every sky body costs a sphere + a texture bake per world load. Keep the most prominent ones
+            // (apparent size ≈ real size / real distance); the far tail wouldn't read as more than a dot.
+            const int MaxSkyBodies = 14;
+            var candidates = new List<NetBody>();
             foreach (var body in system.Bodies)
             {
-                bool landable = body.Kind is "Planet" or "Moon"
+                bool isLandable = body.Kind is "Planet" or "Moon"
                     || WorldConstants.IsAsteroidType(body.PlanetType);
-                if (!landable || body.Id == map.ActiveLocationId)
+                if (isLandable && body.Id != map.ActiveLocationId)
                 {
-                    continue; // stations etc. stay invisible from the surface; the body you stand on too
+                    candidates.Add(body);
                 }
+            }
+
+            if (candidates.Count > MaxSkyBodies)
+            {
+                float Prominence(NetBody b)
+                {
+                    var c = WorldConstants.IsAsteroidType(b.PlanetType)
+                        ? WorldConstants.WorldSizeClass.Asteroid
+                        : b.Kind == "Moon" ? WorldConstants.WorldSizeClass.Moon : WorldConstants.WorldSizeClass.Planet;
+                    float d = 600f;
+                    if (current != null)
+                    {
+                        float dx = b.SystemX - current.SystemX, dy = b.SystemY - current.SystemY, dz = b.SystemZ - current.SystemZ;
+                        d = Mathf.Sqrt(dx * dx + dy * dy + dz * dz);
+                    }
+
+                    return WorldConstants.CircumferenceFor(b.Id, c, b.SizeBias) / Mathf.Max(d, 40f);
+                }
+
+                candidates.Sort((a, b) => Prominence(b).CompareTo(Prominence(a)));
+                candidates.RemoveRange(MaxSkyBodies, candidates.Count - MaxSkyBodies);
+            }
+
+            foreach (var body in candidates)
+            {
 
                 // Deterministic per (current planet, body): the sky choreography is unique to each world.
                 int h = Hash(map.ActiveLocationId + "|" + body.Id);
@@ -267,6 +297,9 @@ namespace BlocksBeyondTheStars.Client
                 var cls = WorldConstants.IsAsteroidType(body.PlanetType)
                     ? WorldConstants.WorldSizeClass.Asteroid
                     : body.Kind == "Moon" ? WorldConstants.WorldSizeClass.Moon : WorldConstants.WorldSizeClass.Planet;
+                // The body's REAL walkable circumference (incl. its archetype size bias, #549) — sizes the
+                // sky disc below, so a 12000 giant genuinely looms larger than a 5000 dwarf.
+                int bodyCirc = WorldConstants.CircumferenceFor(body.Id, cls, body.SizeBias);
 
                 var go = GameObject.CreatePrimitive(PrimitiveType.Sphere);
                 go.name = "SkyBody_" + body.Id;
@@ -292,8 +325,7 @@ namespace BlocksBeyondTheStars.Client
                 Texture2D baked = null;
                 if (planet != null)
                 {
-                    int circ = WorldConstants.CircumferenceFor(body.Id, cls);
-                    baked = WorldMinimap.Bake(Game.Content, Game.Atlas, Game.WorldSeed, locationKey, body.PlanetType, circ, 96, 48,
+                    baked = WorldMinimap.Bake(Game.Content, Game.Atlas, Game.WorldSeed, locationKey, body.PlanetType, bodyCirc, 96, 48,
                         bodyId: body.Id);
                     tint = Color.Lerp(Color.white, sunHue, 0.35f); // light star-hue wash over the real map
                 }
@@ -317,16 +349,13 @@ namespace BlocksBeyondTheStars.Client
                 mr.shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.Off;
                 mr.receiveShadows = false;
 
-                // Apparent size from REAL system-space distance: a per-class "radius" divided by how far the
-                // body is from the world we stand on. A moon's parent planet sits ~90-145 units away → it
-                // fills a chunk of the sky; a neighbour planet hundreds of units out → a small disc; from an
-                // asteroid, nearby planets/moons loom accordingly (the planet largest).
-                float radius = cls switch
-                {
-                    WorldConstants.WorldSizeClass.Asteroid => 6f + (h % 3),
-                    WorldConstants.WorldSizeClass.Moon => 16f + (h % 4),
-                    _ => 36f + (h % 6),
-                };
+                // Apparent size from REAL system-space distance: the body's true circumference (not just a
+                // per-class band — #549: a 12000 giant should dwarf a 5000 world) divided by how far the body
+                // is from the world we stand on. A moon's parent planet sits ~90-145 units away → it fills a
+                // chunk of the sky; a neighbour planet hundreds of units out → a small disc; from an asteroid,
+                // nearby planets/moons loom accordingly. 0.004 keeps the classic per-class midpoints
+                // (asteroid ~10, moon ~18, planet ~39).
+                float radius = 5f + bodyCirc * 0.004f;
                 float dist = 600f; // fallback when coords are missing
                 if (current != null)
                 {

--- a/client/Assets/BlocksBeyondTheStars/Scripts/SpaceView.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/SpaceView.cs
@@ -1303,7 +1303,7 @@ namespace BlocksBeyondTheStars.Client
                 : Game?.LocationName ?? string.Empty;
             int circ = WorldConstants.CircumferenceFor(
                 !string.IsNullOrEmpty(_choosePadBody) ? _choosePadBody : Game?.LocationName ?? "home",
-                ClassOf(body?.Kind, typeKey));
+                ClassOf(body?.Kind, typeKey), body?.SizeBias ?? 0f);
             int latP = WorldConstants.LatitudePeriodFor(circ);
 
             var mapGo = new GameObject("PadMap", typeof(RectTransform));
@@ -2505,10 +2505,11 @@ namespace BlocksBeyondTheStars.Client
             // planet to fly back to — never a decorative filler.
             string homeType = !string.IsNullOrEmpty(current?.PlanetType) ? current.PlanetType : Game?.Environment?.Biome;
             var homePos = new Vector3(0f, -150f, -20f);
-            // Every body has its own size (deterministic from its id), so worlds + moons look big or small in
-            // orbit instead of all identical — an approximate reflection of how varied the bodies are.
-            float homeDiameter = OrbitDiameterFor(current?.Id ?? Game?.LocationName ?? "home", current?.Kind, current?.PlanetType) * 3.2f;
-            SpawnBody("HomePlanet", current?.Id, current?.Kind, Game?.LocationName ?? "home", homePos, homeDiameter, homeType);
+            // Every body has its own size (deterministic from its id + archetype bias), so worlds + moons look
+            // big or small in orbit instead of all identical — an approximate reflection of how varied they are.
+            float homeBias = current?.SizeBias ?? 0f;
+            float homeDiameter = OrbitDiameterFor(current?.Id ?? Game?.LocationName ?? "home", current?.Kind, current?.PlanetType, homeBias) * 3.2f;
+            SpawnBody("HomePlanet", current?.Id, current?.Kind, Game?.LocationName ?? "home", homePos, homeDiameter, homeType, homeBias);
             _landables.Add((string.Empty, Game?.LocationName ?? "home", homePos, homeDiameter * 0.5f));
             _keepOut.Add((homePos, homeDiameter * 0.5f + KeepOutMargin));
             float maxDist = homePos.magnitude;
@@ -2527,20 +2528,23 @@ namespace BlocksBeyondTheStars.Client
                 var radii = new List<float>();
                 var bodyTypes = new List<string>();
                 var kinds = new List<string>(); // star-map Kind — keys each body's true circumference
+                var biases = new List<float>(); // per-body archetype size bias (#549) — keys the circumference too
                 var homeMoons = new List<int>(); // planned in home's plane → must also clear home itself
 
-                void Plan(string id, string name, string kind, Vector3 pos, float diameter, string type)
+                void Plan(string id, string name, string kind, Vector3 pos, float diameter, string type, float sizeBias)
                 {
                     ids.Add(id); names.Add(name); kinds.Add(kind); positions.Add(pos); radii.Add(diameter * 0.5f); bodyTypes.Add(type);
+                    biases.Add(sizeBias);
                     locKeys.Add(PlanetOrbitLook.LocationKeyFor(system?.Name, name));
                 }
 
                 // Pass 1: planets at their scaled orbit coords. Keep system coords + render pos so each moon
-                // can be parented to its nearest planet.
+                // can be parented to its planet (by ParentId, with a nearest-planet fallback).
                 var planets = new List<(float Sx, float Sz, Vector3 Render, float Radius)>
                 {
                     (current.SystemX, current.SystemZ, homePos, homeDiameter * 0.5f),
                 };
+                var planetIndexById = new Dictionary<string, int> { [current.Id ?? string.Empty] = 0 };
                 foreach (var b in system.Bodies)
                 {
                     // Render every real planet in the system — even one whose PlanetType string didn't come
@@ -2552,12 +2556,19 @@ namespace BlocksBeyondTheStars.Client
 
                     string type = string.IsNullOrEmpty(b.PlanetType) ? homeType : b.PlanetType;
                     var pos = new Vector3((b.SystemX - current.SystemX) * SystemViewScale, 0f, (b.SystemZ - current.SystemZ) * SystemViewScale);
-                    float diameter = OrbitDiameterFor(b.Id, b.Kind, b.PlanetType);
-                    Plan(b.Id, b.Name, b.Kind, pos, diameter, type);
+                    float diameter = OrbitDiameterFor(b.Id, b.Kind, b.PlanetType, b.SizeBias);
+                    Plan(b.Id, b.Name, b.Kind, pos, diameter, type, b.SizeBias);
+                    planetIndexById[b.Id] = planets.Count;
                     planets.Add((b.SystemX, b.SystemZ, pos, diameter * 0.5f));
                 }
 
-                // Pass 2: moons, each placed just outside its nearest parent planet's surface.
+                // Pass 2: moons, each placed just outside its parent planet's surface. The star map's ParentId
+                // is authoritative (#548) — the old nearest-planet scan attached a moon to whichever planet
+                // happened to render closest, which breaks as soon as sizes/orbits vary. Because ALL moons
+                // orbit below any planet's rendered radius, each parent hands out ascending orbit SLOTS: the
+                // first moon sits at the minimum clear orbit, every further one a clear gap above the last —
+                // a Lone Giant's 8 moons read as a family of rings instead of one crowded shell.
+                var moonLadder = new Dictionary<int, (float Orbit, float Radius)>(); // parent → outermost slot so far
                 foreach (var b in system.Bodies)
                 {
                     if (b.Id == current.Id || b.Kind != "Moon")
@@ -2566,30 +2577,42 @@ namespace BlocksBeyondTheStars.Client
                     }
 
                     string type = string.IsNullOrEmpty(b.PlanetType) ? homeType : b.PlanetType;
-                    int parentIndex = 0;
-                    float bestSq = float.MaxValue;
-                    for (int p = 0; p < planets.Count; p++)
+                    int parentIndex;
+                    if (string.IsNullOrEmpty(b.ParentId) || !planetIndexById.TryGetValue(b.ParentId, out parentIndex))
                     {
-                        float dx = b.SystemX - planets[p].Sx, dz = b.SystemZ - planets[p].Sz;
-                        float dsq = dx * dx + dz * dz;
-                        if (dsq < bestSq) { bestSq = dsq; parentIndex = p; }
+                        // Fallback for maps without ParentId (old servers): the nearest planet, as before.
+                        parentIndex = 0;
+                        float bestSq = float.MaxValue;
+                        for (int p = 0; p < planets.Count; p++)
+                        {
+                            float dx = b.SystemX - planets[p].Sx, dz = b.SystemZ - planets[p].Sz;
+                            float dsq = dx * dx + dz * dz;
+                            if (dsq < bestSq) { bestSq = dsq; parentIndex = p; }
+                        }
                     }
 
                     var parent = planets[parentIndex];
 
                     var rel = new Vector3((b.SystemX - parent.Sx) * SystemViewScale, 0f, (b.SystemZ - parent.Sz) * SystemViewScale);
-                    float moonDia = OrbitDiameterFor(b.Id, b.Kind, b.PlanetType);
-                    // Outside the planet's surface, with room to spare. This clamp fires for essentially every
-                    // moon — the star map's moon orbit (90 system units ≈ 14 view units) is smaller than any
-                    // planet's rendered radius — so the gap it leaves IS the moon's visible altitude (#493).
+                    float moonDia = OrbitDiameterFor(b.Id, b.Kind, b.PlanetType, b.SizeBias);
+                    // Outside the planet's surface, with room to spare — and above this parent's previous
+                    // moon's ring, so siblings stack outward instead of sharing one radius (#548).
                     float minClear = SystemBodyLayout.MinOrbitFor(parent.Radius, moonDia * 0.5f);
+                    if (moonLadder.TryGetValue(parentIndex, out var last))
+                    {
+                        minClear = Mathf.Max(minClear,
+                            last.Orbit + last.Radius + moonDia * 0.5f + SystemBodyLayout.ClearGapFor(last.Radius, moonDia * 0.5f));
+                    }
+
                     if (rel.magnitude < minClear)
                     {
                         Vector3 dir = rel.sqrMagnitude > 0.0001f ? rel.normalized : Vector3.right;
                         rel = dir * minClear;
                     }
 
-                    Plan(b.Id, b.Name, b.Kind, parent.Render + rel, moonDia, type);
+                    moonLadder[parentIndex] = (rel.magnitude, moonDia * 0.5f);
+
+                    Plan(b.Id, b.Name, b.Kind, parent.Render + rel, moonDia, type, b.SizeBias);
                     if (parentIndex == 0)
                     {
                         // A moon of the body you launched from: planned in HOME'S plane (far below the flight
@@ -2610,8 +2633,8 @@ namespace BlocksBeyondTheStars.Client
 
                     string type = string.IsNullOrEmpty(b.PlanetType) ? "asteroid" : b.PlanetType;
                     var pos = new Vector3((b.SystemX - current.SystemX) * SystemViewScale, 0f, (b.SystemZ - current.SystemZ) * SystemViewScale);
-                    float diameter = OrbitDiameterFor(b.Id, b.Kind, type);
-                    Plan(b.Id, b.Name, b.Kind, pos, diameter, type);
+                    float diameter = OrbitDiameterFor(b.Id, b.Kind, type, b.SizeBias);
+                    Plan(b.Id, b.Name, b.Kind, pos, diameter, type, b.SizeBias);
                 }
 
                 // Separation pass: nudge any overlapping pair apart in the x-z plane until every body has
@@ -2638,7 +2661,7 @@ namespace BlocksBeyondTheStars.Client
                 // Spawn the separated bodies + register them as landable / keep-out.
                 for (int k = 0; k < positions.Count; k++)
                 {
-                    SpawnBody("SystemBody_" + ids[k], ids[k], kinds[k], locKeys[k], positions[k], radii[k] * 2f, bodyTypes[k]);
+                    SpawnBody("SystemBody_" + ids[k], ids[k], kinds[k], locKeys[k], positions[k], radii[k] * 2f, bodyTypes[k], biases[k]);
                     _landables.Add((ids[k], names[k], positions[k], radii[k]));
                     _keepOut.Add((positions[k], radii[k] + KeepOutMargin)); // can't fly into it — slide + press E to land
                     maxDist = Mathf.Max(maxDist, positions[k].magnitude);
@@ -2650,11 +2673,12 @@ namespace BlocksBeyondTheStars.Client
 
         /// <summary>The orbit-view diameter for a body, derived from its real walkable circumference — so a
         /// tiny asteroid reads small, a moon medium and a big planet large, matching how long it'd take to walk
-        /// around. Same body → same size, on the surface (server) and in orbit (here).</summary>
-        private static float OrbitDiameterFor(string id, string kind, string planetType)
+        /// around. Same body → same size, on the surface (server) and in orbit (here). <paramref name="sizeBias"/>
+        /// is the body's archetype size identity (#549) and must always come from its NetBody.</summary>
+        private static float OrbitDiameterFor(string id, string kind, string planetType, float sizeBias)
         {
-            int circ = WorldConstants.CircumferenceFor(id, ClassOf(kind, planetType));
-            return 8f + circ / 220f; // ~13 (asteroid) .. ~23 (moon) .. ~46-62 (planet)
+            int circ = WorldConstants.CircumferenceFor(id, ClassOf(kind, planetType), sizeBias);
+            return 8f + circ / 220f; // ~13 (asteroid) .. ~23 (moon) .. ~46-62 (planet; a lone giant reaches ~81)
         }
 
         /// <summary>Maps a NetBody's string kind + planet type to a size class (matches the server's
@@ -2669,7 +2693,7 @@ namespace BlocksBeyondTheStars.Client
         /// plus a per-type cloud shell and an atmosphere haze rim scaled by atmosphere density.
         /// <paramref name="bodyId"/> keys the body's true circumference; <paramref name="locationName"/>
         /// seeds the per-planet flora hue.</summary>
-        private void SpawnBody(string name, string bodyId, string kind, string locationName, Vector3 pos, float diameter, string planetType)
+        private void SpawnBody(string name, string bodyId, string kind, string locationName, Vector3 pos, float diameter, string planetType, float sizeBias = 0f)
         {
             // B37 rest: planets + cloud shells in the orbit view are lit by THIS system's star, so under a
             // red sun the whole system reads warm (a light wash — the biome tint stays recognisable).
@@ -2693,7 +2717,7 @@ namespace BlocksBeyondTheStars.Client
             if (planet != null && Game != null)
             {
                 int circ = WorldConstants.CircumferenceFor(
-                    string.IsNullOrEmpty(bodyId) ? locationName ?? "home" : bodyId, ClassOf(kind, planetType));
+                    string.IsNullOrEmpty(bodyId) ? locationName ?? "home" : bodyId, ClassOf(kind, planetType), sizeBias);
                 var baked = WorldMinimap.Bake(Game.Content, Game.Atlas, Game.WorldSeed, locationName, planetType, circ, 96, 48,
                     bodyId: string.IsNullOrEmpty(bodyId) ? locationName ?? "home" : bodyId);
                 Color washTint = Color.Lerp(Color.white, sunHue, 0.35f);

--- a/docs/developer/WORLD_GENERATION.md
+++ b/docs/developer/WORLD_GENERATION.md
@@ -51,6 +51,23 @@ The data shapes are in [`Galaxy.cs`](../../src/BlocksBeyondTheStars.Shared/World
   ~420 units out, +520 per planet ± jitter; moons 90 + m·55 around their planet) and an **orbit
   period** (planets 6–40 in-game days, moons 0.4–2.5, ~20 % retrograde). The orbit period is a
   purely visual phase driver — it never disturbs landing, travel distance or pad reservations.
+- **System archetypes (#546, worlds created ≥ 0.9.2):** when `WorldDescription.SystemVariance` is on,
+  each system rolls a character class in
+  [`SystemArchetypes.cs`](../../src/BlocksBeyondTheStars.WorldGeneration/SystemArchetypes.cs)
+  (own `Hash01` salt 500; 501/502 serve the size-bias and twin-orbit draws) that shapes the counts
+  above: **Standard** (30, exactly the legacy rolls), **Lone Giant** (12: 1 size-biased planet,
+  4–8 moons), **Swarm** (12: 6–9 small planets, ≤1 moon), **Belt** (10: 5–8 asteroids), **Hub**
+  (10: stations guaranteed), **Desolate** (12: 1–2 planets, nothing else), **Pirate Haven**
+  (8: no stations, wrecks doubled), **Twin Worlds** (6: two like-sized planets on close orbits).
+  System 0 (home) never rolls Desolate/Pirate Haven. Runtime consumers (trader traffic, pirate flag,
+  camp odds, drones) resolve the archetype from the seed via `SystemArchetypes.For` — nothing is
+  persisted. `SystemVariance` **defaults to false** on `WorldDescription` (old saves regenerate
+  unchanged) and to **true** on `ServerConfig`'s creation-time description (new worlds get it).
+- **Per-body size bias (#549):** archetypes set `CelestialBody.SizeBias` ∈ [-1, 1], which
+  `WorldConstants.CircumferenceFor(key, class, bias)` maps onto an extended band (planets
+  4000–16000 instead of 5000–12000). Bias 0 is bit-identical to the classic hash — that invariant
+  protects every existing save's terrain. The client receives the bias via `NetBody.SizeBias` and
+  must pass it to every `CircumferenceFor` call (orbit spheres, sky bodies, pad-map bakes).
 
 A `CelestialBody` stores only Id, Name, `Kind` (Planet/Moon/AsteroidField/SpaceStation/Wreck), a
 **`PlanetType` key**, and orbit data. The body's *content* is generated only when a player enters it.

--- a/src/BlocksBeyondTheStars.GameServer/GameServer.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServer.cs
@@ -413,6 +413,12 @@ public sealed partial class GameServer
         }
     }
 
+    /// <summary>The archetype a system rolled (#546) — Standard for every system of a pre-variance save.
+    /// Recomputed from the seed on demand (the trader-traffic pattern), so nothing is persisted; all
+    /// inhabitant systems (stations, traders, bandits, camps, drones) consult THIS one resolver.</summary>
+    private SystemArchetype SystemArchetypeOf(string? systemId)
+        => SystemArchetypes.For(_meta.Seed, systemId, _meta.Description);
+
     /// <summary>
     /// Makes <paramref name="locationId"/> (a celestial body of type <paramref name="planetTypeKey"/>)
     /// the active world: rebuilds <see cref="_world"/> (its edits load from that body's persistence key),
@@ -445,7 +451,9 @@ public sealed partial class GameServer
         // (deterministic from the body id + its size class), and the noise/wrap/chunk keys all use it.
         var worldBody = _galaxy?.FindBody(locationId);
         var sizeClass = WorldConstants.SizeClassFor(worldBody?.Kind ?? CelestialKind.Planet, planet.Key);
-        int circumference = WorldConstants.CircumferenceFor(locationId, sizeClass);
+        // #549: the archetype's size bias stretches the band (lone giant up to 16000, swarm dwarf down to
+        // 4000); bodies outside the galaxy (station interiors, ship worlds) carry no bias.
+        int circumference = WorldConstants.CircumferenceFor(locationId, sizeClass, worldBody?.SizeBias ?? 0f);
 
         var world = _worlds.GetOrCreate(planet, locationId, circumference, out bool isNew);
         world.SizeClass = sizeClass; // remembered for the per-world gravity band seeded in InitWeather
@@ -4168,6 +4176,7 @@ public sealed partial class GameServer
             SystemZ = b.SystemZ,
             OrbitPeriodDays = b.OrbitPeriodDays,
             ParentId = b.ParentId,
+            SizeBias = b.SizeBias, // #549: the client sizes this body with the same bias the server does
             PadsTotal = total,
             PadsFree = total > 0 ? FreePadCount(b.Id, total) : 0,
         };

--- a/src/BlocksBeyondTheStars.GameServer/GameServerBanditCamps.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerBanditCamps.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using BlocksBeyondTheStars.Shared.Configuration;
 using BlocksBeyondTheStars.Shared.Geometry;
+using BlocksBeyondTheStars.Shared.World;
 using BlocksBeyondTheStars.WorldGeneration;
 
 namespace BlocksBeyondTheStars.GameServer;
@@ -41,7 +42,22 @@ public sealed partial class GameServer
 
         // Rarer than ruins: most worlds have none. The rule slider nudges the odds, the seeded roll
         // decides — so a given body either is bandit country or it isn't, forever.
-        double odds = Rules.Bandits switch
+        // #547: in a Pirate Haven system the slider is effectively one step hotter (camps are the
+        // archetype's ground presence), and the world's Danger option scales the odds on top
+        // (Normal = ×1.0 keeps them exactly as before; Off yields no camps at all).
+        var activity = Rules.Bandits;
+        if (activity != AlienActivity.Off
+            && SystemArchetypeOf(_galaxy.FindBody(_world.LocationId)?.SystemId) == SystemArchetype.PirateHaven)
+        {
+            activity = activity switch
+            {
+                AlienActivity.Rare => AlienActivity.Normal,
+                AlienActivity.Normal => AlienActivity.Frequent,
+                _ => AlienActivity.Extreme,
+            };
+        }
+
+        double odds = activity switch
         {
             AlienActivity.Rare => 0.75,
             AlienActivity.Normal => 0.60,
@@ -49,6 +65,7 @@ public sealed partial class GameServer
             AlienActivity.Extreme => 0.30,
             _ => 1.0,
         };
+        odds = System.Math.Clamp(1.0 - (1.0 - odds) * _meta.Description.Danger.DangerFactor(), 0.05, 1.0);
         double r = rng.NextDouble();
         int count = r < odds ? 0 : r < odds + (1.0 - odds) * 0.8 ? 1 : 2;
         count = System.Math.Min(BanditCampHardCap, count);

--- a/src/BlocksBeyondTheStars.GameServer/GameServerBanditShips.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerBanditShips.cs
@@ -5,6 +5,7 @@ using BlocksBeyondTheStars.Networking.Messages;
 using BlocksBeyondTheStars.Shared.Configuration;
 using BlocksBeyondTheStars.Shared.Definitions;
 using BlocksBeyondTheStars.Shared.Geometry;
+using BlocksBeyondTheStars.Shared.World;
 using BlocksBeyondTheStars.WorldGeneration;
 
 namespace BlocksBeyondTheStars.GameServer;
@@ -38,10 +39,27 @@ public sealed partial class GameServer
         && !_storyState.GuardianDefeated;
 
     /// <summary>Deterministic "pirate space" flag per star system (trader-traffic pattern): roughly a
-    /// quarter of all systems, always the same ones for a given save.</summary>
+    /// quarter of all systems, always the same ones for a given save. With system variance (#547) the
+    /// archetype tilts the odds — a Pirate Haven IS pirate space, patrolled hub space almost never is;
+    /// Standard keeps the classic 25 so pre-variance saves are untouched.</summary>
     private bool BanditSystem(string systemId)
-        => !string.IsNullOrEmpty(systemId)
-           && (int)(((ulong)(_meta.Seed ^ WorldGenerator.StableHash("banditspace:" + systemId))) % 100) < 25;
+    {
+        if (string.IsNullOrEmpty(systemId))
+        {
+            return false;
+        }
+
+        int threshold = SystemArchetypeOf(systemId) switch
+        {
+            SystemArchetype.PirateHaven => 100,
+            SystemArchetype.Belt => 35, // good ambush cover between the rocks
+            SystemArchetype.Hub => 5,
+            SystemArchetype.Desolate => 15,
+            SystemArchetype.LoneGiant => 20,
+            _ => 25,
+        };
+        return (int)(((ulong)(_meta.Seed ^ WorldGenerator.StableHash("banditspace:" + systemId))) % 100) < threshold;
+    }
 
     private string SystemIdOfInstance(SpaceInstance instance)
     {
@@ -68,6 +86,9 @@ public sealed partial class GameServer
                     AlienActivity.Extreme => 0.70,
                     _ => 0.0,
                 };
+                // #547: the world's Danger option scales the ambush odds on top of the rule slider
+                // (Normal = ×1.0, i.e. exactly the old chance; Off disables ambushes entirely).
+                chance = System.Math.Min(0.9, chance * _meta.Description.Danger.DangerFactor());
                 if (_banditRng.NextDouble() < chance)
                 {
                     instance.BanditAmbushAt = _uptime + BanditAmbushDelayMin

--- a/src/BlocksBeyondTheStars.GameServer/GameServerSpace.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerSpace.cs
@@ -596,7 +596,7 @@ public sealed partial class GameServer
             return new List<LandingPad>();
         }
 
-        int circ = WorldConstants.CircumferenceFor(body.Id, WorldConstants.SizeClassFor(body.Kind, body.PlanetType ?? string.Empty));
+        int circ = WorldConstants.CircumferenceFor(body.Id, WorldConstants.SizeClassFor(body.Kind, body.PlanetType ?? string.Empty), body.SizeBias);
         return ComputeLandingPads(planet, body.Kind, body.Id, circ);
     }
 

--- a/src/BlocksBeyondTheStars.GameServer/GameServerSpaceCombat.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerSpaceCombat.cs
@@ -7,6 +7,7 @@ using BlocksBeyondTheStars.Shared.Definitions;
 using BlocksBeyondTheStars.Shared.Geometry;
 using BlocksBeyondTheStars.Shared.Primitives;
 using BlocksBeyondTheStars.Shared.World;
+using BlocksBeyondTheStars.WorldGeneration;
 
 namespace BlocksBeyondTheStars.GameServer;
 
@@ -549,7 +550,19 @@ public sealed partial class GameServer
                 // Spawn hostiles FAR from the launch point (well beyond ShipEngageRange) so launching/docking is
                 // safe and combat is opt-in — you choose to fly out to them. They used to spawn ~25u away and
                 // hammered the ship the instant it launched (continuous damage → destroyed → respawn at base).
+                // #547: the system archetype shades the ambient hostility — Desolate space is truly empty
+                // (no drones, no UFO), a Pirate Haven runs one extra drone when NPC enemies are on at all.
+                var archetype = SystemArchetypeOf(_galaxy.FindBody(bodyId)?.SystemId);
                 int drones = ActivityCount(Rules.SpaceNpcEnemies);
+                if (archetype == SystemArchetype.Desolate)
+                {
+                    drones = 0;
+                }
+                else if (archetype == SystemArchetype.PirateHaven && drones > 0)
+                {
+                    drones = System.Math.Min(4, drones + 1);
+                }
+
                 for (int i = 0; i < drones; i++)
                 {
                     instance.Entities.Add(new CombatEntity
@@ -565,7 +578,7 @@ public sealed partial class GameServer
                     });
                 }
 
-                if (Rules.AlienUfos != AlienActivity.Off)
+                if (Rules.AlienUfos != AlienActivity.Off && archetype != SystemArchetype.Desolate)
                 {
                     instance.Entities.Add(new CombatEntity
                     {

--- a/src/BlocksBeyondTheStars.GameServer/GameServerSpaceStations.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerSpaceStations.cs
@@ -89,7 +89,13 @@ public sealed partial class GameServer
             .Where(b => b.Kind == CelestialKind.SpaceStation)
             .ToList() ?? new List<CelestialBody>();
 
-        if (bodies.Count == 0 && _meta.Description.SpaceStations != Frequency.Off)
+        // The synthesised fallback station used to appear in EVERY station-less system, which defeated the
+        // generator's per-system station gate entirely. With system variance (#547) it survives only in the
+        // home system ("sys0" — where the start planet lands, see BuildGalaxy): a fresh save always has one
+        // reachable station for missions/trade, while Desolate or Pirate Haven systems out there genuinely
+        // have none. Pre-variance saves keep the old always-a-station behaviour.
+        bool fallbackHere = !_meta.Description.SystemVariance || systemId == "sys0";
+        if (bodies.Count == 0 && fallbackHere && _meta.Description.SpaceStations != Frequency.Off)
         {
             bodies.Add(new CelestialBody
             {

--- a/src/BlocksBeyondTheStars.GameServer/GameServerSpaceTraders.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerSpaceTraders.cs
@@ -143,6 +143,24 @@ public sealed partial class GameServer
 
         uint h = (uint)(_meta.Seed ^ WorldGenerator.StableHash("traffic:" + systemId));
         int bucket = (int)(h % 100u);
+
+        // The system archetype (#547) sets the trade character; Standard (and every pre-variance save)
+        // keeps the classic buckets. Sparse archetypes never exceed Rare — a lone outpost station out
+        // there shouldn't turn a backwater into a shipping lane.
+        switch (SystemArchetypeOf(systemId))
+        {
+            case SystemArchetype.Hub:
+                return TraderTraffic.Often; // civilised space: the lanes are always busy
+            case SystemArchetype.Desolate:
+                return TraderTraffic.None; // nobody trades with empty space
+            case SystemArchetype.PirateHaven:
+                return bucket < 60 ? TraderTraffic.None : TraderTraffic.Rare; // only the brave run this route
+            case SystemArchetype.LoneGiant:
+            case SystemArchetype.Belt:
+                // A lone outpost station still draws the odd freighter, but never a busy lane.
+                return hasStation || bucket >= 30 ? TraderTraffic.Rare : TraderTraffic.None;
+        }
+
         var level = bucket < 30 ? TraderTraffic.None : bucket < 75 ? TraderTraffic.Rare : TraderTraffic.Often;
 
         if (hasStation)

--- a/src/BlocksBeyondTheStars.Networking/Messages.cs
+++ b/src/BlocksBeyondTheStars.Networking/Messages.cs
@@ -961,6 +961,12 @@ public sealed class NetBody
     /// (live occupancy). PadsFree == 0 means the body is full — landing there is refused.</summary>
     public int PadsTotal { get; set; }
     public int PadsFree { get; set; }
+
+    /// <summary>Size bias in [-1, 1] (#549) — the archetype's size identity for this body. The client MUST
+    /// feed it into every <c>WorldConstants.CircumferenceFor</c> call for this body (orbit sphere, sky
+    /// bodies, pad map bake) or its rendered size disagrees with the walkable world the server builds.
+    /// 0 for every pre-variance body, so old saves and old clients keep the classic hashed size.</summary>
+    public float SizeBias { get; set; }
 }
 
 public sealed class NetStarSystem

--- a/src/BlocksBeyondTheStars.Shared/Configuration/ServerConfig.cs
+++ b/src/BlocksBeyondTheStars.Shared/Configuration/ServerConfig.cs
@@ -86,8 +86,11 @@ public sealed class ServerConfig
     /// <summary>Authoritative world rules (mode, PvP, hazards, death penalty, cheats, ...).</summary>
     public GameRules Rules { get; set; } = new();
 
-    /// <summary>Universe description used when first creating the world.</summary>
-    public BlocksBeyondTheStars.Shared.World.WorldDescription World { get; set; } = new();
+    /// <summary>Universe description used when first creating the world. System variance (#546) is on
+    /// here — every NEWLY created world gets archetype-varied star systems — while the
+    /// <see cref="BlocksBeyondTheStars.Shared.World.WorldDescription.SystemVariance"/> property itself
+    /// defaults to false, so a loaded save whose metadata predates the feature stays byte-identical.</summary>
+    public BlocksBeyondTheStars.Shared.World.WorldDescription World { get; set; } = new() { SystemVariance = true };
 
     /// <summary>Optional AI mission backend level (Off keeps the game fully AI-free).</summary>
     public AiLevel AiLevel { get; set; } = AiLevel.Off;
@@ -524,13 +527,40 @@ public sealed class ServerConfig
                     if (int.TryParse(value, out var sy)) { World.StarSystemCount = Math.Clamp(sy, 1, 32); applied.Add("systems"); }
                     break;
                 case "planets-min":
-                    if (int.TryParse(value, out var pmin)) { World.PlanetsPerSystemMin = Math.Clamp(pmin, 1, 10); applied.Add("planets-min"); }
+                    if (int.TryParse(value, out var pmin))
+                    {
+                        World.PlanetsPerSystemMin = Math.Clamp(pmin, 1, 10);
+                        // Keep min ≤ max no matter the arg order: DeterministicRandom.Range silently
+                        // returns min when max < min, which would bypass the max clamp entirely.
+                        World.PlanetsPerSystemMax = Math.Max(World.PlanetsPerSystemMax, World.PlanetsPerSystemMin);
+                        applied.Add("planets-min");
+                    }
+
                     break;
                 case "planets-max":
-                    if (int.TryParse(value, out var pmax)) { World.PlanetsPerSystemMax = Math.Clamp(pmax, 1, 12); applied.Add("planets-max"); }
+                    if (int.TryParse(value, out var pmax))
+                    {
+                        World.PlanetsPerSystemMax = Math.Clamp(pmax, 1, 12);
+                        World.PlanetsPerSystemMin = Math.Min(World.PlanetsPerSystemMin, World.PlanetsPerSystemMax);
+                        applied.Add("planets-max");
+                    }
+
                     break;
                 case "moons-max":
-                    if (int.TryParse(value, out var mm)) { World.MoonsPerPlanetMax = Math.Clamp(mm, 0, 5); applied.Add("moons-max"); }
+                    // Cap raised 5 → 8 (#546): the Lone Giant archetype carries up to 8 moons, so the
+                    // explicit slider may reach the same ceiling.
+                    if (int.TryParse(value, out var mm)) { World.MoonsPerPlanetMax = Math.Clamp(mm, 0, 8); applied.Add("moons-max"); }
+                    break;
+                case "variance":
+                    // System archetype variance (#546). On for every new world by default; "off" is the
+                    // escape hatch for tests/captures that need the classic uniform layout.
+                    if (bool.TryParse(value, out var sv)) { World.SystemVariance = sv; applied.Add("variance"); }
+                    else if (string.Equals(value, "on", StringComparison.OrdinalIgnoreCase)) { World.SystemVariance = true; applied.Add("variance"); }
+                    else if (string.Equals(value, "off", StringComparison.OrdinalIgnoreCase)) { World.SystemVariance = false; applied.Add("variance"); }
+                    break;
+                case "danger":
+                    // Global hostility multiplier (#547) — scales space-ambush odds + bandit-camp presence.
+                    if (Enum.TryParse<BlocksBeyondTheStars.Shared.World.Frequency>(value, ignoreCase: true, out var dg)) { World.Danger = dg; applied.Add("danger"); }
                     break;
                 case "planet-types":
                     // Advanced per-type page: "corrupted=Rare,ocean=Frequent,..." (unknown keys are ignored

--- a/src/BlocksBeyondTheStars.Shared/World/Galaxy.cs
+++ b/src/BlocksBeyondTheStars.Shared/World/Galaxy.cs
@@ -52,6 +52,13 @@ public sealed class CelestialBody
     /// <summary>The body this one orbits: a moon's parent planet, else empty (planets/asteroids orbit the
     /// star at the system origin). Lets the client centre a moon's orbit on its (also-moving) planet.</summary>
     public string ParentId { get; set; } = string.Empty;
+
+    /// <summary>Size bias in [-1, 1] fed into <see cref="WorldConstants.CircumferenceFor(string,
+    /// WorldConstants.WorldSizeClass, float)"/> — set by the system archetype (#549: a lone giant is
+    /// genuinely huge, swarm worlds small, twins matched). 0 (the default, and the value for every body
+    /// of a pre-variance save) keeps the classic hashed size exactly. Not persisted: like the rest of
+    /// the galaxy it re-derives deterministically from the seed.</summary>
+    public float SizeBias { get; set; }
 }
 
 /// <summary>A star system: a named cluster of bodies on the star map.</summary>

--- a/src/BlocksBeyondTheStars.Shared/World/WorldConstants.cs
+++ b/src/BlocksBeyondTheStars.Shared/World/WorldConstants.cs
@@ -207,21 +207,59 @@ public static class WorldConstants
     /// <summary>A deterministic walkable circumference for a body: very small for asteroids, small for moons,
     /// large for planets, varied within each class from the body key, and rounded to a whole number of chunks
     /// (so chunks tile cleanly across the seam). Same body → same size, on server and client.</summary>
-    public static int CircumferenceFor(string bodyKey, WorldSizeClass cls)
-    {
-        (int lo, int hi) = cls switch
-        {
-            WorldSizeClass.Asteroid => (800, 1600),
-            WorldSizeClass.Moon => (2500, 4000),
-            _ => (5000, 12000),
-        };
+    public static int CircumferenceFor(string bodyKey, WorldSizeClass cls) => CircumferenceFor(bodyKey, cls, 0f);
 
+    /// <summary>Size-biased variant (#549): <paramref name="sizeBias"/> in [-1, 1] pulls the hashed base
+    /// size toward an EXTENDED band edge — +1 reaches hi·4/3 (planets: 16000), −1 reaches lo·4/5
+    /// (planets: 4000) — so system archetypes can express giants and dwarfs. A bias of exactly 0 MUST
+    /// reproduce the unbiased value bit-for-bit: existing saves re-derive their terrain from this number,
+    /// and pre-variance bodies all carry bias 0. Callers pass <c>CelestialBody.SizeBias</c> (server) /
+    /// <c>NetBody.SizeBias</c> (client) so both ends keep agreeing on every body's size.</summary>
+    public static int CircumferenceFor(string bodyKey, WorldSizeClass cls, float sizeBias)
+    {
+        (int lo, int hi) = SizeBandFor(cls);
         uint h = (uint)StableHash(bodyKey);
         int span = hi - lo;
         int raw = lo + (int)(h % (uint)span);
+        if (sizeBias > 0f)
+        {
+            int hiExt = hi * 4 / 3;
+            raw += (int)System.Math.Round(System.Math.Min(1f, sizeBias) * (hiExt - raw));
+        }
+        else if (sizeBias < 0f)
+        {
+            int loExt = lo * 4 / 5;
+            raw += (int)System.Math.Round(System.Math.Max(-1f, sizeBias) * (raw - loExt));
+        }
+
         int rounded = (int)System.Math.Round(raw / (double)ChunkSize) * ChunkSize; // whole chunks
         return System.Math.Max(ChunkSize, rounded);
     }
+
+    /// <summary>The bias that makes <paramref name="bodyKey"/>'s circumference land (as close as the
+    /// extended band allows) on <paramref name="targetCircumference"/> — used by the Twin Worlds
+    /// archetype to size the second twin like the first. Inverse of the bias mapping above.</summary>
+    public static float BiasToward(string bodyKey, WorldSizeClass cls, int targetCircumference)
+    {
+        (int lo, int hi) = SizeBandFor(cls);
+        uint h = (uint)StableHash(bodyKey);
+        int raw = lo + (int)(h % (uint)(hi - lo));
+        if (targetCircumference >= raw)
+        {
+            int hiExt = hi * 4 / 3;
+            return hiExt <= raw ? 0f : System.Math.Clamp((targetCircumference - raw) / (float)(hiExt - raw), 0f, 1f);
+        }
+
+        int loExt = lo * 4 / 5;
+        return raw <= loExt ? 0f : System.Math.Clamp((targetCircumference - raw) / (float)(raw - loExt), -1f, 0f);
+    }
+
+    private static (int Lo, int Hi) SizeBandFor(WorldSizeClass cls) => cls switch
+    {
+        WorldSizeClass.Asteroid => (800, 1600),
+        WorldSizeClass.Moon => (2500, 4000),
+        _ => (5000, 12000),
+    };
 
     private static int StableHash(string s)
     {

--- a/src/BlocksBeyondTheStars.Shared/World/WorldDescription.cs
+++ b/src/BlocksBeyondTheStars.Shared/World/WorldDescription.cs
@@ -71,6 +71,19 @@ public static class FrequencyExtensions
         Frequency.Frequent => 1.7,
         _ => 1.0,
     };
+
+    /// <summary>Danger multiplier (#547) for <see cref="WorldDescription.Danger"/>: scales hostile
+    /// encounter odds (space ambush chance, bandit-camp presence) on top of the per-archetype gates.
+    /// Normal = 1.0 so existing saves (and the default) behave exactly as before; Off disables them.</summary>
+    public static double DangerFactor(this Frequency f) => f switch
+    {
+        Frequency.Off => 0.0,
+        Frequency.VeryRare => 0.5,
+        Frequency.Rare => 0.75,
+        Frequency.Normal => 1.0,
+        Frequency.Frequent => 1.5,
+        _ => 1.0,
+    };
 }
 
 /// <summary>
@@ -98,6 +111,14 @@ public sealed class WorldDescription
 
     public Frequency RareResources { get; set; } = Frequency.Rare;
     public Frequency Danger { get; set; } = Frequency.Normal;
+
+    /// <summary>Per-system archetype variance (#546): when true, every star system rolls a character
+    /// class (lone giant, swarm, belt, hub, desolate, pirate haven, twin worlds …) that shapes its
+    /// planet/moon/asteroid/station rolls, sizes and inhabitants. MUST default to false: the galaxy is
+    /// re-derived from the seed on every start, so flipping this on an existing save would change body
+    /// counts and orphan already-visited worlds. New worlds switch it on at creation (ServerConfig's
+    /// default description carries true; a loaded save keeps whatever its metadata stored).</summary>
+    public bool SystemVariance { get; set; }
 
     // --- World options (creation-time; baked into the save's metadata — they shape worldgen) ---
 

--- a/src/BlocksBeyondTheStars.WorldGeneration/SystemArchetypes.cs
+++ b/src/BlocksBeyondTheStars.WorldGeneration/SystemArchetypes.cs
@@ -1,0 +1,109 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using BlocksBeyondTheStars.Shared.World;
+
+namespace BlocksBeyondTheStars.WorldGeneration;
+
+/// <summary>The character class a star system rolls when <see cref="WorldDescription.SystemVariance"/>
+/// is on (#546). The archetype shapes the system's structural rolls in <see cref="UniverseGenerator"/>
+/// (planet/moon/asteroid/station/wreck counts, sizes) AND its inhabitants at runtime (trader traffic,
+/// pirate flag, camp odds) — so a system reads as one coherent place instead of eight unrelated dice.</summary>
+public enum SystemArchetype
+{
+    /// <summary>Today's distribution — the baseline every pre-variance world uses for every system.</summary>
+    Standard,
+    /// <summary>One oversized planet with a large moon family (4–8) — the "gas giant" fantasy.</summary>
+    LoneGiant,
+    /// <summary>Many small planets, almost no moons.</summary>
+    Swarm,
+    /// <summary>Few planets, a dense field of landable asteroids; wrecks likelier.</summary>
+    Belt,
+    /// <summary>Civilised space: stations guaranteed, heavy trade, pirates almost absent.</summary>
+    Hub,
+    /// <summary>Near-empty space: one or two lonely worlds, no stations, no traders.</summary>
+    Desolate,
+    /// <summary>Lawless space: always pirate territory, more camps, no stations, wrecks everywhere.</summary>
+    PirateHaven,
+    /// <summary>Exactly two planets of similar size on close orbits.</summary>
+    TwinWorlds,
+}
+
+/// <summary>Deterministically resolves a system's <see cref="SystemArchetype"/> from the world seed —
+/// the SAME way for the generator and every runtime consumer (traders/bandits/camps), so no persistence
+/// is needed (the trader-traffic pattern). Uses its own <see cref="Noise.Hash"/> salt (500-series),
+/// never the generator's order-sensitive per-system rng stream.</summary>
+public static class SystemArchetypes
+{
+    /// <summary>Hash01 salt for the archetype draw. 5xx is unused by UniverseGenerator's other draws
+    /// (planets 1xx, moons 2xx, wreck/asteroids 3xx, asteroid families 4xx); 501/502 are reserved for
+    /// the archetype's size-bias and twin-orbit draws.</summary>
+    private const long ArchetypeSalt = 500;
+
+    private static readonly (SystemArchetype Archetype, int Weight)[] Table =
+    {
+        (SystemArchetype.Standard, 30),
+        (SystemArchetype.LoneGiant, 12),
+        (SystemArchetype.Swarm, 12),
+        (SystemArchetype.Belt, 10),
+        (SystemArchetype.Hub, 10),
+        (SystemArchetype.Desolate, 12),
+        (SystemArchetype.PirateHaven, 8),
+        (SystemArchetype.TwinWorlds, 6),
+    };
+
+    /// <summary>Archetype for a system id ("sys{i}"). Standard when variance is off, for reserved ids
+    /// (the guardian finale), and for anything unparseable — so pre-variance saves and special systems
+    /// behave exactly as before.</summary>
+    public static SystemArchetype For(long seed, string? systemId, WorldDescription desc)
+    {
+        if (!desc.SystemVariance
+            || string.IsNullOrEmpty(systemId)
+            || !systemId.StartsWith("sys", System.StringComparison.Ordinal)
+            || !int.TryParse(systemId.Substring(3), out int index)
+            || index < 0)
+        {
+            return SystemArchetype.Standard;
+        }
+
+        return ForIndex(seed, index);
+    }
+
+    /// <summary>Archetype for a system INDEX (the generator's loop variable). The home system (index 0)
+    /// never rolls Desolate or Pirate Haven, so a fresh start always has a friendly, non-empty sky.</summary>
+    public static SystemArchetype ForIndex(long seed, int systemIndex)
+    {
+        bool home = systemIndex == 0;
+        int total = 0;
+        foreach (var (archetype, weight) in Table)
+        {
+            if (home && ExcludedForHome(archetype))
+            {
+                continue;
+            }
+
+            total += weight;
+        }
+
+        double h01 = (Noise.Hash(seed, systemIndex, ArchetypeSalt, 1) >> 11) * (1.0 / 9007199254740992.0);
+        int roll = 1 + (int)(h01 * total);
+        foreach (var (archetype, weight) in Table)
+        {
+            if (home && ExcludedForHome(archetype))
+            {
+                continue;
+            }
+
+            roll -= weight;
+            if (roll <= 0)
+            {
+                return archetype;
+            }
+        }
+
+        return SystemArchetype.Standard;
+    }
+
+    private static bool ExcludedForHome(SystemArchetype a)
+        => a is SystemArchetype.Desolate or SystemArchetype.PirateHaven;
+}

--- a/src/BlocksBeyondTheStars.WorldGeneration/UniverseGenerator.cs
+++ b/src/BlocksBeyondTheStars.WorldGeneration/UniverseGenerator.cs
@@ -142,7 +142,25 @@ public sealed class UniverseGenerator
                 MapY = rng.NextFloat() * 1000f,
             };
 
-            int planets = rng.Range(_desc.PlanetsPerSystemMin, _desc.PlanetsPerSystemMax);
+            // The system's character class (#546). With SystemVariance off (every pre-variance save) this
+            // is ALWAYS Standard, and every Standard roll below is the exact draw the legacy code made —
+            // so old worlds regenerate byte-identically. Drawn from its own Hash01 salt (500), never rng.
+            var archetype = _desc.SystemVariance ? SystemArchetypes.ForIndex(_seed, i) : SystemArchetype.Standard;
+            int planetCap = System.Math.Max(1, _desc.PlanetsPerSystemMax); // the world-size slider still caps
+            int moonCap = System.Math.Max(0, _desc.MoonsPerPlanetMax);
+
+            int planets = archetype switch
+            {
+                SystemArchetype.LoneGiant => 1,
+                SystemArchetype.Swarm => rng.Range(System.Math.Min(6, planetCap), System.Math.Min(9, planetCap)),
+                SystemArchetype.Belt => rng.Range(1, System.Math.Min(3, planetCap)),
+                SystemArchetype.Hub => rng.Range(System.Math.Min(3, planetCap), System.Math.Min(5, planetCap)),
+                SystemArchetype.Desolate => rng.Range(1, System.Math.Min(2, planetCap)),
+                SystemArchetype.PirateHaven => rng.Range(System.Math.Min(2, planetCap), System.Math.Min(4, planetCap)),
+                SystemArchetype.TwinWorlds => System.Math.Min(2, planetCap),
+                _ => rng.Range(_desc.PlanetsPerSystemMin, _desc.PlanetsPerSystemMax),
+            };
+            float firstAngle = 0f, firstRadius = 0f; // the first twin's orbit, so the second can sit beside it
             for (int p = 0; p < planets; p++)
             {
                 var planet = new CelestialBody
@@ -158,6 +176,20 @@ public sealed class UniverseGenerator
                 // existing universes — stay byte-identical.
                 float pAngle = Hash01(i, p, 101) * Tau;
                 float pRadius = BaseOrbit + p * OrbitStep + (Hash01(i, p, 102) - 0.5f) * OrbitJitter;
+                if (archetype == SystemArchetype.TwinWorlds && p == 1)
+                {
+                    // The second twin shares the first's orbit band, a nudge along the arc — visually a pair.
+                    // The client's separation pass guarantees they never clip at render scale.
+                    pAngle = firstAngle + 0.25f + Hash01(i, 502, 1) * 0.25f;
+                    pRadius = firstRadius + 230f;
+                }
+
+                if (p == 0)
+                {
+                    firstAngle = pAngle;
+                    firstRadius = pRadius;
+                }
+
                 planet.SystemX = pRadius * System.MathF.Cos(pAngle);
                 planet.SystemZ = pRadius * System.MathF.Sin(pAngle);
                 // Visual/phase orbit (does not move the t=0 coords above). Period seeded from a SEPARATE hash
@@ -165,9 +197,25 @@ public sealed class UniverseGenerator
                 // enough that, at the default ~10-min day, the phase visibly drifts within a play session.
                 planet.OrbitPeriodDays = OrbitSign(i, p, 130) * (6f + Hash01(i, p, 131) * 34f); // 6..40 d
                 planet.ParentId = string.Empty; // orbits the star at the origin
+                // Archetype size identity (#549): the lone giant is genuinely huge, swarm worlds run small.
+                // Salt 501; bias 0 for everything else keeps the classic hashed size (and pre-variance saves).
+                planet.SizeBias = archetype switch
+                {
+                    SystemArchetype.LoneGiant => 0.6f + Hash01(i, 501, p) * 0.4f,
+                    SystemArchetype.Swarm => -(0.2f + Hash01(i, 501, p) * 0.3f),
+                    _ => 0f,
+                };
                 system.Bodies.Add(planet);
 
-                int moons = rng.Range(_desc.MoonsPerPlanetMin, _desc.MoonsPerPlanetMax);
+                int moons = archetype switch
+                {
+                    SystemArchetype.LoneGiant => rng.Range(4, 8), // its identity — deliberately above the slider
+                    SystemArchetype.Swarm => rng.NextDouble() < 0.8 ? 0 : 1,
+                    SystemArchetype.Belt or SystemArchetype.PirateHaven => rng.Range(0, System.Math.Min(2, moonCap)),
+                    SystemArchetype.Desolate => rng.Range(0, System.Math.Min(1, moonCap)),
+                    SystemArchetype.TwinWorlds => rng.Range(System.Math.Min(1, moonCap), System.Math.Min(2, moonCap)),
+                    _ => rng.Range(_desc.MoonsPerPlanetMin, _desc.MoonsPerPlanetMax), // Standard + Hub
+                };
                 for (int m = 0; m < moons; m++)
                 {
                     float mAngle = Hash01(i, p, 200 + m) * Tau;
@@ -188,13 +236,33 @@ public sealed class UniverseGenerator
                 }
             }
 
+            // Twin Worlds (#549): size the second twin like the first — BiasToward inverts the size mapping,
+            // so both land on (almost) the same circumference despite their independent id hashes.
+            if (archetype == SystemArchetype.TwinWorlds)
+            {
+                var twins = system.Bodies.Where(b => b.Kind == CelestialKind.Planet).ToList();
+                if (twins.Count == 2)
+                {
+                    int target = WorldConstants.CircumferenceFor(twins[0].Id, WorldConstants.WorldSizeClass.Planet);
+                    twins[1].SizeBias = WorldConstants.BiasToward(twins[1].Id, WorldConstants.WorldSizeClass.Planet, target);
+                }
+            }
+
             // A few large, landable asteroids per system: walkable "asteroid" worlds you can land on with the
             // ship or on an EVA, each sized deterministically by its id (CircumferenceFor → Asteroid class). The
             // small mineable rocks spawn separately as space entities at any body. (One rng draw, like the old
             // single-belt gate, so existing systems' stations/wrecks downstream stay put.)
             // Each rock also rolls its own FAMILY (#515) — stony, metallic, icy, carbonaceous or crystalline —
             // so a system's asteroids differ in surface, temperature and what they're worth mining.
-            int asteroidCount = 2 + (rng.NextDouble() < 0.5 ? 1 : 0); // 2 or 3
+            int asteroidCount = archetype switch
+            {
+                SystemArchetype.LoneGiant => rng.Range(1, 2),
+                SystemArchetype.Swarm => rng.Range(2, 4),
+                SystemArchetype.Belt => rng.Range(5, 8), // the belt IS the system
+                SystemArchetype.Desolate => rng.Range(0, 1),
+                SystemArchetype.PirateHaven => rng.Range(3, 5), // cover for ambushes
+                _ => 2 + (rng.NextDouble() < 0.5 ? 1 : 0), // Standard/Hub/Twin: 2 or 3, the legacy draw
+            };
             for (int a = 0; a < asteroidCount; a++)
             {
                 var (ax, az) = DiscPoint(i, planets, 310 + a);
@@ -217,13 +285,28 @@ public sealed class UniverseGenerator
             // planet and named after it ("<planet> Station") so they're attributable. A second station is rare and
             // a third very rare. Count + planet picks come from a SEPARATE hash (not rng), so adding stations never
             // disturbs the wreck rng draw below — only the stations themselves change for existing universes.
-            if (rng.NextDouble() < _desc.SpaceStations.Probability())
+            // The archetype overrides the gate where it defines the system's character: a Hub always has
+            // stations, Desolate/Pirate space never does, a Lone Giant/Belt system tops out at one. The
+            // gate draw itself ALWAYS happens so Standard systems keep the legacy rng sequence.
+            double stationGate = rng.NextDouble();
+            bool anyStations = archetype switch
+            {
+                SystemArchetype.Hub => _desc.SpaceStations != Frequency.Off,
+                SystemArchetype.Desolate or SystemArchetype.PirateHaven => false,
+                _ => stationGate < _desc.SpaceStations.Probability(),
+            };
+            if (anyStations)
             {
                 var systemPlanets = system.Bodies.Where(b => b.Kind == CelestialKind.Planet).ToList();
 
                 int stationCount = 1;
                 if (Hash01(i, 320, 1) < 0.25f) stationCount = 2;                          // second station: ~25%
                 if (stationCount == 2 && Hash01(i, 320, 2) < 0.30f) stationCount = 3;      // third: ~7.5% (very rare)
+                if (archetype is SystemArchetype.LoneGiant or SystemArchetype.Belt)
+                {
+                    stationCount = 1; // sparse archetypes: at most a single outpost
+                }
+
                 stationCount = System.Math.Min(stationCount, systemPlanets.Count);        // can't exceed planets (one each)
 
                 // Deterministic shuffle so each station sits over a different planet (no two share one).
@@ -254,7 +337,16 @@ public sealed class UniverseGenerator
                 }
             }
 
-            if (rng.NextDouble() < _desc.Wrecks.Probability())
+            // Wreck odds follow the archetype's story: lawless/derelict space is littered with them,
+            // patrolled hub space is mostly cleaned up. Standard multiplier 1.0 = the legacy chance.
+            double wreckChance = _desc.Wrecks.Probability() * archetype switch
+            {
+                SystemArchetype.Belt or SystemArchetype.Desolate => 1.5,
+                SystemArchetype.PirateHaven => 2.0,
+                SystemArchetype.Hub => 0.5,
+                _ => 1.0,
+            };
+            if (rng.NextDouble() < System.Math.Min(0.95, wreckChance))
             {
                 var (wx, wz) = DiscPoint(i, planets, 303);
                 (wx, wz) = SeparateFromBodies(system, wx, wz); // a wreck shouldn't clip a body either

--- a/tests/BlocksBeyondTheStars.Client.Tests/SystemBodyLayoutTests.cs
+++ b/tests/BlocksBeyondTheStars.Client.Tests/SystemBodyLayoutTests.cs
@@ -22,10 +22,10 @@ public sealed class SystemBodyLayoutTests
     private const float KeepOutMargin = 10f; // the shell the ship is held at, from SpaceView
     private const float Tolerance = 0.01f;
 
-    private static float RadiusOf(string id, CelestialKind kind, string? planetType)
+    private static float RadiusOf(string id, CelestialKind kind, string? planetType, float sizeBias = 0f)
     {
         var cls = WorldConstants.SizeClassFor(kind, planetType ?? string.Empty);
-        return (8f + WorldConstants.CircumferenceFor(id, cls) / 220f) * 0.5f;
+        return (8f + WorldConstants.CircumferenceFor(id, cls, sizeBias) / 220f) * 0.5f;
     }
 
     [Fact]
@@ -64,9 +64,14 @@ public sealed class SystemBodyLayoutTests
         var content = ContentLoader.LoadFromDirectory(ClientTestPaths.DataDir());
         int systemsChecked = 0, bodiesChecked = 0;
 
-        for (long seed = 1; seed <= 40; seed++)
+        // Replay classic worlds AND archetype-varied ones (#546): the lone giant's 8-moon ladder and the
+        // size-biased bodies must keep the same clear-gap guarantee as the uniform layout.
+        // Runs 1..40 use the classic description, 41..80 re-run the same 40 seeds with variance on.
+        for (long run = 1; run <= 80; run++)
         {
-            var galaxy = new UniverseGenerator(seed, new WorldDescription(), content).Generate();
+            long seed = run <= 40 ? run : run - 40;
+            var desc = new WorldDescription { SystemVariance = run > 40 };
+            var galaxy = new UniverseGenerator(seed, desc, content).Generate();
             foreach (var system in galaxy.Systems)
             {
                 // The body you launched from: it stays put and is drawn oversized, as in the view.
@@ -77,7 +82,7 @@ public sealed class SystemBodyLayoutTests
                 }
 
                 systemsChecked++;
-                float homeRadius = RadiusOf(home.Id, home.Kind, home.PlanetType) * 3.2f;
+                float homeRadius = RadiusOf(home.Id, home.Kind, home.PlanetType, home.SizeBias) * 3.2f;
                 const float homeX = 0f, homeZ = -20f;
 
                 var xs = new List<float>();
@@ -90,6 +95,7 @@ public sealed class SystemBodyLayoutTests
                 {
                     (home.SystemX, home.SystemZ, homeX, homeZ, homeRadius),
                 };
+                var parentIndexById = new Dictionary<string, int> { [home.Id] = 0 };
                 foreach (var b in system.Bodies)
                 {
                     if (b.Id == home.Id || b.Kind != CelestialKind.Planet)
@@ -99,12 +105,15 @@ public sealed class SystemBodyLayoutTests
 
                     float x = (b.SystemX - home.SystemX) * SystemViewScale;
                     float z = (b.SystemZ - home.SystemZ) * SystemViewScale;
-                    float r = RadiusOf(b.Id, b.Kind, b.PlanetType);
+                    float r = RadiusOf(b.Id, b.Kind, b.PlanetType, b.SizeBias);
                     xs.Add(x); zs.Add(z); radii.Add(r);
+                    parentIndexById[b.Id] = parents.Count;
                     parents.Add((b.SystemX, b.SystemZ, x, z, r));
                 }
 
-                // Moons, clamped out to the minimum orbit around their nearest planet.
+                // Moons: parented by ParentId (nearest-planet fallback), each on its own ascending orbit
+                // slot around its parent — mirrors SpaceView's moon ladder (#548).
+                var ladder = new Dictionary<int, (float Orbit, float Radius)>();
                 foreach (var b in system.Bodies)
                 {
                     if (b.Id == home.Id || b.Kind != CelestialKind.Moon)
@@ -112,24 +121,33 @@ public sealed class SystemBodyLayoutTests
                         continue;
                     }
 
-                    int best = 0;
-                    float bestSq = float.MaxValue;
-                    for (int i = 0; i < parents.Count; i++)
+                    if (string.IsNullOrEmpty(b.ParentId) || !parentIndexById.TryGetValue(b.ParentId, out int best))
                     {
-                        float ddx = b.SystemX - parents[i].Sx, ddz = b.SystemZ - parents[i].Sz;
-                        float dsq = (ddx * ddx) + (ddz * ddz);
-                        if (dsq < bestSq)
+                        best = 0;
+                        float bestSq = float.MaxValue;
+                        for (int i = 0; i < parents.Count; i++)
                         {
-                            bestSq = dsq;
-                            best = i;
+                            float ddx = b.SystemX - parents[i].Sx, ddz = b.SystemZ - parents[i].Sz;
+                            float dsq = (ddx * ddx) + (ddz * ddz);
+                            if (dsq < bestSq)
+                            {
+                                bestSq = dsq;
+                                best = i;
+                            }
                         }
                     }
 
                     var parent = parents[best];
                     float relX = (b.SystemX - parent.Sx) * SystemViewScale;
                     float relZ = (b.SystemZ - parent.Sz) * SystemViewScale;
-                    float moonRadius = RadiusOf(b.Id, b.Kind, b.PlanetType);
+                    float moonRadius = RadiusOf(b.Id, b.Kind, b.PlanetType, b.SizeBias);
                     float minClear = SystemBodyLayout.MinOrbitFor(parent.R, moonRadius);
+                    if (ladder.TryGetValue(best, out var last))
+                    {
+                        minClear = MathF.Max(minClear,
+                            last.Orbit + last.Radius + moonRadius + SystemBodyLayout.ClearGapFor(last.Radius, moonRadius));
+                    }
+
                     float mag = MathF.Sqrt((relX * relX) + (relZ * relZ));
                     if (mag < minClear)
                     {
@@ -144,7 +162,11 @@ public sealed class SystemBodyLayoutTests
                             relX = minClear;
                             relZ = 0f;
                         }
+
+                        mag = minClear;
                     }
+
+                    ladder[best] = (mag, moonRadius);
 
                     xs.Add(parent.X + relX); zs.Add(parent.Z + relZ); radii.Add(moonRadius);
                     if (best == 0)
@@ -164,7 +186,7 @@ public sealed class SystemBodyLayoutTests
                     string type = string.IsNullOrEmpty(b.PlanetType) ? "asteroid" : b.PlanetType;
                     xs.Add((b.SystemX - home.SystemX) * SystemViewScale);
                     zs.Add((b.SystemZ - home.SystemZ) * SystemViewScale);
-                    radii.Add(RadiusOf(b.Id, b.Kind, type));
+                    radii.Add(RadiusOf(b.Id, b.Kind, type, b.SizeBias));
                 }
 
                 var bx = xs.ToArray();

--- a/tests/BlocksBeyondTheStars.Tests/UniverseTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/UniverseTests.cs
@@ -298,6 +298,192 @@ public sealed class UniverseTests : IDisposable
         }
     }
 
+    // --- System archetype variance (#546/#549) ---
+
+    private static WorldDescription VarianceDesc(int systems = 150) => new()
+    {
+        StarSystemCount = systems,
+        SystemVariance = true,
+        SpaceStations = Frequency.Rare,
+    };
+
+    [Fact]
+    public void VarianceOff_LeavesEveryBodyUnbiased()
+    {
+        // A pre-variance save regenerates its galaxy with this exact path — no body may carry a size bias
+        // (bias 0 keeps CircumferenceFor bit-identical, so existing terrain stays valid).
+        var galaxy = new UniverseGenerator(42, new WorldDescription { StarSystemCount = 20 }, _content).Generate();
+        Assert.All(galaxy.AllBodies(), b => Assert.Equal(0f, b.SizeBias));
+    }
+
+    [Fact]
+    public void Variance_IsDeterministic_ForSameSeed()
+    {
+        var a = new UniverseGenerator(42, VarianceDesc(30), _content).Generate();
+        var b = new UniverseGenerator(42, VarianceDesc(30), _content).Generate();
+        Assert.Equal(BodyKey(a), BodyKey(b));
+        Assert.Equal(
+            a.AllBodies().Select(x => (x.SystemX, x.SystemZ, x.SizeBias)),
+            b.AllBodies().Select(x => (x.SystemX, x.SystemZ, x.SizeBias)));
+    }
+
+    [Fact]
+    public void Variance_EveryArchetypeAppears_AndShapesItsSystems()
+    {
+        var desc = VarianceDesc(150);
+        var galaxy = new UniverseGenerator(7, desc, _content).Generate();
+        var seen = new HashSet<SystemArchetype>();
+
+        for (int i = 0; i < galaxy.Systems.Count; i++)
+        {
+            var sys = galaxy.Systems[i];
+            var archetype = SystemArchetypes.ForIndex(7, i);
+            seen.Add(archetype);
+
+            var planets = sys.Bodies.Where(b => b.Kind == CelestialKind.Planet).ToList();
+            int stations = sys.Bodies.Count(b => b.Kind == CelestialKind.SpaceStation);
+            int asteroids = sys.Bodies.Count(b => b.Kind == CelestialKind.AsteroidField);
+
+            switch (archetype)
+            {
+                case SystemArchetype.LoneGiant:
+                    Assert.Single(planets);
+                    Assert.True(planets[0].SizeBias >= 0.6f, $"{sys.Id}: giant bias {planets[0].SizeBias}");
+                    Assert.InRange(sys.Bodies.Count(b => b.Kind == CelestialKind.Moon), 4, 8);
+                    Assert.InRange(stations, 0, 1);
+                    break;
+                case SystemArchetype.Swarm:
+                    Assert.InRange(planets.Count, 6, 9);
+                    Assert.All(planets, p => Assert.True(p.SizeBias < 0f, $"{p.Id}: swarm worlds run small"));
+                    foreach (var p in planets)
+                    {
+                        Assert.InRange(sys.Bodies.Count(b => b.Kind == CelestialKind.Moon && b.ParentId == p.Id), 0, 1);
+                    }
+
+                    break;
+                case SystemArchetype.Belt:
+                    Assert.InRange(planets.Count, 1, 3);
+                    Assert.InRange(asteroids, 5, 8);
+                    Assert.InRange(stations, 0, 1);
+                    break;
+                case SystemArchetype.Hub:
+                    Assert.InRange(planets.Count, 3, 5);
+                    Assert.InRange(stations, 1, 3); // a hub ALWAYS has stations (SpaceStations is not Off)
+                    break;
+                case SystemArchetype.Desolate:
+                    Assert.InRange(planets.Count, 1, 2);
+                    Assert.Equal(0, stations);
+                    Assert.InRange(asteroids, 0, 1);
+                    break;
+                case SystemArchetype.PirateHaven:
+                    Assert.Equal(0, stations);
+                    Assert.InRange(asteroids, 3, 5);
+                    break;
+                case SystemArchetype.TwinWorlds:
+                    Assert.Equal(2, planets.Count);
+                    int c0 = WorldConstants.CircumferenceFor(planets[0].Id, WorldConstants.WorldSizeClass.Planet, planets[0].SizeBias);
+                    int c1 = WorldConstants.CircumferenceFor(planets[1].Id, WorldConstants.WorldSizeClass.Planet, planets[1].SizeBias);
+                    Assert.True(System.Math.Abs(c0 - c1) <= WorldConstants.ChunkSize,
+                        $"{sys.Id}: twins sized {c0} vs {c1}");
+                    break;
+            }
+        }
+
+        // 150 systems at the table weights: every archetype shows up.
+        foreach (SystemArchetype a in System.Enum.GetValues<SystemArchetype>())
+        {
+            Assert.Contains(a, seen);
+        }
+    }
+
+    [Fact]
+    public void Variance_HomeSystem_NeverRollsDesolateOrPirateHaven()
+    {
+        // The start system must stay friendly: a fresh save needs reachable trade + no forced pirate space.
+        for (long seed = 1; seed <= 300; seed++)
+        {
+            var archetype = SystemArchetypes.ForIndex(seed, 0);
+            Assert.NotEqual(SystemArchetype.Desolate, archetype);
+            Assert.NotEqual(SystemArchetype.PirateHaven, archetype);
+        }
+    }
+
+    [Fact]
+    public void Variance_RespectsTheWorldSizePlanetCap()
+    {
+        // The world-size slider still caps planet counts (a "Klein" world stays small); the Lone Giant's
+        // moons are the one deliberate exception to the moon slider (its identity), capped at 8.
+        var desc = new WorldDescription
+        {
+            StarSystemCount = 60,
+            SystemVariance = true,
+            PlanetsPerSystemMax = 4,
+            MoonsPerPlanetMax = 2,
+        };
+        var galaxy = new UniverseGenerator(11, desc, _content).Generate();
+        foreach (var sys in galaxy.Systems)
+        {
+            Assert.InRange(sys.Bodies.Count(b => b.Kind == CelestialKind.Planet), 1, 4);
+            foreach (var planet in sys.Bodies.Where(b => b.Kind == CelestialKind.Planet))
+            {
+                Assert.InRange(sys.Bodies.Count(b => b.Kind == CelestialKind.Moon && b.ParentId == planet.Id), 0, 8);
+            }
+        }
+    }
+
+    [Fact]
+    public void Variance_NeverCollidesWithTheReservedFinaleArea()
+    {
+        const string reserved = SvGameServer.GuardianFinaleSystemId;
+        foreach (long seed in new long[] { 1, 42, 2026 })
+        {
+            var galaxy = new UniverseGenerator(seed, VarianceDesc(150), _content).Generate();
+            Assert.DoesNotContain(galaxy.Systems, s => s.Id == reserved || s.Id.StartsWith(reserved));
+            Assert.DoesNotContain(galaxy.AllBodies(),
+                b => b.Id == SvGameServer.GuardianCoreBodyId || b.Id.StartsWith(reserved) || b.SystemId == reserved);
+        }
+    }
+
+    [Fact]
+    public void Archetypes_DriveTrafficAndPirateFlags_OnALiveServer()
+    {
+        // The runtime consumers resolve the archetype from the seed the same way the generator does:
+        // a Desolate system has no trade, a Hub is always busy, a Pirate Haven is always pirate space.
+        using var repo = new SqliteWorldRepository(new SaveGamePaths(_root, "arch"));
+        var link = new LoopbackLink();
+        using var st = new LoopbackServerTransport(link);
+
+        var config = new ServerConfig { WorldName = "arch", Seed = 11, AutoSaveIntervalMinutes = 9999 };
+        config.World.StarSystemCount = 32; // ServerConfig's default description has SystemVariance = true
+        config.PlaceBanditCamps = false;   // keep world startup light — we only probe the per-system gates
+
+        var server = new SvGameServer(config, _content, st, repo);
+        server.Start();
+
+        bool sawDesolate = false, sawHub = false, sawPirate = false;
+        for (int i = 0; i < 32; i++)
+        {
+            switch (SystemArchetypes.ForIndex(11, i))
+            {
+                case SystemArchetype.Desolate:
+                    sawDesolate = true;
+                    Assert.Equal("None", server.TrafficLevelForTest($"sys{i}"));
+                    break;
+                case SystemArchetype.Hub:
+                    sawHub = true;
+                    Assert.Equal("Often", server.TrafficLevelForTest($"sys{i}"));
+                    break;
+                case SystemArchetype.PirateHaven:
+                    sawPirate = true;
+                    Assert.True(server.BanditSystemForTest($"sys{i}"), $"sys{i} must be pirate space");
+                    break;
+            }
+        }
+
+        Assert.True(sawDesolate && sawHub && sawPirate,
+            $"seed 11 / 32 systems should roll all three probed archetypes (desolate {sawDesolate}, hub {sawHub}, pirate {sawPirate})");
+    }
+
     [Fact]
     public void Server_BuildsGalaxy_MarksStartVisited_AndServesStarMap()
     {

--- a/tests/BlocksBeyondTheStars.Tests/WorldWrapTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/WorldWrapTests.cs
@@ -264,6 +264,42 @@ public class WorldWrapTests
     }
 
     [Fact]
+    public void CircumferenceFor_SizeBias_ZeroIsBitIdentical_AndFullBiasReachesTheExtendedBand()
+    {
+        // #549: bias 0 MUST reproduce the classic value exactly — existing saves re-derive their terrain
+        // from it. Full bias lands on the extended band edges (planets 4000/16000), still chunk-aligned.
+        foreach (string key in new[] { "sys0-p0", "sys3-p1", "body-a" })
+        {
+            int baseline = WorldConstants.CircumferenceFor(key, WorldConstants.WorldSizeClass.Planet);
+            Assert.Equal(baseline, WorldConstants.CircumferenceFor(key, WorldConstants.WorldSizeClass.Planet, 0f));
+
+            int giant = WorldConstants.CircumferenceFor(key, WorldConstants.WorldSizeClass.Planet, 1f);
+            int dwarf = WorldConstants.CircumferenceFor(key, WorldConstants.WorldSizeClass.Planet, -1f);
+            Assert.Equal(16000, giant);
+            Assert.Equal(4000, dwarf);
+
+            int half = WorldConstants.CircumferenceFor(key, WorldConstants.WorldSizeClass.Planet, 0.5f);
+            Assert.InRange(half, baseline, giant); // monotonic pull toward the giant edge
+            Assert.Equal(0, half % WorldConstants.ChunkSize);
+        }
+    }
+
+    [Fact]
+    public void BiasToward_MakesTwoBodiesLandOnTheSameSize()
+    {
+        // The Twin Worlds archetype sizes the second twin like the first: the inverse mapping must land
+        // within one chunk of the target (the rounding step) for any pair of ids.
+        foreach (var (a, b) in new[] { ("sys1-p0", "sys1-p1"), ("sys7-p0", "sys7-p1"), ("body-a", "body-b") })
+        {
+            int target = WorldConstants.CircumferenceFor(a, WorldConstants.WorldSizeClass.Planet);
+            float bias = WorldConstants.BiasToward(b, WorldConstants.WorldSizeClass.Planet, target);
+            int got = WorldConstants.CircumferenceFor(b, WorldConstants.WorldSizeClass.Planet, bias);
+            Assert.InRange(System.Math.Abs(got - target), 0, WorldConstants.ChunkSize);
+            Assert.InRange(bias, -1f, 1f);
+        }
+    }
+
+    [Fact]
     public void SizeClassFor_DistinguishesAsteroidMoonPlanet()
     {
         Assert.Equal(WorldConstants.WorldSizeClass.Asteroid, WorldConstants.SizeClassFor(CelestialKind.Planet, "asteroid"));


### PR DESCRIPTION
## Summary

Newly created worlds get **high per-system variance**: every star system rolls a character class that shapes its bodies, sizes and inhabitants. Existing saves are completely untouched.

| Archetype | Weight | Character |
|---|---|---|
| Standard | 30 | exactly today''s rolls |
| Lone Giant | 12 | 1 oversized planet (up to 16000 circumference), 4–8 moons |
| Swarm | 12 | 6–9 small planets, ≤1 moon each |
| Belt | 10 | 1–3 planets, 5–8 landable asteroids |
| Hub | 10 | stations guaranteed, trade lanes always busy, pirates ~never |
| Desolate | 12 | 1–2 planets, no stations/traders/drones, wrecks likelier |
| Pirate Haven | 8 | always pirate space, more camps, no stations, wrecks doubled |
| Twin Worlds | 6 | exactly 2 like-sized planets on close orbits |

### Generator (#546)
- `SystemArchetypes` resolves the class deterministically from the seed (own `Hash01` salt 500) — the generator AND every runtime consumer use the same resolver, nothing is persisted.
- The home system (`sys0`) never rolls Desolate/Pirate Haven; the start experience stays friendly.
- `--moons-max` clamp raised 5 → 8 (Lone Giant identity), planets min/max cross-normalise, new `--variance on|off` and `--danger` args.

### Per-body size (#549)
- `CelestialBody.SizeBias` ∈ [-1, 1] → `CircumferenceFor(key, class, bias)` maps onto an extended band (planets 4000–16000 instead of 5000–12000). **Bias 0 is bit-identical to the classic hash** — existing terrain is safe. `BiasToward` inverts the mapping to size the second twin like the first. `NetBody.SizeBias` keeps client and server agreeing.

### Inhabitants (#547)
- Trader traffic, pirate-space flag, bandit-camp odds and ambient drones/UFOs read the archetype; the previously **dead `Danger` world option** now scales hostile odds globally (Normal = ×1.0 = unchanged).
- The synthesised fallback "Orbital Station" now only appears in the **home system** (onboarding needs one reachable station); Desolate/Pirate systems elsewhere genuinely have none. *(Deviation from the issue text "remove entirely" — the home-system exception keeps missions/trade reachable on a fresh save.)*

### Space view (#548)
- Moons parent by `ParentId` (nearest-planet fallback for old servers) and **ladder outward on per-parent orbit slots** — a giant''s 8 moons read as a family of rings instead of one crowded shell.
- The from-the-surface sky sizes bodies by their true circumference (a 12000 giant looms; a 5000 dwarf doesn''t) and caps at the 14 most prominent bodies.

## Save compatibility

`WorldDescription.SystemVariance` defaults **false** — a loaded save regenerates its galaxy byte-identically (the Standard path preserves the legacy rng draw sequence exactly, incl. the station gate draw). `ServerConfig`''s creation-time description sets it **true**, so every world created from now on gets the variance. No UI, no migration.

## Testing

- 1189 server + 138 client tests green locally (Release, non-Slow), clean rebuild with 0 warnings, local Unity Windows build succeeds.
- New tests: archetype distribution + per-archetype shape invariants across 150 systems, home-system exclusion over 300 seeds, bias-0 bit-identity, extended-band edges + chunk alignment, `BiasToward` round-trip, live-server traffic/pirate-flag probes, finale-namespace safety under variance, and the layout replay now runs 40 seeds × {classic, variance} with the new moon ladder.

closes #546
closes #547
closes #548
closes #549

🤖 Generated with [Claude Code](https://claude.com/claude-code)