### PR TITLE
Player avatars wear a spacesuit — NPCs stay civilian

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ the richer, screenshot-laden versions live there. `(#123)` references the pull r
 
 ## [Unreleased]
 
-### 🧑‍🚀 Player avatars now wear a spacesuit
+### 🧑‍🚀 Player avatars now wear a spacesuit (#564)
 - Your avatar (third-person, other players, the avatar editor and colour-menu previews) now reads
   as an astronaut: an open helmet with a raised dark-glass visor band, gloves, a neck seal and
   collar ring, a chest control panel and a life-support backpack with twin tanks. The suit tints

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ the richer, screenshot-laden versions live there. `(#123)` references the pull r
 
 ## [Unreleased]
 
+### 🧑‍🚀 Player avatars now wear a spacesuit
+- Your avatar (third-person, other players, the avatar editor and colour-menu previews) now reads
+  as an astronaut: an open helmet with a raised dark-glass visor band, gloves, a neck seal and
+  collar ring, a chest control panel and a life-support backpack with twin tanks. The suit tints
+  with your chosen avatar colours, and your face — including a drawn pixel face — stays visible
+  through the open visor. Settlement and station NPCs deliberately keep their civilian look, so a
+  suited figure is always a real player at a glance.
+- Fixed invisible head gear: the armor-helmet and helmet-lamp visuals had been buried inside the
+  avatar's head since gear existed (a coordinate-space slip). The armor helmet now shows as an open
+  face-guard shell over the suit helmet, the lamp sits visibly on its side, and the armor backpack
+  replaces the suit's life-support pack while worn.
+
 ### 🧹 Fixed
 - Portal website: the rules-consent checkbox rendered as a centered full-width block (the global
   input styling caught it) and its label wrapped awkwardly around the button — it is now an

--- a/TODO.md
+++ b/TODO.md
@@ -6468,7 +6468,7 @@ is **pre-approved** (keys in `tools/ai-assets/.env`, run via `uv`).
 
 ---
 
-## ✅ Done (2026-07-28): player avatars wear a spacesuit — players distinguishable from NPCs at a glance
+## ✅ Done (2026-07-28): player avatars wear a spacesuit — players distinguishable from NPCs at a glance (#564)
 
 User request: player avatars (own third-person + other players) should read as spacesuit-wearers.
 Analysis first (memory `avatar-spacesuit-look-analysis`): the shared `PlayerAvatar` looked like a
@@ -6487,8 +6487,9 @@ person in a jumpsuit — bare skin head/neck/hands — for players *and* civilia
   0.46-scaled head but sized in world units — buried invisibly *inside* the head since gear
   existed. The helmet is now an open armor shell outside the suit helmet (face stays visible), the
   lamp sits proud on its side; the armor backpack hides the suit's life-support pack while worn.
-- Status: implemented in worktree `SpaceCraft-suit`, branch `feat/avatar-spacesuit`; **local only,
-  no PR yet on user instruction**.
+- Backlit avatars sank to a black silhouette once fully suited (fixed key light + 0.35 floor +
+  linear tints); avatar materials now use the creature-proven `_Floor` 0.62 / `_Fill` 0.3.
+- Status: shipped via branch `feat/avatar-spacesuit` (issue #564); verified with a local Unity build.
 
 ---
 

--- a/TODO.md
+++ b/TODO.md
@@ -6468,6 +6468,30 @@ is **pre-approved** (keys in `tools/ai-assets/.env`, run via `uv`).
 
 ---
 
+## ✅ Done (2026-07-28): player avatars wear a spacesuit — players distinguishable from NPCs at a glance
+
+User request: player avatars (own third-person + other players) should read as spacesuit-wearers.
+Analysis first (memory `avatar-spacesuit-look-analysis`): the shared `PlayerAvatar` looked like a
+person in a jumpsuit — bare skin head/neck/hands — for players *and* civilian NPCs alike.
+
+- **Spacesuit mode** on `PlayerAvatar.Build(..., spacesuit:)`: open helmet shell (top/back/sides/chin)
+  with a raised dark-glass visor band (uses the previously unused `avatar_visor` texture), gloved
+  hands, suit-coloured neck seal + collar ring, chest control panel with status light, life-support
+  backpack with twin tanks. Suit parts reuse the torso/arm materials → the player's chosen colours
+  tint the suit; the face (procedural or custom pixel face) stays visible through the open front
+  (LitColor is opaque-only, so no see-through closed visor — the visor is styled flipped up).
+- Enabled for the local third-person avatar, remote players, the avatar editor and the in-game
+  colour-menu preview. **NPCs deliberately stay civilian** (suit = player, outfit = NPC, bandana =
+  bandit, grey = robot) — free visual faction language.
+- **Fixed a latent gear bug**: the armor-helmet and helmet-lamp gear cubes were children of the
+  0.46-scaled head but sized in world units — buried invisibly *inside* the head since gear
+  existed. The helmet is now an open armor shell outside the suit helmet (face stays visible), the
+  lamp sits proud on its side; the armor backpack hides the suit's life-support pack while worn.
+- Status: implemented in worktree `SpaceCraft-suit`, branch `feat/avatar-spacesuit`; **local only,
+  no PR yet on user instruction**.
+
+---
+
 ## ✅ Done (2026-07-28): account password change + sign-in lockout fixes (#555/#556)
 
 Trigger: the operator locked himself out after "Abmelden" — the sign-in form blanked the account

--- a/client/Assets/BlocksBeyondTheStars/Scripts/AvatarEditor.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/AvatarEditor.cs
@@ -75,7 +75,7 @@ namespace BlocksBeyondTheStars.Client
             _avatarRoot = new GameObject("AvatarPreview").transform;
             _avatarRoot.SetParent(transform, false);
             _avatar = _avatarRoot.gameObject.AddComponent<PlayerAvatar>();
-            _avatar.Build(_col[0], _col[1], _col[2], _col[3]);
+            _avatar.Build(_col[0], _col[1], _col[2], _col[3], spacesuit: true); // preview the player's suited look
             _avatar.SetVisible(true);
             _avatar.SetFace(_face); // show the player's current custom face on the preview figure
         }

--- a/client/Assets/BlocksBeyondTheStars/Scripts/AvatarPreviewRig.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/AvatarPreviewRig.cs
@@ -63,7 +63,7 @@ namespace BlocksBeyondTheStars.Client
             _model.position = Origin;
             _model.localRotation = Quaternion.Euler(0f, 180f, 0f); // face the −Z camera (the lit side)
             _avatar = _model.gameObject.AddComponent<PlayerAvatar>();
-            _avatar.Build(skin, torso, arms, legs);
+            _avatar.Build(skin, torso, arms, legs, spacesuit: true); // preview the player's suited look
             _avatar.SetVisible(true);
 
             SetActive(false);

--- a/client/Assets/BlocksBeyondTheStars/Scripts/NpcView.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/NpcView.cs
@@ -119,6 +119,8 @@ namespace BlocksBeyondTheStars.Client
                     var avatar = go.AddComponent<PlayerAvatar>();
                     Color skin = nd.IsRobot ? new Color(0.75f, 0.78f, 0.82f) : Rgb(nd.SkinRgb);
                     Color outfit = Rgb(nd.OutfitRgb);
+                    // Deliberately NO spacesuit: civilians stay bare-headed so suited players are
+                    // recognisable at a glance (suit = player, outfit = NPC, bandana = bandit).
                     avatar.Build(skin, outfit, outfit * 0.85f, outfit * 0.7f);
                     avatar.SetVisible(true);
 

--- a/client/Assets/BlocksBeyondTheStars/Scripts/PlayerAvatar.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/PlayerAvatar.cs
@@ -583,6 +583,14 @@ namespace BlocksBeyondTheStars.Client
             return tex;
         }
 
+        // Ambient floor + opposite-flank fill for avatar materials, same failure mode and values as
+        // creatures (see CreatureBuilder): LitColor's single FIXED key light leaves camera-away /
+        // backlit faces at the floor, and in Linear colour space the tinted suit textures then sink
+        // to a full black silhouette (obvious once the whole figure is suit — no bright skin head to
+        // save it). The fill lifts the flank facing away from the key without darkening anything.
+        private const float AvatarFloor = 0.62f;
+        private const float AvatarFill = 0.3f;
+
         /// <summary>A lit, tinted, optionally-textured material (the grayscale texture tints by the colour).</summary>
         private static Material Lit(Color color, Texture2D tex)
         {
@@ -591,6 +599,12 @@ namespace BlocksBeyondTheStars.Client
             if (tex != null)
             {
                 m.mainTexture = tex;
+            }
+
+            if (m.HasProperty("_Floor"))
+            {
+                m.SetFloat("_Floor", AvatarFloor); // no-op on the Unlit/Color fallback
+                m.SetFloat("_Fill", AvatarFill);
             }
 
             return m;

--- a/client/Assets/BlocksBeyondTheStars/Scripts/PlayerAvatar.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/PlayerAvatar.cs
@@ -14,6 +14,13 @@ namespace BlocksBeyondTheStars.Client
     /// look-around, a jump/fall tuck, and a tool/weapon <see cref="Swing"/> chop. Per-part colours come
     /// from <see cref="ClientSettings"/> (or explicit colours for remotes / NPCs); equipped gear and a
     /// held item are layered on via <see cref="SetGear"/> / <see cref="SetHeldItem"/>.
+    ///
+    /// <b>Spacesuit mode</b> (players only — local third-person, remotes, avatar-editor previews): the same
+    /// body wears a suit so players read as astronauts and are instantly distinguishable from civilian NPCs
+    /// (who keep the bare-headed look): gloved hands + a suit-coloured neck seal instead of bare skin, an
+    /// open helmet shell with a raised glossy visor band (the face — including a custom pixel face — stays
+    /// visible through the opening), a chest control panel and a life-support backpack. Suit parts reuse the
+    /// torso/arm materials, so the player's chosen colours tint the suit.
     /// </summary>
     public sealed class PlayerAvatar : MonoBehaviour
     {
@@ -27,6 +34,10 @@ namespace BlocksBeyondTheStars.Client
         private readonly List<GameObject> _gear = new List<GameObject>();
         private GameObject _held;
         private bool _visible = true;
+
+        private bool _suit; // spacesuit mode (players); NPCs keep the civilian bare-headed look
+        private readonly List<GameObject> _suitPack = new List<GameObject>(); // hidden while armor-pack gear is worn
+        private bool _gearPack; // armor pack currently worn — suppresses the suit pack (also across SetVisible)
 
         // Custom pixel face (FaceEditor): a textured plate on the head front that replaces the procedural
         // eyes/brow/mouth/visor when set. Placed in head-LOCAL space, where the head is a unit-cube primitive
@@ -50,11 +61,12 @@ namespace BlocksBeyondTheStars.Client
         private float _walkPhase;
         private float _swingTimer;
 
-        public void Build(ClientSettings s) => Build(s.SkinColor, s.TorsoColor, s.ArmColor, s.LegColor);
+        public void Build(ClientSettings s) => Build(s.SkinColor, s.TorsoColor, s.ArmColor, s.LegColor, spacesuit: true);
 
-        public void Build(Color skin, Color torso, Color arms, Color legs)
+        public void Build(Color skin, Color torso, Color arms, Color legs, bool spacesuit = false)
         {
             EnsureTextures();
+            _suit = spacesuit;
             _phase = (GetEntityId().GetHashCode() & 0x3ff) * 0.11f;
             _skinColor = skin;
             _skin = Lit(skin, _skinTex);
@@ -69,8 +81,9 @@ namespace BlocksBeyondTheStars.Client
             AddCube("ShoulderL", transform, new Vector3(-0.30f, 1.55f, 0f), new Vector3(0.18f, 0.18f, 0.30f), _torso);
             AddCube("ShoulderR", transform, new Vector3(0.30f, 1.55f, 0f), new Vector3(0.18f, 0.18f, 0.30f), _torso);
 
-            // Neck + head + a dark visor strip on the front.
-            AddCube("Neck", transform, new Vector3(0f, 1.69f, 0f), new Vector3(0.18f, 0.14f, 0.18f), _skin);
+            // Neck + head + a dark visor strip on the front. Suited players get a suit-coloured neck seal
+            // (no bare skin between collar and helmet); NPCs keep the skin neck.
+            AddCube("Neck", transform, new Vector3(0f, 1.69f, 0f), new Vector3(0.18f, 0.14f, 0.18f), _suit ? _torso : _skin);
             _head = AddCube("Head", transform, new Vector3(0f, 1.86f, 0f), new Vector3(0.46f, 0.46f, 0.46f), _skin).transform;
             // Face features sit on the head's FRONT surface. The head is a unit-cube primitive, so that surface is
             // at head-LOCAL z = 0.5; features must protrude past it (z ≳ 0.5). The old z ≈ 0.235–0.275 placed them
@@ -100,6 +113,51 @@ namespace BlocksBeyondTheStars.Client
             _armR = AddArm("ArmRight", 0.32f, out _elbowR, out _handR);
             _legL = AddLeg("LegLeft", -0.13f, out _kneeL);
             _legR = AddLeg("LegRight", 0.13f, out _kneeR);
+
+            if (_suit)
+            {
+                BuildSuit();
+            }
+        }
+
+        /// <summary>
+        /// The spacesuit layer for players: an OPEN helmet shell (top/back/sides/chin) with a raised glossy
+        /// visor band above the eyes, a collar ring, a chest control panel and a life-support backpack.
+        /// Helmet parts are children of the head (they follow the idle look-around) and use head-LOCAL units —
+        /// the head is a unit cube scaled 0.46, so its surfaces are at ±0.5 and anything wrapping it needs a
+        /// scale &gt; 1 (see the face-feature note above; the pre-suit gear helmet got this wrong and was
+        /// buried invisibly inside the head). The front stays open so the face — procedural or custom pixel
+        /// (<see cref="SetFace"/>) — remains visible; there is no transparent shader to see through a closed
+        /// visor (LitColor is opaque-only), which is why the visor is styled as flipped up.
+        /// </summary>
+        private void BuildSuit()
+        {
+            // Helmet shell in the torso material: tints with the player's suit colour.
+            AddCube("SuitHelmetTop", _head, new Vector3(0f, 0.56f, 0f), new Vector3(1.16f, 0.16f, 1.16f), _torso);
+            AddCube("SuitHelmetBack", _head, new Vector3(0f, 0.04f, -0.55f), new Vector3(1.16f, 1.2f, 0.14f), _torso);
+            AddCube("SuitHelmetL", _head, new Vector3(-0.55f, 0.04f, 0.03f), new Vector3(0.14f, 1.2f, 1.1f), _torso);
+            AddCube("SuitHelmetR", _head, new Vector3(0.55f, 0.04f, 0.03f), new Vector3(0.14f, 1.2f, 1.1f), _torso);
+            AddCube("SuitHelmetChin", _head, new Vector3(0f, -0.56f, 0.03f), new Vector3(1.16f, 0.14f, 1.1f), _torso);
+
+            // Raised visor band across the forehead — dark glossy glass, clear of the brow (brow top ≈ 0.20).
+            AddCube("SuitVisorBand", _head, new Vector3(0f, 0.36f, 0.52f), new Vector3(1.0f, 0.3f, 0.12f),
+                Lit(new Color(0.10f, 0.22f, 0.28f), _visorTex));
+
+            // Collar ring where the helmet locks onto the suit (world units — child of the body root).
+            AddCube("SuitCollar", transform, new Vector3(0f, 1.645f, 0f), new Vector3(0.32f, 0.11f, 0.32f), _torso);
+
+            // Chest control panel + a small status light.
+            var panel = Lit(new Color(0.15f, 0.17f, 0.20f), _armorTex);
+            AddCube("SuitChestPanel", transform, new Vector3(0f, 1.50f, 0.185f), new Vector3(0.22f, 0.14f, 0.04f), panel);
+            AddCube("SuitStatusLight", transform, new Vector3(0.075f, 1.50f, 0.205f), new Vector3(0.045f, 0.045f, 0.02f),
+                Lit(new Color(0.30f, 0.90f, 0.50f), null));
+
+            // Life-support backpack with twin tanks; swapped out for the armor pack gear when carried.
+            var packMat = Lit(new Color(0.30f, 0.34f, 0.40f), _armorTex);
+            var tankMat = Lit(new Color(0.55f, 0.58f, 0.62f), _armorTex);
+            _suitPack.Add(AddCube("SuitPack", transform, new Vector3(0f, 1.40f, -0.24f), new Vector3(0.38f, 0.48f, 0.15f), packMat));
+            _suitPack.Add(AddCube("SuitTankL", transform, new Vector3(-0.09f, 1.42f, -0.33f), new Vector3(0.10f, 0.34f, 0.06f), tankMat));
+            _suitPack.Add(AddCube("SuitTankR", transform, new Vector3(0.09f, 1.42f, -0.33f), new Vector3(0.10f, 0.34f, 0.06f), tankMat));
         }
 
         private Transform AddArm(string name, float x, out Transform elbow, out Transform hand)
@@ -109,7 +167,8 @@ namespace BlocksBeyondTheStars.Client
             elbow = NewPivot(name + "Elbow", shoulder, new Vector3(0f, -0.42f, 0f));
             AddCube(name + "Lower", elbow, new Vector3(0f, -0.21f, 0f), new Vector3(0.15f, 0.42f, 0.15f), _arms);
             hand = NewPivot(name + "Hand", elbow, new Vector3(0f, -0.44f, 0f));
-            AddCube(name + "HandMesh", hand, new Vector3(0f, -0.06f, 0f), new Vector3(0.2f, 0.16f, 0.2f), _skin);
+            // Suited players wear gloves (arm colour); NPCs keep bare hands.
+            AddCube(name + "HandMesh", hand, new Vector3(0f, -0.06f, 0f), new Vector3(0.2f, 0.16f, 0.2f), _suit ? _arms : _skin);
             return shoulder;
         }
 
@@ -306,7 +365,14 @@ namespace BlocksBeyondTheStars.Client
 
             if (helmet)
             {
-                _gear.Add(AddCube("GearHelmet", _head, new Vector3(0f, 0.04f, -0.02f), new Vector3(0.54f, 0.5f, 0.54f), plate));
+                // An open armor shell OUTSIDE the suit helmet, so the face (and a custom pixel face) stays
+                // visible. Head-LOCAL units: the head is a 0.46-scaled unit cube, so wrapping it needs scales
+                // > 1 — the old single 0.54-cube was smaller than the head itself and sat buried invisibly
+                // inside it (same trap as the face features, see the Build note).
+                _gear.Add(AddCube("GearHelmetTop", _head, new Vector3(0f, 0.68f, 0f), new Vector3(1.34f, 0.16f, 1.34f), plate));
+                _gear.Add(AddCube("GearHelmetBack", _head, new Vector3(0f, 0.08f, -0.66f), new Vector3(1.34f, 1.36f, 0.14f), plate));
+                _gear.Add(AddCube("GearHelmetL", _head, new Vector3(-0.66f, 0.08f, 0f), new Vector3(0.14f, 1.36f, 1.2f), plate));
+                _gear.Add(AddCube("GearHelmetR", _head, new Vector3(0.66f, 0.08f, 0f), new Vector3(0.14f, 1.36f, 1.2f), plate));
             }
 
             if (chest)
@@ -325,10 +391,15 @@ namespace BlocksBeyondTheStars.Client
                 _gear.Add(AddCube("GearPack", transform, new Vector3(0f, 1.4f, -0.24f), new Vector3(0.4f, 0.5f, 0.2f), packMat));
             }
 
+            // The armor pack replaces the suit's life-support pack (they occupy the same spot on the back).
+            _gearPack = pack;
+            ApplySuitPackVisible();
+
             if (lamp)
             {
                 // A small bright lamp on the side of the helmet (the actual light cone is the suit lamp).
-                _gear.Add(AddCube("GearLamp", _head, new Vector3(0.25f, 0.05f, 0.12f), new Vector3(0.1f, 0.1f, 0.12f),
+                // Head-LOCAL units — outside the suit/armor helmet side plates (see the helmet note above).
+                _gear.Add(AddCube("GearLamp", _head, new Vector3(0.70f, 0.16f, 0.30f), new Vector3(0.22f, 0.22f, 0.26f),
                     Lit(new Color(1f, 0.96f, 0.7f), null)));
             }
         }
@@ -456,6 +527,24 @@ namespace BlocksBeyondTheStars.Client
 
             ApplyHeldVisible();
             ApplyFaceVisibility(); // re-suppress stock features / show the plate when a custom face is set
+            ApplySuitPackVisible(); // re-suppress the suit pack while the armor pack is worn
+        }
+
+        /// <summary>Reconciles the suit life-support pack with visibility and the armor-pack gear (which
+        /// replaces it on the back). Idempotent — called from <see cref="SetGear"/> and <see cref="SetVisible"/>.</summary>
+        private void ApplySuitPackVisible()
+        {
+            foreach (var p in _suitPack)
+            {
+                if (p != null)
+                {
+                    var r = p.GetComponent<Renderer>();
+                    if (r != null)
+                    {
+                        r.enabled = _visible && !_gearPack;
+                    }
+                }
+            }
         }
 
         // Shared (loaded once) tintable grayscale textures for the suit/armor/visor/skin.

--- a/client/Assets/BlocksBeyondTheStars/Scripts/RemotePlayers.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/RemotePlayers.cs
@@ -103,7 +103,7 @@ namespace BlocksBeyondTheStars.Client
                 go.transform.SetParent(transform, true); // under the game root → not leaked into menus/editors
                 go.transform.position = Game != null ? Game.ScenePos(m.X, m.Y, m.Z) : new Vector3(m.X, m.Y, m.Z);
                 var avatar = go.AddComponent<PlayerAvatar>();
-                avatar.Build(Rgb(m.Skin), Rgb(m.Torso), Rgb(m.Arms), Rgb(m.Legs));
+                avatar.Build(Rgb(m.Skin), Rgb(m.Torso), Rgb(m.Arms), Rgb(m.Legs), spacesuit: true); // players wear the suit
                 if (_faces.TryGetValue(m.PlayerId, out var face))
                 {
                     avatar.SetFace(face); // a face we already received before this first presence


### PR DESCRIPTION
Closes #564

## What

Players now read as **astronauts** at a glance, while civilian NPCs keep their bare-headed look — a free visual faction language (suit = player, outfit = NPC, bandana = bandit, grey = robot).

`PlayerAvatar.Build(...)` gained a `spacesuit` mode, enabled for the local third-person avatar, remote players, the avatar editor and the colour-menu preview (`NpcView` deliberately stays civilian):

- **Open helmet shell** (top/back/sides/chin) with a raised dark-glass **visor band** — first use of the `avatar_visor` texture. Helmet parts are head-local children, so they follow the idle look-around; `LitColor` is opaque-only, so the visor is styled flipped up and the face — procedural or custom pixel face — stays visible through the opening.
- **Gloves** and a **suit-coloured neck seal** + collar ring instead of bare skin.
- **Chest control panel** with status light and a **life-support backpack** with twin tanks.
- Suit parts reuse the torso/arm materials, so the player''s chosen avatar colours tint the suit and `ApplyColors` keeps working unchanged.

## Bug fixes

- **Buried head gear**: the armor-helmet and helmet-lamp cubes were children of the 0.46-scaled head but sized in world units — invisible *inside* the head since gear existed. The armor helmet is now an open shell outside the suit helmet, the lamp sits proud on its side, and the armor pack hides the suit''s life-support pack while worn (reconciled across `SetVisible`).
- **Black-silhouette avatars when backlit**: with the whole figure textured, the fixed key light + 0.35 ambient floor + linear-converted tints rendered near-black. Avatar materials now use the creature-proven per-material `_Floor` 0.62 / `_Fill` 0.3 — this also lifts NPCs, which shared the problem.

## Verification

- Local Windows Unity build, clean log (no C# warnings), fresh `Client.dll` verified.
- In-game check on a planet at dawn: suited figure reads clearly, no more black silhouette.

🤖 Generated with [Claude Code](https://claude.com/claude-code)