### PR TITLE
fix(graphics): daytime atmosphere wash so sky bodies stop reading as dark silhouettes (#585)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ the richer, screenshot-laden versions live there. `(#123)` references the pull r
 
 ## [Unreleased]
 
+### Fixed
+
+- Other planets and moons in the surface sky no longer read as dark silhouettes against the
+  daytime sky: a sky-colour atmosphere wash makes them pale and sky-tinted by day (like the real
+  daytime Moon), and their unlit night sides survive as a faint disc instead of vanishing to
+  black. Airless worlds and the space view are unchanged. (#585)
+
 ## [2026.7.21] — 2026-07-29
 
 The landforms release: worlds finally dare vertical drama. The regional terrain pool grows from

--- a/TODO.md
+++ b/TODO.md
@@ -102,6 +102,17 @@ Per-item detail lives in the dated work log below. **Since 2026-07 versions are 
 
 ---
 
+### ★ Sky bodies no longer read as dark silhouettes by day (#585, 2026-07-29, branch fix/sky-bodies-dark-discs)
+Other planets/moons in the surface sky often looked completely dark. Not a lighting bug (the #400
+`_DayLight` ramp already front-lights them by day) but a luminance ratio: baked-map albedo × the 0.7
+noon dim × limb darkening left the disc at ~0.15–0.33 sRGB against a ~0.6–0.75 daytime sky — 3–4×
+darker, and ACES stretches that into a black blob. Fixed with a **daytime atmosphere wash** in
+`SkyBodyPhase.shader` (both subshaders): the final disc colour lerps toward the `_Sc_Sky` global,
+scaled by `_DayLight` × the sky's own luminance — so day-sky bodies read pale and sky-tinted like
+the real daytime Moon, while airless black-sky worlds, the night sky and the space view
+(`_DayLight` = 0) are untouched. The noon dim in `SkyBodiesView` rises 0.7 → 1.0 and the shader's
+`_Earthshine` night-side floor 0.12 → 0.2 so unlit crescent sides survive tonemapping as a faint disc.
+
 ### ★ Update notice on startup + an official update feed that actually exists (#543, 2026-07-27, branch feat/auto-update-notify)
 Installed clients could never learn about a new release: the in-app Velopack updater only ran from a
 manual settings button, the feed URL shipped empty, and — the real killer — the feed files the

--- a/client/Assets/BlocksBeyondTheStars/Scripts/SkyBodiesView.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/SkyBodiesView.cs
@@ -188,9 +188,10 @@ namespace BlocksBeyondTheStars.Client
                 // feature; the crescent/phase still reads at twilight and night. `day` is 0 at night → 1 at noon.
                 b.Mat.SetFloat(DayLightId, day);
                 float horizon = Mathf.Clamp01((dir.y + 0.04f) / 0.12f);
-                // Overall dim: bodies dominate the night sky and fade toward day — but keep a higher day-time floor
-                // so they don't wash to black against the bright ACES-tonemapped daytime sky (they're a feature).
-                b.Mat.color = ShaderColor.Srgb(b.Tint * Mathf.Lerp(1.25f, 0.7f, day) * horizon);
+                // Overall brightness: a night boost so bodies dominate the dark sky, full strength by day — the
+                // old 0.7 noon dim left the disc 3-4x darker than the ACES-tonemapped daytime sky, which still
+                // read as a silhouette (#585). The shader's sky-colour atmosphere wash now balances the day look.
+                b.Mat.color = ShaderColor.Srgb(b.Tint * Mathf.Lerp(1.25f, 1f, day) * horizon);
             }
         }
 

--- a/client/Assets/BlocksBeyondTheStars/Shaders/SkyBodyPhase.shader
+++ b/client/Assets/BlocksBeyondTheStars/Shaders/SkyBodyPhase.shader
@@ -13,7 +13,7 @@ Shader "BlocksBeyondTheStars/SkyBodyPhase"
         _MainTex ("Texture", 2D) = "white" {}
         // xyz = world-space direction TO the sun (set per-material each frame). w unused.
         _PhaseSunDir ("Sun Direction", Vector) = (0, 0, 1, 0)
-        _Earthshine ("Night-side floor", Range(0, 0.4)) = 0.12
+        _Earthshine ("Night-side floor", Range(0, 0.4)) = 0.2
         _TermSoft ("Terminator softness", Range(0.001, 0.4)) = 0.07
         _LimbDark ("Limb darkening", Range(0, 1)) = 0.35
         // 0 = pure sun-lit phase (space view + night surface). 1 = fully front-lit visible disc. The surface sky
@@ -47,6 +47,7 @@ Shader "BlocksBeyondTheStars/SkyBodyPhase"
             float _TermSoft;
             float _LimbDark;
             float _DayLight;
+            float4 _Sc_Sky; // global: current sky colour (linear, set by Sky.cs) — daytime atmosphere wash
 
             struct Attributes { float4 positionOS : POSITION; float3 normal : NORMAL; float2 uv : TEXCOORD0; };
             struct Varyings { float4 positionCS : SV_POSITION; float3 wn : TEXCOORD0; float2 uv : TEXCOORD1; float3 wp : TEXCOORD2; };
@@ -83,6 +84,13 @@ Shader "BlocksBeyondTheStars/SkyBodyPhase"
                 float3 Vw = normalize(_WorldSpaceCameraPos - i.wp);
                 float facing = saturate(dot(N, Vw)); // ~1 at centre, ~0 at the rim
                 col *= lerp(1.0 - _LimbDark, 1.0, facing);
+                // Daytime atmosphere wash (#585): the disc's albedo tops out at a fraction of the daytime sky's
+                // brightness, so even front-lit it read as a dark silhouette. The air in front of the body
+                // scatters the sky colour over it — wash toward the sky (like the real daytime Moon: pale,
+                // sky-tinted, never black). Scaled by the sky's own luminance so airless (black-sky) worlds and
+                // the night sky get no wash, and gated by _DayLight so the space view (0) is untouched.
+                float skyLum = dot(_Sc_Sky.rgb, float3(0.299, 0.587, 0.114));
+                col = lerp(col, _Sc_Sky.rgb * 1.05, _DayLight * 0.55 * saturate(skyLum * 4.0));
                 return half4(col, 1);
             }
             ENDHLSL
@@ -111,6 +119,7 @@ Shader "BlocksBeyondTheStars/SkyBodyPhase"
             float _TermSoft;
             float _LimbDark;
             float _DayLight;
+            float4 _Sc_Sky; // global: current sky colour (linear, set by Sky.cs) — daytime atmosphere wash
 
             struct appdata { float4 vertex : POSITION; float3 normal : NORMAL; float2 uv : TEXCOORD0; };
             struct v2f { float4 pos : SV_POSITION; float3 wn : TEXCOORD0; float2 uv : TEXCOORD1; float3 wp : TEXCOORD2; };
@@ -141,6 +150,10 @@ Shader "BlocksBeyondTheStars/SkyBodyPhase"
                 float3 Vw = normalize(_WorldSpaceCameraPos - i.wp);
                 float facing = saturate(dot(N, Vw)); // ~1 at centre, ~0 at the rim
                 col *= lerp(1.0 - _LimbDark, 1.0, facing);
+                // Daytime atmosphere wash (#585) — see the URP pass: sky-luminance-scaled blend toward the sky
+                // colour so day-sky bodies read pale instead of silhouette-dark; no-op in space (_DayLight = 0).
+                float skyLum = dot(_Sc_Sky.rgb, float3(0.299, 0.587, 0.114));
+                col = lerp(col, _Sc_Sky.rgb * 1.05, _DayLight * 0.55 * saturate(skyLum * 4.0));
                 return fixed4(col, 1);
             }
             ENDCG


### PR DESCRIPTION
Closes #585

## Problem

Other planets/moons in the surface sky often read as completely dark discs. Not a lighting bug — the #400 `_DayLight` ramp already front-lights them by day. It's a luminance ratio: baked world-map albedo (~0.30–0.50) × the 0.7 noon dim × limb darkening leaves the disc at ~0.15–0.33 sRGB against a ~0.55–0.75 daytime sky — 3–4× darker, and ACES tonemapping stretches that gap into a black silhouette.

## Fix

- **`SkyBodyPhase.shader` (both subshaders): daytime atmosphere wash.** The final disc colour lerps toward the `_Sc_Sky` global (the current sky colour), scaled by `_DayLight` × the sky's own luminance. By day, bodies now read pale and sky-tinted like the real daytime Moon. The luminance scaling means airless black-sky worlds and the night sky get no wash, and the space view (`_DayLight = 0`) is untouched.
- **`SkyBodiesView`: noon dim 0.7 → 1.0** — the wash now balances the day look, so the extra darkening is gone.
- **`_Earthshine` night-side floor 0.12 → 0.2** so unlit crescent sides survive tonemapping as a faint disc instead of vanishing to black.

## Verification

- Local test suite: 140 client + 1202 server tests green (`-c Release --filter Category!=Slow`).
- Local Unity Windows client built from this branch; **hands-on playtest by Marcel: works as intended** (noon = pale sky-washed discs, dusk crescents still read, midnight unchanged).
- Space/orbit view unaffected by design (`_DayLight` stays 0 there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)