### PR TITLE
feat(worldgen): structure placement guarantee + terrain-adaptive foundations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,20 @@ the richer, screenshot-laden versions live there. `(#123)` references the pull r
 
 ## [Unreleased]
 
+### 🏗️ Structure placement guarantee & terrain-adaptive foundations (#586)
+
+- **What the world rolls, the world gets.** Settlements, ruins, factories, bandit camps, monuments,
+  vaults, treasure chests and data cubes are no longer silently dropped when the terrain is dramatic:
+  the placement search now escalates — classic dry-and-flat spots first, then widening best-fit rings —
+  until every rolled structure has a home. (New worlds; existing worlds keep their exact layout.)
+- **Foundations that fit the terrain.** The seat adapts to what it lands on: slopes get stepped terrace
+  aprons instead of sheer foundation walls, rugged massif flanks get a cut-and-fill rock shelf, lakes
+  carry **stilt villages** on pile platforms (and drowned ruins), lava plains may hold a dead city on a
+  basalt plinth, and vaults under a water body rise as a diveable stone **well head**.
+- **Placements are now pinned.** Where each structure landed is stored with the save at first stamp, so
+  future placement improvements can never move villages, camps or vaults out from under their own blocks
+  (previously the positions were re-derived from the seed on every load).
+
 ## [2026.7.21] — 2026-07-29
 
 The landforms release: worlds finally dare vertical drama. The regional terrain pool grows from

--- a/TODO.md
+++ b/TODO.md
@@ -6468,6 +6468,35 @@ is **pre-approved** (keys in `tools/ai-assets/.env`, run via `uv`).
 
 ---
 
+## ✅ Done (2026-07-29): structure placement guarantee + terrain-adaptive foundations (#586)
+
+Whatever the seed rolls for a world now actually lands in it — no more silent drops on dramatic terrain
+(the #576–#580 landforms made this acute):
+
+- **Pinned placements** — `WorldMetadata.Placements` records where every settlement/factory/camp/vault
+  instance landed (or that it found no spot) at first stamp. Re-loads REPLAY the record instead of
+  re-running the search, so the search algorithm may evolve without detaching markers/protection/NPCs
+  from already-stamped blocks. `IWorldRepository.HasAnyBlockEdits` is the fresh-vs-legacy ground truth:
+  worlds with prior edits re-derive through the FROZEN legacy search (bit-identical), then self-record.
+- **Guaranteed search** — `TryPlaceStructureGuaranteed`: ring 1 = the classic dry+flat first-fit
+  (no visual change where it succeeds), then widening best-fit rings ranking every candidate
+  (dry lowest-spread → water for stilt-capable kinds → lava for lava-capable kinds), then a margin-2
+  terminal pass + deterministic longitude sweep. Only documented carve-out: policy-forbidden ground
+  everywhere (e.g. all-lava for an inhabited settlement).
+- **Seat styles** — the stamper adapts per terrain: `flat`/`slope` (+ new stepped terrace apron so no
+  sheer foundation walls), `shelf` (cut & fill at footprint median, sub-surface stone fill, 96 skirt),
+  `stilts` (platform at water line on wood/stone pile columns — stilt villages, drowned ruins), `lava`
+  (basalt plinth, ruins + monuments only), `island` (unchanged). Policy matrix per structure kind;
+  bandit camps prefer rugged shelf spots when escalating.
+- **Vaults** — the pre-deep-floor `surfaceY < 24` skip is legacy-only; fresh worlds bury under any dry
+  column, nudge deterministically off reserved footprints, and water columns get the **wellhead**
+  variant (chamber under the seabed, cased 4×4 stone shaft rising one block above the water line).
+  Chests/data cubes gained deterministic no-rng fallbacks (fresh worlds only — legacy streams stay
+  bit-identical to avoid duplicate loot).
+- **Telemetry + tests** — per-kind requested/placed `StampReport` (drop ⇒ WARN),
+  `PlacementGuaranteeTests`: guarantee across rocky/highland/tablelands/karst/badlands/swamp/ocean,
+  record pinning, reload replay (positions + names + vault entrances), ocean stilt/lava policy.
+
 ## ✅ Done (2026-07-29): terrain extremes & landform variety + the deep kilometre (#576–#580)
 
 One combined worldgen wave (⚠️ one-time reshape of existing worlds, accepted like the 0.9.0 overhaul —

--- a/src/BlocksBeyondTheStars.GameServer/GameServer.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServer.cs
@@ -480,6 +480,12 @@ public sealed partial class GameServer
         ResetWorldRuntimeState();
         InitWeather();
 
+        // #586: decide the placement mode BEFORE anything writes blocks. No persisted edits at all ⇒ the
+        // world was never materialised ⇒ the guaranteed (escalating) placement search may run; otherwise the
+        // frozen legacy search re-derives positions so structures stay attached to their stamped blocks.
+        world.VirginAtLoad = !_repo.HasAnyBlockEdits(locationId);
+        world.StampReport.Clear();
+
         // A void world (an orbital station) has no terrain, so it gets none of the planet-surface content —
         // no fauna/flora/fluids, no settlements/wrecks/landing zones. Only its stamped structure lives there
         // (the caller stamps it). Weather is initialised above so the env reads its clear/space-sky settings.

--- a/src/BlocksBeyondTheStars.GameServer/GameServerBanditCamps.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerBanditCamps.cs
@@ -100,9 +100,48 @@ public sealed partial class GameServer
             var ir = new System.Random(unchecked((int)(instSeed ^ (instSeed >> 32))));
             var structure = BanditCampGenerator.Generate(instSeed, surface, _content);
 
-            if (!TryPlaceSettlement(structure, ir, reserved, wantIsland: false, out var origin, out int groundY, out bool onIsland))
+            // #586: pinned record → legacy re-derive → guaranteed search (fresh worlds; camps prefer rugged
+            // ground when the search escalates — they hide). Camp instances re-derive every load, so the
+            // record keeps guards/markers attached to the once-stamped huts across algorithm changes.
+            Vector3i origin;
+            int groundY;
+            bool onIsland;
+            string seat;
+            var rec = FindPlacementRecord("banditcamp", i);
+            if (rec is not null)
             {
-                continue;
+                if (!rec.Placed)
+                {
+                    continue;
+                }
+
+                origin = new Vector3i(rec.X, rec.GroundY, rec.Z);
+                groundY = rec.GroundY;
+                onIsland = rec.OnIsland;
+                seat = rec.Seat;
+            }
+            else if (!_worlds.Active.VirginAtLoad)
+            {
+                if (!TryPlaceSettlement(structure, ir, reserved, wantIsland: false, out origin, out groundY, out onIsland))
+                {
+                    RecordPlacementSkip("banditcamp", i);
+                    continue;
+                }
+
+                seat = "legacy";
+                RecordPlacement("banditcamp", i, origin, groundY, onIsland, seat, "bandit_camp_" + i);
+            }
+            else
+            {
+                if (!TryPlaceStructureGuaranteed(structure, RngFor(instSeed, "search"), reserved,
+                        wantIsland: false, SeatPolicy.Camp, avoidPlayerEdits: false,
+                        out origin, out groundY, out onIsland, out seat))
+                {
+                    RecordPlacementSkip("banditcamp", i);
+                    continue;
+                }
+
+                RecordPlacement("banditcamp", i, origin, groundY, onIsland, seat, "bandit_camp_" + i);
             }
 
             placed.Add(new PlacedSettlement
@@ -115,11 +154,14 @@ public sealed partial class GameServer
                 OnIsland = onIsland,
                 Name = "bandit_camp_" + i,
                 Rng = ir,
+                Seat = seat,
             });
             reserved.Add((origin.X + structure.Width / 2, origin.Z + structure.Length / 2,
                 structure.Width / 2 + 1, structure.Length / 2 + 1));
         }
 
+        SavePlacementRecords();
+        ReportStamp("banditcamp", count, placed.Count);
         if (placed.Count == 0)
         {
             return;

--- a/src/BlocksBeyondTheStars.GameServer/GameServerChests.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerChests.cs
@@ -42,6 +42,8 @@ public sealed partial class GameServer
         int placed = 0;
         for (int i = 0; i < count; i++)
         {
+            bool done = false;
+
             // A spot well away from the landing zone, on dry land, clear of any settlement/ruin footprint.
             for (int attempt = 0; attempt < 24; attempt++)
             {
@@ -60,10 +62,40 @@ public sealed partial class GameServer
                 int y = _generator.SurfaceHeight(planet, x, z) + 1;
                 SpawnStructureLoot("chest", "chest", new Vector3f(x, y, z), rng);
                 placed++;
+                done = true;
+                break;
+            }
+
+            if (done || !_worlds.Active.VirginAtLoad)
+            {
+                // Legacy worlds keep the frozen behaviour bit-for-bit: the fallback's extra loot-roll
+                // consumption would shift the next chest's position off its GeneratedLoot key and
+                // duplicate it. The guarantee applies to worlds created from now on.
+                continue;
+            }
+
+            // Terminal fallback (#586): the rolled chest must exist. Deterministic longitude walk; a wet
+            // column floats the salvage capsule on the water line, only lava stays excluded. This runs
+            // AFTER the 24 rolled attempts, so worlds where they used to succeed are byte-identical.
+            for (int step = 0; step < circ / 16; step++)
+            {
+                int x = WorldConstants.WrapX(pad0X + 60 + step * 16, circ);
+                int z = pad0Z + (step % 5 - 2) * 24;
+                if (OverlapsAnySettlement(x, z, 2) || _generator.IsSurfaceLava(planet, x, z))
+                {
+                    continue;
+                }
+
+                int y = _generator.TryGetWaterSurface(planet, x, z, out int waterTop, out _)
+                    ? waterTop + 1
+                    : _generator.SurfaceHeight(planet, x, z) + 1;
+                SpawnStructureLoot("chest", "chest", new Vector3f(x, y, z), rng);
+                placed++;
                 break;
             }
         }
 
+        ReportStamp("chest", count, placed);
         if (placed > 0)
         {
             _log.Info($"Scattered {placed} treasure chest(s) on '{_world.LocationId}'.");

--- a/src/BlocksBeyondTheStars.GameServer/GameServerDataCubes.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerDataCubes.cs
@@ -75,6 +75,7 @@ public sealed partial class GameServer
         double r = rng.NextDouble();
         int count = r < 0.45 ? 0 : r < 0.80 ? 1 : r < 0.95 ? 2 : 3;
 
+        int requested = count;
         for (int i = 0; i < count; i++)
         {
             // A deterministic spot away from the spawn/landing area, each cube in its own direction (mirrors vaults).
@@ -82,7 +83,33 @@ public sealed partial class GameServer
             int az = (60 + rng.Next(360)) * (rng.Next(2) == 0 ? 1 : -1);
             if (OverlapsAnySettlement(ax, az))
             {
-                continue; // don't bury a cube inside a settlement
+                // #586: on a fresh world, nudge deterministically off the settlement footprint (no extra
+                // rng, so the other cubes' rolls are untouched). Legacy worlds keep the frozen skip — the
+                // cube ids are sequential, and a retro-inserted cube would shift every later id.
+                bool nudged = false;
+                if (_worlds.Active.VirginAtLoad)
+                {
+                    for (int radius = 12; radius <= 96 && !nudged; radius += 12)
+                    {
+                        for (int step = 0; step < 8 && !nudged; step++)
+                        {
+                            double a = step * System.Math.PI / 4.0;
+                            int nx = WorldConstants.WrapX(ax + (int)(System.Math.Cos(a) * radius), _world.Circumference);
+                            int nz = az + (int)(System.Math.Sin(a) * radius);
+                            if (!OverlapsAnySettlement(nx, nz))
+                            {
+                                ax = nx;
+                                az = nz;
+                                nudged = true;
+                            }
+                        }
+                    }
+                }
+
+                if (!nudged)
+                {
+                    continue; // don't bury a cube inside a settlement
+                }
             }
 
             int surfaceY = _generator.SurfaceHeight(planet, ax, az);
@@ -113,6 +140,7 @@ public sealed partial class GameServer
             });
         }
 
+        ReportStamp("datacube", requested, System.Math.Min(requested, _dataCubes.Count));
         if (_dataCubes.Count > 0)
         {
             _log.Info($"Scattered {_dataCubes.Count} data cube(s) on '{_world.LocationId}'.");

--- a/src/BlocksBeyondTheStars.GameServer/GameServerFactories.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerFactories.cs
@@ -112,12 +112,54 @@ public sealed partial class GameServer
             var roster = factoryRecipes.OrderBy(_ => ir.Next()).Take(rosterSize).ToList();
 
             var structure = FactoryGenerator.Generate(instSeed, roster.Count, _content);
-            if (!TryPlaceSettlement(structure, ir, reserved, wantIsland: false, out var origin, out int groundY, out _))
+
+            // #586: pinned record → legacy re-derive → guaranteed search (fresh worlds). Factories re-derive
+            // every load, so the record is what keeps them attached to their stamped halls (and their claims,
+            // whose keys embed the origin) when the search algorithm evolves.
+            Vector3i origin;
+            int groundY;
+            string seat;
+            string name;
+            var rec = FindPlacementRecord("factory", i);
+            if (rec is not null)
             {
-                continue;
+                if (!rec.Placed)
+                {
+                    continue;
+                }
+
+                origin = new Vector3i(rec.X, rec.GroundY, rec.Z);
+                groundY = rec.GroundY;
+                seat = rec.Seat;
+                name = rec.Name;
+                usedNames.Add(name);
+            }
+            else if (!_worlds.Active.VirginAtLoad)
+            {
+                if (!TryPlaceSettlement(structure, ir, reserved, wantIsland: false, out origin, out groundY, out _))
+                {
+                    RecordPlacementSkip("factory", i);
+                    continue;
+                }
+
+                seat = "legacy";
+                name = UniqueName(FactoryName(ir), usedNames);
+                RecordPlacement("factory", i, origin, groundY, onIsland: false, seat, name);
+            }
+            else
+            {
+                if (!TryPlaceStructureGuaranteed(structure, RngFor(instSeed, "search"), reserved,
+                        wantIsland: false, SeatPolicy.Factory, avoidPlayerEdits: false,
+                        out origin, out groundY, out _, out seat))
+                {
+                    RecordPlacementSkip("factory", i);
+                    continue;
+                }
+
+                name = UniqueName(FactoryName(RngFor(instSeed, "name")), usedNames);
+                RecordPlacement("factory", i, origin, groundY, onIsland: false, seat, name);
             }
 
-            string name = UniqueName(FactoryName(ir), usedNames);
             placed.Add((new PlacedSettlement
             {
                 Structure = structure,
@@ -128,11 +170,14 @@ public sealed partial class GameServer
                 OnIsland = false,
                 Name = name,
                 Rng = ir,
+                Seat = seat,
             }, roster));
             reserved.Add((origin.X + structure.Width / 2, origin.Z + structure.Length / 2,
                 structure.Width / 2 + 1, structure.Length / 2 + 1));
         }
 
+        SavePlacementRecords();
+        ReportStamp("factory", count, placed.Count);
         if (placed.Count == 0)
         {
             return;

--- a/src/BlocksBeyondTheStars.GameServer/GameServerMonuments.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerMonuments.cs
@@ -119,9 +119,23 @@ public sealed partial class GameServer
             var (structure, ir) = BuildMonument(archetype, MonumentSeed(mSeed, i), surface);
 
             // avoidPlayerEdits (#527): monuments are new in this release, so they stamp into worlds people
-            // have already built in — never on top of somebody's base.
-            if (!TryPlaceSettlement(structure, ir, reserved, wantIsland: false,
-                    out var origin, out int groundY, out bool onIsland, avoidPlayerEdits: true))
+            // have already built in — never on top of somebody's base. On a fresh world the guaranteed
+            // search takes over (#586) — a relic may even stand in a lava plain; monuments already pin
+            // their positions via their own record keys, so no extra placement record is needed.
+            Vector3i origin;
+            int groundY;
+            bool onIsland;
+            if (_worlds.Active.VirginAtLoad)
+            {
+                if (!TryPlaceStructureGuaranteed(structure, RngFor(MonumentSeed(mSeed, i), "search"), reserved,
+                        wantIsland: false, SeatPolicy.Monument, avoidPlayerEdits: true,
+                        out origin, out groundY, out onIsland, out _))
+                {
+                    continue;
+                }
+            }
+            else if (!TryPlaceSettlement(structure, ir, reserved, wantIsland: false,
+                    out origin, out groundY, out onIsland, avoidPlayerEdits: true))
             {
                 continue;
             }
@@ -142,6 +156,7 @@ public sealed partial class GameServer
         }
 
         // Even a body that ends up with none records the decision, so the roll never runs twice.
+        ReportStamp("monument", System.Math.Min(count, pool.Count), placed.Count);
         MarkFeatureStamped("monuments");
         if (placed.Count == 0)
         {

--- a/src/BlocksBeyondTheStars.GameServer/GameServerRuins.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerRuins.cs
@@ -103,12 +103,29 @@ public sealed partial class GameServer
             string tier = ir.NextDouble() < 0.55 ? "town" : "city";
             var structure = SettlementGenerator.Generate(tier, ruined: true, instSeed, surface, _content);
 
-            if (!TryPlaceSettlement(structure, ir, reserved, wantIsland: false, out var origin, out int groundY, out bool onIsland))
+            // #586: ruins stamp exactly once and never re-derive positions, so no placement record is
+            // needed — a fresh world gets the guaranteed search (drowned/lava ruins allowed), a legacy
+            // world stamping its one-time ruins now keeps the frozen first-fit search.
+            Vector3i origin;
+            int groundY;
+            bool onIsland;
+            string seat = "legacy";
+            if (_worlds.Active.VirginAtLoad)
+            {
+                if (!TryPlaceStructureGuaranteed(structure, RngFor(instSeed, "search"), reserved,
+                        wantIsland: false, SeatPolicy.Ruin, avoidPlayerEdits: false,
+                        out origin, out groundY, out onIsland, out seat))
+                {
+                    continue;
+                }
+            }
+            else if (!TryPlaceSettlement(structure, ir, reserved, wantIsland: false, out origin, out groundY, out onIsland))
             {
                 continue;
             }
 
-            string name = UniqueName(SettlementDisplayName(tier, true, ir), usedNames);
+            string name = UniqueName(SettlementDisplayName(tier, true,
+                _worlds.Active.VirginAtLoad ? RngFor(instSeed, "name") : ir), usedNames);
             placed.Add(new PlacedSettlement
             {
                 Structure = structure,
@@ -118,12 +135,14 @@ public sealed partial class GameServer
                 Ruined = true,
                 OnIsland = onIsland,
                 Name = name,
+                Seat = seat,
                 Rng = ir,
             });
             reserved.Add((origin.X + structure.Width / 2, origin.Z + structure.Length / 2,
                 structure.Width / 2 + 1, structure.Length / 2 + 1));
         }
 
+        ReportStamp("ruin", count, placed.Count);
         if (placed.Count == 0)
         {
             return;

--- a/src/BlocksBeyondTheStars.GameServer/GameServerSettlements.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerSettlements.cs
@@ -7,6 +7,7 @@ using BlocksBeyondTheStars.Networking.Messages;
 using BlocksBeyondTheStars.Shared.Definitions;
 using BlocksBeyondTheStars.Shared.Geometry;
 using BlocksBeyondTheStars.Shared.Primitives;
+using BlocksBeyondTheStars.Shared.State;
 using BlocksBeyondTheStars.Shared.World;
 using BlocksBeyondTheStars.WorldGeneration;
 
@@ -163,6 +164,11 @@ public sealed partial class GameServer
         public required bool OnIsland;
         public required string Name;
         public required System.Random Rng; // per-instance deterministic rng (loot + names)
+
+        /// <summary>Seat style (#586): how the stamper couples this structure to the terrain —
+        /// "legacy"/"flat"/"slope" (foundation + stepped skirt), "shelf" (cut &amp; fill at median height),
+        /// "stilts" (platform over water on pile columns), "lava" (basalt plinth), "island" (sky deck).</summary>
+        public string Seat = "legacy";
     }
 
     private void StampSettlement()
@@ -239,12 +245,62 @@ public sealed partial class GameServer
             }
 
             bool wantIsland = planet.FloatingIslands && ir.NextDouble() < 0.5;
-            if (!TryPlaceSettlement(structure, ir, reserved, wantIsland, out var origin, out int groundY, out bool onIsland))
+
+            // #586: pinned record → legacy re-derive → guaranteed search (fresh worlds only). The record is
+            // written on whichever path runs first, so the search algorithm can evolve without moving
+            // structures under existing worlds.
+            Vector3i origin;
+            int groundY;
+            bool onIsland;
+            string seat;
+            string name;
+            var rec = FindPlacementRecord("settlement", i);
+            if (rec is not null)
             {
-                continue; // no room on this world for this one — skip (reported below)
+                if (!rec.Placed)
+                {
+                    continue; // decided before: this instance has no spot on this world — forever
+                }
+
+                origin = new Vector3i(rec.X, rec.GroundY, rec.Z);
+                groundY = rec.GroundY;
+                onIsland = rec.OnIsland;
+                seat = rec.Seat;
+                name = rec.Name;
+                usedNames.Add(name);
+            }
+            else if (!_worlds.Active.VirginAtLoad)
+            {
+                // Legacy world (stamped before the record registry existed): the FROZEN first-fit search
+                // reproduces the positions its blocks were stamped at; the outcome is recorded so future
+                // loads replay instead of re-deriving.
+                if (!TryPlaceSettlement(structure, ir, reserved, wantIsland, out origin, out groundY, out onIsland))
+                {
+                    RecordPlacementSkip("settlement", i);
+                    continue;
+                }
+
+                seat = "legacy";
+                name = UniqueName(SettlementDisplayName(tier, ruined, ir), usedNames);
+                RecordPlacement("settlement", i, origin, groundY, onIsland, seat, name);
+            }
+            else
+            {
+                // Fresh world: the escalating search guarantees a spot (terrain adapts via the seat style).
+                // It draws from its own rng lane so the shared per-instance stream stays search-independent;
+                // the name comes from a dedicated lane for the same reason.
+                if (!TryPlaceStructureGuaranteed(structure, RngFor(instSeed, "search"), reserved, wantIsland,
+                        ruined ? SeatPolicy.Ruin : SeatPolicy.Inhabited, avoidPlayerEdits: false,
+                        out origin, out groundY, out onIsland, out seat))
+                {
+                    RecordPlacementSkip("settlement", i); // all-lava carve-out — see TryPlaceStructureGuaranteed
+                    continue;
+                }
+
+                name = UniqueName(SettlementDisplayName(tier, ruined, RngFor(instSeed, "name")), usedNames);
+                RecordPlacement("settlement", i, origin, groundY, onIsland, seat, name);
             }
 
-            string name = UniqueName(SettlementDisplayName(tier, ruined, ir), usedNames);
             placed.Add(new PlacedSettlement
             {
                 Structure = structure,
@@ -255,14 +311,16 @@ public sealed partial class GameServer
                 OnIsland = onIsland,
                 Name = name,
                 Rng = ir,
+                Seat = seat,
             });
             reserved.Add((origin.X + structure.Width / 2, origin.Z + structure.Length / 2,
                 structure.Width / 2 + 1, structure.Length / 2 + 1));
         }
 
+        SavePlacementRecords();
+        ReportStamp("settlement", requested, placed.Count);
         if (placed.Count == 0)
         {
-            _log.Info($"No room to place any of {requested} requested settlement(s) on '{_world.LocationId}'.");
             return;
         }
 
@@ -324,20 +382,37 @@ public sealed partial class GameServer
     }
 
     /// <summary>Carves the footprint clear of terrain, lays a flat foundation, then stamps the structure's blocks.
-    /// Must run inside a repo transaction (called once per settlement from the batched stamp).</summary>
+    /// The seat style (#586) picks how the foundation couples to the terrain: legacy/flat/slope keep the classic
+    /// foundation + stepped skirt, shelf cuts into rugged relief and fills with stone, stilts raise a platform
+    /// over water on pile columns, lava raises a basalt plinth above a lava sheet, island keeps the floating
+    /// deck. Must run inside a repo transaction (called once per settlement from the batched stamp).</summary>
     private void StampSettlementBlocks(PlacedSettlement p, string surface)
     {
         var s = p.Structure;
         int gy = p.GroundY;
         var origin = p.Origin;
+        bool shelf = p.Seat == "shelf";
+        bool stilts = p.Seat == "stilts";
+        bool lavaSeat = p.Seat == "lava";
         var foundationId = _content.GetBlock(surface)?.NumericId ?? BlockId.Air;
 
-        // Carve only as high as terrain actually rises above the foundation. Placement guarantees a low height
-        // spread, so the surface never climbs more than a handful of blocks over gy — clearing the structure's
-        // FULL height (up to 128 for a hand-authored tower) would be millions of pointless air writes. Sample
-        // the footprint coarsely to find that intrusion height. (On a sky island the ground is far below, so
-        // maxSurf - gy goes negative and the carve collapses to the minimum.)
+        // Seat materials. The shelf fills with the biome's sub-surface block so the cut reads as bedrock, a
+        // lava plinth is basalt, stilt piles are logs for inhabited builds and weathered stone for ruins.
         var planet = _world.Planet;
+        string sub = planet.Biomes.Count > 0 ? planet.Biomes[0].SubSurfaceBlock : planet.SubSurfaceBlock;
+        var shelfFillId = _content.GetBlock(sub)?.NumericId ?? foundationId;
+        var basaltId = (_content.GetBlock("basalt") ?? _content.GetBlock("stone"))?.NumericId ?? foundationId;
+        var pileId = p.Ruined
+            ? (_content.GetBlock("stone")?.NumericId ?? foundationId)
+            : (_content.GetBlock("wood_log") ?? _content.GetBlock("stone"))?.NumericId ?? foundationId;
+        var floorId = lavaSeat ? basaltId : stilts && !p.Ruined ? pileId : foundationId;
+
+        // Carve only as high as terrain actually rises above the foundation. The classic gates guarantee a
+        // low spread, so clearing the structure's FULL height (up to 128 for a hand-authored tower) would be
+        // millions of pointless air writes; a SHELF seat sits in genuinely rugged relief, so its cut may run
+        // higher than the buildings to open the mountainside above them. Sample the footprint coarsely to
+        // find the intrusion height. (On a sky island the ground is far below, so maxSurf - gy goes negative
+        // and the carve collapses to the minimum.)
         int maxSurf = gy;
         for (int x = 0; x < s.Width; x += 8)
             for (int z = 0; z < s.Length; z += 8)
@@ -345,7 +420,7 @@ public sealed partial class GameServer
                 maxSurf = System.Math.Max(maxSurf, _generator.SurfaceHeight(planet, origin.X + x, origin.Z + z));
             }
 
-        int clearH = System.Math.Clamp(maxSurf - gy + 3, 2, s.Height);
+        int clearH = System.Math.Clamp(maxSurf - gy + 3, 2, shelf ? System.Math.Max(s.Height, 96) : s.Height);
 
         // 1) Clear any terrain occupying the build volume above the foundation, so a hill never buries the
         //    buildings (the structure's own air cells are otherwise left as whatever was there).
@@ -361,18 +436,39 @@ public sealed partial class GameServer
         //    each column also gets a stepped plinth: solid fill from gy down to the natural surface, deep on the
         //    downhill side, shallow uphill. The result is a real multi-level foundation that meets the ground
         //    all the way round instead of a flat platform floating over a dip. (Skipped on sky islands, whose
-        //    deck is meant to float over the void.) Depth is capped so a missed crevasse can't fill a chasm.
-        if (!foundationId.IsAir)
+        //    deck is meant to float over the void.) Depth is capped so a missed crevasse can't fill a chasm —
+        //    a SHELF seat, cut into rugged relief on purpose, gets double the cap. A STILTS seat swaps the
+        //    solid fill for pile columns on a sparse grid over the wet cells (a platform, not a dam).
+        if (!floorId.IsAir)
         {
-            const int maxSkirt = 48;
+            int maxSkirt = shelf ? 96 : 48;
+            var skirtId = shelf ? shelfFillId : lavaSeat ? basaltId : foundationId;
             for (int x = 0; x < s.Width; x++)
                 for (int z = 0; z < s.Length; z++)
                 {
                     int wx = origin.X + x, wz = origin.Z + z;
-                    _world.SetBlock(new Vector3i(wx, gy, wz), foundationId); // flat floor row
+                    _world.SetBlock(new Vector3i(wx, gy, wz), floorId); // flat floor row
 
                     if (p.OnIsland)
                     {
+                        continue;
+                    }
+
+                    if (stilts && _generator.TryGetWaterSurface(planet, wx, wz, out _, out int seabedY))
+                    {
+                        // Wet column: no solid fill — a pile column every few cells plus the footprint rim
+                        // carries the platform down to the seabed; the water flows on beneath the deck.
+                        bool pile = (x % 3 == 0 && z % 3 == 0)
+                            || ((x == 0 || x == s.Width - 1 || z == 0 || z == s.Length - 1) && (x + z) % 3 == 0);
+                        if (pile)
+                        {
+                            int pileFloor = System.Math.Max(seabedY + 1, gy - maxSkirt);
+                            for (int y = gy - 1; y >= pileFloor; y--)
+                            {
+                                _world.SetBlock(new Vector3i(wx, y, wz), pileId);
+                            }
+                        }
+
                         continue;
                     }
 
@@ -380,9 +476,16 @@ public sealed partial class GameServer
                     int floorY = System.Math.Max(colSurf + 1, gy - maxSkirt);
                     for (int y = gy - 1; y >= floorY; y--) // fill the gap down to the natural ground
                     {
-                        _world.SetBlock(new Vector3i(wx, y, wz), foundationId);
+                        _world.SetBlock(new Vector3i(wx, y, wz), skirtId);
                     }
                 }
+
+            // Slope/shelf seats get a stepped apron around the plinth so no sheer foundation wall meets the
+            // ground (#586) — one terrace ring per step, only where the plinth actually stands proud.
+            if (p.Seat is "slope" or "shelf")
+            {
+                StampFoundationApron(p, skirtId);
+            }
         }
 
         // 3) Stamp the structure above the foundation (y=0 of the structure is the foundation row).
@@ -482,6 +585,403 @@ public sealed partial class GameServer
         }
 
         return false;
+    }
+
+    // --- guaranteed placement (#586) ------------------------------------------------------------------------
+
+    /// <summary>Which seatings a structure kind tolerates: inhabited builds may stand on stilts but never in
+    /// lava; ruins and monuments may do both (a drowned ruin / a dead relic in a lava plain); factories and
+    /// camps stay on dry land, and camps prefer rugged ground when the search has to escalate (they hide).</summary>
+    private readonly record struct SeatPolicy(bool AllowStilts, bool AllowLava, bool PreferRugged)
+    {
+        public static SeatPolicy Inhabited => new(true, false, false);
+        public static SeatPolicy Ruin => new(true, true, false);
+        public static SeatPolicy Factory => new(false, false, false);
+        public static SeatPolicy Camp => new(false, false, true);
+        public static SeatPolicy Monument => new(false, true, false);
+    }
+
+    /// <summary>Footprint statistics for one candidate spot, gathered over the sample columns.</summary>
+    private sealed class SeatCandidate
+    {
+        public int Cx, Cz;              // footprint centre (world)
+        public int Spread;              // max-min ground height over the samples
+        public int MedianY;             // median ground height (shelf seat level)
+        public int MaxY;                // highest ground sample (lava plinth clears the sheet from here)
+        public int WetSamples;          // water-covered sample columns
+        public int LavaSamples;         // lava-covered sample columns
+        public int Samples;             // total sample columns
+        public int WaterTop = int.MinValue; // highest water surface over the wet samples
+    }
+
+    /// <summary>A deterministic rng lane per instance seed, so the guaranteed search and the display name
+    /// never share draws with the legacy per-instance stream — the search can then grow or shrink its
+    /// consumption freely without shifting any other roll (#586).</summary>
+    private static System.Random RngFor(long instSeed, string lane)
+    {
+        long s = instSeed ^ WorldGenerator.StableHash(lane);
+        return new System.Random(unchecked((int)(s ^ (s >> 32))));
+    }
+
+    /// <summary>The pinned placement record for a structure instance on the active world, or null.</summary>
+    private StructurePlacementRecord? FindPlacementRecord(string kind, int index)
+        => _meta.Placements.Find(r => r.LocationId == _world.LocationId && r.Kind == kind && r.Index == index);
+
+    private bool _placementRecordsDirty;
+
+    /// <summary>Pins where a structure instance landed (#586). Batched — call
+    /// <see cref="SavePlacementRecords"/> once per stamper after its loop.</summary>
+    private void RecordPlacement(string kind, int index, Vector3i origin, int groundY, bool onIsland,
+        string seat, string name)
+    {
+        var rec = FindPlacementRecord(kind, index);
+        if (rec is null)
+        {
+            rec = new StructurePlacementRecord { LocationId = _world.LocationId, Kind = kind, Index = index };
+            _meta.Placements.Add(rec);
+        }
+
+        rec.Placed = true;
+        rec.X = origin.X;
+        rec.GroundY = groundY;
+        rec.Z = origin.Z;
+        rec.OnIsland = onIsland;
+        rec.Seat = seat;
+        rec.Name = name;
+        _placementRecordsDirty = true;
+    }
+
+    /// <summary>Pins the decision that an instance found NO spot (legacy worlds / the all-lava carve-out),
+    /// so later loads don't re-roll it.</summary>
+    private void RecordPlacementSkip(string kind, int index)
+    {
+        if (FindPlacementRecord(kind, index) is not null)
+        {
+            return;
+        }
+
+        _meta.Placements.Add(new StructurePlacementRecord
+        {
+            LocationId = _world.LocationId,
+            Kind = kind,
+            Index = index,
+            Placed = false,
+        });
+        _placementRecordsDirty = true;
+    }
+
+    private void SavePlacementRecords()
+    {
+        if (_placementRecordsDirty)
+        {
+            _placementRecordsDirty = false;
+            _repo.SaveMetadata(_meta);
+        }
+    }
+
+    /// <summary>Per-kind requested/placed telemetry: a drop is a WARN — with the guaranteed search it should
+    /// only ever fire on legacy worlds and the documented all-lava carve-out.</summary>
+    private void ReportStamp(string kind, int requested, int placedCount)
+    {
+        _worlds.Active.StampReport.Add((kind, requested, placedCount));
+        if (placedCount < requested)
+        {
+            _log.Warn($"Placed only {placedCount}/{requested} {kind}(s) on '{_world.LocationId}'.");
+        }
+    }
+
+    /// <summary>Test seam: this load's per-kind requested/placed stamp report.</summary>
+    public IReadOnlyList<(string Kind, int Requested, int Placed)> StampReportForTest
+        => _worlds.Active.StampReport;
+
+    /// <summary>Test seam: the pinned placement records of the active world.</summary>
+    public IReadOnlyList<StructurePlacementRecord> PlacementRecordsForTest
+        => _meta.Placements.Where(r => r.LocationId == _world.LocationId).ToList();
+
+    /// <summary>The guaranteed placement search (#586): first the classic gates (ring 1 — first-fit on dry,
+    /// flat ground, no visual change where they succeed), then widening best-fit rings that rank every seen
+    /// candidate (dry lowest-spread first, then water for stilt-capable kinds, lava last for lava-capable
+    /// kinds), then a terminal pass with the collision margin relaxed 6 → 2, and finally a deterministic
+    /// longitude sweep. The chosen spot is classified into a seat style; the stamper adapts the terrain to
+    /// it. Returns false only when policy forbids every reachable column (in practice: an all-lava ring for
+    /// a kind that may not stand in lava) — the one documented carve-out from the guarantee. Player-edit
+    /// avoidance and pad/settlement reservations are never relaxed beyond margin 2.</summary>
+    private bool TryPlaceStructureGuaranteed(SettlementStructure s, System.Random rng,
+        List<(int Cx, int Cz, int Hw, int Hl)> reserved, bool wantIsland, SeatPolicy policy,
+        bool avoidPlayerEdits, out Vector3i origin, out int groundY, out bool onIsland, out string seat)
+    {
+        origin = default;
+        groundY = 0;
+        onIsland = false;
+        seat = "flat";
+
+        var planet = _world.Planet;
+        int circ = _world.Circumference;
+        int latP = WorldConstants.LatitudePeriodFor(circ);
+        int w = s.Width, l = s.Length;
+        int hw = w / 2 + 1, hl = l / 2 + 1;
+        int latBand = System.Math.Max(8, latP / 2 - System.Math.Max(w, l) / 2 - 16);
+        int pad0X = _landingPads.Count > 0 ? _landingPads[0].CenterX : 0;
+        int pad0Z = _landingPads.Count > 0 ? _landingPads[0].CenterZ : 0;
+        int baseDist = System.Math.Max(80, (int)(circ * 0.4));
+        int maxSpread = System.Math.Clamp(System.Math.Max(w, l) / 8, 8, 24);
+        bool canIsland = wantIsland && System.Math.Max(w, l) <= 40;
+
+        bool Blocked(int cx, int cz, int margin)
+            => OverlapsFootprint(cx, cz, hw, hl, reserved, margin);
+
+        bool EditGate(int ox, int oz, int gy)
+            => avoidPlayerEdits && FootprintHasPlayerEdits(ox, oz, gy, w, s.Height, l);
+
+        // Ring 1 — the classic gates, first-fit. Where they succeed nothing changes visually.
+        int attempts = System.Math.Max(w, l) > 48 ? 160 : 64;
+        for (int attempt = 0; attempt < attempts; attempt++)
+        {
+            double ang = rng.NextDouble() * System.Math.PI * 2.0;
+            int dist = 40 + rng.Next(0, baseDist);
+            int cx = pad0X + (int)System.Math.Round(System.Math.Cos(ang) * dist);
+            int cz = System.Math.Clamp(pad0Z + (int)System.Math.Round(System.Math.Sin(ang) * dist), -latBand, latBand);
+            if (Blocked(cx, cz, SettlementCollisionMargin))
+            {
+                continue;
+            }
+
+            int ox = cx - w / 2, oz = cz - l / 2;
+            if (canIsland)
+            {
+                if (TryIslandFootprint(planet, ox, oz, w, l, out int itop) && !EditGate(ox, oz, itop))
+                {
+                    origin = new Vector3i(ox, itop, oz);
+                    groundY = itop;
+                    onIsland = true;
+                    seat = "island";
+                    return true;
+                }
+
+                continue;
+            }
+
+            if (FootprintWet(planet, ox, oz, w, l) || FootprintSpread(planet, ox, oz, w, l) > maxSpread)
+            {
+                continue;
+            }
+
+            int gy = _generator.SurfaceHeight(planet, cx, cz);
+            if (EditGate(ox, oz, gy))
+            {
+                continue;
+            }
+
+            origin = new Vector3i(ox, gy, oz);
+            groundY = gy;
+            seat = FootprintSpread(planet, ox, oz, w, l) <= 4 ? "flat" : "slope";
+            return true;
+        }
+
+        // Rings 2+ — collect + rank. Widening rings, then a terminal margin-2 ring; the best candidate seen
+        // anywhere wins. Ranking tiers: dry (spread asc — desc for rugged-preferring kinds), then water for
+        // stilt-capable kinds (least wet first), then water for everyone (function over matrix — better a
+        // dry-land kind on stilts than a world missing its rolled structure), then lava if allowed.
+        SeatCandidate? best = null;
+        int bestTier = int.MaxValue, bestScore = int.MaxValue;
+
+        void Consider(SeatCandidate c)
+        {
+            int tier;
+            int score;
+            if (c.LavaSamples > 0)
+            {
+                if (!policy.AllowLava)
+                {
+                    return; // lava is the one absolute no-go for kinds that may not stand in it
+                }
+
+                tier = 3;
+                score = c.LavaSamples * 1000 / System.Math.Max(1, c.Samples);
+            }
+            else if (c.WetSamples > 0)
+            {
+                tier = policy.AllowStilts ? 1 : 2;
+                score = c.WetSamples * 1000 / System.Math.Max(1, c.Samples);
+            }
+            else
+            {
+                tier = 0;
+                score = policy.PreferRugged ? -c.Spread : c.Spread;
+            }
+
+            if (tier < bestTier || (tier == bestTier && score < bestScore))
+            {
+                best = c;
+                bestTier = tier;
+                bestScore = score;
+            }
+        }
+
+        foreach (var (scale, margin, tries) in new[] { (1.0, 6, attempts), (1.5, 6, attempts), (2.0, 6, attempts), (2.0, 2, attempts * 2) })
+        {
+            int maxDist = System.Math.Min(circ / 2, (int)(baseDist * scale));
+            for (int attempt = 0; attempt < tries; attempt++)
+            {
+                double ang = rng.NextDouble() * System.Math.PI * 2.0;
+                int dist = 40 + rng.Next(0, maxDist);
+                int cx = pad0X + (int)System.Math.Round(System.Math.Cos(ang) * dist);
+                int cz = System.Math.Clamp(pad0Z + (int)System.Math.Round(System.Math.Sin(ang) * dist), -latBand, latBand);
+                if (Blocked(cx, cz, margin))
+                {
+                    continue;
+                }
+
+                var c = EvaluateFootprint(planet, cx - w / 2, cz - l / 2, w, l);
+                c.Cx = cx;
+                c.Cz = cz;
+                if (EditGate(cx - w / 2, cz - l / 2, c.MedianY))
+                {
+                    continue;
+                }
+
+                Consider(c);
+            }
+
+            if (best is not null && bestTier == 0)
+            {
+                break; // a dry spot in a tighter ring beats walking further out
+            }
+        }
+
+        // Terminal sweep — deterministic longitude walk on three latitude lines. Only reachable when even
+        // the widened rings found nothing rankable (tiny bodies saturated with reservations).
+        if (best is null)
+        {
+            foreach (int cz in new[] { 0, latBand / 2, -latBand / 2 })
+            {
+                for (int cx = pad0X + 40; cx < pad0X + circ - 40 && best is null; cx += 16)
+                {
+                    int wxc = WorldConstants.WrapX(cx, circ);
+                    if (Blocked(wxc, cz, 2))
+                    {
+                        continue;
+                    }
+
+                    var c = EvaluateFootprint(planet, wxc - w / 2, cz - l / 2, w, l);
+                    c.Cx = wxc;
+                    c.Cz = cz;
+                    if (EditGate(wxc - w / 2, cz - l / 2, c.MedianY))
+                    {
+                        continue;
+                    }
+
+                    Consider(c);
+                }
+            }
+        }
+
+        if (best is null)
+        {
+            return false; // the documented carve-out (e.g. an all-lava surface for a no-lava kind)
+        }
+
+        // Classify the winning footprint into a seat style + its ground level.
+        var bc = best;
+        int bx = bc.Cx - w / 2, bz = bc.Cz - l / 2;
+        if (bc.LavaSamples > 0)
+        {
+            seat = "lava";
+            groundY = bc.MaxY + 2; // the basalt plinth clears the lava sheet
+        }
+        else if (bc.WetSamples > 0)
+        {
+            seat = "stilts";
+            groundY = bc.WaterTop + 1; // platform just above the water line
+        }
+        else if (bc.Spread <= 4)
+        {
+            seat = "flat";
+            groundY = _generator.SurfaceHeight(planet, bc.Cx, bc.Cz);
+        }
+        else if (bc.Spread <= maxSpread)
+        {
+            seat = "slope";
+            groundY = _generator.SurfaceHeight(planet, bc.Cx, bc.Cz);
+        }
+        else
+        {
+            seat = "shelf";
+            groundY = bc.MedianY; // cut & fill around the median so the shelf splits the relief evenly
+        }
+
+        origin = new Vector3i(bx, groundY, bz);
+        return true;
+    }
+
+    /// <summary>Gathers footprint statistics (spread/median over ground heights, wet/lava sample counts,
+    /// highest water surface) for the seat classification — one pass over the standard sample columns.</summary>
+    private SeatCandidate EvaluateFootprint(PlanetType planet, int ox, int oz, int w, int l)
+    {
+        var c = new SeatCandidate();
+        var heights = new List<int>();
+        foreach (var (x, z) in FootprintSamples(ox, oz, w, l))
+        {
+            c.Samples++;
+            if (_generator.IsSurfaceLava(planet, x, z))
+            {
+                c.LavaSamples++;
+            }
+            else if (_generator.TryGetWaterSurface(planet, x, z, out int waterTop, out _))
+            {
+                c.WetSamples++;
+                c.WaterTop = System.Math.Max(c.WaterTop, waterTop);
+            }
+
+            heights.Add(_generator.SurfaceHeight(planet, x, z));
+        }
+
+        heights.Sort();
+        c.MedianY = heights[heights.Count / 2];
+        c.MaxY = heights[^1];
+        c.Spread = heights[^1] - heights[0];
+        return c;
+    }
+
+    /// <summary>Stamps a stepped apron around a slope/shelf plinth (#586): terrace rings just outside the
+    /// footprint, one step lower per ring, filled a few blocks down to the natural ground — so the foundation
+    /// meets the terrain as steps instead of a sheer wall.</summary>
+    private void StampFoundationApron(PlacedSettlement p, BlockId fill)
+    {
+        if (fill.IsAir)
+        {
+            return;
+        }
+
+        var planet = _world.Planet;
+        var s = p.Structure;
+        int gy = p.GroundY;
+        for (int ring = 1; ring <= 2; ring++)
+        {
+            int stepY = gy - ring;
+            int x0 = p.Origin.X - ring, x1 = p.Origin.X + s.Width - 1 + ring;
+            int z0 = p.Origin.Z - ring, z1 = p.Origin.Z + s.Length - 1 + ring;
+            for (int x = x0; x <= x1; x++)
+                for (int z = z0; z <= z1; z++)
+                {
+                    if (x != x0 && x != x1 && z != z0 && z != z1)
+                    {
+                        continue; // ring perimeter only
+                    }
+
+                    int colSurf = _generator.SurfaceHeight(planet, x, z);
+                    if (colSurf >= stepY || _generator.IsSurfaceWater(planet, x, z) || _generator.IsSurfaceLava(planet, x, z))
+                    {
+                        continue; // uphill side / wet ground — no terrace needed or wanted
+                    }
+
+                    int floorY = System.Math.Max(colSurf + 1, stepY - 4); // short footing, not another wall
+                    for (int y = stepY; y >= floorY; y--)
+                    {
+                        _world.SetBlock(new Vector3i(x, y, z), fill);
+                    }
+                }
+        }
     }
 
     /// <summary>True if any cell in the build volume carries a player-authored block edit (#527). Worldgen

--- a/src/BlocksBeyondTheStars.GameServer/GameServerVaults.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerVaults.cs
@@ -73,18 +73,96 @@ public sealed partial class GameServer
             : 0;
         for (int i = 0; i < count; i++)
         {
-            // A deterministic spot away from the spawn/landing area, each vault in its own direction.
+            // A deterministic spot away from the spawn/landing area, each vault in its own direction. The
+            // rolls are consumed unconditionally so every path (fresh/legacy/replay) walks the same stream.
             int ax = (120 + rng.Next(320)) * (rng.Next(2) == 0 ? 1 : -1);
             int az = (90 + rng.Next(280)) * (rng.Next(2) == 0 ? 1 : -1);
             int wx = WorldConstants.WrapX(ax, _world.Circumference);
-            if (OverlapsAnySettlement(wx, az, 6))
+
+            // #586: pinned record → legacy re-derive → guaranteed placement (fresh worlds).
+            var rec = FindPlacementRecord("vault", i);
+            if (rec is not null)
             {
-                continue; // don't drop a vault entrance inside a settlement footprint
+                if (rec.Placed)
+                {
+                    StampVault(rec.X, rec.Z, rng, write, rec.Seat == "wellhead", legacyGate: false);
+                }
+
+                continue;
             }
 
-            StampVault(wx, az, rng, write);
+            if (!_worlds.Active.VirginAtLoad)
+            {
+                // Legacy world: the frozen behaviour (silent skips included), recorded for future loads.
+                if (OverlapsAnySettlement(wx, az, 6))
+                {
+                    RecordPlacementSkip("vault", i);
+                    continue;
+                }
+
+                int before = _vaultEntrances.Count;
+                StampVault(wx, az, rng, write, wellhead: false, legacyGate: true);
+                if (_vaultEntrances.Count > before)
+                {
+                    var e = _vaultEntrances[^1];
+                    RecordPlacement("vault", i, e, e.Y, onIsland: false, "buried", string.Empty);
+                }
+                else
+                {
+                    RecordPlacementSkip("vault", i);
+                }
+
+                continue;
+            }
+
+            // Fresh world, guaranteed: nudge off reserved footprints deterministically; a dry column always
+            // works (the old `surfaceY < 24` gate predates the deep floor — a chamber fits under any dry
+            // ground now), a water column gets the WELLHEAD variant (chamber under the seabed, cased shaft
+            // rising through the water). Lava columns are skipped by the nudge (nobody dives into lava).
+            bool Fits(int x, int z) => !OverlapsAnySettlement(x, z, 6) && !_generator.IsSurfaceLava(planet, x, z);
+            int vx = wx, vz = az;
+            if (!Fits(vx, vz))
+            {
+                bool found = false;
+                for (int radius = 12; radius <= 96 && !found; radius += 12)
+                {
+                    for (int step = 0; step < 8 && !found; step++)
+                    {
+                        double a = step * System.Math.PI / 4.0;
+                        int nx = WorldConstants.WrapX(wx + (int)(System.Math.Cos(a) * radius), _world.Circumference);
+                        int nz = az + (int)(System.Math.Sin(a) * radius);
+                        if (Fits(nx, nz))
+                        {
+                            vx = nx;
+                            vz = nz;
+                            found = true;
+                        }
+                    }
+                }
+
+                if (!found)
+                {
+                    RecordPlacementSkip("vault", i); // all-lava/all-reserved carve-out
+                    continue;
+                }
+            }
+
+            bool wet = _generator.TryGetWaterSurface(planet, vx, vz, out _, out _);
+            int cnt = _vaultEntrances.Count;
+            StampVault(vx, vz, rng, write, wellhead: wet, legacyGate: false);
+            if (_vaultEntrances.Count > cnt)
+            {
+                var e = _vaultEntrances[^1];
+                RecordPlacement("vault", i, e, e.Y, onIsland: false, wet ? "wellhead" : "buried", string.Empty);
+            }
+            else
+            {
+                RecordPlacementSkip("vault", i);
+            }
         }
 
+        SavePlacementRecords();
+        ReportStamp("vault", count, _vaultEntrances.Count);
         if (write && _vaultEntrances.Count > 0)
         {
             _log.Info($"Stamped {_vaultEntrances.Count} buried vault(s) on '{_world.LocationId}'.");
@@ -98,14 +176,28 @@ public sealed partial class GameServer
 
     /// <summary>Carves one vault: surface pillar ring → 2×2 shaft → buried 9×9 chamber (deepslate shell, air
     /// inside) with data caches + two loot containers and a data terminal. With <paramref name="write"/>
-    /// false only the runtime state (entrances, loot markers) is re-derived (#467).</summary>
-    private void StampVault(int ax, int az, System.Random rng, bool write)
+    /// false only the runtime state (entrances, loot markers) is re-derived (#467). The WELLHEAD variant
+    /// (#586) buries the chamber under a water body's seabed and cases the shaft up through the water as a
+    /// stone well tube. <paramref name="legacyGate"/> keeps the pre-deep-floor `surfaceY &lt; 24` skip for
+    /// legacy worlds whose stamped state depends on it; fresh worlds bury under any dry column.</summary>
+    private void StampVault(int ax, int az, System.Random rng, bool write, bool wellhead, bool legacyGate)
     {
         var planet = _world.Planet;
-        int surfaceY = _generator.SurfaceHeight(planet, ax, az);
-        if (surfaceY < 24)
+        int surfaceY;
+        int waterTop = int.MinValue;
+        if (wellhead && _generator.TryGetWaterSurface(planet, ax, az, out int wTop, out int seabed))
         {
-            return; // too low to bury a chamber under (sea floors etc.)
+            surfaceY = seabed; // the chamber hides under the seabed; the shaft cases up through the water
+            waterTop = wTop;
+        }
+        else
+        {
+            surfaceY = _generator.SurfaceHeight(planet, ax, az);
+        }
+
+        if (legacyGate && surfaceY < 24)
+        {
+            return; // frozen legacy behaviour: too low to bury a chamber under (sea floors etc.)
         }
 
         var shell = (_content.GetBlock("deepslate") ?? _content.GetBlock("stone"))!.NumericId;
@@ -143,6 +235,22 @@ public sealed partial class GameServer
                 {
                     Put(new Vector3i(WorldConstants.WrapX(ax + dx, _world.Circumference), dy, az + dz), BlockId.Air);
                 }
+        }
+
+        // Wellhead (#586): case the shaft up through the water column as a 4×4 stone well tube with the
+        // 2×2 drop inside, mouth one block above the water line — a diveable ancient well.
+        if (waterTop != int.MinValue)
+        {
+            for (int dy = surfaceY + 2; dy <= waterTop + 1; dy++)
+            {
+                for (int dx = -2; dx <= 1; dx++)
+                    for (int dz = -2; dz <= 1; dz++)
+                    {
+                        bool casing = dx is -2 or 1 || dz is -2 or 1;
+                        Put(new Vector3i(WorldConstants.WrapX(ax + dx, _world.Circumference), dy, az + dz),
+                            casing ? shell : BlockId.Air);
+                    }
+            }
         }
 
         // Surface hint: a broken ring of weathered pillars (1–2 tall, some missing) around the shaft mouth.

--- a/src/BlocksBeyondTheStars.GameServer/WorldManager.cs
+++ b/src/BlocksBeyondTheStars.GameServer/WorldManager.cs
@@ -136,6 +136,15 @@ internal sealed class LoadedWorld
         return ship;
     }
 
+    // Placement-guarantee state (#586). VirginAtLoad: captured BEFORE the stamp chain runs — true when the
+    // location held no persisted block edits at all, i.e. the world has never been materialised. Only then
+    // may the placement search use the current (escalating) algorithm; a world with prior edits re-derives
+    // through the frozen legacy search so structures stay attached to their already-stamped blocks.
+    public bool VirginAtLoad { get; set; }
+
+    // Per-kind requested/placed telemetry from this load's stamp chain (test seam + WARN logging).
+    public List<(string Kind, int Requested, int Placed)> StampReport { get; } = new();
+
     // Wreck stamp state.
     public bool WreckStamped { get; set; }
     public Vector3i WreckOrigin { get; set; }

--- a/src/BlocksBeyondTheStars.Persistence/IWorldRepository.cs
+++ b/src/BlocksBeyondTheStars.Persistence/IWorldRepository.cs
@@ -313,6 +313,14 @@ public interface IWorldRepository : IDisposable
     /// question needs its own bounded query.</summary>
     bool HasPlayerBlockEdits(string planet, Vector3i min, Vector3i max);
 
+    /// <summary>True if the location holds ANY persisted block edit, by any writer — worldgen stamps
+    /// included. This is the ground truth for "was this world ever materialised before?" (#586): a world
+    /// with zero edits has never had its stamp chain run, so the placement search may use the current
+    /// algorithm freely; a world with edits must re-derive legacy positions so structures stay attached
+    /// to their stamped blocks. Metadata markers can't answer this — saves from before the stamp registry
+    /// carry none.</summary>
+    bool HasAnyBlockEdits(string planet);
+
     /// <summary>Records the generation/discovery status of a location (system or body).</summary>
     void SetLocationStatus(string locationId, string status);
 

--- a/src/BlocksBeyondTheStars.Persistence/MemoryWorldRepository.cs
+++ b/src/BlocksBeyondTheStars.Persistence/MemoryWorldRepository.cs
@@ -504,6 +504,22 @@ public sealed class MemoryWorldRepository : IWorldRepository
         }
     }
 
+    public bool HasAnyBlockEdits(string planet)
+    {
+        lock (_gate)
+        {
+            foreach (var kv in _blockEdits)
+            {
+                if (kv.Key.Planet == planet)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+
     public void DeleteBlockEdits(string planet, Vector3i min, Vector3i max)
     {
         lock (_gate)

--- a/src/BlocksBeyondTheStars.Persistence/PostgreSqlWorldRepository.cs
+++ b/src/BlocksBeyondTheStars.Persistence/PostgreSqlWorldRepository.cs
@@ -411,6 +411,17 @@ public sealed class PostgreSqlWorldRepository : IWorldRepository
         }
     }
 
+    public bool HasAnyBlockEdits(string planet)
+    {
+        lock (_gate)
+        {
+            using var cmd = Connection.CreateCommand();
+            cmd.CommandText = "SELECT 1 FROM block_edit WHERE planet = @p LIMIT 1;";
+            cmd.Parameters.AddWithValue("@p", planet);
+            return cmd.ExecuteScalar() is not null;
+        }
+    }
+
     public IReadOnlyList<BlockEdit> LoadChunkEdits(string planet, ChunkCoord chunk)
     {
         var origin = WorldConstants.ChunkOrigin(chunk);

--- a/src/BlocksBeyondTheStars.Persistence/SqliteWorldRepository.cs
+++ b/src/BlocksBeyondTheStars.Persistence/SqliteWorldRepository.cs
@@ -435,6 +435,17 @@ public sealed class SqliteWorldRepository : IWorldRepository
         }
     }
 
+    public bool HasAnyBlockEdits(string planet)
+    {
+        lock (_gate)
+        {
+            using var cmd = Connection.CreateCommand();
+            cmd.CommandText = "SELECT 1 FROM block_edit WHERE planet = $p LIMIT 1;";
+            cmd.Parameters.AddWithValue("$p", planet);
+            return cmd.ExecuteScalar() is not null;
+        }
+    }
+
     public IReadOnlyList<BlockEdit> LoadChunkEdits(string planet, ChunkCoord chunk)
     {
         var origin = WorldConstants.ChunkOrigin(chunk);

--- a/src/BlocksBeyondTheStars.Shared/State/WorldMetadata.cs
+++ b/src/BlocksBeyondTheStars.Shared/State/WorldMetadata.cs
@@ -63,6 +63,16 @@ public sealed class WorldMetadata
     public System.Collections.Generic.List<string> StampedFeatures { get; set; } = new();
 
     /// <summary>
+    /// Persisted structure placements (#586): where each rolled structure instance actually landed (or that
+    /// it could not land), pinned at first stamp. Without this the positions re-derived from re-running the
+    /// placement SEARCH on every load — which froze the search algorithm forever: any improvement would have
+    /// detached existing worlds' markers/protection/NPCs from their already-stamped blocks. A missing entry
+    /// means "this world predates the registry": the frozen legacy search re-derives it once, then records
+    /// the outcome here (self-healing migration; monuments pioneered this pattern via StampedFeatures).
+    /// </summary>
+    public System.Collections.Generic.List<StructurePlacementRecord> Placements { get; set; } = new();
+
+    /// <summary>
     /// Persisted body identity (#468): bodyId → planetType, pinned when a body is first generated. Without
     /// it the whole galaxy's types re-derived from <c>planets.json</c> on every start — ANY data edit (a
     /// new type, a weight rebalance, a reorder) silently re-typed bodies under players' buildings (it
@@ -88,6 +98,23 @@ public sealed class WorldMetadata
     /// Null on saves from before world options existed (the launch config's rules apply then).
     /// </summary>
     public BlocksBeyondTheStars.Shared.Configuration.GameRules? RulesOverride { get; set; }
+}
+
+/// <summary>Where one rolled structure instance landed (#586), pinned at first stamp so the placement search
+/// can evolve without moving structures under existing worlds. <see cref="Placed"/> false records the
+/// decision "no spot" permanently (legacy worlds only — the guaranteed search always finds one).</summary>
+public sealed class StructurePlacementRecord
+{
+    public string LocationId { get; set; } = string.Empty;
+    public string Kind { get; set; } = string.Empty; // settlement | factory | banditcamp | ruin | vault
+    public int Index { get; set; }                    // instance index within its kind's deterministic roll order
+    public bool Placed { get; set; }
+    public int X { get; set; }                        // structure-local (0,0,0) world column (vaults: shaft centre)
+    public int GroundY { get; set; }
+    public int Z { get; set; }
+    public bool OnIsland { get; set; }
+    public string Seat { get; set; } = "legacy";      // seat style: legacy|flat|slope|shelf|stilts|lava|island|buried|wellhead
+    public string Name { get; set; } = string.Empty;  // display name (derives from rng draws AFTER the search, so it must be pinned too)
 }
 
 /// <summary>One player claim over a spawned structure: a stable per-world key, the owner, and a display name.

--- a/tests/BlocksBeyondTheStars.Tests/PlacementGuaranteeTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/PlacementGuaranteeTests.cs
@@ -1,0 +1,144 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using System.Linq;
+using BlocksBeyondTheStars.Networking.Transport;
+using BlocksBeyondTheStars.Persistence;
+using BlocksBeyondTheStars.Shared.Configuration;
+using BlocksBeyondTheStars.Shared.Content;
+using Xunit;
+using SvGameServer = BlocksBeyondTheStars.GameServer.GameServer;
+
+namespace BlocksBeyondTheStars.Tests;
+
+/// <summary>
+/// Placement guarantee + terrain-adaptive seating (#586): whatever the deterministic rolls decide a world
+/// gets (settlements, ruins, factories, camps, monuments, vaults, chests, cubes) must actually be placed —
+/// the escalating search adapts the foundation to the terrain (slope skirt, rugged shelf, stilts over
+/// water, basalt in lava) instead of silently dropping instances on dramatic worlds. Placements are pinned
+/// in WorldMetadata at first stamp, so a reload replays the exact positions instead of re-running the
+/// search (whose algorithm may evolve).
+/// </summary>
+public sealed class PlacementGuaranteeTests : IDisposable
+{
+    private readonly string _root;
+    private readonly GameContent _content;
+
+    public PlacementGuaranteeTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "bbts_placement_" + Guid.NewGuid().ToString("N"));
+        _content = ContentLoader.LoadFromDirectory(TestPaths.DataDir());
+    }
+
+    private SvGameServer Start(string world, string planet, long seed, out SqliteWorldRepository repo)
+    {
+        repo = new SqliteWorldRepository(new SaveGamePaths(_root, world));
+        var st = new LoopbackServerTransport(new LoopbackLink());
+        var config = new ServerConfig
+        {
+            WorldName = world,
+            Seed = seed,
+            StartPlanet = planet,
+            AutoSaveIntervalMinutes = 9999,
+            PlaceStarterShip = false,
+        };
+        var server = new SvGameServer(config, _content, st, repo);
+        server.Start();
+        return server;
+    }
+
+    // Rugged/extreme landform types + water-heavy types are exactly where the old first-fit search used
+    // to drop instances; seeds are arbitrary but fixed (deterministic worldgen ⇒ no flakiness).
+    [Theory]
+    [InlineData("rocky", 11)]
+    [InlineData("highland", 23)]
+    [InlineData("tablelands", 37)]
+    [InlineData("karst", 41)]
+    [InlineData("badlands", 53)]
+    [InlineData("swamp", 67)]
+    [InlineData("ocean", 71)]
+    public void FreshWorld_PlacesEverythingTheRollsRequested(string planet, long seed)
+    {
+        var server = Start("guarantee_" + planet, planet, seed, out var repo);
+        using (repo)
+        {
+            foreach (var (kind, requested, placed) in server.StampReportForTest)
+            {
+                Assert.True(placed == requested,
+                    $"{planet}/{seed}: {kind} placed {placed}/{requested} — the guarantee must not drop instances on a fresh world.");
+            }
+        }
+    }
+
+    [Fact]
+    public void FreshWorld_PinsPlacementsInMetadata()
+    {
+        var server = Start("pinning", "highland", 23, out var repo);
+        using (repo)
+        {
+            int settlements = server.SettlementCount;
+            var records = server.PlacementRecordsForTest;
+            Assert.Equal(settlements, records.Count(r => r.Kind == "settlement" && r.Placed));
+
+            // Every pinned settlement carries a non-legacy seat style and its display name.
+            foreach (var r in records.Where(r => r.Kind == "settlement" && r.Placed))
+            {
+                Assert.NotEqual("legacy", r.Seat);
+                Assert.False(string.IsNullOrEmpty(r.Name));
+            }
+        }
+    }
+
+    [Fact]
+    public void Reload_ReplaysPinnedPositionsAndNames()
+    {
+        var first = Start("replay", "tablelands", 37, out var repoA);
+        var bounds = first.SettlementsForTest.ToList();
+        var names = first.PlacementRecordsForTest.Where(r => r.Kind == "settlement" && r.Placed)
+            .OrderBy(r => r.Index).Select(r => r.Name).ToList();
+        var vaults = first.VaultEntrances.ToList();
+        repoA.Dispose();
+
+        // Second boot on the SAME save: the replay path must reproduce positions + names from the records
+        // (not by re-running the search — that is the whole point of pinning).
+        var second = Start("replay", "tablelands", 37, out var repoB);
+        using (repoB)
+        {
+            Assert.Equal(bounds.Count, second.SettlementsForTest.Count);
+            for (int i = 0; i < bounds.Count; i++)
+            {
+                Assert.Equal(bounds[i], second.SettlementsForTest[i]);
+            }
+
+            var namesB = second.PlacementRecordsForTest.Where(r => r.Kind == "settlement" && r.Placed)
+                .OrderBy(r => r.Index).Select(r => r.Name).ToList();
+            Assert.Equal(names, namesB);
+            Assert.Equal(vaults, second.VaultEntrances.ToList());
+        }
+    }
+
+    [Fact]
+    public void OceanWorld_SettlementsStandOnStiltsOrDryGround_NeverInLava()
+    {
+        var server = Start("stilts", "ocean", 71, out var repo);
+        using (repo)
+        {
+            foreach (var r in server.PlacementRecordsForTest.Where(x => x.Kind == "settlement" && x.Placed))
+            {
+                Assert.NotEqual("lava", r.Seat); // inhabited/ruined settlements never seat IN lava...
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true);
+        }
+        catch (IOException)
+        {
+            // A repo file may still be locked on Windows — the temp dir is disposable either way.
+        }
+    }
+}


### PR DESCRIPTION
closes #586

## What

Whatever the seed rolls for a world (settlements, ruins, factories, bandit camps, monuments, vaults, chests, data cubes) now actually lands in it — and the foundation adapts to the terrain it lands on. Previously the first-fit placement search silently dropped instances on dramatic terrain (acute since the #581 landforms), and there was no mechanism that says "this goes here, adapt the ground".

## How

**1. Pinned placements (the prerequisite).** Structure positions used to be re-derived by re-running the placement search on every load — freezing the algorithm forever, since any change would detach markers/protection/NPCs from already-stamped blocks. Now `WorldMetadata.Placements` records every instance's outcome (position, seat style, name — or the no-spot decision) at first stamp; reloads **replay** the record. New `IWorldRepository.HasAnyBlockEdits` is the ground truth for fresh vs. legacy: worlds with prior edits re-derive through the **frozen** legacy search (bit-identical, then self-record); only never-materialised worlds use the new search. (Monuments pioneered this pattern in #540; this generalises it.)

**2. Guaranteed escalating search** (`TryPlaceStructureGuaranteed`, shared by settlements/ruins/factories/camps/monuments): ring 1 = the classic dry+flat first-fit (zero visual change where it succeeds) → widening best-fit rings ranking every candidate (dry lowest-spread → water for stilt-capable kinds → lava for lava-capable kinds) → margin-2 terminal pass → deterministic longitude sweep. Never relaxed: player-edit avoidance (#527), pad reservations, the finale area. Only documented carve-out: policy-forbidden ground everywhere (e.g. an all-lava ring for an inhabited settlement).

**3. Terrain-adaptive seat styles** in the stamper:

| Seat | Terrain | Foundation |
|---|---|---|
| `flat` / `slope` | classic gates | unchanged + new stepped terrace **apron** (no sheer walls) |
| `shelf` | rugged massif flanks / rift edges | cut & fill at footprint **median**, sub-surface stone fill, 96-deep skirt |
| `stilts` | water | platform at the water line on wood/stone **pile columns** — stilt villages, drowned ruins |
| `lava` | lava plains (ruins + monuments only) | basalt plinth above the sheet |
| `island` | sky islands | unchanged |

Policy matrix per kind: inhabited settlements may stand on stilts but never in lava; bandit camps *prefer* rugged shelf spots when escalating; factories stay on dry land.

**4. Vaults/chests/cubes:** the pre-deep-floor `surfaceY < 24` vault skip is legacy-only now; fresh worlds bury under any dry column, nudge deterministically off reserved footprints, and water columns get the **wellhead** variant (chamber under the seabed, cased stone shaft rising one block above the water line). Chests and data cubes gained deterministic no-rng fallbacks — fresh worlds only, so legacy loot streams stay bit-identical (no duplicates).

**5. Telemetry + tests:** per-kind requested/placed `StampReport` (a drop logs WARN); `PlacementGuaranteeTests` covers the guarantee across rocky/highland/tablelands/karst/badlands/swamp/ocean, record pinning, reload replay (positions + names + vault entrances), and the ocean stilt/lava policy.

## Compatibility

- **Existing worlds are untouched**: legacy search is frozen bit-for-bit; records self-heal on first post-PR load.
- Old saves deserialize the missing `Placements` list as empty (System.Text.Json POCO).
- New worlds get the guarantee + seat styles from their first stamp.

## Verification

- 1212/1212 fast-tier tests green locally (incl. 10 new placement tests), 0 build warnings.
- Local Unity client build + hands-on playtest by Marcel (stilt village / shelf / terrace apron spot checks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
