### PR TITLE
Flight system chart: draw the planets' orbital paths (#623)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -6786,6 +6786,52 @@ is **pre-approved** (keys in `tools/ai-assets/.env`, run via `uv`).
 
 ---
 
+## ✅ Done (2026-07-30): the flight chart reads as a star-system chart — drawn orbital paths (#623, branch feat/flight-chart-orbits)
+
+The in-flight chart (`M`, #597) already drew the system's bodies at their real flight coordinates, but
+nothing showed that they *orbit* anything: the star was a dot pushed to the rim whenever it fell outside
+the framing, and the bodies read as a random scatter of discs. Client-only — every input was already on
+the client (`NetBody.SystemX/Z`, `ParentId`, `RingSeed`), so no wire/server/worldgen change and no world
+regeneration.
+
+- **Star-centred projection** — the chart now centres on the system's star (rim-pinning gone), drawn with
+  a soft three-layer corona, so an orbit is a real circle around the middle of the chart. `_centre` feeds
+  both `ToChart` and its **inverse in `HandleClick`** — the free-waypoint click would otherwise land at
+  the wrong scene position.
+- **Orbit paths for planets + landable asteroid bodies**, tinted from each body's own `PlanetColor` at
+  α 0.34. **Moons deliberately get none**: they are re-laddered onto `SystemBodyLayout.MinOrbitFor` slots
+  just outside their parent's drawn radius, so their rings would collapse into the planet's disc.
+- **`SystemChartLayout`** (new, in Shared next to `SystemBodyLayout` so it is testable) holds the two
+  invariants: the fit that keeps everything on the chart, and `OrbitRadius`, which derives a ring's radius
+  from the body's **projected** position — never from its star-map orbit radius, which the launch-body
+  pinning and `SeparateXZ` distort, so a ring drawn from the star-map value visibly misses its planet.
+- **`UiOrbitRing`** (new) — the client's first custom `MaskableGraphic`: a `VertexHelper` annulus with
+  radius-independent line weight. A stretched ring sprite scales its own thickness (fat outer orbits,
+  hairline inner ones); this is one draw element per ring instead of ~50 dot images. Default UI material,
+  so nothing to always-include. Reusable for any circle/line UI. A non-square rect gives an ellipse —
+  which is how a **`RingSeed != 0` planet now wears its #596 rings on the chart** (near-edge-on ellipse).
+- **Fit bugfix found on the way:** the old fit padded each body by its **scene** radius, while the drawn
+  discs are clamped to ≤ 46 units regardless — so the launch body, rendered 3.2× oversized, needlessly
+  zoomed the whole chart out. `FitScale` now measures positions and holds back a flat marker margin.
+- **Bonus:** the launch body finally gets its **real planet colour**. Its `Landables` entry carries an
+  empty id, so the old `BodyColor` always fell through to a pale green; it now resolves via
+  `StarMap.ActiveLocationId` through the new per-system `id → NetBody` cache (which also replaces two
+  full star-map walks per open).
+- **Measured, not assumed:** star-centring costs up to **1.72× zoom-out** on real systems (worst case:
+  the launch body sitting inside a far-flung asteroid's orbit). The 12-unit minimum disc size absorbs it,
+  and `StarCentring_CostsAtMostABoundedZoomOut` bounds it at 2× so a future layout change can't quietly
+  make the chart useless. An earlier assumption that star-centring would be *tighter* was wrong and the
+  test is what caught it.
+- Tests: `SystemChartLayoutTests` (6) over real `UniverseGenerator` systems, classic **and**
+  archetype-varied — everything fits, rings pass through their markers and stay on the chart, the
+  bounded zoom-out, plus a guard that the star-map radius is **not** interchangeable with the projection.
+- Deliberately **out**: moon rings, direction arrowheads / retrograde marking (the flight scene is a t=0
+  snapshot — the bodies never move, so an arrow would imply motion the game doesn't deliver), zoom/pan.
+  `SystemMapWidget` (the Tab travel-screen orrery) stays a decorative fake with invented orbits and now
+  visibly disagrees with the honest flight chart — worth a separate follow-up.
+
+---
+
 ## ✅ Done (2026-07-29): planetary rings + flight system chart with nav waypoint (#596/#597, branch feat/planet-rings-space-map)
 
 Two features in one pass (Marcel: "beides komplett in einem Rutsch"):

--- a/client/Assets/BlocksBeyondTheStars/Scripts/SpaceMap.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/SpaceMap.cs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
 using System.Collections.Generic;
+using BlocksBeyondTheStars.Networking.Messages;
+using BlocksBeyondTheStars.Shared.World;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -11,11 +13,17 @@ namespace BlocksBeyondTheStars.Client
     /// The flight system chart (#597): a top-down map of the CURRENT system opened while cruising
     /// (FlightMap action, default M) — the space sibling of the surface world map (M, #592). Drawn from
     /// the REAL flight coordinates (<see cref="SpaceView.Landables"/> + the live space entities), i.e.
-    /// exactly the positions the ship flies between, with the ship marker + heading in the middle of it.
+    /// exactly the positions the ship flies between, with the ship marker + heading on it.
     /// Clicking a body/station marker targets it; clicking empty space sets a free waypoint there. The
     /// waypoint shows on the space radar with a distance readout, and the VEGA autopilot steers to it.
     /// Opening takes menu ownership (the cursor arbiter frees the mouse and the ship holds position, as
     /// with the Tab travel screen); Esc or M closes.
+    /// <para>The chart is centred on the system's STAR and draws the orbital path of every body that
+    /// circles it (#623), so it reads as a chart of a star system rather than a scatter of discs. The
+    /// paths come from the bodies' PROJECTED positions (<see cref="SystemChartLayout"/>) — never from
+    /// their star-map orbit radii, which the render layout deliberately distorts — so every ring passes
+    /// exactly through its own marker. The markers themselves never move: the flight scene is a t=0
+    /// snapshot, so an animated body would drift away from the position the ship can actually fly to.</para>
     /// </summary>
     public sealed class SpaceMap : MonoBehaviour
     {
@@ -26,6 +34,10 @@ namespace BlocksBeyondTheStars.Client
         private const float ChartSize = 900f;     // square chart area, canvas units (1920×1080 reference)
         private const float ChartHalf = ChartSize * 0.5f - 30f; // usable radius: margin keeps rim markers inside
         private const float SnapRadius = 26f;     // click-snap distance to a marker, canvas units
+        private const float OrbitThickness = 2f;  // orbit-path line weight, canvas units (radius-independent)
+        private const float OrbitAlpha = 0.34f;   // faint enough to stay behind the markers it connects
+        private const float MaxBodyDisc = 46f;    // body discs are clamped to this diameter, however big the body
+        private const float MarkerPad = MaxBodyDisc * 0.5f + 8f; // chart room a rim body's disc + backing needs
 
         private static readonly Color WaypointCol = new Color(1f, 0.85f, 0.3f);
         private static readonly Color DiscCol = new Color(0.01f, 0.03f, 0.07f, 0.78f); // WorldMap's backing disc
@@ -38,6 +50,9 @@ namespace BlocksBeyondTheStars.Client
         private RectTransform _ship;
         private RectTransform _waypoint;
         private float _scale; // scene units → chart canvas units
+        private Vector3 _centre; // scene point the chart centres on: the star (Vector3.zero without a star map)
+        private string _systemName;
+        private readonly Dictionary<string, NetBody> _sysBodies = new(); // current system, by body id
         private readonly List<(string Id, Vector2 Chart, string Name)> _targets = new(); // snap candidates
         private readonly List<Image> _entityBlips = new();
 
@@ -128,14 +143,14 @@ namespace BlocksBeyondTheStars.Client
 
             _targets.Clear();
             _entityBlips.Clear();
+            LoadCurrentSystem();
 
             _canvas = UiKit.CreateCanvas("SpaceMapUI");
             _canvas.sortingOrder = 60; // above the flight HUD, like the surface map
             var root = _canvas.transform;
 
             UiKit.AddImage(root, 0, 0, 1920, 1080, UiKit.SolidSprite, new Color(0.02f, 0.04f, 0.08f, 0.92f));
-            string sysName = CurrentSystemName();
-            UiKit.AddLogo(root, 40, 24, 700, 40, L("ui.spacemap.title").ToUpperInvariant() + (string.IsNullOrEmpty(sysName) ? string.Empty : "  —  " + sysName), 26);
+            UiKit.AddLogo(root, 40, 24, 700, 40, L("ui.spacemap.title").ToUpperInvariant() + (string.IsNullOrEmpty(_systemName) ? string.Empty : "  —  " + _systemName), 26);
 
             // Square chart on the left; a faint projection disc gives it the orrery look.
             const float ax = 40f, ay = 100f;
@@ -150,15 +165,25 @@ namespace BlocksBeyondTheStars.Client
             _chart = chartGo.GetComponent<RectTransform>();
             Centered(_chart, Vector2.zero, new Vector2(ChartSize - 8f, ChartSize - 8f), UiKit.DiscSprite, new Color(0.10f, 0.16f, 0.24f, 0.35f));
 
-            // Scale: fit every body (plus its rendered radius) and the ship into the chart. The star may
-            // sit far outside — it rim-pins rather than dictating the scale.
-            float extent = 60f;
+            // The chart centres on the system's STAR, so an orbit is a real circle around the middle of the
+            // chart (#623) and the star no longer has to be pinned to the rim. It costs some zoom where the
+            // launch body sits inside a far-flung asteroid's orbit — measured at up to 1.72× across real
+            // systems, bounded by a test, and absorbed by the 12-unit minimum disc size. Without a star map
+            // there is no star and nothing to orbit — fall back to the launch-body-centred chart.
             var landables = SpaceView != null ? SpaceView.Landables : null;
+            bool starCentred = SpaceView != null && SpaceView.HasStar;
+            _centre = starCentred ? SpaceView.StarPosition : Vector3.zero;
+
+            // Everything whose position has to fit: the bodies, the stations and the ship. Marker sizes are
+            // held back as a flat chart-unit margin instead of per-body scene radii — see FitScale.
+            var fitX = new List<float>();
+            var fitZ = new List<float>();
             if (landables != null)
             {
                 foreach (var b in landables)
                 {
-                    extent = Mathf.Max(extent, new Vector2(b.Pos.x, b.Pos.z).magnitude + b.Radius);
+                    fitX.Add(b.Pos.x);
+                    fitZ.Add(b.Pos.z);
                 }
             }
 
@@ -168,28 +193,55 @@ namespace BlocksBeyondTheStars.Client
                 {
                     if (e.Kind == "SpaceStation")
                     {
-                        extent = Mathf.Max(extent, new Vector2(e.X, e.Z).magnitude);
+                        fitX.Add(e.X);
+                        fitZ.Add(e.Z);
                     }
                 }
             }
 
             if (Camera != null)
             {
-                extent = Mathf.Max(extent, new Vector2(Camera.transform.localPosition.x, Camera.transform.localPosition.z).magnitude);
+                fitX.Add(Camera.transform.localPosition.x);
+                fitZ.Add(Camera.transform.localPosition.z);
             }
 
-            _scale = ChartHalf / (extent * 1.05f);
+            _scale = SystemChartLayout.FitScale(
+                ChartHalf, fitX.ToArray(), fitZ.ToArray(), _centre.x, _centre.z, MarkerPad);
 
-            // The star (rim-pinned when outside the chart).
-            if (SpaceView != null && SpaceView.HasStar)
+            // The star, at the true centre with a soft corona. Drawn before the orbit paths so the rings
+            // read on top of the glow rather than being swallowed by it.
+            if (starCentred)
             {
-                var sp = ToChart(SpaceView.StarPosition);
-                if (sp.magnitude > ChartHalf)
-                {
-                    sp = sp.normalized * ChartHalf;
-                }
+                Centered(_chart, Vector2.zero, new Vector2(64f, 64f), UiKit.DiscSprite, new Color(1f, 0.86f, 0.5f, 0.14f));
+                Centered(_chart, Vector2.zero, new Vector2(38f, 38f), UiKit.DiscSprite, new Color(1f, 0.89f, 0.58f, 0.45f));
+                Centered(_chart, Vector2.zero, new Vector2(24f, 24f), UiKit.DiscSprite, new Color(1f, 0.94f, 0.74f));
+            }
 
-                Centered(_chart, sp, new Vector2(26f, 26f), UiKit.DiscSprite, new Color(1f, 0.86f, 0.5f));
+            // Orbit paths: one ring per body that circles the star — planets and the landable asteroid
+            // bodies. Moons are deliberately left out: they are re-laddered onto clearance slots just
+            // outside their parent's drawn radius, so their rings would collapse into the planet's disc
+            // and turn the chart into noise. Each radius comes from the body's own projected position, so
+            // the ring is guaranteed to pass through its marker whatever the layout passes did to it.
+            if (starCentred && landables != null)
+            {
+                foreach (var b in landables)
+                {
+                    if (!OrbitsStar(BodyFor(b.Id)))
+                    {
+                        continue;
+                    }
+
+                    var p = ToChart(b.Pos);
+                    float r = SystemChartLayout.OrbitRadius(p.x, p.y);
+                    if (!SystemChartLayout.ShowRing(r))
+                    {
+                        continue;
+                    }
+
+                    var ringCol = BodyColor(b.Id);
+                    ringCol.a = OrbitAlpha;
+                    UiOrbitRing.Create(_chart, Vector2.zero, new Vector2(r * 2f, r * 2f), ringCol, OrbitThickness);
+                }
             }
 
             // Bodies: a coloured disc on a dark backing, radius-proportional, named — the same legibility
@@ -199,10 +251,21 @@ namespace BlocksBeyondTheStars.Client
                 foreach (var b in landables)
                 {
                     var p = ToChart(b.Pos);
-                    float size = Mathf.Clamp(b.Radius * _scale * 2f, 12f, 46f);
+                    float size = Mathf.Clamp(b.Radius * _scale * 2f, 12f, MaxBodyDisc);
                     var col = BodyColor(b.Id);
                     Centered(_chart, p, new Vector2(size + 8f, size + 8f), UiKit.DiscSprite, DiscCol);
                     Centered(_chart, p, new Vector2(size, size), UiKit.DiscSprite, col);
+
+                    // A ringed planet (#596) wears its rings on the chart too: a flattened ellipse over the
+                    // disc, which is what a ring system looks like seen near-edge-on.
+                    var nb = BodyFor(b.Id);
+                    if (nb != null && nb.RingSeed != 0)
+                    {
+                        var glyph = Color.Lerp(col, Color.white, 0.5f);
+                        glyph.a = 0.85f;
+                        UiOrbitRing.Create(_chart, p, new Vector2(size * 2f, Mathf.Max(9f, size * 0.7f)), glyph);
+                    }
+
                     Label(_chart, p + new Vector2(0f, -size * 0.5f - 12f), b.Name);
                     _targets.Add((string.IsNullOrEmpty(b.Id) ? SpaceView.HomeWaypointId : b.Id, p, b.Name));
                 }
@@ -349,7 +412,8 @@ namespace BlocksBeyondTheStars.Client
             }
             else
             {
-                var scene = new Vector3(lp.x / _scale, 0f, lp.y / _scale);
+                // Inverse of ToChart — the chart is centred on the star, so the centre offset comes back.
+                var scene = new Vector3(lp.x / _scale + _centre.x, 0f, lp.y / _scale + _centre.z);
                 float bounds = SpaceView != null ? SpaceView.FlightBounds : 130f;
                 if (scene.magnitude > bounds)
                 {
@@ -416,49 +480,74 @@ namespace BlocksBeyondTheStars.Client
             return null;
         }
 
-        private string CurrentSystemName()
+        /// <summary>Caches the system the player is in: its name (for the title) and its bodies by id, so
+        /// the per-body look-ups below don't re-walk the whole star map. The chart only ever shows this one
+        /// system.</summary>
+        private void LoadCurrentSystem()
         {
+            _systemName = null;
+            _sysBodies.Clear();
             var map = Game?.StarMap;
             if (map?.Systems == null)
             {
-                return null;
+                return;
             }
 
             foreach (var sys in map.Systems)
             {
+                bool mine = false;
                 foreach (var b in sys.Bodies)
                 {
                     if (b.Id == map.ActiveLocationId)
                     {
-                        return sys.Name;
+                        mine = true;
+                        break;
                     }
                 }
-            }
 
-            return null;
+                if (!mine)
+                {
+                    continue;
+                }
+
+                _systemName = sys.Name;
+                foreach (var b in sys.Bodies)
+                {
+                    if (!string.IsNullOrEmpty(b.Id))
+                    {
+                        _sysBodies[b.Id] = b;
+                    }
+                }
+
+                return;
+            }
         }
+
+        /// <summary>The star-map body behind a <see cref="SpaceView.Landables"/> entry, or null if the map
+        /// doesn't know it. The launch body's entry carries an EMPTY id (the scene is centred on it), so it
+        /// resolves through the active location — which is also why it now gets its real planet colour.</summary>
+        private NetBody BodyFor(string landableId)
+        {
+            string id = string.IsNullOrEmpty(landableId) ? Game?.StarMap?.ActiveLocationId : landableId;
+            return !string.IsNullOrEmpty(id) && _sysBodies.TryGetValue(id, out var body) ? body : null;
+        }
+
+        /// <summary>Whether this body circles the star itself and so gets an orbit path drawn: planets and
+        /// the landable asteroid bodies. A moon carries its parent's id and is deliberately excluded.</summary>
+        private static bool OrbitsStar(NetBody body)
+            => body != null
+            && string.IsNullOrEmpty(body.ParentId)
+            && (body.Kind == "Planet" || body.Kind == "AsteroidField");
 
         private Color BodyColor(string id)
         {
-            var map = Game?.StarMap;
-            if (!string.IsNullOrEmpty(id) && map?.Systems != null)
-            {
-                foreach (var sys in map.Systems)
-                {
-                    foreach (var b in sys.Bodies)
-                    {
-                        if (b.Id == id)
-                        {
-                            return SystemMapWidget.PlanetColor(b.PlanetType, b.Kind);
-                        }
-                    }
-                }
-            }
-
-            return new Color(0.6f, 0.85f, 0.7f); // the launch body (empty id) / unknown
+            var body = BodyFor(id);
+            return body != null
+                ? SystemMapWidget.PlanetColor(body.PlanetType, body.Kind)
+                : new Color(0.6f, 0.85f, 0.7f); // unknown to the star map
         }
 
-        private Vector2 ToChart(Vector3 scene) => new Vector2(scene.x, scene.z) * _scale;
+        private Vector2 ToChart(Vector3 scene) => new Vector2(scene.x - _centre.x, scene.z - _centre.z) * _scale;
 
         private static Vector2 Clamp(Vector2 p) => p.magnitude > ChartHalf ? p.normalized * ChartHalf : p;
 

--- a/client/Assets/BlocksBeyondTheStars/Scripts/SpaceMap.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/SpaceMap.cs
@@ -365,10 +365,17 @@ namespace BlocksBeyondTheStars.Client
             }
 
             if (!RectTransformUtility.RectangleContainsScreenPoint(_chart, Input.mousePosition, null)
-                || !RectTransformUtility.ScreenPointToLocalPointInRectangle(_chart, Input.mousePosition, null, out var lp))
+                || !RectTransformUtility.ScreenPointToLocalPointInRectangle(_chart, Input.mousePosition, null, out var local))
             {
                 return;
             }
+
+            // Re-base the click onto the frame the markers live in. ScreenPointToLocalPointInRectangle
+            // measures from the rect's PIVOT, which UiKit.Place puts at the TOP-LEFT, while every marker is
+            // anchored around the chart's CENTRE — so the two frames sat half a chart apart (a click in the
+            // middle came out as (450, -450)). That put every free waypoint in the wrong place and pushed
+            // marker snapping ~636 units out of range, so clicking a body to target it almost never took.
+            var lp = local - _chart.rect.center;
 
             // Snap to the nearest body/station marker; otherwise a free waypoint at the clicked spot,
             // clamped into the flight volume so the autopilot can actually reach it.
@@ -412,8 +419,7 @@ namespace BlocksBeyondTheStars.Client
             }
             else
             {
-                // Inverse of ToChart — the chart is centred on the star, so the centre offset comes back.
-                var scene = new Vector3(lp.x / _scale + _centre.x, 0f, lp.y / _scale + _centre.z);
+                var scene = FromChart(lp);
                 float bounds = SpaceView != null ? SpaceView.FlightBounds : 130f;
                 if (scene.magnitude > bounds)
                 {
@@ -547,7 +553,19 @@ namespace BlocksBeyondTheStars.Client
                 : new Color(0.6f, 0.85f, 0.7f); // unknown to the star map
         }
 
-        private Vector2 ToChart(Vector3 scene) => new Vector2(scene.x - _centre.x, scene.z - _centre.z) * _scale;
+        private Vector2 ToChart(Vector3 scene)
+        {
+            SystemChartLayout.ToChart(scene.x, scene.z, _scale, _centre.x, _centre.z, out float x, out float y);
+            return new Vector2(x, y);
+        }
+
+        /// <summary>The flight-scene point under a chart position — the exact inverse of
+        /// <see cref="ToChart"/>, so a click resolves to the spot it was made on.</summary>
+        private Vector3 FromChart(Vector2 chart)
+        {
+            SystemChartLayout.FromChart(chart.x, chart.y, _scale, _centre.x, _centre.z, out float x, out float z);
+            return new Vector3(x, 0f, z);
+        }
 
         private static Vector2 Clamp(Vector2 p) => p.magnitude > ChartHalf ? p.normalized * ChartHalf : p;
 

--- a/client/Assets/BlocksBeyondTheStars/Scripts/UiOrbitRing.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/UiOrbitRing.cs
@@ -1,0 +1,82 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace BlocksBeyondTheStars.Client
+{
+    /// <summary>
+    /// A hairline ring (annulus) inscribed in its RectTransform, drawn as generated geometry rather than
+    /// a stretched sprite — the orbit paths on the flight system chart (#623) and the "this planet has
+    /// rings" glyph beside a ringed body.
+    /// <para>Why a custom graphic instead of a ring texture: a sprite stretched to the orbit diameter
+    /// scales its own line weight with the radius, so an outer orbit comes out fat and an inner one a
+    /// hairline. Here <see cref="Thickness"/> is in canvas units and independent of the radius, so every
+    /// orbit reads with the same line weight at any size — and one ring is a single draw element instead
+    /// of the ~50 dot images a dashed-sprite ring would need.</para>
+    /// <para>A non-square rect yields an ellipse (the ring glyph uses that for its tilted look). Uses the
+    /// default UI material — no shader of its own, so nothing to always-include in the build.</para>
+    /// </summary>
+    public sealed class UiOrbitRing : MaskableGraphic
+    {
+        /// <summary>Line weight in canvas units, measured inwards from the rect edge.</summary>
+        public float Thickness = 2f;
+
+        /// <summary>Segments around the ring. 72 is smooth at chart size (5° per segment) and still only
+        /// 144 vertices.</summary>
+        public int Segments = 72;
+
+        /// <summary>Creates a centre-pivot ring under <paramref name="parent"/>, sized
+        /// <paramref name="size"/> (outer diameter, x × y) around <paramref name="pos"/>. Never a raycast
+        /// target: the chart's own click handler must keep receiving clicks through it.</summary>
+        public static UiOrbitRing Create(Transform parent, Vector2 pos, Vector2 size, Color color, float thickness = 2f)
+        {
+            var go = new GameObject("OrbitRing", typeof(RectTransform));
+            go.transform.SetParent(parent, false);
+            var rt = go.GetComponent<RectTransform>();
+            rt.anchorMin = rt.anchorMax = rt.pivot = new Vector2(0.5f, 0.5f);
+            rt.sizeDelta = size;
+            rt.anchoredPosition = pos;
+            var ring = go.AddComponent<UiOrbitRing>();
+            ring.Thickness = thickness;
+            ring.color = color;
+            ring.raycastTarget = false;
+            return ring;
+        }
+
+        protected override void OnPopulateMesh(VertexHelper vh)
+        {
+            vh.Clear();
+            var rect = GetPixelAdjustedRect();
+            float outerX = rect.width * 0.5f, outerY = rect.height * 0.5f;
+            if (outerX <= 0.5f || outerY <= 0.5f || Segments < 3)
+            {
+                return;
+            }
+
+            // Pull the inner edge in by the same number of units on both axes → constant line weight,
+            // whatever the radius (and never past the centre, so a tiny ring degenerates to a filled dot).
+            float innerX = Mathf.Max(0f, outerX - Thickness);
+            float innerY = Mathf.Max(0f, outerY - Thickness);
+            float cx = rect.x + outerX, cy = rect.y + outerY;
+
+            var col = (Color32)color;
+            for (int i = 0; i < Segments; i++)
+            {
+                float a = i / (float)Segments * Mathf.PI * 2f;
+                float cos = Mathf.Cos(a), sin = Mathf.Sin(a);
+                vh.AddVert(new Vector3(cx + cos * outerX, cy + sin * outerY), col, Vector2.zero);
+                vh.AddVert(new Vector3(cx + cos * innerX, cy + sin * innerY), col, Vector2.zero);
+            }
+
+            for (int i = 0; i < Segments; i++)
+            {
+                int outerA = i * 2, innerA = outerA + 1;
+                int outerB = (i + 1) % Segments * 2, innerB = outerB + 1;
+                vh.AddTriangle(outerA, outerB, innerA);
+                vh.AddTriangle(innerA, outerB, innerB);
+            }
+        }
+    }
+}

--- a/client/Assets/BlocksBeyondTheStars/Scripts/UiOrbitRing.cs.meta
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/UiOrbitRing.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7e3c1a9d5b2f48e6ac04d81b6f2a5c37

--- a/src/BlocksBeyondTheStars.Shared/World/SystemChartLayout.cs
+++ b/src/BlocksBeyondTheStars.Shared/World/SystemChartLayout.cs
@@ -1,0 +1,87 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+namespace BlocksBeyondTheStars.Shared.World;
+
+/// <summary>
+/// The projection behind the flight system chart (#597, orbit paths #623): how the current system's
+/// flight coordinates are fitted into the square chart, and how an orbit ring's radius follows from a
+/// body's projected position. Pure math, no Unity — the client's <c>SpaceMap</c> is the only caller,
+/// but keeping it here (beside <see cref="SystemBodyLayout"/>, which decides where the bodies are
+/// rendered in the first place) makes the two invariants testable.
+/// <para>Invariant 1 — <b>everything fits</b>: <see cref="FitScale"/> is chosen so every body, plus the
+/// marker drawn at it, lands inside the chart's usable half-width. Without that the star would have to be
+/// rim-pinned again and every ring centred on it would be in the wrong place. Centring on the star rather
+/// than on the launch body is not free — it zooms out by up to a measured 1.72× on real systems, where the
+/// launch body sits inside a far-flung asteroid's orbit — which the drawn-marker floor absorbs.</para>
+/// <para>Invariant 2 — <b>rings pass through their markers</b>: an orbit radius is derived from the
+/// body's PROJECTED position (<see cref="OrbitRadius"/>), never from its star-map orbit radius. Three
+/// passes distort the latter before a body is drawn — the launch body is pinned to a fixed spot below
+/// the flight plane, moons are re-laddered onto <see cref="SystemBodyLayout.MinOrbitFor"/> slots, and
+/// <see cref="SystemBodyLayout.SeparateXZ"/> nudges overlapping pairs apart — so a ring drawn at the
+/// star-map radius would visibly miss its planet.</para>
+/// </summary>
+public static class SystemChartLayout
+{
+    /// <summary>Breathing room on the fitted extent, so the outermost body's label and ring don't sit
+    /// exactly on the chart edge.</summary>
+    public const float FitMargin = 1.05f;
+
+    /// <summary>Smallest orbit radius, in chart units, still worth drawing a ring for. Below this the
+    /// ring is inside its own body's disc and reads as a smudge rather than a path — the guard that
+    /// keeps a tightly-packed system legible.</summary>
+    public const float MinRingRadius = 10f;
+
+    /// <summary>Smallest extent the chart is ever fitted to, so a system with a single nearby body
+    /// doesn't zoom in absurdly far.</summary>
+    public const float MinExtent = 60f;
+
+    /// <summary>
+    /// Scene units → chart units, chosen so every point fits inside <paramref name="chartHalf"/> of
+    /// <paramref name="centreX"/>/<paramref name="centreZ"/> (the star, once the chart is star-centred),
+    /// with <paramref name="markerPad"/> chart units held back for the marker drawn at each point.
+    /// <para>The fit deliberately measures POSITIONS only and reserves a flat chart-unit margin for the
+    /// markers, rather than padding each point by its body's scene radius. A body's drawn disc is clamped
+    /// to a maximum size no matter how big the body is, so its scene radius is not what it occupies on the
+    /// chart — and the launch body, drawn 3.2× oversized in the flight scene, would otherwise dominate the
+    /// fit and zoom the whole chart out (measured: up to 1.77× on real systems) for a disc that is capped
+    /// anyway.</para>
+    /// </summary>
+    /// <param name="chartHalf">Usable half-width of the chart, in chart units.</param>
+    /// <param name="x">Scene x of every point that must fit.</param>
+    /// <param name="z">Scene z, parallel to <paramref name="x"/>.</param>
+    /// <param name="centreX">Scene x the chart centres on.</param>
+    /// <param name="centreZ">Scene z the chart centres on.</param>
+    /// <param name="markerPad">Chart units to hold back for the largest marker drawn at a point.</param>
+    public static float FitScale(
+        float chartHalf,
+        System.ReadOnlySpan<float> x,
+        System.ReadOnlySpan<float> z,
+        float centreX,
+        float centreZ,
+        float markerPad = 0f)
+    {
+        float extent = MinExtent;
+        for (int i = 0; i < x.Length; i++)
+        {
+            float dx = x[i] - centreX, dz = z[i] - centreZ;
+            float reach = System.MathF.Sqrt(dx * dx + dz * dz);
+            if (reach > extent)
+            {
+                extent = reach;
+            }
+        }
+
+        return System.MathF.Max(1f, chartHalf - markerPad) / (extent * FitMargin);
+    }
+
+    /// <summary>The orbit radius to draw for a body whose projected chart position is
+    /// <paramref name="chartX"/>/<paramref name="chartZ"/>, measured from the chart's centre — i.e. from
+    /// the star. Guarantees the ring passes exactly through the body's own marker.</summary>
+    public static float OrbitRadius(float chartX, float chartZ)
+        => System.MathF.Sqrt(chartX * chartX + chartZ * chartZ);
+
+    /// <summary>Whether an orbit of this drawn radius is worth a ring (see
+    /// <see cref="MinRingRadius"/>).</summary>
+    public static bool ShowRing(float chartRadius) => chartRadius >= MinRingRadius;
+}

--- a/src/BlocksBeyondTheStars.Shared/World/SystemChartLayout.cs
+++ b/src/BlocksBeyondTheStars.Shared/World/SystemChartLayout.cs
@@ -75,6 +75,30 @@ public static class SystemChartLayout
         return System.MathF.Max(1f, chartHalf - markerPad) / (extent * FitMargin);
     }
 
+    /// <summary>
+    /// Projects a flight-scene point onto the chart: chart units from the chart's centre, with
+    /// <paramref name="chartY"/> carrying the scene's z. Paired with <see cref="FromChart"/> — the two live
+    /// together so the click path cannot drift out of step with the drawing path, which is exactly how
+    /// clicks ended up landing somewhere other than where they were made.
+    /// </summary>
+    public static void ToChart(
+        float sceneX, float sceneZ, float scale, float centreX, float centreZ,
+        out float chartX, out float chartY)
+    {
+        chartX = (sceneX - centreX) * scale;
+        chartY = (sceneZ - centreZ) * scale;
+    }
+
+    /// <summary>The exact inverse of <see cref="ToChart"/>: the flight-scene point under a chart position
+    /// (a click). <paramref name="scale"/> must be the one the chart was drawn with.</summary>
+    public static void FromChart(
+        float chartX, float chartY, float scale, float centreX, float centreZ,
+        out float sceneX, out float sceneZ)
+    {
+        sceneX = (scale == 0f ? 0f : chartX / scale) + centreX;
+        sceneZ = (scale == 0f ? 0f : chartY / scale) + centreZ;
+    }
+
     /// <summary>The orbit radius to draw for a body whose projected chart position is
     /// <paramref name="chartX"/>/<paramref name="chartZ"/>, measured from the chart's centre — i.e. from
     /// the star. Guarantees the ring passes exactly through the body's own marker.</summary>

--- a/tests/BlocksBeyondTheStars.Client.Tests/SystemChartLayoutTests.cs
+++ b/tests/BlocksBeyondTheStars.Client.Tests/SystemChartLayoutTests.cs
@@ -1,0 +1,239 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using BlocksBeyondTheStars.Shared.Content;
+using BlocksBeyondTheStars.Shared.World;
+using BlocksBeyondTheStars.WorldGeneration;
+using Xunit;
+
+namespace BlocksBeyondTheStars.Client.Tests;
+
+/// <summary>
+/// The flight system chart's projection (#623): the chart is centred on the STAR and draws an orbit
+/// path for every body circling it. Both invariants are checked against REAL generated systems, fed
+/// through the same conversion <c>SpaceMap</c> uses, so a regression shows up here and not only on
+/// screen.
+/// <list type="number">
+/// <item>Everything fits — the star can be the chart centre only if no body needs to be pushed
+/// outside it, otherwise the rings centred on the star would be in the wrong place.</item>
+/// <item>Rings pass through their markers — the radius comes from the body's PROJECTED position, not
+/// from its star-map orbit radius, which the render layout deliberately distorts.</item>
+/// </list>
+/// </summary>
+public sealed class SystemChartLayoutTests
+{
+    // Mirrors SpaceMap / SpaceView.
+    private const float ChartHalf = (900f * 0.5f) - 30f; // usable chart radius, canvas units
+    private const float MaxBodyDisc = 46f;               // discs are clamped to this diameter
+    private const float MarkerPad = (MaxBodyDisc * 0.5f) + 8f;
+    private const float SystemViewScale = 0.16f;         // system units → flight-view units
+    private const float HomeZ = -20f;                    // the launch body's fixed spot (x = 0)
+    private const float Tolerance = 0.05f;
+
+    private static float RadiusOf(CelestialBody b)
+    {
+        var cls = WorldConstants.SizeClassFor(b.Kind, b.PlanetType ?? string.Empty);
+        return (8f + WorldConstants.CircumferenceFor(b.Id, cls, b.SizeBias) / 220f) * 0.5f;
+    }
+
+    /// <summary>One projected body: where the chart draws it, and how big.</summary>
+    private readonly record struct Drawn(string Id, float X, float Z, float Radius, bool OrbitsStar, float StarMapRadius);
+
+    /// <summary>Rebuilds what the chart would draw for one system, launched from <paramref name="home"/>:
+    /// scene coordinates relative to the launch body, exactly as <c>SpaceView.BuildSystemBodies</c> does.
+    /// Moons are skipped — they get no rings and their ladder placement is covered by
+    /// <see cref="SystemBodyLayoutTests"/>.</summary>
+    private static (List<Drawn> Bodies, float StarX, float StarZ) Project(StarSystem system, CelestialBody home)
+    {
+        var bodies = new List<Drawn>
+        {
+            // The launch body: pinned below the flight plane, drawn oversized, and — being a planet —
+            // ringed like any other. Its star-map radius is its true distance from the star.
+            new(home.Id, 0f, HomeZ, RadiusOf(home) * 3.2f, home.Kind == CelestialKind.Planet,
+                MathF.Sqrt((home.SystemX * home.SystemX) + (home.SystemZ * home.SystemZ)) * SystemViewScale),
+        };
+
+        foreach (var b in system.Bodies)
+        {
+            if (b.Id == home.Id || b.Kind == CelestialKind.Moon)
+            {
+                continue;
+            }
+
+            bool orbits = b.Kind is CelestialKind.Planet or CelestialKind.AsteroidField
+                       && string.IsNullOrEmpty(b.ParentId);
+            bodies.Add(new(
+                b.Id,
+                (b.SystemX - home.SystemX) * SystemViewScale,
+                (b.SystemZ - home.SystemZ) * SystemViewScale,
+                RadiusOf(b),
+                orbits,
+                MathF.Sqrt((b.SystemX * b.SystemX) + (b.SystemZ * b.SystemZ)) * SystemViewScale));
+        }
+
+        return (bodies, -home.SystemX * SystemViewScale, -home.SystemZ * SystemViewScale);
+    }
+
+    private static float Fit(List<Drawn> bodies, float centreX, float centreZ)
+        => SystemChartLayout.FitScale(
+            ChartHalf,
+            bodies.Select(b => b.X).ToArray(),
+            bodies.Select(b => b.Z).ToArray(),
+            centreX,
+            centreZ,
+            MarkerPad);
+
+    /// <summary>Every generated system, launched from its first planet — the shape the chart faces.</summary>
+    private static IEnumerable<(StarSystem System, CelestialBody Home)> RealSystems(int runs = 30)
+    {
+        var content = ContentLoader.LoadFromDirectory(ClientTestPaths.DataDir());
+        for (long run = 1; run <= runs * 2; run++)
+        {
+            long seed = run <= runs ? run : run - runs;
+            var desc = new WorldDescription { SystemVariance = run > runs }; // classic AND archetype-varied
+            foreach (var system in new UniverseGenerator(seed, desc, content).Generate().Systems)
+            {
+                var home = system.Bodies.FirstOrDefault(b => b.Kind == CelestialKind.Planet);
+                if (home is not null)
+                {
+                    yield return (system, home);
+                }
+            }
+        }
+    }
+
+    [Fact]
+    public void FitScale_KeepsEveryBodyAndItsOwnRadiusInsideTheChart()
+    {
+        int checked_ = 0;
+        foreach (var (system, home) in RealSystems())
+        {
+            var (bodies, starX, starZ) = Project(system, home);
+            float scale = Fit(bodies, starX, starZ);
+
+            foreach (var b in bodies)
+            {
+                // What the chart actually occupies at this body: its projected distance from the star plus
+                // its DRAWN disc (clamped, with the dark backing ring around it) — not its scene radius.
+                float dx = b.X - starX, dz = b.Z - starZ;
+                float discHalf = (Math.Clamp(b.Radius * scale * 2f, 12f, MaxBodyDisc) + 8f) * 0.5f;
+                float reach = (MathF.Sqrt((dx * dx) + (dz * dz)) * scale) + discHalf;
+                Assert.True(
+                    reach <= ChartHalf + Tolerance,
+                    $"{b.Id} reaches {reach} of the chart's {ChartHalf} — it would be clipped or rim-pinned");
+                checked_++;
+            }
+        }
+
+        Assert.True(checked_ > 200, $"only {checked_} bodies checked — the generator sweep is not covering enough");
+    }
+
+    [Fact]
+    public void OrbitRings_PassThroughTheirMarkerAndStayInsideTheChart()
+    {
+        int rings = 0;
+        foreach (var (system, home) in RealSystems())
+        {
+            var (bodies, starX, starZ) = Project(system, home);
+            float scale = Fit(bodies, starX, starZ);
+
+            foreach (var b in bodies.Where(b => b.OrbitsStar))
+            {
+                // Projected chart position (the star is the chart's origin).
+                float px = (b.X - starX) * scale, pz = (b.Z - starZ) * scale;
+                float radius = SystemChartLayout.OrbitRadius(px, pz);
+                if (!SystemChartLayout.ShowRing(radius))
+                {
+                    continue;
+                }
+
+                // The ring passes exactly through the marker: the marker lies ON the circle.
+                Assert.Equal(MathF.Sqrt((px * px) + (pz * pz)), radius, Tolerance);
+
+                // …and the fit guarantees the whole ring is on the chart with the marker margin intact,
+                // which is what makes centring on the star possible at all (the old chart had to pin the
+                // star to the rim).
+                Assert.True(
+                    radius <= ChartHalf - MarkerPad + Tolerance,
+                    $"{b.Id}'s orbit ring of {radius} spills outside the chart's usable {ChartHalf - MarkerPad}");
+                rings++;
+            }
+        }
+
+        Assert.True(rings > 150, $"only {rings} orbit rings exercised — expected the sweep to draw far more");
+    }
+
+    [Fact]
+    public void StarCentring_CostsAtMostABoundedZoomOut()
+    {
+        // Centring on the star is what makes the orbit paths possible, and it is not free: where the
+        // launch body sits INSIDE a far-flung asteroid's orbit, framing on the launch body is tighter
+        // than framing on the star, so the chart zooms out. Measured worst case across real systems is
+        // ~1.72×, and the 12-unit minimum disc size keeps every marker legible through it. This bounds
+        // the cost so a future layout change can't quietly make the chart useless.
+        const float Budget = 2.0f;
+
+        float worst = 1f;
+        string worstId = string.Empty;
+        foreach (var (system, home) in RealSystems(15))
+        {
+            var (bodies, starX, starZ) = Project(system, home);
+            float starScale = Fit(bodies, starX, starZ);
+            float homeScale = Fit(bodies, 0f, HomeZ); // today's framing: launch body, star free to rim-pin
+
+            float zoomOut = homeScale / starScale;
+            if (zoomOut > worst)
+            {
+                worst = zoomOut;
+                worstId = system.Id;
+            }
+        }
+
+        Assert.True(
+            worst <= Budget,
+            $"star-centring zooms the chart out {worst}× at {worstId} — over the {Budget}× budget");
+    }
+
+    [Fact]
+    public void ProjectedRadius_IsNotInterchangeableWithTheStarMapOrbitRadius()
+    {
+        // Guards invariant 2 against a "simplification": the launch body is pinned to a fixed spot and
+        // SeparateXZ nudges crowded pairs, so a ring drawn at the star-map orbit radius visibly misses
+        // its planet. If this ever stops finding disagreements, the projection has changed and the
+        // comment in SystemChartLayout needs re-checking.
+        int disagreements = 0;
+        foreach (var (system, home) in RealSystems(15))
+        {
+            var (bodies, starX, starZ) = Project(system, home);
+            float scale = Fit(bodies, starX, starZ);
+
+            foreach (var b in bodies.Where(b => b.OrbitsStar))
+            {
+                float px = (b.X - starX) * scale, pz = (b.Z - starZ) * scale;
+                if (MathF.Abs(SystemChartLayout.OrbitRadius(px, pz) - (b.StarMapRadius * scale)) > 1f)
+                {
+                    disagreements++;
+                }
+            }
+        }
+
+        Assert.True(disagreements > 0, "the star-map radius now matches the projection everywhere — re-check the invariant");
+    }
+
+    [Fact]
+    public void ShowRing_SuppressesOrbitsTooSmallToRead()
+    {
+        Assert.False(SystemChartLayout.ShowRing(0f));
+        Assert.False(SystemChartLayout.ShowRing(SystemChartLayout.MinRingRadius - 0.1f));
+        Assert.True(SystemChartLayout.ShowRing(SystemChartLayout.MinRingRadius));
+        Assert.True(SystemChartLayout.ShowRing(ChartHalf));
+    }
+
+    [Fact]
+    public void FitScale_FallsBackToAMinimumExtent_ForASystemWithNothingInIt()
+    {
+        // A lone body right next to the chart centre must not zoom the chart in absurdly far.
+        float scale = SystemChartLayout.FitScale(ChartHalf, new[] { 1f }, new[] { 1f }, 0f, 0f);
+        Assert.Equal(ChartHalf / (SystemChartLayout.MinExtent * SystemChartLayout.FitMargin), scale, Tolerance);
+    }
+}

--- a/tests/BlocksBeyondTheStars.Client.Tests/SystemChartLayoutTests.cs
+++ b/tests/BlocksBeyondTheStars.Client.Tests/SystemChartLayoutTests.cs
@@ -221,6 +221,32 @@ public sealed class SystemChartLayoutTests
     }
 
     [Fact]
+    public void FromChart_IsTheExactInverseOfToChart_AcrossRealSystems()
+    {
+        // A click has to resolve to the scene point it was made on. The chart being star-centred means the
+        // centre offset appears in BOTH directions; when only the drawing path had it, every free waypoint
+        // landed somewhere else. Round-tripping every real body pins the pair together.
+        foreach (var (system, home) in RealSystems(10))
+        {
+            var (bodies, starX, starZ) = Project(system, home);
+            float scale = Fit(bodies, starX, starZ);
+
+            foreach (var b in bodies)
+            {
+                SystemChartLayout.ToChart(b.X, b.Z, scale, starX, starZ, out float cx, out float cy);
+                SystemChartLayout.FromChart(cx, cy, scale, starX, starZ, out float sx, out float sz);
+                Assert.Equal(b.X, sx, Tolerance);
+                Assert.Equal(b.Z, sz, Tolerance);
+            }
+
+            // And the chart's own centre must map back to the star, not to the launch body.
+            SystemChartLayout.FromChart(0f, 0f, scale, starX, starZ, out float centreX, out float centreZ);
+            Assert.Equal(starX, centreX, Tolerance);
+            Assert.Equal(starZ, centreZ, Tolerance);
+        }
+    }
+
+    [Fact]
     public void ShowRing_SuppressesOrbitsTooSmallToRead()
     {
         Assert.False(SystemChartLayout.ShowRing(0f));


### PR DESCRIPTION
## What does this change?

The in-flight system chart (`M`, #597) drew the current system's bodies at their real flight
coordinates, but nothing showed that they *orbit* anything — the star was a dot pushed to the rim
whenever it fell outside the framing, and the bodies read as a random scatter of discs. It now reads
as a chart of a star system.

Client-only: every input was already on the client (`NetBody.SystemX/Z`, `ParentId`, `RingSeed`), so
there is **no wire, server or worldgen change and no world regeneration**. The surface planet map
(`WorldMap.cs`) is deliberately untouched.

- **Star-centred projection** with a soft three-layer corona; rim-pinning gone, so an orbit is a real
  circle around the middle of the chart.
- **An orbit path per planet and landable asteroid body**, tinted from that body's own `PlanetColor`.
  **Moons get none on purpose**: they are re-laddered onto `SystemBodyLayout.MinOrbitFor` slots just
  outside their parent's drawn radius, so their rings would collapse into the planet's disc.
- **`SystemChartLayout`** (new, in Shared beside `SystemBodyLayout` so it is testable) owns the
  projection and its inverse plus the fit. A ring's radius comes from the body's **projected**
  position, never from its star-map orbit radius — the launch-body pinning and `SeparateXZ` distort
  that, so a ring drawn from it visibly misses its planet.
- **`UiOrbitRing`** (new) — the client's first custom `MaskableGraphic`: a `VertexHelper` annulus with
  radius-independent line weight. A stretched ring sprite scales its own thickness (fat outer orbits,
  hairline inner ones); this is one draw element per ring instead of ~50 dot images. Default UI
  material, so nothing to always-include. A non-square rect gives an ellipse — which is how a
  `RingSeed != 0` planet now wears its #596 rings on the chart.

### Two bugs found on the way

- **Clicks landed half a chart away (pre-existing since #597).** `UiKit.Place` anchors the chart rect
  at the top-left (pivot `0,1`), so `ScreenPointToLocalPointInRectangle` reports `x ∈ [0..900]`,
  `y ∈ [-900..0]`, while every marker is anchored around the chart's **centre** (`[-450..+450]`). A
  click in the middle came out as `(450, -450)`: free waypoints always resolved to a positive-x /
  negative-z scene point, and marker snapping sat ~636 units out of range, so clicking a body to
  target it practically never took. Re-based by the rect's own centre (pivot-independent). To stop the
  two directions drifting apart again, the projection and its inverse now live together as
  `ToChart`/`FromChart` instead of the inverse being hand-written at the click site.
- **The fit padded each body by its *scene* radius** while the drawn discs are clamped to ≤46 units
  regardless — so the launch body, rendered 3.2× oversized, needlessly zoomed the whole chart out.
  `FitScale` now measures positions and holds back a flat marker margin.

Bonus: the launch body finally gets its **real planet colour** (its `Landables` entry carries an empty
id, so `BodyColor` always fell through to a pale green); it resolves via `StarMap.ActiveLocationId`
through a new per-system `id → NetBody` cache, which also replaces two full star-map walks per open.

### Measured, not assumed

Star-centring costs up to **1.72× zoom-out** on real systems (worst case: the launch body sitting
inside a far-flung asteroid's orbit). The 12-unit minimum disc size absorbs it and a test bounds it at
2× so a future layout change can't quietly make the chart useless. An earlier assumption that
star-centring would be *tighter* was wrong — the test is what caught it.

### Deliberately out of scope

Moon rings; direction arrowheads / retrograde marking (the flight scene is a t=0 snapshot, so the
bodies never move — an arrow would imply motion the game doesn't deliver); zoom/pan.
`SystemMapWidget` (the Tab travel-screen orrery) stays a decorative fake with invented orbits and now
visibly disagrees with the honest flight chart — worth a separate follow-up.

## Related issue

Closes #623

## Checklist

- [x] I built and ran the tests before pushing (`dotnet build BlocksBeyondTheStars.sln` and `dotnet test`) — they pass.
- [x] Player-facing text is localized (keys in `data/locales/{en,de}.json`), not hardcoded. — no new strings; the chart is graphics-only.
- [x] The server stays authoritative — the client doesn't decide resources, inventory, crafting, ship state, oxygen, damage, blueprints or travel.
- [x] I updated `TODO.md` and any `docs/` that my change makes stale (if applicable).

### Verification

- `dotnet build BlocksBeyondTheStars.sln -c Release`: **0 warnings, 0 errors**.
- Full fast tier green: 1292 server + 154 client tests, including 7 new `SystemChartLayoutTests` over
  real `UniverseGenerator` systems (classic **and** archetype-varied) — everything fits, rings pass
  through their markers and stay on the chart, `FromChart` round-trips `ToChart` for every body, the
  bounded zoom-out, and a guard that the star-map radius is **not** interchangeable with the projection.
- **Local Unity Windows build**: 0 C# errors/warnings; play-verified by Marcel in the real client
  (orbits, ringed-planet glyph, and both click paths after the fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
