### PR TITLE
Commit the Unity .meta files for the greenhouse textures

### DIFF
--- a/client/Assets/Resources/textures/flora_cropberry.bytes.meta
+++ b/client/Assets/Resources/textures/flora_cropberry.bytes.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6e4a6f969c255c94e9fb641110add50c
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/client/Assets/Resources/textures/hydro_tray.bytes.meta
+++ b/client/Assets/Resources/textures/hydro_tray.bytes.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a45ee982c48b4c842a67e734607e3758
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Follow-up to #631.

Unity writes a `.meta` beside every asset it imports. The two block tiles that came with the greenhouses
(`flora_cropberry.bytes`, `hydro_tray.bytes`) were bundled by `tools/ai-assets/bundle_textures.py` without
theirs, so the first local player build produced them as untracked files. An asset whose `.meta` is missing
from the repo gets a **fresh GUID on every machine that imports it**, which is exactly the kind of drift
that shows up later as a phantom diff.

Generated by a local Windows player build (Unity 6000.4.9f1). Both are plain `TextScriptImporter` entries,
identical in shape to every other tile in `client/Assets/Resources/textures`.

## Verification

- Local Windows player build succeeded end to end; `BlocksBeyondTheStars.Client.dll` in
  `client/Build/Windows/.../Managed/` carries the fresh build timestamp (not just the `.exe`).
- No other files changed — the build produced exactly these two `.meta` files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
