### PR TITLE
fix(locale): beam_block block description now matches the teleporter pad (#646)

### DIFF
--- a/data/locales/de.json
+++ b/data/locales/de.json
@@ -2127,7 +2127,7 @@
   "block.light_green.desc": "Ein massiver Leuchtblock, der grün leuchtet, freistehend und ohne Strombedarf.",
   "block.strip_light_cyan.desc": "Ein helles cyanfarbenes Streiflicht, das ohne Strom leuchtet — saubere Stationsbeleuchtung.",
   "block.strip_light_warm.desc": "Ein warmes Streiflicht, das ohne Strom leuchtet — behagliche Innenbeleuchtung.",
-  "block.beam_block.desc": "Ein leuchtender Strukturbalken, der einen Lichtschacht wirft.",
+  "block.beam_block.desc": "Ein benanntes Transporter-Pad. Draufstellen und E drücken, um zu eigenen oder verbündeten Beamer-Blöcken auf dieser Welt zu beamen.",
   "block.radio_beacon.desc": "Eine aufstellbare, sanft leuchtende Bake — eine Navigationsmarke, die man von Weitem sieht.",
   "block.engine_nozzle.desc": "Eine dekorative Triebwerksdüse mit schwachem Glühen — der Look von Schub.",
   "block.medbay_panel.desc": "Ein klinisches Wandpaneel für Krankenstationen.",

--- a/data/locales/en.json
+++ b/data/locales/en.json
@@ -2126,7 +2126,7 @@
   "block.light_green.desc": "A solid light block that glows green, free-standing and needing no power.",
   "block.strip_light_cyan.desc": "A bright cyan strip light that glows without power — clean station lighting.",
   "block.strip_light_warm.desc": "A warm strip light that glows without power — cosy interior lighting.",
-  "block.beam_block.desc": "A glowing structural beam that throws a shaft of light.",
+  "block.beam_block.desc": "A named teleporter pad. Stand on it and press E to beam to your own or allied beam blocks on this world.",
   "block.radio_beacon.desc": "A placeable, softly glowing beacon — a navigation landmark you can spot from afar.",
   "block.engine_nozzle.desc": "A decorative engine nozzle with a faint glow — the look of thrust.",
   "block.medbay_panel.desc": "A clinical wall panel for medbays.",


### PR DESCRIPTION
`block.beam_block.desc` described *"a glowing structural beam that throws a shaft of light"* — leftover text from an early concept. The beam block is the named teleporter pad, as `item.beam_block.desc`, `blueprint.beam_block.desc`, the user manual, `BeamView.cs` and the texture prompt all agree.

Reported by @alessandroquirino-lab in #646, who caught it while translating `item.*` — the wrong text had already propagated into `de.json` (and `it.json`, which he'll fix in the Italian part 2 PR).

### Changes

- `en.json`: **"A named teleporter pad. Stand on it and press E to beam to your own or allied beam blocks on this world."**
- `de.json`: **"Ein benanntes Transporter-Pad. Draufstellen und E drücken, um zu eigenen oder verbündeten Beamer-Blöcken auf dieser Welt zu beamen."**

`tools/locale_report.py --check` passes.

closes #646

🤖 Generated with [Claude Code](https://claude.com/claude-code)