### PR TITLE
fix(fauna): terrain-aware roaming — cliffs are soft walls, no seabed marches, no stranded medusae

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7,7 +7,7 @@ plans live under [docs/](docs/) (committed); the long-range direction is the str
 keep it current when controls/features change. Last consolidated 2026-06-04.
 
 **Build:** `scripts/build-client.ps1` (Windows) or `scripts/build-client.sh` (Linux) — publishes shared libs + bundled server + Unity player.
-**Test:** `./scripts/run-tests.sh` — currently **1312 server + 147 client passing** (2026-07-30). Locale parity (en/de) is enforced by a test.
+**Test:** `./scripts/run-tests.sh` — currently **1325 server + 147 client passing** (2026-08-01). Locale parity (en/de) is enforced by a test.
 CI runs two tiers: PRs skip the tests marked `[Trait("Category", "Slow")]`; pushes to `main` and the release workflow run the full suite. CI builds/runs
 tests in Release, and a per-test duration guardrail (`scripts/check-test-durations.py`, PRs only) fails the gate when a non-Slow test exceeds 120 s.
 **Conventions:** English docs/comments; in-game text bilingual DE+EN; commit to `main` with the
@@ -102,6 +102,20 @@ Per-item detail lives in the dated work log below. **Since 2026-07 versions are 
 
 ---
 
+### ★ Terrain-aware creature roaming: cliffs are soft walls, no seabed marches, no stranded medusae (#648, 2026-08-01, branch fix/creature-terrain-gates)
+Creatures have no colliders — the server snaps their Y to the habitat height every tick — so terrain
+never blocked movement: a roaming titan crossing a mesa/rift edge got the full cliff height as its
+new Y in one tick (the client lerp rendered that as a diagonal glide *through* the rock face), any
+land animal wandering into a sea marched along the bottom fully submerged, and a water medusa or a
+whole fish school could drift onto the beach and roam dry land until despawn (the dry-column
+fallback never steered them back). The titan flatness gate ran at spawn only. **Fix:** a pure,
+unit-tested step gate (`CreatureBehaviour.TerrainStepBlocked`) wired into the movement tick's
+existing barrier mechanic (discard the step + re-roll the heading — exactly how the ship hull and
+energy fences already work, so the "nothing can ever get stuck" property is preserved): land
+walkers accept at most a 2-block surface step (titans 1, mirroring their 3×3 spawn gate) and never
+enter water deeper than 1 cell; water species never step out of their water body (already-stranded
+individuals keep their legacy freedom); fliers, cave/lava dwellers and amphibians are unaffected.
+Server-only — no client change, no wire change, no save impact.
 ### ★ More creature kinds: floating medusae, huntable titans, herds & bigger rosters (#637–#640, 2026-07-30, branch feat/creature-kinds)
 Fauna was one body plan: every species — whatever its traits said — rendered as the same segment-row
 cube animal, and `Size` was capped five times over (generator 2.2, locomotion 2.2, renderer 3, three

--- a/docs/developer/WORLD_GENERATION.md
+++ b/docs/developer/WORLD_GENERATION.md
@@ -276,6 +276,14 @@ despawn beyond 70 blocks (titans 110 — a landmark animal must not evaporate mi
 which species are awake. Bite + aggro ranges grow gently with species size past 2 (bite capped at
 the player's own 6-block attack reach).
 
+**Terrain-aware roaming (#648):** creatures have no colliders — their Y is snapped to the habitat
+height every tick — so movement is gated per step instead (`CreatureBehaviour.TerrainStepBlocked`,
+the same discard-and-re-roll mechanic as the ship hull and energy fences): land walkers accept at
+most a 2-block surface step (titans 1, mirroring their spawn gate) and never enter water deeper
+than 1 cell; water species never step out of their water body; fliers, cave/lava dwellers and
+amphibians are unaffected. Cliffs thus act as soft walls rather than single-tick teleports, and
+nothing can ever get stuck (a blocked step just rolls a fresh heading).
+
 ---
 
 ## 8. Water, rivers & seas

--- a/src/BlocksBeyondTheStars.GameServer/GameServerCreatures.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerCreatures.cs
@@ -769,9 +769,12 @@ public sealed partial class GameServer
             var next = AdjustHabitatHeight(sp, stepped, res.VertWave, profile);
 
             // Creatures don't walk into the player's ship — hold position at the hull. Energy fences
-            // pen them in the same way: the step is discarded and a fresh heading is rolled next tick,
-            // so a fenced creature keeps milling about inside instead of grinding against the wire.
-            if (EntityBlockedByShip(next) || BlockedByEnergyFence(creature.Position, next))
+            // pen them in the same way, and terrain gates (#648) reuse the exact same mechanic: cliffs
+            // are soft walls (no more single-tick teleports up a rock face), land animals stay out of
+            // deep water and water animals stay in it. The step is discarded and a fresh heading is
+            // rolled next tick, so a blocked creature keeps milling about instead of getting stuck.
+            if (EntityBlockedByShip(next) || BlockedByEnergyFence(creature.Position, next)
+                || StepBlockedByTerrain(sp, creature.Position, next))
             {
                 creature.Loco.ModeTimer = 0f;
             }
@@ -780,6 +783,33 @@ public sealed partial class GameServer
                 creature.Position = next;
             }
         }
+    }
+
+    /// <summary>Feeds the world's column data (surface heights + water depths) into the pure
+    /// <see cref="CreatureBehaviour.TerrainStepBlocked"/> gate (#648). Only consulted when the step
+    /// actually crosses a column boundary, and only for the habitats the gate cares about — so the
+    /// extra generator queries stay off the common same-column tick.</summary>
+    private bool StepBlockedByTerrain(CreatureSpecies sp, Vector3f cur, Vector3f next)
+    {
+        if (sp.Habitat != CreatureHabitat.Land && sp.Habitat != CreatureHabitat.Water)
+        {
+            return false; // fliers, cave/lava dwellers and amphibians keep their existing freedom
+        }
+
+        int cx = (int)System.Math.Floor(cur.X), cz = (int)System.Math.Floor(cur.Z);
+        int nx = (int)System.Math.Floor(next.X), nz = (int)System.Math.Floor(next.Z);
+        if (cx == nx && cz == nz)
+        {
+            return false; // same column — nothing to gate
+        }
+
+        int curSurface = _generator.SurfaceHeight(_world.Planet, cx, cz);
+        int nextSurface = _generator.SurfaceHeight(_world.Planet, nx, nz);
+        int curDepth = _generator.TryGetWaterSurface(_world.Planet, cx, cz, out int curTop, out int curBed)
+            ? curTop - curBed : 0;
+        int nextDepth = _generator.TryGetWaterSurface(_world.Planet, nx, nz, out int nextTop, out int nextBed)
+            ? nextTop - nextBed : 0;
+        return CreatureBehaviour.TerrainStepBlocked(sp.Habitat, sp.BodyPlan, curSurface, nextSurface, curDepth, nextDepth);
     }
 
     private const float GroupCohesionRange = 24f;   // kin within this count toward the group centre (#639)

--- a/src/BlocksBeyondTheStars.Shared/Definitions/CreatureBehaviour.cs
+++ b/src/BlocksBeyondTheStars.Shared/Definitions/CreatureBehaviour.cs
@@ -123,6 +123,46 @@ public static class CreatureBehaviour
     }
 
     /// <summary>
+    /// Whether a roaming step from one terrain column into another is blocked for this creature (#648).
+    /// Creatures have no colliders — their Y is snapped to the habitat height every tick — so without
+    /// this gate cliffs are climbed in a single-tick teleport, land animals march along the seabed and
+    /// water animals strand ashore. Blocked steps are handled like the ship-hull barrier: the caller
+    /// discards the move and re-rolls a heading, so nothing can ever get stuck.
+    /// <list type="bullet">
+    /// <item><b>Land</b>: the surface may step by at most 2 blocks (1 for a <see cref="CreatureBodyPlan.Titan"/>,
+    /// matching its spawn flatness gate), and the target column's water must be wadeable (≤ 1 deep).</item>
+    /// <item><b>Water</b>: a creature that is in water never steps into a dry column (an already-stranded
+    /// individual keeps its legacy freedom so it can still wander at all).</item>
+    /// <item>Fliers, cave and lava dwellers and amphibians are unaffected.</item>
+    /// </list>
+    /// Depths are in water cells (surface − bed); pass 0 for a dry column.
+    /// </summary>
+    public static bool TerrainStepBlocked(
+        CreatureHabitat habitat,
+        CreatureBodyPlan bodyPlan,
+        int curSurfaceY,
+        int nextSurfaceY,
+        int curWaterDepth,
+        int nextWaterDepth)
+    {
+        switch (habitat)
+        {
+            case CreatureHabitat.Land:
+                int limit = bodyPlan == CreatureBodyPlan.Titan ? 1 : 2;
+                if (System.Math.Abs(nextSurfaceY - curSurfaceY) > limit)
+                {
+                    return true; // cliff — a soft wall in both directions (no climbing, no plunging)
+                }
+
+                return nextWaterDepth > 1; // wading is fine, swimming is not
+            case CreatureHabitat.Water:
+                return curWaterDepth > 0 && nextWaterDepth <= 0; // never leave the water body
+            default:
+                return false;
+        }
+    }
+
+    /// <summary>
     /// Whether a creature fights back when attacked. Already-hostile hunters do; <b>territorial</b>
     /// species turn hostile when provoked; passive grazers and skittish fleers do not retaliate.
     /// </summary>

--- a/tests/BlocksBeyondTheStars.Tests/CreatureTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/CreatureTests.cs
@@ -664,6 +664,60 @@ public sealed class CreatureTests : IDisposable
         Assert.True(XzDist(next, player) >= XzDist(cur, player) - 0.01f);
     }
 
+    // ---------------- Terrain gates (#648, pure) ----------------
+
+    [Fact]
+    public void TerrainGate_LandWalker_TreatsCliffsAsSoftWalls_BothDirections()
+    {
+        // A standard ground walker steps at most 2 surface blocks per column — steeper is a wall,
+        // uphill and downhill alike (the Y-snap would otherwise teleport it up/down the face).
+        Assert.False(CreatureBehaviour.TerrainStepBlocked(CreatureHabitat.Land, CreatureBodyPlan.Standard, 64, 66, 0, 0));
+        Assert.False(CreatureBehaviour.TerrainStepBlocked(CreatureHabitat.Land, CreatureBodyPlan.Standard, 64, 62, 0, 0));
+        Assert.True(CreatureBehaviour.TerrainStepBlocked(CreatureHabitat.Land, CreatureBodyPlan.Standard, 64, 67, 0, 0));
+        Assert.True(CreatureBehaviour.TerrainStepBlocked(CreatureHabitat.Land, CreatureBodyPlan.Standard, 64, 34, 0, 0));
+    }
+
+    [Fact]
+    public void TerrainGate_Titan_NeedsTheGentleSlopes_ItsSpawnGateDemands()
+    {
+        // Titans mirror their 3×3 ±1 spawn flatness gate (#638) while roaming: a step of 1 is fine,
+        // 2 is already a wall — a six-block giant must never stair-step a rock face.
+        Assert.False(CreatureBehaviour.TerrainStepBlocked(CreatureHabitat.Land, CreatureBodyPlan.Titan, 64, 65, 0, 0));
+        Assert.True(CreatureBehaviour.TerrainStepBlocked(CreatureHabitat.Land, CreatureBodyPlan.Titan, 64, 66, 0, 0));
+        Assert.True(CreatureBehaviour.TerrainStepBlocked(CreatureHabitat.Land, CreatureBodyPlan.Titan, 64, 62, 0, 0));
+    }
+
+    [Fact]
+    public void TerrainGate_LandWalker_WadesButNeverSwims()
+    {
+        // Ankle-deep water (1 cell) is wadeable; anything deeper would put the animal on the seabed.
+        Assert.False(CreatureBehaviour.TerrainStepBlocked(CreatureHabitat.Land, CreatureBodyPlan.Standard, 64, 64, 0, 1));
+        Assert.True(CreatureBehaviour.TerrainStepBlocked(CreatureHabitat.Land, CreatureBodyPlan.Standard, 64, 64, 0, 2));
+        Assert.True(CreatureBehaviour.TerrainStepBlocked(CreatureHabitat.Land, CreatureBodyPlan.Titan, 64, 64, 1, 8));
+    }
+
+    [Fact]
+    public void TerrainGate_WaterSpecies_NeverLeavesItsWaterBody()
+    {
+        // In water → dry column is blocked (no more medusae/schools stranding on the beach); moving
+        // between wet columns is free; an already-stranded individual keeps its legacy freedom so it
+        // is never wedged in place.
+        Assert.True(CreatureBehaviour.TerrainStepBlocked(CreatureHabitat.Water, CreatureBodyPlan.Medusa, 60, 64, 3, 0));
+        Assert.False(CreatureBehaviour.TerrainStepBlocked(CreatureHabitat.Water, CreatureBodyPlan.Medusa, 60, 60, 3, 2));
+        Assert.False(CreatureBehaviour.TerrainStepBlocked(CreatureHabitat.Water, CreatureBodyPlan.Standard, 64, 64, 0, 0));
+    }
+
+    [Fact]
+    public void TerrainGate_FliersCaveLavaAndAmphibians_AreUnaffected()
+    {
+        // Air medusae/gliders swoop over any relief, cave dwellers hug their own floor, lava dwellers
+        // stay in the melt and amphibians legitimately cross the shoreline — no gate for any of them.
+        Assert.False(CreatureBehaviour.TerrainStepBlocked(CreatureHabitat.Air, CreatureBodyPlan.Medusa, 64, 120, 0, 0));
+        Assert.False(CreatureBehaviour.TerrainStepBlocked(CreatureHabitat.Cave, CreatureBodyPlan.Standard, 64, 20, 0, 0));
+        Assert.False(CreatureBehaviour.TerrainStepBlocked(CreatureHabitat.Lava, CreatureBodyPlan.Standard, 64, 90, 0, 0));
+        Assert.False(CreatureBehaviour.TerrainStepBlocked(CreatureHabitat.Amphibian, CreatureBodyPlan.Standard, 64, 64, 4, 0));
+    }
+
     // ---------------- Territorial retaliation (provoke) ----------------
 
     [Fact]


### PR DESCRIPTION
## Summary

Creatures have no colliders — the server snaps their Y to the habitat height every tick — so terrain never blocked movement: a titan (#638) crossing a mesa/rift edge got the full cliff height as its new Y in one tick (rendered client-side as a diagonal glide *through* the rock face), any land animal wandering into a sea marched along the bottom fully submerged, and a water medusa or fish school could drift ashore and roam dry land until despawn. The titan flatness gate ran at spawn only.

## Fix

A pure, unit-tested step gate (`CreatureBehaviour.TerrainStepBlocked`) wired into the movement tick''s existing barrier mechanic — discard the step and re-roll the heading, exactly how the ship hull and energy fences already work, so the "nothing can ever get stuck" property is preserved:

- **Land walkers** accept at most a 2-block surface step (**titans 1**, mirroring their 3×3 spawn flatness gate) and never enter water deeper than 1 cell (wading stays fine).
- **Water species** never step out of their water body; an already-stranded individual keeps its legacy freedom so it is never wedged in place.
- **Fliers, cave/lava dwellers and amphibians** are unaffected.

Only consulted when a step actually crosses a column boundary, and only for the two gated habitats — no extra generator queries on the common same-column tick. Server-only: no client change, no wire change, no save impact.

## Verification

- 1325 server + 147 client tests green locally (Release, non-Slow), full Slow tier green as well (52 + 7).
- 5 new pure gate tests in `CreatureTests` (cliff both directions, titan threshold, wade-vs-swim, shore gate, unaffected habitats).
- `dotnet format --verify-no-changes` clean.
- Docs: fauna section of `WORLD_GENERATION.md` + `TODO.md` work log updated.

closes #648

🤖 Generated with [Claude Code](https://claude.com/claude-code)