### PR TITLE
feat(fauna+audio): creature movement realism wave + fluid/positional block sounds

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -102,6 +102,17 @@ Per-item detail lives in the dated work log below. **Since 2026-07 versions are 
 
 ---
 
+### ★ Water flow no longer knocks + block sounds are positional (#655, 2026-08-01, branch feat/creature-movement-realism — LOCAL, no PR yet)
+Every server `BlockChanged` played a full-volume 2D cue — including EVERY fluid-sim spread/drain
+step, so flowing water hammered a rhythmic `place_block` knocking (and draining water played mining
+crunches). `GameBootstrap` now raises a local `BlockChangeApplied(pos, oldId, newId)` event after
+applying a change (the raw message can't tell a drained fluid from a mined block); `ClientAudio`
+skips the per-cell cue for water/lava transitions and kicks an immediate fluid-bed rescan instead —
+the existing `water_brook`/`water_fall`/`water_surf` rush IS the water sound and now reacts
+instantly instead of on the 0.5 s scan beat. Follow-up in the same wave: the mine/place cues moved
+from flat 2D to **positional 3D** at the changed cell (`At`, scene-space via `ScenePos`, 4 m
+full-volume radius → own mining feel unchanged, linear rolloff to silence at 20 m → remote players'
+edits no longer knock in your ear). Client-only, no wire/server change.
 ### ★ Creature movement realism wave: real-block awareness, steering, boids, vertical easing, herd panic, crisp motion (#650–#654, 2026-08-01, branch feat/creature-movement-realism — LOCAL, no PR yet)
 Five packages on top of the #648 terrain gates. **Real blocks (#650):** land Y-snap, terrain gates,
 titan flatness gate and land spawn placement now read the ACTUAL world via a nearest-standable-cell

--- a/TODO.md
+++ b/TODO.md
@@ -7,7 +7,7 @@ plans live under [docs/](docs/) (committed); the long-range direction is the str
 keep it current when controls/features change. Last consolidated 2026-06-04.
 
 **Build:** `scripts/build-client.ps1` (Windows) or `scripts/build-client.sh` (Linux) — publishes shared libs + bundled server + Unity player.
-**Test:** `./scripts/run-tests.sh` — currently **1325 server + 147 client passing** (2026-08-01). Locale parity (en/de) is enforced by a test.
+**Test:** `./scripts/run-tests.sh` — currently **1331 server + 147 client passing** (2026-08-01). Locale parity (en/de) is enforced by a test.
 CI runs two tiers: PRs skip the tests marked `[Trait("Category", "Slow")]`; pushes to `main` and the release workflow run the full suite. CI builds/runs
 tests in Release, and a per-test duration guardrail (`scripts/check-test-durations.py`, PRs only) fails the gate when a non-Slow test exceeds 120 s.
 **Conventions:** English docs/comments; in-game text bilingual DE+EN; commit to `main` with the
@@ -102,6 +102,29 @@ Per-item detail lives in the dated work log below. **Since 2026-07 versions are 
 
 ---
 
+### ★ Creature movement realism wave: real-block awareness, steering, boids, vertical easing, herd panic, crisp motion (#650–#654, 2026-08-01, branch feat/creature-movement-realism — LOCAL, no PR yet)
+Five packages on top of the #648 terrain gates. **Real blocks (#650):** land Y-snap, terrain gates,
+titan flatness gate and land spawn placement now read the ACTUAL world via a nearest-standable-cell
+probe (`GetBlockIfLoaded`, ±6 window, downward-first tie-break so bridges don't grab the creature
+under them; generator-surface fallback for unloaded columns) — fauna honours player walls, dug pits,
+ramps and built floors; players can pen animals with builds. **Steering (#651):** a blocked step
+probes ±35°/±70°/±110° (per-individual side order) and adopts the first free heading — contour/wall
+following; only when all probes fail does the old heading re-roll fire (never-stuck preserved).
+**Boids completed (#651):** separation (size-scaled personal space — titans stop overlapping) and
+Schooler heading alignment (`CreatureBehaviour.BlendHeading`, wrap-safe) joined the existing
+cohesion in one O(n) scan. **Vertical easing (#652):** land walkers ease toward the ground at
+6 blocks/s (snap beyond 4 — spawns/teleports stay instant; hoppers keep the snap, their pop IS the
+motion), fliers ease at 4 blocks/s toward hover+swoop (no more contour-pen terrain tracing); client
+bodies pitch along real motion (±25°) and Air species bank into turns (±20°), medusae excluded.
+**Herd panic + jink (#653):** `CombatEntity.PanicTimer` — a hit (fatal or not) or a skittish bolt
+startles same-species kin within 12 blocks for 4 s; non-retaliators flee the nearest player (range
+24), retaliators charge instead, no chain re-triggering; fleeing gains a deterministic zig-zag jink
+in the controller (NPCs/bandits inherit a modest jink; enemies never flee). **Crisp motion (#654):**
+client dead reckoning extrapolates the 2 Hz creature stream (clamped 0.3 s, teleport-safe) and
+Hopper strides pulse with the pop wave (25 % shuffle between hops). Server-only + client-view only:
+no wire change, no save impact; companions keep all freedoms (they must follow owners through
+bases). Tests: 6 new (platform pen + real-floor easing + panic integration on stone-pad arenas;
+jink + hop-pulse + BlendHeading pure) — suite 1331 + 147 green, format clean.
 ### ★ Terrain-aware creature roaming: cliffs are soft walls, no seabed marches, no stranded medusae (#648, 2026-08-01, branch fix/creature-terrain-gates)
 Creatures have no colliders — the server snaps their Y to the habitat height every tick — so terrain
 never blocked movement: a roaming titan crossing a mesa/rift edge got the full cliff height as its

--- a/client/Assets/BlocksBeyondTheStars/Scripts/ClientAudio.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/ClientAudio.cs
@@ -3,6 +3,8 @@
 // This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
 using System.Collections.Generic;
 using BlocksBeyondTheStars.Networking.Messages;
+using BlocksBeyondTheStars.Shared.Geometry;
+using BlocksBeyondTheStars.Shared.Primitives;
 using UnityEngine;
 
 namespace BlocksBeyondTheStars.Client
@@ -150,7 +152,7 @@ namespace BlocksBeyondTheStars.Client
             if (!_subscribed && Game?.Network != null)
             {
                 var n = Game.Network;
-                n.BlockChanged += OnBlock;
+                Game.BlockChangeApplied += OnBlockApplied; // old→new transition, not the raw message (#655)
                 n.CraftCompleted += m =>
                 {
                     // Crafting at the algae tank bubbles (recorded cue) instead of the generic confirm beep.
@@ -555,9 +557,23 @@ namespace BlocksBeyondTheStars.Client
             _ => "wind_light", // rocky / crystal / varied / asteroid → light wind
         };
 
-        private void OnBlock(BlockChanged m)
+        private void OnBlockApplied(Vector3i pos, BlockId oldId, BlockId newId)
         {
-            if (m.Block == 0)
+            // Fluid-sim steps (#655): the server broadcasts EVERY spread/drain cell as a block change, so
+            // flowing water used to hammer the place-knock (and draining water the mining crunch) several
+            // times a second. Water/lava transitions play no per-cell cue — the looping fluid bed IS the
+            // water sound — and instead kick an immediate bed rescan so the rush reacts right away
+            // instead of on the 0.5 s scan beat.
+            string oldKey = Game?.Content?.BlockById(oldId)?.Key ?? string.Empty;
+            string newKey = Game?.Content?.BlockById(newId)?.Key ?? string.Empty;
+            if (oldKey.Contains("water") || oldKey.Contains("lava")
+                || newKey.Contains("water") || newKey.Contains("lava"))
+            {
+                _fluidScanTimer = 0f;
+                return;
+            }
+
+            if (newId.Value == 0)
             {
                 // Mined → a random material variant for variety (material-accurate later).
                 string[] v = { "mine_stone", "mine_metal", "mine_crystal", "mine_dirt" };
@@ -619,7 +635,7 @@ namespace BlocksBeyondTheStars.Client
 
             if (_subscribed && Game?.Network != null)
             {
-                Game.Network.BlockChanged -= OnBlock;
+                Game.BlockChangeApplied -= OnBlockApplied;
                 Game.Network.ShipCombatStatusChanged -= OnShip;
                 Game.Network.PlayerStateUpdated -= OnPlayerHealth;
                 Game.Network.WorldEnvironmentReceived -= OnEnvironment;

--- a/client/Assets/BlocksBeyondTheStars/Scripts/ClientAudio.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/ClientAudio.cs
@@ -573,15 +573,22 @@ namespace BlocksBeyondTheStars.Client
                 return;
             }
 
+            // Positional (#655 follow-up): the cue plays AT the changed cell (scene space — the world wraps
+            // in longitude) instead of flat 2D at full volume. Your own mining target sits well inside the
+            // 4 m full-volume radius so the hand-feel is unchanged; another player's edits across the map
+            // attenuate away instead of knocking in your ear.
+            var at = Game != null
+                ? Game.ScenePos(pos.X + 0.5f, pos.Y + 0.5f, pos.Z + 0.5f)
+                : new Vector3(pos.X + 0.5f, pos.Y + 0.5f, pos.Z + 0.5f);
             if (newId.Value == 0)
             {
                 // Mined → a random material variant for variety (material-accurate later).
                 string[] v = { "mine_stone", "mine_metal", "mine_crystal", "mine_dirt" };
-                Cue(v[_rng.Next(v.Length)]);
+                At(v[_rng.Next(v.Length)], at);
             }
             else
             {
-                Cue("place_block");
+                At("place_block", at);
             }
         }
 

--- a/client/Assets/BlocksBeyondTheStars/Scripts/CreatureView.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/CreatureView.cs
@@ -31,6 +31,11 @@ namespace BlocksBeyondTheStars.Client
             public Vector3 Settled;  // smoothed position (the lunge is added on top for display)
             public Vector3 PrevSettled; // last frame's smoothed position → velocity for facing
             public Vector3 FaceDir;     // smoothed heading the body turns to face (so it doesn't moonwalk)
+            public Vector3 TargetVel;     // velocity estimated from consecutive server updates (#654)
+            public float LastTargetChange; // Time.time of the last authoritative position change (#654)
+            public float PitchDeg;         // smoothed slope pitch (#652) — nose up/down along real motion
+            public float RollDeg;          // smoothed banking roll (#652) — fliers lean into turns
+            public Vector3 PrevFaceDir;    // last frame's facing → heading rate for the banking roll
             public float AttackUntil; // a visible lunge window when attacking
             public GameObject Stasis; // icy-blue stasis shell shown while frozen (item 36)
             public bool Echo;     // cave dwellers' calls get a reverberant echo (item 21)
@@ -84,16 +89,32 @@ namespace BlocksBeyondTheStars.Client
                         Settled = pos,
                         PrevSettled = pos,
                         FaceDir = Vector3.forward,
+                        PrevFaceDir = Vector3.forward,
+                        LastTargetChange = Time.time,
                         PrevHostile = c.Hostile,
                         PrevHull = c.Hull,
                     };
                     _creatures[c.Id] = entry;
                 }
 
+                // Dead reckoning (#654): positions arrive at ~2 Hz, so chasing the newest (stale) target
+                // rounds every dart into the same soft curve. Estimate the velocity from consecutive
+                // updates and extrapolate the target briefly (clamped) — motion reads crisp between
+                // packets and degrades to plain smoothing when updates stall. Teleport-sized jumps
+                // (spawn shove, eviction) reset the estimate instead of predicting through them.
+                if ((pos - entry.Target).sqrMagnitude > 1e-6f)
+                {
+                    float gap = Mathf.Max(0.05f, Time.time - entry.LastTargetChange);
+                    var estimated = (pos - entry.Target) / gap;
+                    entry.TargetVel = estimated.sqrMagnitude > 64f ? Vector3.zero : estimated;
+                    entry.LastTargetChange = Time.time;
+                }
+
                 entry.Target = pos;
-                // Smoothly chase the authoritative position; a visible lunge toward the player is added
-                // on top during an attack so attacks read clearly.
-                entry.Settled = Vector3.Lerp(entry.Settled, entry.Target, Time.deltaTime * 8f);
+                var predicted = entry.Target + entry.TargetVel * Mathf.Min(Time.time - entry.LastTargetChange, 0.3f);
+                // Smoothly chase the (extrapolated) authoritative position; a visible lunge toward the
+                // player is added on top during an attack so attacks read clearly.
+                entry.Settled = Vector3.Lerp(entry.Settled, predicted, Time.deltaTime * 8f);
                 Vector3 lunge = Vector3.zero;
                 if (Time.time < entry.AttackUntil)
                 {
@@ -111,15 +132,38 @@ namespace BlocksBeyondTheStars.Client
                 // Turn the body to face the way it's actually moving (it used to slide/moonwalk — the server never
                 // sent a facing). Derived from the smoothed velocity; held when standing still. Direction is the
                 // same in world + scene space (the scene only offsets for longitude wrap, it doesn't rotate).
-                Vector3 vel = entry.Settled - entry.PrevSettled;
+                // On top of the yaw (#652): bodies pitch along their real vertical motion (a titan descending a
+                // slope noses down instead of levitating level), and fliers bank into turns. Medusae are a bell —
+                // no nose to pitch, no wings to bank.
+                Vector3 vel3 = entry.Settled - entry.PrevSettled;
                 entry.PrevSettled = entry.Settled;
+                Vector3 vel = vel3;
                 vel.y = 0f;
                 if (vel.sqrMagnitude > 1e-5f)
                 {
                     entry.FaceDir = Vector3.Slerp(entry.FaceDir, vel.normalized, 1f - Mathf.Exp(-8f * Time.deltaTime));
+                    bool medusa = string.Equals(c.BodyPlan, "Medusa", System.StringComparison.OrdinalIgnoreCase);
+                    float targetPitch = 0f, targetRoll = 0f;
+                    if (!medusa)
+                    {
+                        float horiz = vel.magnitude;
+                        targetPitch = Mathf.Clamp(
+                            Mathf.Atan2(vel3.y, Mathf.Max(horiz, 0.01f)) * Mathf.Rad2Deg, -25f, 25f);
+                        if (string.Equals(c.Habitat, "Air", System.StringComparison.OrdinalIgnoreCase))
+                        {
+                            float turnRate = Vector3.SignedAngle(entry.PrevFaceDir, entry.FaceDir, Vector3.up)
+                                / Mathf.Max(Time.deltaTime, 1e-4f);
+                            targetRoll = Mathf.Clamp(-turnRate * 0.25f, -20f, 20f);
+                        }
+                    }
+
+                    entry.PrevFaceDir = entry.FaceDir;
+                    entry.PitchDeg = Mathf.Lerp(entry.PitchDeg, targetPitch, 1f - Mathf.Exp(-6f * Time.deltaTime));
+                    entry.RollDeg = Mathf.Lerp(entry.RollDeg, targetRoll, 1f - Mathf.Exp(-6f * Time.deltaTime));
                     if (entry.FaceDir.sqrMagnitude > 1e-4f)
                     {
-                        entry.Root.transform.rotation = Quaternion.LookRotation(entry.FaceDir, Vector3.up);
+                        entry.Root.transform.rotation = Quaternion.LookRotation(entry.FaceDir, Vector3.up)
+                            * Quaternion.Euler(-entry.PitchDeg, 0f, entry.RollDeg);
                     }
                 }
 

--- a/client/Assets/BlocksBeyondTheStars/Scripts/GameBootstrap.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/GameBootstrap.cs
@@ -1927,12 +1927,20 @@ namespace BlocksBeyondTheStars.Client
             }
         }
 
+        /// <summary>Raised after a server block change was applied to the local world: position, the block
+        /// that WAS in the cell and the block that is there now. The raw network message alone cannot tell
+        /// a drained fluid from a mined block — audio needs the transition (#655).</summary>
+        public event System.Action<Vector3i, BlockId, BlockId> BlockChangeApplied;
+
         private void OnBlockChanged(BlocksBeyondTheStars.Networking.Messages.BlockChanged m)
         {
+            var oldId = World.GetBlock(m.X, m.Y, m.Z);
             if (!World.ApplyBlockChange(m.X, m.Y, m.Z, m.Block, m.Tint, m.Glow, m.Shape, out var coord))
             {
                 return;
             }
+
+            BlockChangeApplied?.Invoke(new Vector3i(m.X, m.Y, m.Z), oldId, new BlockId(m.Block));
 
             // A cell that just became solid where we are standing must lift us out, not swallow us: the server
             // allows placing into your own feet cell (pillar jumping), and mid-fall that used to drop the player

--- a/docs/developer/WORLD_GENERATION.md
+++ b/docs/developer/WORLD_GENERATION.md
@@ -276,13 +276,21 @@ despawn beyond 70 blocks (titans 110 — a landmark animal must not evaporate mi
 which species are awake. Bite + aggro ranges grow gently with species size past 2 (bite capped at
 the player's own 6-block attack reach).
 
-**Terrain-aware roaming (#648):** creatures have no colliders — their Y is snapped to the habitat
-height every tick — so movement is gated per step instead (`CreatureBehaviour.TerrainStepBlocked`,
-the same discard-and-re-roll mechanic as the ship hull and energy fences): land walkers accept at
-most a 2-block surface step (titans 1, mirroring their spawn gate) and never enter water deeper
-than 1 cell; water species never step out of their water body; fliers, cave/lava dwellers and
-amphibians are unaffected. Cliffs thus act as soft walls rather than single-tick teleports, and
-nothing can ever get stuck (a blocked step just rolls a fresh heading).
+**Terrain-aware roaming (#648, extended by #650–#654):** creatures have no colliders — their Y is
+kept by the server — so movement is gated per step instead (`CreatureBehaviour.TerrainStepBlocked`,
+the same discard mechanic as the ship hull and energy fences): land walkers accept at most a
+2-block ground step (titans 1, mirroring their spawn gate) and never enter water deeper than
+1 cell; water species never step out of their water body; fliers, cave/lava dwellers and amphibians
+are unaffected. Ground heights come from **real blocks** (#650 — a nearest-standable-cell probe via
+`GetBlockIfLoaded`, generator fallback for unloaded columns), so fauna honours player walls, dug
+pits and built floors, and land walkers **ease** toward the ground at a capped vertical rate (#652;
+fliers ease toward hover — no contour-pen terrain tracing; hoppers keep the snap, their pop is the
+motion, and their stride pulses with it, #654). A blocked step first **probes alternative headings**
+(±35°/±70°/±110°, #651) and only re-rolls when boxed in — contour/wall following with the
+never-stuck property intact. Social species run the full boids trio (#639/#651): cohesion,
+size-scaled separation, and heading alignment for schoolers. Hurting a creature (or a skittish bolt)
+**startles** same-species kin within 12 blocks for 4 s (#653): non-retaliators flee the nearest
+player, retaliators charge, and fleeing prey jinks off the straight escape ray.
 
 ---
 

--- a/src/BlocksBeyondTheStars.GameServer/GameServerCreatures.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerCreatures.cs
@@ -437,7 +437,9 @@ public sealed partial class GameServer
                 }
                 else
                 {
-                    y = surface + (sp.Habitat == CreatureHabitat.Air ? 4f : 1f);
+                    // Land spawns stand on the REAL ground (#650) — a dug pit's floor or a built platform,
+                    // not the generator's original surface (which would float them over player terraforming).
+                    y = sp.Habitat == CreatureHabitat.Air ? surface + 4f : GroundFeetYAt(x, z, surface + 1);
                 }
 
                 var pos = new Vector3f(px + 0.5f, y, pz + 0.5f);
@@ -466,16 +468,18 @@ public sealed partial class GameServer
         return false;
     }
 
-    /// <summary>3×3 flatness gate for titan spawns (#638): every neighbouring column's surface must sit
-    /// within ±1 block of the centre's, and none may be blocked by a landed ship.</summary>
+    /// <summary>3×3 flatness gate for titan spawns (#638): every neighbouring column's ground must sit
+    /// within ±1 block of the centre's. Reads REAL blocks (#650), so a titan neither materialises against
+    /// a player wall nor half-buried in an edited cliff face.</summary>
     private bool TitanGroundClear(int x, int z, int centerSurface)
     {
+        int centerFeet = GroundFeetYAt(x, z, centerSurface + 1);
         for (int dx = -1; dx <= 1; dx++)
         {
             for (int dz = -1; dz <= 1; dz++)
             {
-                int s = _generator.SurfaceHeight(_world.Planet, x + dx, z + dz);
-                if (System.Math.Abs(s - centerSurface) > 1)
+                int feet = GroundFeetYAt(x + dx, z + dz, centerFeet);
+                if (System.Math.Abs(feet - centerFeet) > 1)
                 {
                     return false;
                 }
@@ -537,7 +541,7 @@ public sealed partial class GameServer
                     continue; // herd members need the same level ground the leader did
                 }
 
-                y = surface + (sp.Habitat == CreatureHabitat.Air ? 4f : 1f);
+                y = sp.Habitat == CreatureHabitat.Air ? surface + 4f : GroundFeetYAt(mx, mz, surface + 1); // real ground (#650)
             }
 
             var pos = new Vector3f(mx + 0.5f, y, mz + 0.5f);
@@ -669,6 +673,11 @@ public sealed partial class GameServer
                 creature.ProvokeTimer = System.Math.Max(0, creature.ProvokeTimer - dt);
             }
 
+            if (creature.PanicTimer > 0)
+            {
+                creature.PanicTimer = System.Math.Max(0, creature.PanicTimer - dt); // startle (#653) wears off
+            }
+
             if (creature.AwakeOverrideTimer > 0)
             {
                 creature.AwakeOverrideTimer = System.Math.Max(0, creature.AwakeOverrideTimer - dt);
@@ -725,13 +734,14 @@ public sealed partial class GameServer
             // behaviour (skittish ones flee, hunters seek, others just wander).
             if (!SpeciesActive(sp) && creature.AwakeOverrideTimer <= 0)
             {
-                creature.Position = AdjustHabitatHeight(sp, creature.Position, 0f, profile);
+                creature.Position = AdjustHabitatHeight(sp, creature.Position, 0f, profile, moveDt);
                 continue;
             }
 
             // Decide intent: hunters Seek a nearby player, skittish flee one, everyone else (and a give-up
             // aggressor) roams with stop-and-go. Pack-hunters angle their approach so kin converge from spread
-            // directions (encircle) rather than all stacking on one beeline.
+            // directions (encircle) rather than all stacking on one beeline. A startled non-retaliator (#653)
+            // flees too — panic reaches further than the skittish reflex and moves even placid grazers.
             var intent = MoveMode.Roam;
             Vector3f? target = null;
             Vector3f? stepTarget = aggressor && creature.GiveUpTimer > 0 ? null : nearest;
@@ -749,34 +759,59 @@ public sealed partial class GameServer
                     intent = MoveMode.Flee;
                     target = tp;
                 }
+                else if (creature.PanicTimer > 0 && dist <= CreaturePanicFleeRange
+                         && !CreatureBehaviour.RetaliatesWhenAttacked(temperament))
+                {
+                    intent = MoveMode.Flee;
+                    target = tp;
+                }
+            }
+
+            // A skittish animal BOLTING (entering flee) startles its nearby kin (#653) — the whole herd
+            // takes off together. Only the genuine reflex spreads panic; already-panicked members don't
+            // re-trigger it, so a startled herd settles back down instead of chain-panicking forever.
+            if (intent == MoveMode.Flee && temperament == CreatureTemperament.Skittish
+                && creature.PanicTimer <= 0 && creature.Loco.Mode != MoveMode.Flee)
+            {
+                StartleKin(creature);
             }
 
             uint seed = (uint)StableStringHash(creature.Id);
             var res = LocomotionController.Step(creature.Loco, profile, creature.Position, intent, target, moveDt, seed);
             creature.Loco = res.State;
 
-            // Group cohesion (#639): a roaming member of a social species drifts gently toward its
-            // nearby kin, so a spawned herd/school/flock stays loosely together instead of dissolving.
-            // A gentle positional pull only — fleeing/hunting always wins, and loners are unaffected.
+            // Group steering (#639/#651): a roaming member of a social species drifts gently toward its
+            // nearby kin (cohesion), keeps its personal space (separation) and — for schoolers — falls in
+            // with the group's heading (alignment). Fleeing/hunting always wins, loners are unaffected.
             var stepped = res.Position;
             if (intent == MoveMode.Roam && sp.SocialGroupSize > 1 && res.Moving)
             {
-                stepped = PullTowardGroup(creature, sp, stepped, moveDt, profile.CruiseSpeed);
+                stepped = GroupSteer(creature, sp, stepped, moveDt, profile);
             }
 
             // Follow the world as they roam: land/lava walkers track the ground (hoppers pop up), fliers hover +
             // swoop, swimmers porpoise through the water column — driven by the per-creature vertical wave.
-            var next = AdjustHabitatHeight(sp, stepped, res.VertWave, profile);
+            var next = AdjustHabitatHeight(sp, stepped, res.VertWave, profile, moveDt);
 
             // Creatures don't walk into the player's ship — hold position at the hull. Energy fences
-            // pen them in the same way, and terrain gates (#648) reuse the exact same mechanic: cliffs
-            // are soft walls (no more single-tick teleports up a rock face), land animals stay out of
-            // deep water and water animals stay in it. The step is discarded and a fresh heading is
-            // rolled next tick, so a blocked creature keeps milling about instead of getting stuck.
+            // pen them in the same way, and terrain gates (#648) reuse the exact same mechanic. Instead of
+            // only re-rolling a random heading, a blocked creature first probes alternative headings around
+            // the obstacle (#651) — so it slides along cliff bases, walls and fence lines like an animal
+            // skirting an obstacle. Only when every probe is blocked too does it fall back to the re-roll,
+            // which preserves the "nothing can ever get stuck" property.
             if (EntityBlockedByShip(next) || BlockedByEnergyFence(creature.Position, next)
                 || StepBlockedByTerrain(sp, creature.Position, next))
             {
-                creature.Loco.ModeTimer = 0f;
+                if (TrySteerAround(creature, sp, res.Position, res.VertWave, profile, moveDt,
+                        out var detour, out float detourHeading))
+                {
+                    creature.Loco.Heading = detourHeading;
+                    creature.Position = detour;
+                }
+                else
+                {
+                    creature.Loco.ModeTimer = 0f; // boxed in — re-roll a fresh heading next tick
+                }
             }
             else
             {
@@ -785,10 +820,78 @@ public sealed partial class GameServer
         }
     }
 
-    /// <summary>Feeds the world's column data (surface heights + water depths) into the pure
+    private const float CreaturePanicRadius = 12f;    // how far a startle (#653) spreads to same-species kin
+    private const double CreaturePanicSeconds = 4.0;  // how long the startle lasts
+    private const float CreaturePanicFleeRange = 24f; // a panicked animal flees players well past the skittish reflex
+
+    /// <summary>Startles a hurt/bolting creature's same-species kin within <see cref="CreaturePanicRadius"/>
+    /// (#653): non-retaliators among them flee the nearest player while their timer runs. The source itself is
+    /// startled too (a hurt passive grazer bolts even though nothing else scares it).</summary>
+    private void StartleKin(CombatEntity source)
+    {
+        source.PanicTimer = System.Math.Max(source.PanicTimer, CreaturePanicSeconds);
+        foreach (var other in _creatures)
+        {
+            if (ReferenceEquals(other, source) || other.IsCompanion || other.SpeciesId != source.SpeciesId)
+            {
+                continue;
+            }
+
+            if (WrapDistSq(other.Position, source.Position) <= CreaturePanicRadius * CreaturePanicRadius)
+            {
+                other.PanicTimer = System.Math.Max(other.PanicTimer, CreaturePanicSeconds);
+            }
+        }
+    }
+
+    private static readonly float[] SteerOffsets = { 0.61f, 1.22f, 1.92f }; // ±35°, ±70°, ±110°
+
+    /// <summary>Probes alternative headings around a blocked step (#651): the intended step length swung
+    /// ±35°/±70°/±110° off the blocked heading (side order fixed per individual, so a herd doesn't wheel in
+    /// unison), first candidate that passes every barrier wins and becomes the new heading — contour/wall
+    /// following. Returns false when all probes are blocked (caller falls back to the heading re-roll).</summary>
+    private bool TrySteerAround(CombatEntity c, CreatureSpecies sp, Vector3f stepped, float vertWave,
+        in LocomotionProfile prof, double dt, out Vector3f detour, out float heading)
+    {
+        detour = default;
+        heading = 0f;
+        float dx = stepped.X - c.Position.X, dz = stepped.Z - c.Position.Z;
+        float len = (float)System.Math.Sqrt(dx * dx + dz * dz);
+        if (len < 1e-5f)
+        {
+            return false; // not actually moving — nothing to steer
+        }
+
+        float baseHeading = (float)System.Math.Atan2(dz, dx);
+        float side = (StableStringHash(c.Id) & 1) == 0 ? 1f : -1f;
+        foreach (float off in SteerOffsets)
+        {
+            for (int s = 0; s < 2; s++)
+            {
+                float h = baseHeading + off * (s == 0 ? side : -side);
+                var cand = new Vector3f(
+                    c.Position.X + (float)System.Math.Cos(h) * len,
+                    c.Position.Y,
+                    c.Position.Z + (float)System.Math.Sin(h) * len);
+                var adjusted = AdjustHabitatHeight(sp, cand, vertWave, prof, dt);
+                if (!EntityBlockedByShip(adjusted) && !BlockedByEnergyFence(c.Position, adjusted)
+                    && !StepBlockedByTerrain(sp, c.Position, adjusted))
+                {
+                    detour = adjusted;
+                    heading = h;
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>Feeds the world's column data (ground heights + water depths) into the pure
     /// <see cref="CreatureBehaviour.TerrainStepBlocked"/> gate (#648). Only consulted when the step
     /// actually crosses a column boundary, and only for the habitats the gate cares about — so the
-    /// extra generator queries stay off the common same-column tick.</summary>
+    /// extra world queries stay off the common same-column tick. Ground heights come from REAL blocks
+    /// (#650), so player-built walls read as impassable steps and dug ramps as walkable ones.</summary>
     private bool StepBlockedByTerrain(CreatureSpecies sp, Vector3f cur, Vector3f next)
     {
         if (sp.Habitat != CreatureHabitat.Land && sp.Habitat != CreatureHabitat.Water)
@@ -803,25 +906,64 @@ public sealed partial class GameServer
             return false; // same column — nothing to gate
         }
 
-        int curSurface = _generator.SurfaceHeight(_world.Planet, cx, cz);
-        int nextSurface = _generator.SurfaceHeight(_world.Planet, nx, nz);
+        int refY = (int)System.Math.Floor(cur.Y);
+        int curFeet = GroundFeetYAt(cx, cz, refY);
+        int nextFeet = GroundFeetYAt(nx, nz, refY);
         int curDepth = _generator.TryGetWaterSurface(_world.Planet, cx, cz, out int curTop, out int curBed)
             ? curTop - curBed : 0;
         int nextDepth = _generator.TryGetWaterSurface(_world.Planet, nx, nz, out int nextTop, out int nextBed)
             ? nextTop - nextBed : 0;
-        return CreatureBehaviour.TerrainStepBlocked(sp.Habitat, sp.BodyPlan, curSurface, nextSurface, curDepth, nextDepth);
+        return CreatureBehaviour.TerrainStepBlocked(sp.Habitat, sp.BodyPlan, curFeet, nextFeet, curDepth, nextDepth);
+    }
+
+    /// <summary>The standable feet cell in a column nearest to <paramref name="refY"/> (#650), read from
+    /// REAL blocks via <see cref="ServerWorld.GetBlockIfLoaded"/> (unloaded chunks read as air and fall
+    /// through to the generator surface — today's behaviour). Scanned outward from the reference, downward
+    /// first at equal distance, so a creature under a player bridge keeps the ground instead of snapping
+    /// onto the deck. This is what makes fauna honour player builds: dug pits, ramps, walls, floors.</summary>
+    private int GroundFeetYAt(int x, int z, int refY)
+    {
+        for (int r = 0; r <= 6; r++)
+        {
+            if (StandableAt(x, refY - r, z))
+            {
+                return refY - r;
+            }
+
+            if (r > 0 && StandableAt(x, refY + r, z))
+            {
+                return refY + r;
+            }
+        }
+
+        return _generator.SurfaceHeight(_world.Planet, x, z) + 1;
+    }
+
+    /// <summary>Whether feet placed at <paramref name="y"/> stand on something real: solid (non-water)
+    /// support below, air at feet and head height. Uses the no-load block read.</summary>
+    private bool StandableAt(int x, int y, int z)
+    {
+        var below = _world.GetBlockIfLoaded(new Vector3i(x, y - 1, z));
+        return !below.IsAir && below.Value != _creatureWaterId
+            && _world.GetBlockIfLoaded(new Vector3i(x, y, z)).IsAir
+            && _world.GetBlockIfLoaded(new Vector3i(x, y + 1, z)).IsAir;
     }
 
     private const float GroupCohesionRange = 24f;   // kin within this count toward the group centre (#639)
     private const float GroupCohesionMinDist = 3f;  // close enough — no pull (herds shouldn't stack up)
 
-    /// <summary>Nudges a social creature's step toward the centre of its same-species neighbours within
-    /// <see cref="GroupCohesionRange"/> (#639). Plain-coordinate scan (the odd seam-straddling herd just
-    /// loses cohesion for a moment); O(n) per social creature against a ≤64-entity list, at 15 Hz.</summary>
-    private Vector3f PullTowardGroup(CombatEntity self, CreatureSpecies sp, Vector3f stepped, double dt, float cruise)
+    /// <summary>The boids trio for a social creature's roam step (#639/#651): <b>cohesion</b> toward the
+    /// centre of same-species neighbours within <see cref="GroupCohesionRange"/>, <b>separation</b> away
+    /// from the nearest kin when it is inside the personal-space bubble (size-scaled — titans stop standing
+    /// inside each other), and <b>alignment</b> for schooler-style species (the heading eases toward the kin
+    /// average, so schools/flocks actually swim/fly as one). Plain-coordinate scan (the odd seam-straddling
+    /// herd just loses cohesion for a moment); O(n) per social creature against a ≤64-entity list, at 15 Hz.</summary>
+    private Vector3f GroupSteer(CombatEntity self, CreatureSpecies sp, Vector3f stepped, double dt, in LocomotionProfile prof)
     {
         float cx = 0f, cz = 0f;
         int kin = 0;
+        float nearestSq = float.MaxValue, nearX = 0f, nearZ = 0f;
+        float headSin = 0f, headCos = 0f;
         foreach (var other in _creatures)
         {
             if (ReferenceEquals(other, self) || other.IsCompanion || other.SpeciesId != self.SpeciesId)
@@ -830,11 +972,22 @@ public sealed partial class GameServer
             }
 
             float dx = other.Position.X - stepped.X, dz = other.Position.Z - stepped.Z;
-            if (dx * dx + dz * dz <= GroupCohesionRange * GroupCohesionRange)
+            float distSq = dx * dx + dz * dz;
+            if (distSq > GroupCohesionRange * GroupCohesionRange)
             {
-                cx += other.Position.X;
-                cz += other.Position.Z;
-                kin++;
+                continue;
+            }
+
+            cx += other.Position.X;
+            cz += other.Position.Z;
+            headSin += (float)System.Math.Sin(other.Loco.Heading);
+            headCos += (float)System.Math.Cos(other.Loco.Heading);
+            kin++;
+            if (distSq < nearestSq)
+            {
+                nearestSq = distSq;
+                nearX = other.Position.X;
+                nearZ = other.Position.Z;
             }
         }
 
@@ -843,17 +996,35 @@ public sealed partial class GameServer
             return stepped; // no kin in range — roam free
         }
 
-        float tx = cx / kin - stepped.X, tz = cz / kin - stepped.Z;
+        var pos = stepped;
+        float tx = cx / kin - pos.X, tz = cz / kin - pos.Z;
         float dist = (float)System.Math.Sqrt(tx * tx + tz * tz);
-        if (dist <= GroupCohesionMinDist)
+        if (dist > GroupCohesionMinDist)
         {
-            return stepped; // already with the group
+            // Cohesion: pull a fraction of the cruise step toward the centroid — strongest when far.
+            float k = System.Math.Min(1f, (dist - GroupCohesionMinDist) / GroupCohesionRange);
+            float pull = prof.CruiseSpeed * 0.35f * k * (float)dt / dist;
+            pos = new Vector3f(pos.X + tx * pull, pos.Y, pos.Z + tz * pull);
         }
 
-        // Pull a fraction of the cruise step toward the centroid — strongest when far, fading near it.
-        float k = System.Math.Min(1f, (dist - GroupCohesionMinDist) / GroupCohesionRange);
-        float pull = cruise * 0.35f * k * (float)dt / dist;
-        return new Vector3f(stepped.X + tx * pull, stepped.Y, stepped.Z + tz * pull);
+        // Separation (#651): personal space scaled by species size, so herd members never overlap bodies.
+        float sepDist = System.Math.Max(1.5f, sp.Size * 0.6f);
+        float nd = (float)System.Math.Sqrt(nearestSq);
+        if (nd > 1e-4f && nd < sepDist)
+        {
+            float push = System.Math.Min(sepDist - nd, (float)(prof.CruiseSpeed * dt));
+            pos = new Vector3f(pos.X + (pos.X - nearX) / nd * push, pos.Y, pos.Z + (pos.Z - nearZ) / nd * push);
+        }
+
+        // Alignment (#651): schoolers fall in with the group's average heading (bounded ease per tick).
+        if (sp.LocoStyle == LocomotionStyle.Schooler)
+        {
+            float avg = (float)System.Math.Atan2(headSin / kin, headCos / kin);
+            self.Loco.Heading = CreatureBehaviour.BlendHeading(
+                self.Loco.Heading, avg, (float)System.Math.Min(1.0, 1.5 * dt));
+        }
+
+        return pos;
     }
 
     /// <summary>Pushes any WILD creature standing inside a parked ship's hull back outside (companions are left
@@ -901,23 +1072,27 @@ public sealed partial class GameServer
     private const float CreatureFlyAltitude = 5f; // how high above the ground fliers hover
 
     /// <summary>Habitat Y-snap for a one-off placement (spawn / teleport) — no vertical-life wave.</summary>
-    private Vector3f AdjustHabitatHeight(CreatureSpecies sp, Vector3f p) => AdjustHabitatHeight(sp, p, 0f, default);
+    private Vector3f AdjustHabitatHeight(CreatureSpecies sp, Vector3f p)
+        => AdjustHabitatHeight(sp, p, 0f, default, double.PositiveInfinity);
 
-    /// <summary>Snaps a creature's Y to suit its habitat as it roams: land/lava walk on the ground (hoppers pop
-    /// up on their hop beat), fliers hover above it (gliders swoop), swimmers porpoise between the seabed and the
-    /// surface. <paramref name="vertWave"/> is the creature's own vertical-life wave (sin, ∈ [-1,1]) and
-    /// <paramref name="prof"/> supplies its amplitude — so each animal's vertical motion is its own, not a shared
-    /// global sine.</summary>
-    private Vector3f AdjustHabitatHeight(CreatureSpecies sp, Vector3f p, float vertWave, in LocomotionProfile prof)
+    /// <summary>Keeps a creature's Y suited to its habitat as it roams: land walkers track the REAL ground
+    /// (#650 — dug pits and built floors included) at a capped vertical rate (#652 — no more stair-step
+    /// teleports; hoppers keep the snap, their pop IS the motion), fliers ease toward hover + swoop, swimmers
+    /// porpoise the water column. <paramref name="vertWave"/> is the creature's own vertical-life wave
+    /// (sin, ∈ [-1,1]) and <paramref name="prof"/> supplies its amplitude. <paramref name="dt"/> drives the
+    /// vertical easing — pass <see cref="double.PositiveInfinity"/> for a one-off placement snap.</summary>
+    private Vector3f AdjustHabitatHeight(CreatureSpecies sp, Vector3f p, float vertWave, in LocomotionProfile prof, double dt)
     {
         int surface = _generator.SurfaceHeight(_world.Planet, (int)System.Math.Floor(p.X), (int)System.Math.Floor(p.Z));
         switch (sp.Habitat)
         {
             case CreatureHabitat.Air:
-                // Hover above the ground at the species' own altitude (#637 — 0 = the legacy default),
-                // so the sky gets layers; gliders/drifters swoop up and down on their own wave.
+                // Hover above the ground at the species' own altitude (#637 — 0 = the legacy default), the
+                // gliders/drifters swooping on their own wave. Altitude is EASED (#652), so a flier glides
+                // over gullies and boulders instead of tracing every terrain dimple like a contour pen.
                 float hover = sp.HoverAltitude > 0f ? sp.HoverAltitude : CreatureFlyAltitude;
-                return new Vector3f(p.X, surface + hover + prof.VertAmp * vertWave, p.Z);
+                float airTarget = surface + hover + prof.VertAmp * vertWave;
+                return new Vector3f(p.X, EaseY(p.Y, airTarget, dt, rate: 4.0, snapBeyond: 24f), p.Z);
             case CreatureHabitat.Water:
                 // Use the LOCAL water column (sea or upland pond) — not just the global sea level — so swimmers
                 // stay submerged in the upland lakes they were spawned in, not only the deep sea.
@@ -961,11 +1136,37 @@ public sealed partial class GameServer
 
                 return new Vector3f(p.X, surface + 1f, p.Z); // genuinely ashore → waddle on land
             default:
-                // Land creatures follow the ground. Hoppers (and floaty drifters) pop up on their own
-                // wave; everyone else has VertAmp 0 and walks flat.
-                float pop = prof.VertAmp > 0f ? System.Math.Max(0f, prof.VertAmp * vertWave) : 0f;
-                return new Vector3f(p.X, surface + 1f + pop, p.Z);
+                // Land creatures follow the REAL ground (#650): player floors, dug ramps and pit bottoms,
+                // falling back to the generator surface where no blocks are loaded. Poppers (hoppers, floaty
+                // drifters) keep the snap — their vertical wave IS the motion; everyone else eases toward the
+                // ground at a capped rate (#652) so slopes read as walking, not stair-step teleports. The
+                // #648 gates bound every legal step to ≤2 blocks of relief, which is what makes easing safe.
+                int feet = GroundFeetYAt((int)System.Math.Floor(p.X), (int)System.Math.Floor(p.Z),
+                    (int)System.Math.Floor(p.Y));
+                if (prof.VertAmp > 0f)
+                {
+                    float pop = System.Math.Max(0f, prof.VertAmp * vertWave);
+                    return new Vector3f(p.X, feet + pop, p.Z);
+                }
+
+                return new Vector3f(p.X, EaseY(p.Y, feet, dt, rate: 6.0, snapBeyond: 4f), p.Z);
         }
+    }
+
+    /// <summary>Moves a Y toward its habitat target at a capped vertical rate (#652). Snaps outright for
+    /// one-off placements (infinite <paramref name="dt"/>) and whenever the gap exceeds
+    /// <paramref name="snapBeyond"/> (spawn, teleport, shove — easing across such a gap would look like
+    /// levitation and could lag through terrain).</summary>
+    private static float EaseY(float cur, float target, double dt, double rate, float snapBeyond)
+    {
+        float d = target - cur;
+        if (double.IsPositiveInfinity(dt) || System.Math.Abs(d) > snapBeyond)
+        {
+            return target;
+        }
+
+        float maxStep = (float)(rate * dt);
+        return System.Math.Abs(d) <= maxStep ? target : cur + System.Math.Sign(d) * maxStep;
     }
 
     /// <summary>Finds a standable cave floor (an air pocket on solid ground, with headroom) in a column, scanning

--- a/src/BlocksBeyondTheStars.GameServer/GameServerEnemies.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerEnemies.cs
@@ -514,6 +514,13 @@ public sealed partial class GameServer
             : 15f + tool.Tier * 10f;
         target.Hull -= damage;
 
+        if (isCreature)
+        {
+            // Any hit — surviving or fatal — startles the victim's nearby kin (#653): non-retaliating
+            // herd members scatter instead of grazing on beside the corpse; retaliators charge instead.
+            StartleKin(target);
+        }
+
         if (target.Hull > 0f)
         {
             // A surviving creature that retaliates (territorial / already hostile) is provoked:

--- a/src/BlocksBeyondTheStars.GameServer/GameServerSpaceCombat.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerSpaceCombat.cs
@@ -75,6 +75,11 @@ public sealed class CombatEntity
     /// decays each tick, after which it settles back to sleep. Server-only.</summary>
     public double AwakeOverrideTimer { get; set; }
 
+    /// <summary>Seconds this creature stays startled (#653): set on itself and its nearby same-species kin when
+    /// one of them is hurt or bolts. While &gt; 0 a NON-retaliating creature flees the nearest player; retaliators
+    /// ignore it (they charge instead). Server-only, never persisted.</summary>
+    public double PanicTimer { get; set; }
+
     /// <summary>What this entity drops when destroyed.</summary>
     public List<ItemAmount> Loot { get; set; } = new();
 

--- a/src/BlocksBeyondTheStars.GameServer/GameServerTaming.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerTaming.cs
@@ -527,7 +527,7 @@ public sealed partial class GameServer
         var res = LocomotionController.FollowStep(
             c.Loco, profile, c.Position, owner.State.Position, CompanionFollowDistance, moveDt, Hash(c.Id, "wander"));
         c.Loco = res.State;
-        var next = AdjustHabitatHeight(sp, res.Position, res.VertWave, profile);
+        var next = AdjustHabitatHeight(sp, res.Position, res.VertWave, profile, moveDt);
         // Companions respect energy fences like wild fauna do — a penned companion stays penned even
         // when its owner steps out through the gate membrane (that is the point of the pen).
         if (EntityBlockedByShip(next) || BlockedByEnergyFence(c.Position, next))

--- a/src/BlocksBeyondTheStars.Shared/Definitions/CreatureBehaviour.cs
+++ b/src/BlocksBeyondTheStars.Shared/Definitions/CreatureBehaviour.cs
@@ -162,6 +162,17 @@ public static class CreatureBehaviour
         }
     }
 
+    /// <summary>Blends a heading toward a target heading by fraction <paramref name="t"/> (0..1) along the
+    /// SHORT way around the circle (#651 — school/flock alignment). Pure and wrap-safe, so ±π seams never
+    /// produce a spin the long way round.</summary>
+    public static float BlendHeading(float current, float target, float t)
+    {
+        float diff = target - current;
+        while (diff > System.Math.PI) diff -= 6.2831853f;
+        while (diff < -System.Math.PI) diff += 6.2831853f;
+        return current + diff * System.Math.Clamp(t, 0f, 1f);
+    }
+
     /// <summary>
     /// Whether a creature fights back when attacked. Already-hostile hunters do; <b>territorial</b>
     /// species turn hostile when provoked; passive grazers and skittish fleers do not retaliate.

--- a/src/BlocksBeyondTheStars.Shared/Definitions/LocomotionController.cs
+++ b/src/BlocksBeyondTheStars.Shared/Definitions/LocomotionController.cs
@@ -121,6 +121,14 @@ public static class LocomotionController
 
             s.WeavePhase += ft * p.WeaveFreq;
             desired += (float)System.Math.Sin(s.WeavePhase) * p.WeaveAmp * 0.4f;
+            if (intent == MoveMode.Flee)
+            {
+                // Jink (#653): fleeing prey zig-zags off the direct escape ray instead of running a straight,
+                // perfectly predictable line. Rides the weave phase (faster beat) so it stays deterministic;
+                // the turn-rate clamp below keeps the flips from snapping.
+                desired += (float)System.Math.Sin(s.WeavePhase * 2.7f) * 0.6f;
+            }
+
             targetSpeed = p.BurstSpeed > 0f ? p.BurstSpeed : p.CruiseSpeed;
         }
         else
@@ -169,6 +177,13 @@ public static class LocomotionController
         s.VertPhase += ft * p.VertFreq;
 
         float move = s.Speed * ft;
+        if (p.Style == LocomotionStyle.Hopper && p.VertAmp > 0f)
+        {
+            // Real hops (#654): the horizontal stride pulses with the vertical pop — a light ground shuffle
+            // between hops, the full stride at the peak — instead of a constant glide with a cosmetic bob.
+            move *= 0.25f + 0.75f * System.Math.Max(0f, (float)System.Math.Sin(s.VertPhase));
+        }
+
         var pos = new Vector3f(
             cur.X + (float)System.Math.Cos(s.Heading) * move,
             cur.Y,

--- a/tests/BlocksBeyondTheStars.Tests/CreatureTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/CreatureTests.cs
@@ -718,6 +718,198 @@ public sealed class CreatureTests : IDisposable
         Assert.False(CreatureBehaviour.TerrainStepBlocked(CreatureHabitat.Amphibian, CreatureBodyPlan.Standard, 64, 64, 4, 0));
     }
 
+    // ---------------- Real-block terrain, panic & alignment (#650/#651/#652/#653) ----------------
+
+    /// <summary>Topmost non-air block Y in a column, read from the real world (generates the chunk).</summary>
+    private static int SurfaceTopY(SvGameServer server, int x, int z)
+    {
+        for (int y = 200; y > -200; y--)
+        {
+            if (!server.World.GetBlock(new Vector3i(x, y, z)).IsAir)
+            {
+                return y;
+            }
+        }
+
+        return 0;
+    }
+
+    /// <summary>Forces roster slot 0 into a plain, always-awake, solitary land walker so the terrain
+    /// probes and gates fully apply to it (traits are read live each tick; the cached locomotion
+    /// profile keeps its rolled speed, which these tests don't depend on).</summary>
+    private static CreatureSpecies ForcePlainLandWalker(SvGameServer server)
+    {
+        var sp = server.SpeciesRoster.First();
+        sp.Habitat = CreatureHabitat.Land;
+        sp.Temperament = CreatureTemperament.Passive;
+        sp.Activity = CreatureActivity.Cathemeral;
+        sp.BodyPlan = CreatureBodyPlan.Standard;
+        sp.SocialGroupSize = 1;
+        return sp;
+    }
+
+    /// <summary>Highest natural block top over a square area — used to place test arenas safely above
+    /// any terrain feature (jungle hills, tree crowns) so natural blocks can never interfere.</summary>
+    private static int MaxTopY(SvGameServer server, int cx, int cz, int r)
+    {
+        int max = int.MinValue;
+        for (int dx = -r; dx <= r; dx++)
+        {
+            for (int dz = -r; dz <= r; dz++)
+            {
+                max = System.Math.Max(max, SurfaceTopY(server, cx + dx, cz + dz));
+            }
+        }
+
+        return max;
+    }
+
+    /// <summary>Builds a flat stone pad (one solid layer) at <paramref name="padY"/> — a fully
+    /// controlled arena floating above all natural terrain, so the real-block tests are deterministic.</summary>
+    private void BuildPad(SvGameServer server, int cx, int cz, int r, int padY)
+    {
+        var stone = _content.GetBlock("stone")!.NumericId;
+        for (int dx = -r; dx <= r; dx++)
+        {
+            for (int dz = -r; dz <= r; dz++)
+            {
+                server.World.SetBlock(new Vector3i(cx + dx, padY, cz + dz), stone);
+            }
+        }
+    }
+
+    [Fact]
+    public void RealBlocks_ARaisedStonePlatform_CarriesAndPens_ARoamingCreature()
+    {
+        // #650: the platform floats 8+ blocks above anything natural — invisible to the old noise-based
+        // movement (the creature would have snapped down through the slabs and wandered off). With
+        // real-block ground it must stand ON the platform, and the edge is an 8-block cliff, so it
+        // must also stay on it for as long as we care to simulate.
+        var server = Started("jungle", out var repo);
+        using (repo)
+        {
+            var p = server.AddLocalPlayer("Builder");
+            p.State.AboardShip = false;
+            ForcePlainLandWalker(server);
+
+            const int cx = 40, cz = 40;
+            int baseY = MaxTopY(server, cx, cz, 6) + 8;
+            BuildPad(server, cx, cz, 4, baseY);
+
+            p.State.Position = new Vector3f(cx + 10, baseY + 1, cz);
+            string id = server.SpawnCreatureAtForTest(new Vector3f(cx + 0.5f, baseY + 1, cz + 0.5f));
+
+            for (int i = 0; i < 100; i++)
+            {
+                server.TickForTest(0.2);
+            }
+
+            var c = server.Creatures.First(x => x.Id == id);
+            Assert.True(
+                System.Math.Abs(c.Position.X - (cx + 0.5f)) <= 4.6f
+                && System.Math.Abs(c.Position.Z - (cz + 0.5f)) <= 4.6f,
+                $"the platform edge is an 8-block cliff — the creature must stay on it (ended at {c.Position.X:F1}/{c.Position.Z:F1}, centre {cx + 0.5f}/{cz + 0.5f})");
+            Assert.True(System.Math.Abs(c.Position.Y - (baseY + 1)) <= 1.6f,
+                $"it must stand on the REAL platform floor, not the noise surface far below (Y {c.Position.Y:F1}, platform feet {baseY + 1})");
+        }
+    }
+
+    [Fact]
+    public void RealBlocks_ACreature_EasesDownOntoTheRealFloor_InsteadOfHoldingItsOldHeight()
+    {
+        // #650 + #652: a creature placed above a real stone floor must settle DOWN onto it at the
+        // capped vertical rate — the old code would have held it at the generator surface forever
+        // when the actual ground differed.
+        var server = Started("jungle", out var repo);
+        using (repo)
+        {
+            var p = server.AddLocalPlayer("Digger");
+            p.State.AboardShip = false;
+            ForcePlainLandWalker(server);
+
+            const int cx = -40, cz = -40;
+            int padY = MaxTopY(server, cx, cz, 6) + 8;
+            BuildPad(server, cx, cz, 4, padY);
+
+            p.State.Position = new Vector3f(cx + 8, padY + 1, cz);
+            // Plant it 3 blocks above the pad (inside the easing window, below the snap threshold).
+            string id = server.SpawnCreatureAtForTest(new Vector3f(cx + 0.5f, padY + 4, cz + 0.5f));
+
+            for (int i = 0; i < 6; i++)
+            {
+                server.TickForTest(0.2);
+            }
+
+            var c = server.Creatures.First(x => x.Id == id);
+            Assert.True(System.Math.Abs(c.Position.Y - (padY + 1)) <= 1.2f,
+                $"it must settle onto the real pad floor (Y {c.Position.Y:F1}, pad feet {padY + 1})");
+        }
+    }
+
+    [Fact]
+    public void HurtingOneHerdMember_StartlesItsKin_WhoFleeThePlayer()
+    {
+        // #653: shooting one animal must panic its same-species kin nearby — they flee the player even
+        // though they are passive (non-retaliating) — and the startle wears off again. Runs on a large
+        // flat stone pad so no terrain gate can pin the fleeing kin in place.
+        var server = Started("jungle", out var repo);
+        using (repo)
+        {
+            var p = server.AddLocalPlayer("Hunter");
+            p.State.AboardShip = false;
+            ForcePlainLandWalker(server);
+
+            const int cx = 60, cz = 60;
+            int padY = MaxTopY(server, cx, cz, 11) + 8;
+            BuildPad(server, cx, cz, 10, padY);
+
+            p.State.Position = new Vector3f(cx + 0.5f, padY + 1, cz + 0.5f);
+            string idA = server.SpawnCreatureAtForTest(new Vector3f(cx + 3.5f, padY + 1, cz + 0.5f));
+            string idB = server.SpawnCreatureAtForTest(new Vector3f(cx + 6.5f, padY + 1, cz + 0.5f));
+            var victim = server.Creatures.First(x => x.Id == idA);
+            victim.Hull = 9999f; // survives the swing — panic must not need a kill
+
+            server.AttackEntity("Hunter", idA);
+
+            var kin = server.Creatures.First(x => x.Id == idB);
+            Assert.True(kin.PanicTimer > 0, "a hit must startle same-species kin within the panic radius");
+
+            float before = kin.Position.DistanceSquared(p.State.Position);
+            for (int i = 0; i < 10; i++)
+            {
+                server.TickForTest(0.2);
+            }
+
+            float after = kin.Position.DistanceSquared(p.State.Position);
+            Assert.True(after > before, $"a startled passive must flee the player (dist² {before:F1} → {after:F1})");
+
+            for (int i = 0; i < 25 && kin.PanicTimer > 0; i++)
+            {
+                server.TickForTest(0.2);
+            }
+
+            Assert.Equal(0.0, kin.PanicTimer); // the startle wears off — the herd settles again
+        }
+    }
+
+    [Fact]
+    public void BlendHeading_TakesTheShortWayAroundTheSeam()
+    {
+        // #651 alignment helper: blending across the ±π seam must rotate the short way.
+        float full = CreatureBehaviour.BlendHeading(3.0f, -3.0f, 1f);
+        Assert.Equal(0f, WrapAngle(full - (-3.0f)), 3);
+
+        float half = CreatureBehaviour.BlendHeading(0f, 1.5707964f, 0.5f);
+        Assert.Equal(0.7853982f, half, 3);
+    }
+
+    private static float WrapAngle(float a)
+    {
+        while (a > System.Math.PI) a -= 6.2831853f;
+        while (a < -System.Math.PI) a += 6.2831853f;
+        return a;
+    }
+
     // ---------------- Territorial retaliation (provoke) ----------------
 
     [Fact]

--- a/tests/BlocksBeyondTheStars.Tests/LocomotionControllerTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/LocomotionControllerTests.cs
@@ -205,6 +205,67 @@ public sealed class LocomotionControllerTests
         Assert.Equal(prof.TurnRate, prof2.TurnRate, 5);
     }
 
+    [Fact]
+    public void Flee_Jinks_InsteadOfRunningAStraightRay()
+    {
+        // #653: with a weave configured, a fleer's heading must swing to BOTH sides of the direct
+        // escape ray (zig-zag), not hold one straight line — and stay deterministic.
+        var p = Roamer(cruise: 3f, turn: 6f);
+        p.WeaveAmp = 0.3f;
+        p.WeaveFreq = 1.4f;
+
+        var s = default(LocomotionState);
+        var pos = new Vector3f(0, 0, 0);
+        var threat = new Vector3f(-30, 0, 0); // directly behind → escape ray points at +X (heading 0)
+        float minDev = 999f, maxDev = -999f;
+        for (int i = 0; i < 200; i++)
+        {
+            var r = LocomotionController.Step(s, p, pos, MoveMode.Flee, threat, 0.05, 9u);
+            s = r.State; pos = r.Position;
+            if (i > 20) // let the turn inertia settle onto the escape ray first
+            {
+                float dev = WrapPi(r.Facing); // deviation from the +X escape heading
+                if (dev < minDev) minDev = dev;
+                if (dev > maxDev) maxDev = dev;
+            }
+        }
+
+        Assert.True(maxDev > 0.15f && minDev < -0.15f,
+            $"fleer should jink to both sides of the escape ray (got {minDev:F2}..{maxDev:F2})");
+    }
+
+    [Fact]
+    public void Hopper_Strides_PulseWithThePopWave()
+    {
+        // #654: a hopper's horizontal step is scaled by its own vertical pop — near-still between hops
+        // (25 % shuffle), full stride at the peak — instead of a constant glide.
+        var p = Roamer(cruise: 2f, accel: 99f, turn: 0.0001f); // frozen heading → distance is pure speed
+        p.Style = LocomotionStyle.Hopper;
+        p.VertAmp = 0.5f;
+        p.VertFreq = 3f;
+
+        var s = default(LocomotionState);
+        var pos = new Vector3f(0, 0, 0);
+        float minStep = 999f, maxStep = 0f;
+        for (int i = 0; i < 100; i++)
+        {
+            var r = LocomotionController.Step(s, p, pos, MoveMode.Roam, null, 0.05, 5u);
+            if (i > 10) // past the speed ease-in
+            {
+                float dx = r.Position.X - pos.X, dz = r.Position.Z - pos.Z;
+                float step = (float)System.Math.Sqrt(dx * dx + dz * dz);
+                if (step < minStep) minStep = step;
+                if (step > maxStep) maxStep = step;
+            }
+
+            s = r.State; pos = r.Position;
+        }
+
+        Assert.True(maxStep > 0f, "the hopper must actually move");
+        Assert.True(minStep < maxStep * 0.5f,
+            $"strides should pulse with the pop (min {minStep:F4} vs max {maxStep:F4})");
+    }
+
     private static float WrapPi(float a)
     {
         while (a > System.Math.PI) a -= 6.2831853f;


### PR DESCRIPTION
## Summary

Five movement-realism packages on top of the #648 terrain gates, plus the fluid-audio fix found while playtesting. All verified in a local playtest by Marcel.

### Movement (server + client)

- **Real-block awareness (#650):** land Y-snap, terrain gates, titan flatness gate and land spawns read the ACTUAL world via a nearest-standable-cell probe (`GetBlockIfLoaded`, +-6 window, downward-first tie-break so bridges don''t grab the creature beneath them; generator fallback for unloaded columns). Fauna honours player walls, dug pits, ramps and built floors — animals can be penned with builds.
- **Steering + full boids (#651):** a blocked step probes +-35/70/110 degree detours (stable per-individual side order) before falling back to the heading re-roll — contour/wall following with the never-stuck property intact. Separation (size-scaled personal space) and wrap-safe Schooler heading alignment join cohesion in one O(n) scan.
- **Vertical smoothness (#652):** land walkers ease toward the ground at 6 blocks/s (snap beyond 4; hoppers keep the snap — the pop IS their motion), fliers ease at 4 blocks/s toward hover+swoop. Client: bodies pitch along real motion (+-25 deg), Air species bank into turns (+-20 deg), medusae excluded.
- **Herd panic + flee jink (#653):** a hit (fatal or not) or a skittish bolt startles same-species kin within 12 blocks for 4 s; non-retaliators flee the nearest player, retaliators charge, no chain re-triggering. Fleeing gains a deterministic zig-zag jink.
- **Crisp motion (#654):** client dead reckoning extrapolates the 2 Hz creature stream (clamped 0.3 s, teleport-safe); Hopper strides pulse with the pop wave.

### Audio (#655, found in the playtest)

Every server `BlockChanged` played a full-volume 2D cue — including every fluid-sim spread/drain step, so flowing water sounded like rhythmic knocking. `GameBootstrap` now raises `BlockChangeApplied(pos, oldId, newId)`; fluid transitions skip the per-cell cue and kick an instant fluid-bed rescan (the existing `water_brook`/`water_fall` rush is the water sound). The mine/place cues moved to positional 3D at the changed cell (4 m full-volume radius keeps the own-mining feel, linear rolloff to silence at 20 m).

## Impact / safety

No wire change (Habitat was already on the wire), no save migration (nothing creature-side is persisted), companions keep all freedoms. Perf bounded: block probes only on column crossings, boids O(n) at n<=64.

## Verification

- 1331 server + 147 client tests green (6 new: stone-pad arena integrations for platform-pen / real-floor easing / herd panic; pure jink / hop-pulse / BlendHeading), full Slow tier green, `dotnet format` clean.
- Local Unity build + hands-on playtest (movement wave and both audio changes) by Marcel.
- Docs: `WORLD_GENERATION.md` fauna section + `TODO.md` work log updated.

closes #650
closes #651
closes #652
closes #653
closes #654
closes #655

🤖 Generated with [Claude Code](https://claude.com/claude-code)