### PR TITLE
fix(fluids): flowing water survives restarts as flow, not sources + shallow water surface inset

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7,7 +7,7 @@ plans live under [docs/](docs/) (committed); the long-range direction is the str
 keep it current when controls/features change. Last consolidated 2026-06-04.
 
 **Build:** `scripts/build-client.ps1` (Windows) or `scripts/build-client.sh` (Linux) — publishes shared libs + bundled server + Unity player.
-**Test:** `./scripts/run-tests.sh` — currently **1331 server + 147 client passing** (2026-08-01). Locale parity (en/de) is enforced by a test.
+**Test:** `./scripts/run-tests.sh` — currently **1332 server + 154 client passing** (2026-08-01). Locale parity (en/de) is enforced by a test.
 CI runs two tiers: PRs skip the tests marked `[Trait("Category", "Slow")]`; pushes to `main` and the release workflow run the full suite. CI builds/runs
 tests in Release, and a per-test duration guardrail (`scripts/check-test-durations.py`, PRs only) fails the gate when a non-Slow test exceeds 120 s.
 **Conventions:** English docs/comments; in-game text bilingual DE+EN; commit to `main` with the
@@ -102,6 +102,24 @@ Per-item detail lives in the dated work log below. **Since 2026-07 versions are 
 
 ---
 
+### ★ Flowing water survives restarts as FLOW (not as sources) + shallow water reads as liquid (#657, #658, 2026-08-01, branch fix/fluid-flow-persistence-and-surface — LOCAL, no PR yet)
+Two fluid fixes. **Persistence (#657, server):** the automaton's per-cell levels (1..8) and falling
+flags were memory-only while every spread step's fluid BLOCK persisted as a block edit — after a
+reload every formerly-flowing cell was untracked, i.e. by definition a full, never-receding SOURCE.
+Transient tongues fossilised into permanent 1-block sheets that could even multiply on the next dig.
+New `fluid_cell` table (SQLite/PostgreSQL/Memory repos) mirrors the flora-regrow pattern:
+`TrackFluid`/`UntrackFluid` keep the row in sync at every level change, and `LoadFluidState()` (after
+`InitFluids()` in the world-load chain) restores + wakes the cells so orphaned streams retract across
+restarts; stale rows are dropped by the tick's existing not-a-fluid check (no chunk gen forced at
+load). **Surface rendering (#658, client):** the mesher built every fluid cell as a full unit cube —
+levels never reach the client — so a thin spread tongue looked identical to a full basin, flush with
+the bank ("water standing 1 block high"). Water SURFACE cells (air above) now drop their top face by
+`WaterSurfaceInset` (0.15) and shorten exposed side faces to match (bottom edges stay flush; B43
+submerged-side culling, waterfall flanks/mode-4 streaks and the non-colliding water collider are all
+unaffected). Lava deliberately stays full-height: it is opaque, so neighbours cull their faces
+against it (a lowered top would open bank seams) and the player stands on its collider. Tests: new
+`FlowingWater_Recedes_AfterAServerRestart` (spread → repo restart → cut source → sheet dries up) —
+suite 1332 + 154 green.
 ### ★ Water flow no longer knocks + block sounds are positional (#655, 2026-08-01, branch feat/creature-movement-realism — LOCAL, no PR yet)
 Every server `BlockChanged` played a full-volume 2D cue — including EVERY fluid-sim spread/drain
 step, so flowing water hammered a rhythmic `place_block` knocking (and draining water played mining

--- a/client/Assets/BlocksBeyondTheStars/Scripts/ChunkMesher.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/ChunkMesher.cs
@@ -34,6 +34,12 @@ namespace BlocksBeyondTheStars.Client
         /// faces are hidden, so it has no convex edges). Set to 0 to disable the whole bevel pass. Tunable.</summary>
         public const float BevelAmount = 0.06f;
 
+        /// <summary>How far a water SURFACE cell's top face sits below the block top (fraction of a block), so
+        /// standing water reads as liquid in a hollow instead of a glass cube flush with the bank (#658). Water
+        /// only: lava is opaque, so its neighbours cull their faces against it and a lowered lava top would open
+        /// a seam into the bank (and the player stands ON lava's full-height collider).</summary>
+        public const float WaterSurfaceInset = 0.15f;
+
         // Per-build scratch caches, reused across builds instead of freshly allocated each time. Thread-static
         // because desktop geometry builds run on thread-pool workers (each thread runs at most one build at a
         // time, and none of these ever escapes the call), so a Clear() at the point of use is all the isolation
@@ -53,6 +59,7 @@ namespace BlocksBeyondTheStars.Client
         [System.ThreadStatic] private static Vector3[] _faceAoQuadScratch;
         [System.ThreadStatic] private static Vector3[] _addFaceQuadScratch;
         [System.ThreadStatic] private static Vector3[] _bevelQuadScratch;
+        [System.ThreadStatic] private static Vector3[] _waterQuadScratch;
         [System.ThreadStatic] private static Vector3[] _greebleQuadScratch;
         [System.ThreadStatic] private static Vector2[] _uvCornersScratch;
 
@@ -587,6 +594,17 @@ namespace BlocksBeyondTheStars.Client
                     // Bevel cubes inset each exposed convex edge of the face by BevelAmount (edges against a
                     // solid neighbour stay flush → no gap); the chamfer strips + corners are added after the loop.
                     Vector3[] bevelQuad = bevel ? BevelInsetQuad(new Vector3(x, y, z), f, openMask) : null;
+
+                    // Water SURFACE cells (#658): drop the top face by WaterSurfaceInset and shorten the exposed
+                    // side faces to match, so shallow/standing water sits visibly IN the terrain hollow instead
+                    // of ending flush with the bank like a glass cube. Bottom face stays flush; submerged cells
+                    // (water above) keep the full cube (B43 culls their sides), and a falling column is never a
+                    // surface cell (it has water above), so cascades keep their full flanks. Water never bevels,
+                    // so bevelQuad is free here.
+                    if (isWaterSurface && dir.Y >= 0)
+                    {
+                        bevelQuad = WaterSurfaceQuad(new Vector3(x, y, z), f);
+                    }
                     AddFace(verts, transparent ? trisT : tris, colors, uvs, tangents, new Vector3(x, y, z), f,
                         c0, c1, c2, c3, uv,
                         dir.Y != 0 ? uvRot : 0, bevelQuad); // rotate only top/bottom faces — sides keep their up-orientation
@@ -1507,6 +1525,24 @@ namespace BlocksBeyondTheStars.Client
             var v = Vector3.zero;
             v[a0] = c0; v[a1] = c1; v[a2] = c2;
             return v;
+        }
+
+        /// <summary>The face quad for a water SURFACE cell with every top-of-cell corner pulled down by
+        /// <see cref="WaterSurfaceInset"/> (#658): the +Y face drops whole, a side face keeps its bottom edge
+        /// flush and shortens at the top. Corners on the cell floor are untouched, so the water still meets
+        /// the ground/bank exactly where the full cube would.</summary>
+        private static Vector3[] WaterSurfaceQuad(Vector3 cell, int face)
+        {
+            var q = FaceQuad(cell, face, ref _waterQuadScratch);
+            for (int i = 0; i < 4; i++)
+            {
+                if (q[i].y - cell.y > 0.5f)
+                {
+                    q[i].y = cell.y + 1f - WaterSurfaceInset;
+                }
+            }
+
+            return q;
         }
 
         /// <summary>The face quad with each corner pulled inward by <see cref="BevelAmount"/> along an in-plane

--- a/src/BlocksBeyondTheStars.GameServer/GameServer.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServer.cs
@@ -517,6 +517,7 @@ public sealed partial class GameServer
         {
             BuildLandingPads(); // FIRST: the pads must reach worldgen before any pad-area chunk generates
             InitFluids();
+            LoadFluidState(); // #657: restore flowing cells so a restart doesn't promote them to sources
             InitFire();
             InitCreatures();
             LoadContainers();

--- a/src/BlocksBeyondTheStars.GameServer/GameServerFluids.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerFluids.cs
@@ -22,7 +22,9 @@ namespace BlocksBeyondTheStars.GameServer;
 /// it (fluid above, or a stronger horizontal neighbour); when its feed is cut it <b>retracts</b> (dries
 /// up) instead of hanging in the air. The <c>_fallingFluid</c> set marks cells filled by a downward flow
 /// so a cell feeding a waterfall doesn't crawl sideways at its own elevation (which used to leave a sheet
-/// of water floating over the drop). Levels are in-memory (not persisted).
+/// of water floating over the drop). Levels are persisted alongside the fluid block edits (#657): the
+/// block itself survives a restart as a block edit, so without its level row every flowing tongue would
+/// reload as untracked — i.e. as a permanent full source that can never dry up.
 /// </summary>
 public sealed partial class GameServer
 {
@@ -50,9 +52,55 @@ public sealed partial class GameServer
     /// worldgen sea. Flowing cells, by contrast, live in <c>_fluidLevel</c> and dry up when cut off.</summary>
     public void RegisterFluidSource(Vector3i pos)
     {
-        _fluidLevel.Remove(pos);
-        _fallingFluid.Remove(pos);
+        UntrackFluid(pos);
         _activeFluid.Add(pos);
+    }
+
+    /// <summary>Records a flowing cell's level (memory + save). The persisted row is what stops a restart from
+    /// promoting the cell to an untracked source (#657).</summary>
+    private void TrackFluid(Vector3i pos, byte level, bool falling)
+    {
+        _fluidLevel[pos] = level;
+        if (falling)
+        {
+            _fallingFluid.Add(pos);
+        }
+        else
+        {
+            _fallingFluid.Remove(pos); // a cell filled sideways rests on the surface it spread across
+        }
+
+        _repo.SaveFluidCell(_world.LocationId, pos, level, falling);
+    }
+
+    /// <summary>Drops a cell's flowing state (memory + save) — it dried up, became a source, or its block
+    /// was replaced. Safe to call for cells that were never tracked.</summary>
+    private void UntrackFluid(Vector3i pos)
+    {
+        if (_fluidLevel.Remove(pos))
+        {
+            _repo.DeleteFluidCell(_world.LocationId, pos);
+        }
+
+        _fallingFluid.Remove(pos);
+    }
+
+    /// <summary>Restores this world's persisted flowing-fluid cells (levels + falling flags) and wakes them,
+    /// so streams keep flowing/retracting across a restart instead of fossilising into full sources (#657).
+    /// Deliberately does not touch the world's blocks here (that would force chunk generation at load) — the
+    /// tick's own stale-cell check drops any row whose block is no longer a fluid.</summary>
+    private void LoadFluidState()
+    {
+        foreach (var cell in _repo.ListFluidCells(_world.LocationId))
+        {
+            _fluidLevel[cell.WorldPosition] = Math.Clamp(cell.Level, (byte)1, FluidFull);
+            if (cell.Falling)
+            {
+                _fallingFluid.Add(cell.WorldPosition);
+            }
+
+            _activeFluid.Add(cell.WorldPosition); // wake: orphans retract, still-fed cells settle again
+        }
     }
 
     /// <summary>Places a fluid source block and registers it (gameplay/admin/tests).</summary>
@@ -98,8 +146,7 @@ public sealed partial class GameServer
             ushort id = _world.GetBlock(pos).Value;
             if (!IsFluid(id))
             {
-                _fluidLevel.Remove(pos);
-                _fallingFluid.Remove(pos);
+                UntrackFluid(pos);
                 continue;
             }
 
@@ -131,7 +178,7 @@ public sealed partial class GameServer
                 level = (byte)supported;
                 if (level != old)
                 {
-                    _fluidLevel[pos] = level;
+                    TrackFluid(pos, level, _fallingFluid.Contains(pos));
                     changed = true;
                     WakeNeighbors(pos); // a level drop must ripple downstream so the whole tail recedes too
                 }
@@ -245,24 +292,14 @@ public sealed partial class GameServer
         if (_obsidianId != 0 && TouchesOtherFluid(pos, kind.Value))
         {
             _world.SetBlock(pos, new BlockId(_obsidianId));
-            _fluidLevel.Remove(pos);
-            _fallingFluid.Remove(pos);
+            UntrackFluid(pos);
             BroadcastToWorld(new BlockChanged { X = pos.X, Y = pos.Y, Z = pos.Z, Block = _obsidianId });
             WakeNeighbors(pos);
             return;
         }
 
         _world.SetBlock(pos, kind);
-        _fluidLevel[pos] = level;
-        if (falling)
-        {
-            _fallingFluid.Add(pos); // a cell filled from above feeds a waterfall column
-        }
-        else
-        {
-            _fallingFluid.Remove(pos); // a cell filled sideways rests on the surface it spread across
-        }
-
+        TrackFluid(pos, level, falling);
         BroadcastToWorld(new BlockChanged { X = pos.X, Y = pos.Y, Z = pos.Z, Block = kind.Value });
         _activeFluid.Add(pos);
     }
@@ -273,8 +310,7 @@ public sealed partial class GameServer
     private void RetractFluid(Vector3i pos)
     {
         _world.SetBlock(pos, BlockId.Air);
-        _fluidLevel.Remove(pos);
-        _fallingFluid.Remove(pos);
+        UntrackFluid(pos);
         BroadcastToWorld(new BlockChanged { X = pos.X, Y = pos.Y, Z = pos.Z, Block = BlockId.AirValue });
         WakeNeighbors(pos);
     }
@@ -329,8 +365,7 @@ public sealed partial class GameServer
         var pos = new Vector3i(x, y, z);
         bool wasFluid = IsFluid(_world.GetBlock(pos).Value);
         _world.SetBlock(pos, BlockId.Air);
-        _fluidLevel.Remove(pos);
-        _fallingFluid.Remove(pos);
+        UntrackFluid(pos);
         BroadcastToWorld(new BlockChanged { X = x, Y = y, Z = z, Block = BlockId.AirValue });
         if (wasFluid || HasFluidNeighbor(pos))
         {

--- a/src/BlocksBeyondTheStars.Persistence/IWorldRepository.cs
+++ b/src/BlocksBeyondTheStars.Persistence/IWorldRepository.cs
@@ -163,6 +163,25 @@ public readonly struct StoredFloraRegrow
     }
 }
 
+/// <summary>A persisted <b>flowing</b> fluid cell: its level (1..8) and whether it was filled from above (feeds
+/// a waterfall column). Sources are deliberately NOT stored — an untracked fluid block IS a source by definition.
+/// Persisted because the fluid block itself survives a restart as a block edit while the in-memory level table
+/// would not: without this row every flowing tongue reloads as untracked, i.e. as a permanent full source that
+/// can never dry up (#657).</summary>
+public readonly struct StoredFluidCell
+{
+    public readonly Vector3i WorldPosition;
+    public readonly byte Level;
+    public readonly bool Falling;
+
+    public StoredFluidCell(Vector3i worldPosition, byte level, bool falling)
+    {
+        WorldPosition = worldPosition;
+        Level = level;
+        Falling = falling;
+    }
+}
+
 /// <summary>
 /// Abstraction over savegame persistence. SQLite remains the portable default; PostgreSQL is available
 /// for hosted dedicated servers that need managed storage and easier cloud operations.
@@ -210,6 +229,17 @@ public interface IWorldRepository : IDisposable
 
     /// <summary>Removes a scheduled flora regrowth (the plant returned, or its host was lost).</summary>
     void DeleteFloraRegrow(string planet, Vector3i worldPosition);
+
+    /// <summary>Stores (inserts or replaces) a flowing fluid cell's level state, keyed by its world cell.</summary>
+    void SaveFluidCell(string planet, Vector3i worldPosition, byte level, bool falling);
+
+    /// <summary>Lists all flowing fluid cells on a planet (restored into the fluid automaton on world load,
+    /// so a restart doesn't promote them to sources).</summary>
+    IReadOnlyList<StoredFluidCell> ListFluidCells(string planet);
+
+    /// <summary>Removes a flowing fluid cell's level state (it dried up, settled into a source, or its block
+    /// was replaced).</summary>
+    void DeleteFluidCell(string planet, Vector3i worldPosition);
 
     PlayerState? LoadPlayer(string playerId);
     void SavePlayer(PlayerState player);

--- a/src/BlocksBeyondTheStars.Persistence/MemoryWorldRepository.cs
+++ b/src/BlocksBeyondTheStars.Persistence/MemoryWorldRepository.cs
@@ -93,6 +93,7 @@ public sealed class MemoryWorldRepository : IWorldRepository
     private readonly Dictionary<(string Planet, int X, int Y, int Z), (ushort Block, int Tint, int Glow, int Shape, string Owner, DateTime? EditedUtc)> _blockEdits = new();
     private readonly Dictionary<(string Planet, int Cx, int Cy, int Cz), List<(string Planet, int X, int Y, int Z)>> _blockEditsByChunk = new();
     private readonly Dictionary<(string Planet, int X, int Y, int Z), (ushort Block, double Timer)> _flora = new();
+    private readonly Dictionary<(string Planet, int X, int Y, int Z), (byte Level, bool Falling)> _fluidCells = new();
     private readonly Dictionary<string, string> _players = new();       // id → PlayerSnapshot JSON
     private readonly Dictionary<string, string> _ships = new();         // id → ShipSnapshot JSON
     private readonly Dictionary<string, string> _containers = new();    // id → StoredContainer JSON
@@ -573,6 +574,35 @@ public sealed class MemoryWorldRepository : IWorldRepository
         lock (_gate)
         {
             _flora.Remove((planet, worldPosition.X, worldPosition.Y, worldPosition.Z));
+        }
+    }
+
+    // ---------------- Flowing fluid cells (#657) ----------------
+
+    public void SaveFluidCell(string planet, Vector3i worldPosition, byte level, bool falling)
+    {
+        lock (_gate)
+        {
+            _fluidCells[(planet, worldPosition.X, worldPosition.Y, worldPosition.Z)] = (level, falling);
+        }
+    }
+
+    public IReadOnlyList<StoredFluidCell> ListFluidCells(string planet)
+    {
+        lock (_gate)
+        {
+            return _fluidCells
+                .Where(kv => kv.Key.Planet == planet)
+                .Select(kv => new StoredFluidCell(new Vector3i(kv.Key.X, kv.Key.Y, kv.Key.Z), kv.Value.Level, kv.Value.Falling))
+                .ToList();
+        }
+    }
+
+    public void DeleteFluidCell(string planet, Vector3i worldPosition)
+    {
+        lock (_gate)
+        {
+            _fluidCells.Remove((planet, worldPosition.X, worldPosition.Y, worldPosition.Z));
         }
     }
 

--- a/src/BlocksBeyondTheStars.Persistence/PostgreSqlWorldRepository.cs
+++ b/src/BlocksBeyondTheStars.Persistence/PostgreSqlWorldRepository.cs
@@ -96,6 +96,9 @@ public sealed class PostgreSqlWorldRepository : IWorldRepository
             CREATE TABLE IF NOT EXISTS flora_regrow (
                 planet TEXT NOT NULL, x INTEGER NOT NULL, y INTEGER NOT NULL, z INTEGER NOT NULL,
                 block INTEGER NOT NULL, timer DOUBLE PRECISION NOT NULL, PRIMARY KEY (planet, x, y, z));
+            CREATE TABLE IF NOT EXISTS fluid_cell (
+                planet TEXT NOT NULL, x INTEGER NOT NULL, y INTEGER NOT NULL, z INTEGER NOT NULL,
+                level INTEGER NOT NULL, falling INTEGER NOT NULL, PRIMARY KEY (planet, x, y, z));
             CREATE TABLE IF NOT EXISTS block_palette (numeric_id INTEGER PRIMARY KEY, key TEXT NOT NULL);");
         // (Landing pads are deterministic + live-occupancy now — no per-player landing_zone table; item 38.)
 
@@ -713,6 +716,61 @@ public sealed class PostgreSqlWorldRepository : IWorldRepository
         }
     }
 
+    // --- Flowing fluid cells (level state, so a restart doesn't promote them to sources — #657) ---
+
+    public void SaveFluidCell(string planet, Vector3i worldPosition, byte level, bool falling)
+    {
+        lock (_gate)
+        {
+            using var cmd = Connection.CreateCommand();
+            cmd.CommandText = "INSERT INTO fluid_cell (planet, x, y, z, level, falling) " +
+                              "VALUES (@p, @x, @y, @z, @l, @f) " +
+                              "ON CONFLICT(planet, x, y, z) DO UPDATE SET level=excluded.level, falling=excluded.falling;";
+            cmd.Parameters.AddWithValue("@p", planet);
+            cmd.Parameters.AddWithValue("@x", worldPosition.X);
+            cmd.Parameters.AddWithValue("@y", worldPosition.Y);
+            cmd.Parameters.AddWithValue("@z", worldPosition.Z);
+            cmd.Parameters.AddWithValue("@l", (int)level);
+            cmd.Parameters.AddWithValue("@f", falling ? 1 : 0);
+            cmd.ExecuteNonQuery();
+        }
+    }
+
+    public IReadOnlyList<StoredFluidCell> ListFluidCells(string planet)
+    {
+        var result = new List<StoredFluidCell>();
+        lock (_gate)
+        {
+            using var cmd = Connection.CreateCommand();
+            cmd.CommandText = "SELECT x, y, z, level, falling FROM fluid_cell WHERE planet = @p;";
+            cmd.Parameters.AddWithValue("@p", planet);
+            using var reader = cmd.ExecuteReader();
+            while (reader.Read())
+            {
+                result.Add(new StoredFluidCell(
+                    new Vector3i(reader.GetInt32(0), reader.GetInt32(1), reader.GetInt32(2)),
+                    (byte)reader.GetInt32(3),
+                    reader.GetInt32(4) != 0));
+            }
+        }
+
+        return result;
+    }
+
+    public void DeleteFluidCell(string planet, Vector3i worldPosition)
+    {
+        lock (_gate)
+        {
+            using var cmd = Connection.CreateCommand();
+            cmd.CommandText = "DELETE FROM fluid_cell WHERE planet = @p AND x = @x AND y = @y AND z = @z;";
+            cmd.Parameters.AddWithValue("@p", planet);
+            cmd.Parameters.AddWithValue("@x", worldPosition.X);
+            cmd.Parameters.AddWithValue("@y", worldPosition.Y);
+            cmd.Parameters.AddWithValue("@z", worldPosition.Z);
+            cmd.ExecuteNonQuery();
+        }
+    }
+
     // --- Player-built space stations (item 20 S4) ---
 
     public void SaveSpaceStructure(StoredSpaceStructure s)
@@ -1297,7 +1355,7 @@ public sealed class PostgreSqlWorldRepository : IWorldRepository
     {
         "world_meta", "block_edit", "player", "player_ref", "ship", "container", "door", "beacon", "beam",
         "base_claim", "alliance", "story_state", "location_status", "mission",
-        "space_structure", "structure_edit", "flora_regrow",
+        "space_structure", "structure_edit", "flora_regrow", "fluid_cell",
     };
 
     private List<Dictionary<string, object?>> ReadTableForBackup(string table)

--- a/src/BlocksBeyondTheStars.Persistence/SqliteWorldRepository.cs
+++ b/src/BlocksBeyondTheStars.Persistence/SqliteWorldRepository.cs
@@ -100,6 +100,9 @@ public sealed class SqliteWorldRepository : IWorldRepository
             CREATE TABLE IF NOT EXISTS flora_regrow (
                 planet TEXT NOT NULL, x INTEGER NOT NULL, y INTEGER NOT NULL, z INTEGER NOT NULL,
                 block INTEGER NOT NULL, timer REAL NOT NULL, PRIMARY KEY (planet, x, y, z));
+            CREATE TABLE IF NOT EXISTS fluid_cell (
+                planet TEXT NOT NULL, x INTEGER NOT NULL, y INTEGER NOT NULL, z INTEGER NOT NULL,
+                level INTEGER NOT NULL, falling INTEGER NOT NULL, PRIMARY KEY (planet, x, y, z));
             CREATE TABLE IF NOT EXISTS block_palette (numeric_id INTEGER PRIMARY KEY, key TEXT NOT NULL);");
         // (Landing pads are deterministic + live-occupancy now — no per-player landing_zone table; item 38.)
 
@@ -731,6 +734,61 @@ public sealed class SqliteWorldRepository : IWorldRepository
         {
             using var cmd = Connection.CreateCommand();
             cmd.CommandText = "DELETE FROM flora_regrow WHERE planet = $p AND x = $x AND y = $y AND z = $z;";
+            cmd.Parameters.AddWithValue("$p", planet);
+            cmd.Parameters.AddWithValue("$x", worldPosition.X);
+            cmd.Parameters.AddWithValue("$y", worldPosition.Y);
+            cmd.Parameters.AddWithValue("$z", worldPosition.Z);
+            cmd.ExecuteNonQuery();
+        }
+    }
+
+    // --- Flowing fluid cells (level state, so a restart doesn't promote them to sources — #657) ---
+
+    public void SaveFluidCell(string planet, Vector3i worldPosition, byte level, bool falling)
+    {
+        lock (_gate)
+        {
+            using var cmd = Connection.CreateCommand();
+            cmd.CommandText = "INSERT INTO fluid_cell (planet, x, y, z, level, falling) " +
+                              "VALUES ($p, $x, $y, $z, $l, $f) " +
+                              "ON CONFLICT(planet, x, y, z) DO UPDATE SET level=excluded.level, falling=excluded.falling;";
+            cmd.Parameters.AddWithValue("$p", planet);
+            cmd.Parameters.AddWithValue("$x", worldPosition.X);
+            cmd.Parameters.AddWithValue("$y", worldPosition.Y);
+            cmd.Parameters.AddWithValue("$z", worldPosition.Z);
+            cmd.Parameters.AddWithValue("$l", level);
+            cmd.Parameters.AddWithValue("$f", falling ? 1 : 0);
+            cmd.ExecuteNonQuery();
+        }
+    }
+
+    public IReadOnlyList<StoredFluidCell> ListFluidCells(string planet)
+    {
+        var result = new List<StoredFluidCell>();
+        lock (_gate)
+        {
+            using var cmd = Connection.CreateCommand();
+            cmd.CommandText = "SELECT x, y, z, level, falling FROM fluid_cell WHERE planet = $p;";
+            cmd.Parameters.AddWithValue("$p", planet);
+            using var reader = cmd.ExecuteReader();
+            while (reader.Read())
+            {
+                result.Add(new StoredFluidCell(
+                    new Vector3i(reader.GetInt32(0), reader.GetInt32(1), reader.GetInt32(2)),
+                    (byte)reader.GetInt32(3),
+                    reader.GetInt32(4) != 0));
+            }
+        }
+
+        return result;
+    }
+
+    public void DeleteFluidCell(string planet, Vector3i worldPosition)
+    {
+        lock (_gate)
+        {
+            using var cmd = Connection.CreateCommand();
+            cmd.CommandText = "DELETE FROM fluid_cell WHERE planet = $p AND x = $x AND y = $y AND z = $z;";
             cmd.Parameters.AddWithValue("$p", planet);
             cmd.Parameters.AddWithValue("$x", worldPosition.X);
             cmd.Parameters.AddWithValue("$y", worldPosition.Y);

--- a/tests/BlocksBeyondTheStars.Tests/FluidTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/FluidTests.cs
@@ -258,6 +258,40 @@ public sealed class FluidTests : IDisposable
         }
     }
 
+    [Fact]
+    public void FlowingWater_Recedes_AfterAServerRestart()
+    {
+        var stone = _content.GetBlock("stone")!.NumericId;
+        var water = _content.GetBlock("water")!.NumericId.Value;
+        int y = 138;
+
+        // Session 1: a source on a floor in the air spreads a thin sheet of flowing water.
+        var server1 = Started(out var repo1);
+        for (int x = -1; x <= 6; x++) server1.World.SetBlock(new Vector3i(x, y - 1, 0), stone);
+        server1.PlaceFluidSource("water", 0, y, 0);
+        for (int i = 0; i < 10; i++) server1.Tick(0.3);
+        Assert.Equal(water, server1.World.GetBlock(new Vector3i(3, y, 0)).Value); // it flowed out
+        repo1.Dispose(); // simulate a server restart on the same save
+
+        // Session 2 on the same save: the sheet's cells must come back as FLOWING (tracked), not as sources.
+        // The old bug (#657): levels were memory-only, so after a reload every flowing cell was untracked —
+        // a permanent full source — and cutting the original source no longer dried anything up.
+        var server2 = Started(out var repo2);
+        using (repo2)
+        {
+            Assert.Equal(water, server2.World.GetBlock(new Vector3i(3, y, 0)).Value); // sheet survived the reload
+
+            server2.RemoveBlockForTest(0, y, 0); // cut the source
+            for (int i = 0; i < 40; i++) server2.Tick(0.3);
+
+            for (int x = 1; x <= 6; x++)
+            {
+                Assert.True(server2.World.GetBlock(new Vector3i(x, y, 0)).IsAir,
+                    $"flowing water at x={x} should have receded after the restart + source cut");
+            }
+        }
+    }
+
     public void Dispose()
     {
         try


### PR DESCRIPTION
closes #657, closes #658

## Server (#657)

The fluid automaton's per-cell levels (1..8) and falling flags were memory-only while every spread step's fluid **block** persisted as a block edit. After a reload every formerly-flowing cell was untracked — i.e. by definition a full, never-receding **source**. Transient tongues fossilised into permanent 1-block standing-water sheets that could even multiply on the next dig.

- New `fluid_cell` table in all three repositories (SQLite / PostgreSQL / Memory), mirroring the `flora_regrow` pattern; PostgreSQL backup table list extended.
- `TrackFluid` / `UntrackFluid` keep the persisted row in sync at every fill, level change, retraction, obsidian chill and source registration.
- `LoadFluidState()` (after `InitFluids()` in the world-load chain) restores the levels + falling flags and wakes the cells, so orphaned streams retract across restarts. Deliberately touches no blocks at load (no forced chunk generation) — the tick's existing not-a-fluid check drops stale rows.

## Client (#658)

The mesher built every fluid cell as a full unit cube (levels never reach the client), so a thin spread tongue looked identical to a full basin, flush with the bank — the reported "water standing 1 block high in the landscape".

- Water **surface** cells (air above) drop their top face by `WaterSurfaceInset` (0.15) and shorten exposed side faces to match; bottom edges stay flush with the bank.
- B43 submerged-side culling, waterfall mode-4 flanks, and water's non-collision are unaffected; the wave shader displaces downward only, so waves never clip the bank.
- Lava deliberately stays full-height: it is opaque, so neighbours cull their faces against it (a lowered top would open seams into the bank) and the player stands on its collider.

## Verification

- New regression test `FlowingWater_Recedes_AfterAServerRestart` (spread → repo restart → cut source → sheet dries up).
- Suite: 1332 server + 154 client green, 0 warnings.
- Local Unity build verified; in-game playtest on a local build (water sits visibly below the bank; a cut-off tongue dries up after a restart).

🤖 Generated with [Claude Code](https://claude.com/claude-code)