### PR TITLE
feat(modes): true Sandbox game mode selectable at world creation

### DIFF
--- a/client/Assets/BlocksBeyondTheStars/Scripts/AppShell.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/AppShell.cs
@@ -545,8 +545,9 @@ namespace BlocksBeyondTheStars.Client
         /// creative flags are only honoured when the world is first created (the server bakes them into the save).</summary>
         public void StartSingleplayerWorld(string worldName, long seed = 0,
             bool creativeUnlockAll = false, bool creativeAllShips = false, bool creativeKit = false,
+            bool sandbox = false,
             WorldCreationOptions worldOptions = null)
-            => StartLocalWorld(worldName, seed, creativeUnlockAll, creativeAllShips, creativeKit, worldOptions,
+            => StartLocalWorld(worldName, seed, creativeUnlockAll, creativeAllShips, creativeKit, sandbox, worldOptions,
                 maxPlayers: 1, password: null);
 
         /// <summary>Hosts a multiplayer world in-game: launches the bundled server on a singleplayer save
@@ -555,12 +556,13 @@ namespace BlocksBeyondTheStars.Client
         /// player of a fresh world is its WorldAdmin anyway).</summary>
         public void StartHostWorld(string worldName, int maxPlayers, string password, long seed = 0,
             bool creativeUnlockAll = false, bool creativeAllShips = false, bool creativeKit = false,
+            bool sandbox = false,
             WorldCreationOptions worldOptions = null)
-            => StartLocalWorld(worldName, seed, creativeUnlockAll, creativeAllShips, creativeKit, worldOptions,
+            => StartLocalWorld(worldName, seed, creativeUnlockAll, creativeAllShips, creativeKit, sandbox, worldOptions,
                 Mathf.Clamp(maxPlayers, 2, 16), password);
 
         private void StartLocalWorld(string worldName, long seed,
-            bool creativeUnlockAll, bool creativeAllShips, bool creativeKit, WorldCreationOptions worldOptions,
+            bool creativeUnlockAll, bool creativeAllShips, bool creativeKit, bool sandbox, WorldCreationOptions worldOptions,
             int maxPlayers, string password)
         {
             if (ShowBrowserLocalServerBlockedNotice())
@@ -581,7 +583,7 @@ namespace BlocksBeyondTheStars.Client
             // blocking Process.Start (a Defender first-scan of the freshly-built EXE can stall it for seconds)
             // would freeze the menu so "nothing happens" before the loading screen appears.
             if (_localServer.Prepare(LocalServerLauncher.DefaultPort, Settings.ViewDistanceChunks, worldName, seed,
-                    creativeUnlockAll, creativeAllShips, creativeKit, worldOptions?.ToArgs(),
+                    creativeUnlockAll, creativeAllShips, creativeKit, sandbox, worldOptions?.ToArgs(),
                     maxPlayers, password, hosting ? worldName : "Singleplayer", PlayerName))
             {
                 Host = _localServer.Host;

--- a/client/Assets/BlocksBeyondTheStars/Scripts/LocalServerLauncher.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/LocalServerLauncher.cs
@@ -125,6 +125,7 @@ namespace BlocksBeyondTheStars.Client
         /// (passed as <c>--admins</c> so the host is admin even on a save where someone else joined first).</summary>
         public bool Prepare(int port = DefaultPort, int viewDistanceChunks = 0, string worldName = "singleplayer", long seed = 0,
             bool creativeUnlockAll = false, bool creativeAllShips = false, bool creativeKit = false,
+            bool sandbox = false,
             string worldOptionArgs = null,
             int maxPlayers = 1, string password = null, string serverName = "Singleplayer", string adminName = null)
         {
@@ -191,7 +192,10 @@ namespace BlocksBeyondTheStars.Client
             string creativeArgs =
                 (creativeUnlockAll ? " --unlock-all-blueprints true" : string.Empty) +
                 (creativeAllShips ? " --start-all-ships true" : string.Empty) +
-                (creativeKit ? " --creative-kit true" : string.Empty);
+                (creativeKit ? " --creative-kit true" : string.Empty) +
+                // True sandbox (#662): free crafting + no oxygen/hunger + peaceful. Creation-only like the
+                // creative args — the server bakes the mode into the save's RulesOverride.
+                (sandbox ? " --game-mode Creative" : string.Empty);
             // World options (sliders at creation): non-default values only; the server bakes them into the
             // new save's rules/description, so later launches don't need to repeat them.
             string optionArgs = string.IsNullOrEmpty(worldOptionArgs) ? string.Empty : worldOptionArgs;

--- a/client/Assets/BlocksBeyondTheStars/Scripts/PerfProbe.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/PerfProbe.cs
@@ -184,7 +184,7 @@ namespace BlocksBeyondTheStars.Client
                 : null;
 
             Debug.Log($"[PerfProbe] Starting world (seed {_seed}, preset {shell.Settings.Preset}, view distance {shell.Settings.ViewDistanceChunks}{(_dense ? ", dense scene" : "")}).");
-            shell.StartSingleplayerWorld(WorldName, _seed, creativeUnlockAll: false, creativeAllShips: false, creativeKit: false, worldOptions);
+            shell.StartSingleplayerWorld(WorldName, _seed, creativeUnlockAll: false, creativeAllShips: false, creativeKit: false, worldOptions: worldOptions);
 
             yield return WaitForPhase(shell, ShellPhase.InGame, WorldLoadTimeout);
             var boot = shell.CurrentBoot;

--- a/client/Assets/BlocksBeyondTheStars/Scripts/UiSaveSelect.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/UiSaveSelect.cs
@@ -35,15 +35,15 @@ namespace BlocksBeyondTheStars.Client
             bool host = shell.HostMode;
             int[] maxPlayers = { 12 };
             string[] hostPass = { "" };
-            void Launch(string world, bool unlockAll = false, bool allShips = false, bool kit = false, WorldCreationOptions options = null)
+            void Launch(string world, bool unlockAll = false, bool allShips = false, bool kit = false, bool sandbox = false, WorldCreationOptions options = null)
             {
                 if (host)
                 {
-                    shell.StartHostWorld(world, maxPlayers[0], hostPass[0], 0, unlockAll, allShips, kit, options);
+                    shell.StartHostWorld(world, maxPlayers[0], hostPass[0], 0, unlockAll, allShips, kit, sandbox, options);
                 }
                 else
                 {
-                    shell.StartSingleplayerWorld(world, 0, unlockAll, allShips, kit, options);
+                    shell.StartSingleplayerWorld(world, 0, unlockAll, allShips, kit, sandbox, options);
                 }
             }
 
@@ -90,24 +90,29 @@ namespace BlocksBeyondTheStars.Client
             string[] name = { "new_world" };
             UiKit.AddInput(right, 20f, 82f, 660f, 34f, name[0], v => name[0] = v, maxLength: 24);
 
-            // Mode: Explorer (normal) vs Creative (everything unlocked + a starter set; survival mechanics stay on).
-            bool[] creative = { false };
+            // Mode: Explorer (normal) vs Creative (everything unlocked + a starter set; survival mechanics
+            // stay on) vs Sandbox (#662: free crafting, no oxygen/hunger, peaceful, everything unlocked).
+            int[] mode = { 0 }; // 0 Explorer · 1 Creative · 2 Sandbox
             bool[] optBlueprints = { true };
             bool[] optShips = { true };
             bool[] optKit = { true };
 
             UiKit.AddText(right, 20f, 124f, 660f, 24f, shell.L("ui.save.mode"), 15, UiKit.TextCol, TextAnchor.MiddleLeft);
-            Button explorerBtn = null, creativeBtn = null;
+            Button explorerBtn = null, creativeBtn = null, sandboxBtn = null;
             GameObject creativePanel = null;
+            GameObject sandboxHint = null;
             void RefreshMode()
             {
-                if (explorerBtn != null) explorerBtn.image.color = creative[0] ? UiKit.PanelFill : UiKit.Cyan;
-                if (creativeBtn != null) creativeBtn.image.color = creative[0] ? UiKit.Cyan : UiKit.PanelFill;
-                if (creativePanel != null) creativePanel.SetActive(creative[0]);
+                if (explorerBtn != null) explorerBtn.image.color = mode[0] == 0 ? UiKit.Cyan : UiKit.PanelFill;
+                if (creativeBtn != null) creativeBtn.image.color = mode[0] == 1 ? UiKit.Cyan : UiKit.PanelFill;
+                if (sandboxBtn != null) sandboxBtn.image.color = mode[0] == 2 ? UiKit.Cyan : UiKit.PanelFill;
+                if (creativePanel != null) creativePanel.SetActive(mode[0] == 1);
+                if (sandboxHint != null) sandboxHint.SetActive(mode[0] == 2);
             }
 
-            explorerBtn = UiKit.AddButton(right, 20f, 152f, 320f, 46f, shell.L("ui.save.mode_explorer"), () => { creative[0] = false; RefreshMode(); });
-            creativeBtn = UiKit.AddButton(right, 360f, 152f, 320f, 46f, shell.L("ui.save.mode_creative"), () => { creative[0] = true; RefreshMode(); });
+            explorerBtn = UiKit.AddButton(right, 20f, 152f, 210f, 46f, shell.L("ui.save.mode_explorer"), () => { mode[0] = 0; RefreshMode(); });
+            creativeBtn = UiKit.AddButton(right, 245f, 152f, 210f, 46f, shell.L("ui.save.mode_creative"), () => { mode[0] = 1; RefreshMode(); });
+            sandboxBtn = UiKit.AddButton(right, 470f, 152f, 210f, 46f, shell.L("ui.save.mode_sandbox"), () => { mode[0] = 2; RefreshMode(); });
 
             // Creative sub-options (a checklist; shown only when Creative is selected).
             var cp = UiKit.AddPanel(right, 20f, 206f, 660f, 150f, new Color(0.05f, 0.10f, 0.16f, 0.55f));
@@ -127,6 +132,12 @@ namespace BlocksBeyondTheStars.Client
             Toggle(8f, shell.L("ui.save.opt_blueprints"), optBlueprints);
             Toggle(52f, shell.L("ui.save.opt_ships"), optShips);
             Toggle(96f, shell.L("ui.save.opt_kit"), optKit);
+
+            // Sandbox: no checklist — everything is on by design; a short hint says what the mode does.
+            var sh = UiKit.AddText(right, 20f, 210f, 660f, 140f, shell.L("ui.save.sandbox_hint"), 15,
+                UiKit.CyanDim, TextAnchor.UpperLeft);
+            sh.horizontalOverflow = HorizontalWrapMode.Wrap;
+            sandboxHint = sh.gameObject;
             RefreshMode(); // start on Explorer (sub-options hidden)
 
             // World options (sliders + presets): collected here, baked into the save at creation.
@@ -138,10 +149,15 @@ namespace BlocksBeyondTheStars.Client
                 optionsOverlay.SetActive(true);
             });
 
+            // Creative honours the checklist; Sandbox forces every grant on (free crafting makes blueprints
+            // moot, but owning all ships + the kit keeps testing friction-free).
+            bool UnlockAll() => mode[0] == 2 || (mode[0] == 1 && optBlueprints[0]);
+            bool AllShips() => mode[0] == 2 || (mode[0] == 1 && optShips[0]);
+            bool Kit() => mode[0] == 2 || (mode[0] == 1 && optKit[0]);
             UiKit.AddButton(right, 20f, 428f, 320f, 50f, shell.L("ui.save.create"),
-                () => Launch(name[0], creative[0] && optBlueprints[0], creative[0] && optShips[0], creative[0] && optKit[0], worldOptions), "btn_singleplayer");
+                () => Launch(name[0], UnlockAll(), AllShips(), Kit(), mode[0] == 2, worldOptions), "btn_singleplayer");
             UiKit.AddButton(right, 360f, 428f, 320f, 50f, shell.L("ui.save.random"),
-                () => Launch("world_" + Random.Range(1000, 999999), creative[0] && optBlueprints[0], creative[0] && optShips[0], creative[0] && optKit[0], worldOptions), "btn_join");
+                () => Launch("world_" + Random.Range(1000, 999999), UnlockAll(), AllShips(), Kit(), mode[0] == 2, worldOptions), "btn_join");
             UiKit.AddText(right, 20f, 486f, 660f, 50f, shell.L("ui.save.hint"), 14, UiKit.CyanDim, TextAnchor.UpperLeft).horizontalOverflow = HorizontalWrapMode.Wrap;
 
             // ── Host options (host mode only): player cap + optional join password ───────────────

--- a/data/locales/de.json
+++ b/data/locales/de.json
@@ -857,6 +857,8 @@
   "ui.save.mode": "Modus",
   "ui.save.mode_explorer": "Explorer",
   "ui.save.mode_creative": "Kreativ",
+  "ui.save.mode_sandbox": "Sandbox",
+  "ui.save.sandbox_hint": "Freies Bauen: Crafting kostet keine Materialien, kein Sauerstoff oder Hunger, keine Gegner — mit allen Blaupausen, Schiffen und dem Startset freigeschaltet. Perfekt zum Testen und Bauen.",
   "ui.save.opt_blueprints": "Alle Blaupausen freigeschaltet",
   "ui.save.opt_ships": "Alle Schiffe verfügbar",
   "ui.save.opt_kit": "Kreativ-Startset (Werkzeuge + Materialien)",

--- a/data/locales/en.json
+++ b/data/locales/en.json
@@ -856,6 +856,8 @@
   "ui.save.mode": "Mode",
   "ui.save.mode_explorer": "Explorer",
   "ui.save.mode_creative": "Creative",
+  "ui.save.mode_sandbox": "Sandbox",
+  "ui.save.sandbox_hint": "Free building: crafting costs no materials, no oxygen or hunger, no enemies — with all blueprints, ships and the starter kit unlocked. Perfect for testing and building.",
   "ui.save.opt_blueprints": "All blueprints unlocked",
   "ui.save.opt_ships": "All ships available",
   "ui.save.opt_kit": "Creative starter kit (tools + materials)",

--- a/src/BlocksBeyondTheStars.Shared/Configuration/ServerConfig.cs
+++ b/src/BlocksBeyondTheStars.Shared/Configuration/ServerConfig.cs
@@ -422,6 +422,17 @@ public sealed class ServerConfig
                 case "admin-bind":
                     AdminBindAddress = value; applied.Add("admin-bind");
                     break;
+                case "game-mode":
+                    // True sandbox (issue #662): "Creative" makes crafting free, disables oxygen/hunger and
+                    // keeps planet enemies/bandits off (both gate on Survival). Passed by the launcher only
+                    // at world creation — thereafter the save's baked RulesOverride carries the mode.
+                    if (Enum.TryParse<GameMode>(value, ignoreCase: true, out var gm))
+                    {
+                        Rules.GameMode = gm;
+                        applied.Add("game-mode");
+                    }
+
+                    break;
                 case "admin-cheats":
                     // Allow admin cheat commands (/tp, /give, /fly …) in every game mode. Passed by the
                     // bundled singleplayer/host launcher, where the solo player is the WorldAdmin anyway;

--- a/tests/BlocksBeyondTheStars.Tests/GameModeTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/GameModeTests.cs
@@ -69,6 +69,35 @@ public sealed class GameModeTests : IDisposable
     }
 
     [Fact]
+    public void SandboxMode_PersistsAcrossRestart_WithoutTheFlag()
+    {
+        // #662: the launcher passes --game-mode Creative only at world creation. A relaunch of the same
+        // save (no flag → Survival launch default) must keep Sandbox via the baked RulesOverride.
+        {
+            var config = new ServerConfig { WorldName = "sandbox", Seed = 1, AutoSaveIntervalMinutes = 9999 };
+            config.ApplyCommandLine(new[] { "--game-mode", "Creative" });
+            using var repo = new SqliteWorldRepository(new SaveGamePaths(_root, "sandbox"));
+            var st = new LoopbackServerTransport(new LoopbackLink());
+            var server = new SvGameServer(config, _content, st, repo);
+            server.Start();
+            Assert.Equal(GameMode.Creative, server.Metadata.RulesOverride!.GameMode);
+            repo.Flush();
+        }
+
+        {
+            var config = new ServerConfig { WorldName = "sandbox", Seed = 1, AutoSaveIntervalMinutes = 9999 };
+            using var repo = new SqliteWorldRepository(new SaveGamePaths(_root, "sandbox"));
+            var st = new LoopbackServerTransport(new LoopbackLink());
+            var server = new SvGameServer(config, _content, st, repo);
+            server.Start();
+
+            // The save's baked rules win over the flag-less launch default: still Sandbox, crafting free.
+            Assert.Equal(GameMode.Creative, server.Metadata.RulesOverride!.GameMode);
+            Assert.False(server.Metadata.RulesOverride.CraftingCostsMaterials);
+        }
+    }
+
+    [Fact]
     public void ServerRules_AreSentOnJoin()
     {
         using var repo = new SqliteWorldRepository(new SaveGamePaths(_root, "rules"));

--- a/tests/BlocksBeyondTheStars.Tests/ServerConfigTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/ServerConfigTests.cs
@@ -126,6 +126,25 @@ public sealed class ServerConfigTests
     }
 
     [Fact]
+    public void ApplyCommandLine_GameModeFlagSelectsSandbox()
+    {
+        // #662: the launcher passes --game-mode Creative when the player picks Sandbox at world
+        // creation. Case-insensitive; an unknown value leaves the Survival default untouched.
+        var config = new ServerConfig();
+        var applied = config.ApplyCommandLine(new[] { "--game-mode", "creative" });
+
+        Assert.Equal(GameMode.Creative, config.Rules.GameMode);
+        Assert.False(config.Rules.CraftingCostsMaterials);
+        Assert.False(config.Rules.OxygenEnabled);
+        Assert.False(config.Rules.HungerEnabled);
+        Assert.Contains("game-mode", applied);
+
+        var bad = new ServerConfig();
+        bad.ApplyCommandLine(new[] { "--game-mode", "nonsense" });
+        Assert.Equal(GameMode.Survival, bad.Rules.GameMode);
+    }
+
+    [Fact]
     public void ApplyCommandLine_OverridesShipWeaponsAndKeepRules()
     {
         var config = new ServerConfig();


### PR DESCRIPTION
## Summary

Adds a true **Sandbox** game mode, selectable as a third option (Explorer / Creative / Sandbox) in the new-world panel.

The rules layer already supported this via `GameMode.Creative` — free crafting at every craft/build/repair site, no oxygen/hunger drain, planet enemies + bandits off (both gate on `GameMode.Survival`), cheats allowed — but nothing settable ever reached it. This PR wires it up end to end.

## Changes

- **Server**: new `--game-mode <Survival|Creative>` CLI flag (`ServerConfig.ApplyCommandLine`). The mode is baked into the save's `RulesOverride` at creation, so it persists across relaunches without the flag. Existing saves are unaffected (default stays Survival, no lift needed).
- **Client UI**: `UiSaveSelect` mode row is now three buttons — Explorer / Creative / Sandbox. Sandbox forces all three creative grants on (all blueprints, all ships, starter kit) and shows a hint text instead of the checklist.
- **Launcher**: `LocalServerLauncher`/`AppShell` pass `--game-mode Creative` at world creation only.
- **Locales**: `ui.save.mode_sandbox` + `ui.save.sandbox_hint` (EN/DE).
- **Tests**: flag parsing (incl. invalid value → Survival default) and mode persistence across a server restart without the flag.

## Verification

- Full non-slow suite: 1481 tests green; Release build with 0 warnings.
- Local Unity client built from this branch; verified in the new-world panel and in-game (free crafting, no drains, peaceful, persistence across reload).

Closes #662

🤖 Generated with [Claude Code](https://claude.com/claude-code)