### PR TITLE
feat(ui): visible scrollbars on in-game menu, codex + vendor lists

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -102,6 +102,18 @@ Per-item detail lives in the dated work log below. **Since 2026-07 versions are 
 
 ---
 
+### ★ In-game menu lists show a scrollbar (#664, 2026-08-02, branch feat/ui-inline-scrollbars)
+The ship-computer menu (all 12 tabs), the Codex and the vendor dialog scrolled only via wheel/drag —
+nothing showed THAT a list continues or WHERE you are. New `UiKit.AddInlineScrollbar(scroll, width)`
+generalises ArcadeUI's thin cyan bar: anchored to the ScrollRect viewport's right edge (no per-pane
+coordinates), `AutoHide` so it vanishes when a page fits (plays with the floor-at-viewport-height
+content sizing), parented to the viewport so per-tab `ClearChildren` rebuilds can't destroy it.
+Wired in `CraftingTechShipUI.MakeScroll` (sidebar + card list + detail pane in one line),
+`WikiUI.BuildContentScroll`, and ArcadeUI now uses the shared helper instead of its private copy.
+Bonus (#664): `VendorTradeUI` rows had NO ScrollRect at all — long offer lists clipped past the
+panel; they now live in a masked scroll viewport with the same bar, keeping (clamped) scroll
+position across the inventory-update rebuild after a trade.
+
 ### ★ Flowing water survives restarts as FLOW (not as sources) + shallow water reads as liquid (#657, #658, 2026-08-01, branch fix/fluid-flow-persistence-and-surface — LOCAL, no PR yet)
 Two fluid fixes. **Persistence (#657, server):** the automaton's per-cell levels (1..8) and falling
 flags were memory-only while every spread step's fluid BLOCK persisted as a block edit — after a

--- a/client/Assets/BlocksBeyondTheStars/Scripts/ArcadeUI.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/ArcadeUI.cs
@@ -146,20 +146,7 @@ namespace BlocksBeyondTheStars.Client
             content.anchorMin = new Vector2(0f, 1f); content.anchorMax = new Vector2(0f, 1f); content.pivot = new Vector2(0f, 1f);
             content.sizeDelta = new Vector2(w, h); content.anchoredPosition = Vector2.zero;
             sr.content = content; sr.viewport = (RectTransform)viewGo.transform;
-
-            // Thin vertical scrollbar on the right edge.
-            var sbGo = new GameObject("Scrollbar", typeof(RectTransform), typeof(Image), typeof(Scrollbar));
-            var sbRT = (RectTransform)sbGo.transform; sbRT.SetParent(viewGo.transform, false);
-            sbRT.anchorMin = new Vector2(1f, 0f); sbRT.anchorMax = new Vector2(1f, 1f); sbRT.pivot = new Vector2(1f, 0.5f);
-            sbRT.sizeDelta = new Vector2(7f, 0f); sbRT.anchoredPosition = Vector2.zero;
-            sbGo.GetComponent<Image>().color = new Color(0.27f, 0.55f, 0.72f, 0.12f);
-            var sb = sbGo.GetComponent<Scrollbar>(); sb.direction = Scrollbar.Direction.BottomToTop;
-            var handleGo = new GameObject("Handle", typeof(RectTransform), typeof(Image));
-            var hRT = (RectTransform)handleGo.transform; hRT.SetParent(sbGo.transform, false);
-            hRT.anchorMin = Vector2.zero; hRT.anchorMax = Vector2.one; hRT.sizeDelta = Vector2.zero; hRT.anchoredPosition = Vector2.zero;
-            handleGo.GetComponent<Image>().color = new Color(0.27f, 0.84f, 1f, 0.55f);
-            sb.handleRect = hRT; sb.targetGraphic = handleGo.GetComponent<Image>();
-            sr.verticalScrollbar = sb; sr.verticalScrollbarVisibility = ScrollRect.ScrollbarVisibility.AutoHide;
+            UiKit.AddInlineScrollbar(sr, 7f);
             return content;
         }
 

--- a/client/Assets/BlocksBeyondTheStars/Scripts/CraftingTechShipUI.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/CraftingTechShipUI.cs
@@ -3370,6 +3370,7 @@ namespace BlocksBeyondTheStars.Client
             sr.content = content;
             sr.viewport = viewGo.GetComponent<RectTransform>();
             sr.scrollSensitivity = 30f;
+            UiKit.AddInlineScrollbar(sr); // sidebar/list/detail all get a position indicator (#664)
             return content;
         }
 

--- a/client/Assets/BlocksBeyondTheStars/Scripts/UiKit.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/UiKit.cs
@@ -544,6 +544,44 @@ namespace BlocksBeyondTheStars.Client
             return bar;
         }
 
+        /// <summary>A thin auto-hiding scrollbar hugging the ScrollRect viewport's right edge — anchor-based,
+        /// so callers need no coordinates, and AutoHide keeps it invisible whenever the page fits. Parent it
+        /// to the VIEWPORT (done here), never the content: per-tab rebuilds clear content children and would
+        /// destroy it. Visibility must stay AutoHide, not AutoHideAndExpandViewport — expanding would resize
+        /// the viewport and shift Place()-positioned children.</summary>
+        public static Scrollbar AddInlineScrollbar(ScrollRect scroll, float width = 8f)
+        {
+            var go = new GameObject("InlineScrollbar", typeof(RectTransform));
+            var rt = (RectTransform)go.transform;
+            rt.SetParent(scroll.viewport, false);
+            rt.anchorMin = new Vector2(1f, 0f);
+            rt.anchorMax = Vector2.one;
+            rt.pivot = new Vector2(1f, 0.5f);
+            rt.sizeDelta = new Vector2(width, 0f);
+            rt.anchoredPosition = Vector2.zero;
+            var track = go.AddComponent<Image>();
+            track.color = new Color(0.27f, 0.55f, 0.72f, 0.12f);
+
+            var bar = go.AddComponent<Scrollbar>();
+            bar.direction = Scrollbar.Direction.BottomToTop;
+
+            var handleGo = new GameObject("Handle", typeof(RectTransform));
+            var handleRt = (RectTransform)handleGo.transform;
+            handleRt.SetParent(go.transform, false);
+            handleRt.anchorMin = Vector2.zero;
+            handleRt.anchorMax = Vector2.one;
+            handleRt.sizeDelta = Vector2.zero;
+            handleRt.anchoredPosition = Vector2.zero;
+            var handle = handleGo.AddComponent<Image>();
+            handle.color = new Color(Cyan.r, Cyan.g, Cyan.b, 0.55f);
+
+            bar.handleRect = handleRt;
+            bar.targetGraphic = handle;
+            scroll.verticalScrollbar = bar;
+            scroll.verticalScrollbarVisibility = ScrollRect.ScrollbarVisibility.AutoHide;
+            return bar;
+        }
+
         public static Text AddText(Transform parent, float x, float y, float w, float h, string text, int size,
             Color color, TextAnchor anchor = TextAnchor.MiddleLeft, FontStyle style = FontStyle.Normal)
         {

--- a/client/Assets/BlocksBeyondTheStars/Scripts/VendorTradeUI.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/VendorTradeUI.cs
@@ -115,10 +115,28 @@ namespace BlocksBeyondTheStars.Client
             UiKit.AddText(_root, px + 40, py + 116, 380, 22, L("ui.vendor.give"), 15, UiKit.TextCol, TextAnchor.MiddleLeft, FontStyle.Bold);
             UiKit.AddText(_root, px + 470, py + 116, 320, 22, L("ui.vendor.get"), 15, UiKit.TextCol, TextAnchor.MiddleLeft, FontStyle.Bold);
 
+            // The rows live in a masked scroll viewport — a settlement can post more trades than the
+            // fixed panel height fits (they used to clip past the panel bottom).
             var rowsGo = new GameObject("Rows", typeof(RectTransform));
             rowsGo.transform.SetParent(_root, false);
             UiKit.Place(rowsGo, px, py + RowsTop, PanelW, PanelH - RowsTop - 80);
-            _rows = rowsGo.transform;
+            var scroll = rowsGo.AddComponent<ScrollRect>();
+            scroll.horizontal = false;
+            scroll.movementType = ScrollRect.MovementType.Clamped;
+            scroll.scrollSensitivity = 30f;
+            rowsGo.AddComponent<RectMask2D>();
+
+            var content = new GameObject("Content", typeof(RectTransform)).GetComponent<RectTransform>();
+            content.SetParent(rowsGo.transform, false);
+            content.anchorMin = new Vector2(0f, 1f);
+            content.anchorMax = new Vector2(0f, 1f);
+            content.pivot = new Vector2(0f, 1f);
+            content.sizeDelta = new Vector2(PanelW, PanelH - RowsTop - 80);
+            content.anchoredPosition = Vector2.zero;
+            scroll.content = content;
+            scroll.viewport = (RectTransform)rowsGo.transform;
+            UiKit.AddInlineScrollbar(scroll);
+            _rows = content;
 
             UiKit.AddText(_root, px + 40, py + PanelH - 50, PanelW - 320, 26, L("ui.vendor.hint"), 14, UiKit.CyanDim, TextAnchor.MiddleLeft);
             UiKit.AddButton(_root, px + PanelW - 220, py + PanelH - 64, 180, 46, L("ui.action.close"), Close);
@@ -166,6 +184,15 @@ namespace BlocksBeyondTheStars.Client
             {
                 UiKit.AddText(_rows, 20, 10, PanelW - 40, 30, L("ui.vendor.empty"), 18, UiKit.CyanDim, TextAnchor.MiddleLeft);
             }
+
+            // Size the scroll content to the rows (floored at the viewport so short lists don't scroll) and
+            // clamp the kept scroll position — an inventory-update rebuild mid-browse must not jump to the top.
+            var rows = (RectTransform)_rows;
+            float viewportH = ((RectTransform)rows.parent).rect.height;
+            float contentH = Mathf.Max(row * RowH + 8f, viewportH);
+            rows.sizeDelta = new Vector2(rows.sizeDelta.x, contentH);
+            rows.anchoredPosition = new Vector2(rows.anchoredPosition.x,
+                Mathf.Clamp(rows.anchoredPosition.y, 0f, contentH - viewportH));
         }
 
         private void AddRow(int index, BlocksBeyondTheStars.Shared.Definitions.RecipeDefinition r)

--- a/client/Assets/BlocksBeyondTheStars/Scripts/WikiUI.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/WikiUI.cs
@@ -164,6 +164,7 @@ namespace BlocksBeyondTheStars.Client
 
             scroll.viewport = (RectTransform)viewGo.transform;
             scroll.content = content;
+            UiKit.AddInlineScrollbar(scroll);
             return content;
         }
 


### PR DESCRIPTION
## Summary

The in-game ship-computer menu (all 12 tabs), the Codex and the vendor trade dialog scrolled only via mouse wheel / drag — nothing showed *that* a list continues below the fold or *where* you are in it.

- **New `UiKit.AddInlineScrollbar(scroll, width = 8f)`** — generalizes ArcadeUI''s thin cyan bar: anchored to the ScrollRect viewport''s right edge (no per-pane coordinates), `AutoHide` visibility so it vanishes whenever a page fits (plays with the floor-at-viewport-height content sizing), and parented to the **viewport** so per-tab `ClearChildren` rebuilds can''t destroy it.
- **`CraftingTechShipUI.MakeScroll`** — one line covers sidebar + card list + detail pane on all 12 tabs (widest card is 780 px of a 796 px viewport, so the 8 px edge bar never overlaps content).
- **`WikiUI.BuildContentScroll`** — Codex chapter pane gets the same bar.
- **`ArcadeUI`** — drops its private scrollbar copy for the shared helper.
- **`VendorTradeUI`** — adjacent find: the rows region had **no ScrollRect at all**, so a long offer list clipped past the panel. Rows now live in a masked scroll viewport with the same bar; the scroll position is kept (clamped) across the inventory-update rebuild after a trade.

## Verification

- Fast test suite green locally: 1334 + 147 passed, 0 failed.
- Local Unity batch build green, no C# warnings in `build.log`; fresh `BlocksBeyondTheStars.Client.dll` verified.

closes #664

🤖 Generated with [Claude Code](https://claude.com/claude-code)