### PR TITLE
feat(ships): Hammerhead — heavy gunship with the game's first multi-room interior

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7099,6 +7099,27 @@ is **pre-approved** (keys in `tools/ai-assets/.env`, run via `uv`).
 
 ---
 
+## ✅ Done (2026-08-04): Hammerhead — a heavy gunship with the game's first multi-room interior (#723)
+
+A fifth ship type above the corvette, built from a hand-drawn floor plan: a wide 12-block bridge (the
+"hammer head") up front, a central corridor running aft, and a workshop (port) + sleeping cabins
+(starboard) flanking it — each room behind its own interior door, stern airlock between the split main
+engine block. First layout with interior doors and a non-rectangular (T-shaped) hull.
+
+- **Layout** — new composite builder in `tools/gen_ship_layouts.py` (multi-room `room_box`/`doorway`
+  helpers) → `data/ship_layouts/ship_hammerhead.json` (14×4×15, 4 doors, 6 stations: cockpit/console
+  on the bridge, workshop/cargo, quarters/medbay). Existing layouts untouched (the generator drifted
+  from the committed, hand-tuned scout/corvette/hauler files — regen output for those is reverted).
+- **Server** — the layout floor-fill guarantee now fills only columns the hull encloses (floor or roof
+  cell) instead of the whole bounding rect: no floating floor tiles in the T-notches or under nav-light
+  attachments. Ship door registration forces the across-X axis only for the rear-wall (z=0) hatch
+  (B41a); interior doors resolve their axis from the jamb probe.
+- **Data** — `ships.json` (hull 220 / shield 60, speed 0.9 / handling 0.75, cargo 72, starts with
+  `ship_cannon_1`), `blueprints.json` (prereqs corvette + ship cannon), DE+EN locale strings.
+- **Tests** — `HammerheadShipTests` (T-footprint floor, 4 doors, room stations, no floor under nav
+  lights); the doorway-clearance test is now door-axis-aware and covers all four layouts.
+- NPC traders pick up the new type automatically. Doorway rule kept: 3-tall openings, clear gap columns.
+
 ## ✅ Done (2026-08-04): seed-determinism fixes — asteroid roll keys on the saved seed; stable audio hashing (#719/#720)
 
 Two findings from a worldgen-determinism audit (world = seed-recomputed baseline + persisted deltas;

--- a/data/blueprints.json
+++ b/data/blueprints.json
@@ -160,6 +160,11 @@
     "unlockCost": [ { "item": "data_fragment", "count": 4 }, { "item": "titanium_plate", "count": 11 }, { "item": "cable", "count": 5 } ]
   },
   {
+    "key": "ship_hammerhead", "nameKey": "blueprint.ship_hammerhead.name", "descriptionKey": "blueprint.ship_hammerhead.desc",
+    "category": "Ship", "prerequisites": [ "ship_corvette", "ship_cannon_1" ],
+    "unlockCost": [ { "item": "data_fragment", "count": 6 }, { "item": "titanium_plate", "count": 18 }, { "item": "steel", "count": 4 } ]
+  },
+  {
     "key": "stealth_suit", "nameKey": "blueprint.stealth_suit.name", "descriptionKey": "blueprint.stealth_suit.desc",
     "category": "Suit", "prerequisites": [], "knowledgeCost": 14,
     "unlockCost": [ { "item": "data_fragment", "count": 4 }, { "item": "titanium_plate", "count": 8 }, { "item": "cable", "count": 8 } ]

--- a/data/locales/de.json
+++ b/data/locales/de.json
@@ -495,6 +495,8 @@
   "blueprint.ship_scout.desc": "Schaltet den Bau des Kundschafters frei — ein kleines, geschütztes Schiff.",
   "blueprint.ship_corvette.name": "Korvette",
   "blueprint.ship_corvette.desc": "Schaltet den Bau der Korvette frei — ein ausgewogenes Schiff der Mittelklasse.",
+  "blueprint.ship_hammerhead.name": "Hammerhai",
+  "blueprint.ship_hammerhead.desc": "Schaltet den Bau des Hammerhais frei — ein schweres Kanonenschiff mit mehreren Räumen.",
   "ship.starter.name": "Startschiff",
   "ship.starter.desc": "Dein erstes Schiff — Werkstatt, Medbay, Quartier und ein einfacher Frachtraum.",
   "ship.hauler.name": "Frachter",
@@ -503,6 +505,8 @@
   "ship.scout.desc": "Ein kleines, geschütztes Schiff für schnelle Ausflüge.",
   "ship.corvette.name": "Korvette",
   "ship.corvette.desc": "Ein ausgewogenes Schiff der Mittelklasse — solide Hülle, Schild, Tempo und Fracht.",
+  "ship.hammerhead.name": "Hammerhai",
+  "ship.hammerhead.desc": "Ein schweres Kanonenschiff mit breiter Brücke und echten Räumen — Werkbereich und Schlafkabinen an einem langen Mittelgang. Trifft hart, fühlt sich wie Zuhause an.",
 
   "ui.hud.health": "Gesundheit",
   "ui.hud.oxygen": "Sauerstoff",

--- a/data/locales/en.json
+++ b/data/locales/en.json
@@ -446,6 +446,8 @@
   "blueprint.ship_scout.desc": "Unlocks crafting the Scout — a small, shielded ship.",
   "blueprint.ship_corvette.name": "Corvette",
   "blueprint.ship_corvette.desc": "Unlocks crafting the Corvette — a balanced mid-class ship.",
+  "blueprint.ship_hammerhead.name": "Hammerhead",
+  "blueprint.ship_hammerhead.desc": "Unlocks crafting the Hammerhead — a heavy gunship with a multi-room interior.",
   "ship.starter.name": "Starter Ship",
   "ship.starter.desc": "Your first ship — workshop, medbay, quarters and a basic cargo hold.",
   "ship.hauler.name": "Hauler",
@@ -454,6 +456,8 @@
   "ship.scout.desc": "A small, shielded ship for quick trips.",
   "ship.corvette.name": "Corvette",
   "ship.corvette.desc": "A balanced mid-class ship — solid hull, shield, speed and cargo.",
+  "ship.hammerhead.name": "Hammerhead",
+  "ship.hammerhead.desc": "A heavy gunship with a wide bridge and real rooms — workshop and sleeping cabins off a long central corridor. Hits hard, feels like home.",
 
   "module.cockpit.name": "Cockpit",
   "module.cockpit.desc": "Access the star map, travel and scanning.",

--- a/data/ship_layouts/ship_hammerhead.json
+++ b/data/ship_layouts/ship_hammerhead.json
@@ -1,0 +1,3955 @@
+{
+ "width": 14,
+ "height": 4,
+ "length": 15,
+ "cells": [
+  {
+   "x": 0,
+   "y": 0,
+   "z": 0,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 0,
+   "y": 0,
+   "z": 1,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 0,
+   "y": 0,
+   "z": 2,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 0,
+   "y": 0,
+   "z": 3,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 0,
+   "y": 0,
+   "z": 4,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 0,
+   "y": 0,
+   "z": 5,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 0,
+   "y": 1,
+   "z": 0,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 0,
+   "y": 1,
+   "z": 1,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 0,
+   "y": 1,
+   "z": 2,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 0,
+   "y": 1,
+   "z": 3,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 0,
+   "y": 1,
+   "z": 4,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 0,
+   "y": 1,
+   "z": 5,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 0,
+   "y": 2,
+   "z": 0,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 0,
+   "y": 2,
+   "z": 1,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 0,
+   "y": 2,
+   "z": 2,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 0,
+   "y": 2,
+   "z": 3,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 0,
+   "y": 2,
+   "z": 4,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 0,
+   "y": 2,
+   "z": 5,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 0,
+   "y": 2,
+   "z": 12,
+   "kind": "block",
+   "id": "light_red"
+  },
+  {
+   "x": 0,
+   "y": 3,
+   "z": 0,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 0,
+   "y": 3,
+   "z": 1,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 0,
+   "y": 3,
+   "z": 2,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 0,
+   "y": 3,
+   "z": 3,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 0,
+   "y": 3,
+   "z": 4,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 0,
+   "y": 3,
+   "z": 5,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 0,
+   "y": 4,
+   "z": 0,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 0,
+   "y": 4,
+   "z": 1,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 0,
+   "y": 4,
+   "z": 2,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 0,
+   "y": 4,
+   "z": 3,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 0,
+   "y": 4,
+   "z": 4,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 0,
+   "y": 4,
+   "z": 5,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 1,
+   "y": 0,
+   "z": 0,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 1,
+   "y": 0,
+   "z": 1,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 1,
+   "y": 0,
+   "z": 2,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 1,
+   "y": 0,
+   "z": 3,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 1,
+   "y": 0,
+   "z": 4,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 1,
+   "y": 0,
+   "z": 5,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 1,
+   "y": 0,
+   "z": 10,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 1,
+   "y": 0,
+   "z": 11,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 1,
+   "y": 0,
+   "z": 12,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 1,
+   "y": 0,
+   "z": 13,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 1,
+   "y": 0,
+   "z": 14,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 1,
+   "y": 1,
+   "z": 0,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 1,
+   "y": 1,
+   "z": 5,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 1,
+   "y": 1,
+   "z": 10,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 1,
+   "y": 1,
+   "z": 11,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 1,
+   "y": 1,
+   "z": 12,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 1,
+   "y": 1,
+   "z": 13,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 1,
+   "y": 1,
+   "z": 14,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 1,
+   "y": 2,
+   "z": 0,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 1,
+   "y": 2,
+   "z": 5,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 1,
+   "y": 2,
+   "z": 10,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 1,
+   "y": 2,
+   "z": 11,
+   "kind": "block",
+   "id": "glass"
+  },
+  {
+   "x": 1,
+   "y": 2,
+   "z": 12,
+   "kind": "block",
+   "id": "glass"
+  },
+  {
+   "x": 1,
+   "y": 2,
+   "z": 13,
+   "kind": "block",
+   "id": "glass"
+  },
+  {
+   "x": 1,
+   "y": 2,
+   "z": 14,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 1,
+   "y": 3,
+   "z": 0,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 1,
+   "y": 3,
+   "z": 5,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 1,
+   "y": 3,
+   "z": 10,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 1,
+   "y": 3,
+   "z": 11,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 1,
+   "y": 3,
+   "z": 12,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 1,
+   "y": 3,
+   "z": 13,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 1,
+   "y": 3,
+   "z": 14,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 1,
+   "y": 4,
+   "z": 0,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 1,
+   "y": 4,
+   "z": 1,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 1,
+   "y": 4,
+   "z": 2,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 1,
+   "y": 4,
+   "z": 3,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 1,
+   "y": 4,
+   "z": 4,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 1,
+   "y": 4,
+   "z": 5,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 1,
+   "y": 4,
+   "z": 10,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 1,
+   "y": 4,
+   "z": 11,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 1,
+   "y": 4,
+   "z": 12,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 1,
+   "y": 4,
+   "z": 13,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 1,
+   "y": 4,
+   "z": 14,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 2,
+   "y": 0,
+   "z": 0,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 2,
+   "y": 0,
+   "z": 1,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 2,
+   "y": 0,
+   "z": 2,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 2,
+   "y": 0,
+   "z": 3,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 2,
+   "y": 0,
+   "z": 4,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 2,
+   "y": 0,
+   "z": 5,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 2,
+   "y": 0,
+   "z": 10,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 2,
+   "y": 0,
+   "z": 11,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 2,
+   "y": 0,
+   "z": 12,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 2,
+   "y": 0,
+   "z": 13,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 2,
+   "y": 0,
+   "z": 14,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 2,
+   "y": 1,
+   "z": -1,
+   "kind": "block",
+   "id": "engine"
+  },
+  {
+   "x": 2,
+   "y": 1,
+   "z": 0,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 2,
+   "y": 1,
+   "z": 1,
+   "kind": "station",
+   "id": "workshop"
+  },
+  {
+   "x": 2,
+   "y": 1,
+   "z": 4,
+   "kind": "station",
+   "id": "cargo"
+  },
+  {
+   "x": 2,
+   "y": 1,
+   "z": 5,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 2,
+   "y": 1,
+   "z": 10,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 2,
+   "y": 1,
+   "z": 14,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 2,
+   "y": 2,
+   "z": 0,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 2,
+   "y": 2,
+   "z": 5,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 2,
+   "y": 2,
+   "z": 10,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 2,
+   "y": 2,
+   "z": 14,
+   "kind": "block",
+   "id": "glass"
+  },
+  {
+   "x": 2,
+   "y": 3,
+   "z": 0,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 2,
+   "y": 3,
+   "z": 5,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 2,
+   "y": 3,
+   "z": 10,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 2,
+   "y": 3,
+   "z": 14,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 2,
+   "y": 4,
+   "z": 0,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 2,
+   "y": 4,
+   "z": 1,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 2,
+   "y": 4,
+   "z": 2,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 2,
+   "y": 4,
+   "z": 3,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 2,
+   "y": 4,
+   "z": 4,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 2,
+   "y": 4,
+   "z": 5,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 2,
+   "y": 4,
+   "z": 10,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 2,
+   "y": 4,
+   "z": 11,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 2,
+   "y": 4,
+   "z": 12,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 2,
+   "y": 4,
+   "z": 13,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 2,
+   "y": 4,
+   "z": 14,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 3,
+   "y": 0,
+   "z": 0,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 3,
+   "y": 0,
+   "z": 1,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 3,
+   "y": 0,
+   "z": 2,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 3,
+   "y": 0,
+   "z": 3,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 3,
+   "y": 0,
+   "z": 4,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 3,
+   "y": 0,
+   "z": 5,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 3,
+   "y": 0,
+   "z": 10,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 3,
+   "y": 0,
+   "z": 11,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 3,
+   "y": 0,
+   "z": 12,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 3,
+   "y": 0,
+   "z": 13,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 3,
+   "y": 0,
+   "z": 14,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 3,
+   "y": 1,
+   "z": 0,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 3,
+   "y": 1,
+   "z": 5,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 3,
+   "y": 1,
+   "z": 10,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 3,
+   "y": 1,
+   "z": 14,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 3,
+   "y": 2,
+   "z": 0,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 3,
+   "y": 2,
+   "z": 5,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 3,
+   "y": 2,
+   "z": 10,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 3,
+   "y": 2,
+   "z": 14,
+   "kind": "block",
+   "id": "glass"
+  },
+  {
+   "x": 3,
+   "y": 3,
+   "z": 0,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 3,
+   "y": 3,
+   "z": 5,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 3,
+   "y": 3,
+   "z": 10,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 3,
+   "y": 3,
+   "z": 14,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 3,
+   "y": 4,
+   "z": 0,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 3,
+   "y": 4,
+   "z": 1,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 3,
+   "y": 4,
+   "z": 2,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 3,
+   "y": 4,
+   "z": 3,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 3,
+   "y": 4,
+   "z": 4,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 3,
+   "y": 4,
+   "z": 5,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 3,
+   "y": 4,
+   "z": 10,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 3,
+   "y": 4,
+   "z": 11,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 3,
+   "y": 4,
+   "z": 12,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 3,
+   "y": 4,
+   "z": 13,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 3,
+   "y": 4,
+   "z": 14,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 4,
+   "y": 0,
+   "z": 0,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 4,
+   "y": 0,
+   "z": 1,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 4,
+   "y": 0,
+   "z": 2,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 4,
+   "y": 0,
+   "z": 3,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 4,
+   "y": 0,
+   "z": 4,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 4,
+   "y": 0,
+   "z": 5,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 4,
+   "y": 0,
+   "z": 10,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 4,
+   "y": 0,
+   "z": 11,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 4,
+   "y": 0,
+   "z": 12,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 4,
+   "y": 0,
+   "z": 13,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 4,
+   "y": 0,
+   "z": 14,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 4,
+   "y": 1,
+   "z": -1,
+   "kind": "block",
+   "id": "engine"
+  },
+  {
+   "x": 4,
+   "y": 1,
+   "z": 0,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 4,
+   "y": 1,
+   "z": 5,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 4,
+   "y": 1,
+   "z": 10,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 4,
+   "y": 1,
+   "z": 13,
+   "kind": "station",
+   "id": "console"
+  },
+  {
+   "x": 4,
+   "y": 1,
+   "z": 14,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 4,
+   "y": 2,
+   "z": -1,
+   "kind": "block",
+   "id": "engine"
+  },
+  {
+   "x": 4,
+   "y": 2,
+   "z": 0,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 4,
+   "y": 2,
+   "z": 5,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 4,
+   "y": 2,
+   "z": 10,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 4,
+   "y": 2,
+   "z": 14,
+   "kind": "block",
+   "id": "glass"
+  },
+  {
+   "x": 4,
+   "y": 2,
+   "z": 15,
+   "kind": "block",
+   "id": "light"
+  },
+  {
+   "x": 4,
+   "y": 3,
+   "z": 0,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 4,
+   "y": 3,
+   "z": 5,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 4,
+   "y": 3,
+   "z": 10,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 4,
+   "y": 3,
+   "z": 14,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 4,
+   "y": 4,
+   "z": 0,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 4,
+   "y": 4,
+   "z": 1,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 4,
+   "y": 4,
+   "z": 2,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 4,
+   "y": 4,
+   "z": 3,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 4,
+   "y": 4,
+   "z": 4,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 4,
+   "y": 4,
+   "z": 5,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 4,
+   "y": 4,
+   "z": 10,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 4,
+   "y": 4,
+   "z": 11,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 4,
+   "y": 4,
+   "z": 12,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 4,
+   "y": 4,
+   "z": 13,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 4,
+   "y": 4,
+   "z": 14,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 5,
+   "y": 0,
+   "z": 0,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 5,
+   "y": 0,
+   "z": 1,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 5,
+   "y": 0,
+   "z": 2,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 5,
+   "y": 0,
+   "z": 3,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 5,
+   "y": 0,
+   "z": 4,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 5,
+   "y": 0,
+   "z": 5,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 5,
+   "y": 0,
+   "z": 6,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 5,
+   "y": 0,
+   "z": 7,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 5,
+   "y": 0,
+   "z": 8,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 5,
+   "y": 0,
+   "z": 9,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 5,
+   "y": 0,
+   "z": 10,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 5,
+   "y": 0,
+   "z": 11,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 5,
+   "y": 0,
+   "z": 12,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 5,
+   "y": 0,
+   "z": 13,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 5,
+   "y": 0,
+   "z": 14,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 5,
+   "y": 1,
+   "z": -1,
+   "kind": "block",
+   "id": "engine"
+  },
+  {
+   "x": 5,
+   "y": 1,
+   "z": 0,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 5,
+   "y": 1,
+   "z": 1,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 5,
+   "y": 1,
+   "z": 2,
+   "kind": "element",
+   "id": "door_slide"
+  },
+  {
+   "x": 5,
+   "y": 1,
+   "z": 4,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 5,
+   "y": 1,
+   "z": 5,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 5,
+   "y": 1,
+   "z": 6,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 5,
+   "y": 1,
+   "z": 7,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 5,
+   "y": 1,
+   "z": 8,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 5,
+   "y": 1,
+   "z": 9,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 5,
+   "y": 1,
+   "z": 10,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 5,
+   "y": 1,
+   "z": 14,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 5,
+   "y": 2,
+   "z": -1,
+   "kind": "block",
+   "id": "engine"
+  },
+  {
+   "x": 5,
+   "y": 2,
+   "z": 0,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 5,
+   "y": 2,
+   "z": 1,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 5,
+   "y": 2,
+   "z": 4,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 5,
+   "y": 2,
+   "z": 5,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 5,
+   "y": 2,
+   "z": 6,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 5,
+   "y": 2,
+   "z": 7,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 5,
+   "y": 2,
+   "z": 8,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 5,
+   "y": 2,
+   "z": 9,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 5,
+   "y": 2,
+   "z": 10,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 5,
+   "y": 2,
+   "z": 14,
+   "kind": "block",
+   "id": "glass"
+  },
+  {
+   "x": 5,
+   "y": 3,
+   "z": 0,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 5,
+   "y": 3,
+   "z": 1,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 5,
+   "y": 3,
+   "z": 4,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 5,
+   "y": 3,
+   "z": 5,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 5,
+   "y": 3,
+   "z": 6,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 5,
+   "y": 3,
+   "z": 7,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 5,
+   "y": 3,
+   "z": 8,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 5,
+   "y": 3,
+   "z": 9,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 5,
+   "y": 3,
+   "z": 10,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 5,
+   "y": 3,
+   "z": 14,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 5,
+   "y": 4,
+   "z": 0,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 5,
+   "y": 4,
+   "z": 1,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 5,
+   "y": 4,
+   "z": 2,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 5,
+   "y": 4,
+   "z": 3,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 5,
+   "y": 4,
+   "z": 4,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 5,
+   "y": 4,
+   "z": 5,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 5,
+   "y": 4,
+   "z": 6,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 5,
+   "y": 4,
+   "z": 7,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 5,
+   "y": 4,
+   "z": 8,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 5,
+   "y": 4,
+   "z": 9,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 5,
+   "y": 4,
+   "z": 10,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 5,
+   "y": 4,
+   "z": 11,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 5,
+   "y": 4,
+   "z": 12,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 5,
+   "y": 4,
+   "z": 13,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 5,
+   "y": 4,
+   "z": 14,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 6,
+   "y": 0,
+   "z": 0,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 6,
+   "y": 0,
+   "z": 1,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 6,
+   "y": 0,
+   "z": 2,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 6,
+   "y": 0,
+   "z": 3,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 6,
+   "y": 0,
+   "z": 4,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 6,
+   "y": 0,
+   "z": 5,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 6,
+   "y": 0,
+   "z": 6,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 6,
+   "y": 0,
+   "z": 7,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 6,
+   "y": 0,
+   "z": 8,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 6,
+   "y": 0,
+   "z": 9,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 6,
+   "y": 0,
+   "z": 10,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 6,
+   "y": 0,
+   "z": 11,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 6,
+   "y": 0,
+   "z": 12,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 6,
+   "y": 0,
+   "z": 13,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 6,
+   "y": 0,
+   "z": 14,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 6,
+   "y": 1,
+   "z": 0,
+   "kind": "element",
+   "id": "door_slide"
+  },
+  {
+   "x": 6,
+   "y": 1,
+   "z": 10,
+   "kind": "element",
+   "id": "door_slide"
+  },
+  {
+   "x": 6,
+   "y": 1,
+   "z": 14,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 6,
+   "y": 2,
+   "z": 14,
+   "kind": "block",
+   "id": "glass"
+  },
+  {
+   "x": 6,
+   "y": 3,
+   "z": 14,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 6,
+   "y": 4,
+   "z": 0,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 6,
+   "y": 4,
+   "z": 1,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 6,
+   "y": 4,
+   "z": 2,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 6,
+   "y": 4,
+   "z": 3,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 6,
+   "y": 4,
+   "z": 4,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 6,
+   "y": 4,
+   "z": 5,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 6,
+   "y": 4,
+   "z": 6,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 6,
+   "y": 4,
+   "z": 7,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 6,
+   "y": 4,
+   "z": 8,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 6,
+   "y": 4,
+   "z": 9,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 6,
+   "y": 4,
+   "z": 10,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 6,
+   "y": 4,
+   "z": 11,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 6,
+   "y": 4,
+   "z": 12,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 6,
+   "y": 4,
+   "z": 13,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 6,
+   "y": 4,
+   "z": 14,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 6,
+   "y": 5,
+   "z": 12,
+   "kind": "block",
+   "id": "glass"
+  },
+  {
+   "x": 6,
+   "y": 5,
+   "z": 13,
+   "kind": "block",
+   "id": "glass"
+  },
+  {
+   "x": 7,
+   "y": 0,
+   "z": 0,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 7,
+   "y": 0,
+   "z": 1,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 7,
+   "y": 0,
+   "z": 2,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 7,
+   "y": 0,
+   "z": 3,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 7,
+   "y": 0,
+   "z": 4,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 7,
+   "y": 0,
+   "z": 5,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 7,
+   "y": 0,
+   "z": 6,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 7,
+   "y": 0,
+   "z": 7,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 7,
+   "y": 0,
+   "z": 8,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 7,
+   "y": 0,
+   "z": 9,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 7,
+   "y": 0,
+   "z": 10,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 7,
+   "y": 0,
+   "z": 11,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 7,
+   "y": 0,
+   "z": 12,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 7,
+   "y": 0,
+   "z": 13,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 7,
+   "y": 0,
+   "z": 14,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 7,
+   "y": 1,
+   "z": 13,
+   "kind": "station",
+   "id": "cockpit"
+  },
+  {
+   "x": 7,
+   "y": 1,
+   "z": 14,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 7,
+   "y": 2,
+   "z": 14,
+   "kind": "block",
+   "id": "glass"
+  },
+  {
+   "x": 7,
+   "y": 3,
+   "z": 14,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 7,
+   "y": 4,
+   "z": 0,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 7,
+   "y": 4,
+   "z": 1,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 7,
+   "y": 4,
+   "z": 2,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 7,
+   "y": 4,
+   "z": 3,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 7,
+   "y": 4,
+   "z": 4,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 7,
+   "y": 4,
+   "z": 5,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 7,
+   "y": 4,
+   "z": 6,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 7,
+   "y": 4,
+   "z": 7,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 7,
+   "y": 4,
+   "z": 8,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 7,
+   "y": 4,
+   "z": 9,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 7,
+   "y": 4,
+   "z": 10,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 7,
+   "y": 4,
+   "z": 11,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 7,
+   "y": 4,
+   "z": 12,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 7,
+   "y": 4,
+   "z": 13,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 7,
+   "y": 4,
+   "z": 14,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 7,
+   "y": 5,
+   "z": 12,
+   "kind": "block",
+   "id": "glass"
+  },
+  {
+   "x": 7,
+   "y": 5,
+   "z": 13,
+   "kind": "block",
+   "id": "glass"
+  },
+  {
+   "x": 8,
+   "y": 0,
+   "z": 0,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 8,
+   "y": 0,
+   "z": 1,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 8,
+   "y": 0,
+   "z": 2,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 8,
+   "y": 0,
+   "z": 3,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 8,
+   "y": 0,
+   "z": 4,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 8,
+   "y": 0,
+   "z": 5,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 8,
+   "y": 0,
+   "z": 6,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 8,
+   "y": 0,
+   "z": 7,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 8,
+   "y": 0,
+   "z": 8,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 8,
+   "y": 0,
+   "z": 9,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 8,
+   "y": 0,
+   "z": 10,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 8,
+   "y": 0,
+   "z": 11,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 8,
+   "y": 0,
+   "z": 12,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 8,
+   "y": 0,
+   "z": 13,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 8,
+   "y": 0,
+   "z": 14,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 8,
+   "y": 1,
+   "z": -1,
+   "kind": "block",
+   "id": "engine"
+  },
+  {
+   "x": 8,
+   "y": 1,
+   "z": 0,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 8,
+   "y": 1,
+   "z": 1,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 8,
+   "y": 1,
+   "z": 3,
+   "kind": "element",
+   "id": "door_slide"
+  },
+  {
+   "x": 8,
+   "y": 1,
+   "z": 4,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 8,
+   "y": 1,
+   "z": 5,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 8,
+   "y": 1,
+   "z": 6,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 8,
+   "y": 1,
+   "z": 7,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 8,
+   "y": 1,
+   "z": 8,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 8,
+   "y": 1,
+   "z": 9,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 8,
+   "y": 1,
+   "z": 10,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 8,
+   "y": 1,
+   "z": 14,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 8,
+   "y": 2,
+   "z": -1,
+   "kind": "block",
+   "id": "engine"
+  },
+  {
+   "x": 8,
+   "y": 2,
+   "z": 0,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 8,
+   "y": 2,
+   "z": 1,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 8,
+   "y": 2,
+   "z": 4,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 8,
+   "y": 2,
+   "z": 5,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 8,
+   "y": 2,
+   "z": 6,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 8,
+   "y": 2,
+   "z": 7,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 8,
+   "y": 2,
+   "z": 8,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 8,
+   "y": 2,
+   "z": 9,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 8,
+   "y": 2,
+   "z": 10,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 8,
+   "y": 2,
+   "z": 14,
+   "kind": "block",
+   "id": "glass"
+  },
+  {
+   "x": 8,
+   "y": 3,
+   "z": 0,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 8,
+   "y": 3,
+   "z": 1,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 8,
+   "y": 3,
+   "z": 4,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 8,
+   "y": 3,
+   "z": 5,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 8,
+   "y": 3,
+   "z": 6,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 8,
+   "y": 3,
+   "z": 7,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 8,
+   "y": 3,
+   "z": 8,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 8,
+   "y": 3,
+   "z": 9,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 8,
+   "y": 3,
+   "z": 10,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 8,
+   "y": 3,
+   "z": 14,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 8,
+   "y": 4,
+   "z": 0,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 8,
+   "y": 4,
+   "z": 1,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 8,
+   "y": 4,
+   "z": 2,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 8,
+   "y": 4,
+   "z": 3,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 8,
+   "y": 4,
+   "z": 4,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 8,
+   "y": 4,
+   "z": 5,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 8,
+   "y": 4,
+   "z": 6,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 8,
+   "y": 4,
+   "z": 7,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 8,
+   "y": 4,
+   "z": 8,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 8,
+   "y": 4,
+   "z": 9,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 8,
+   "y": 4,
+   "z": 10,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 8,
+   "y": 4,
+   "z": 11,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 8,
+   "y": 4,
+   "z": 12,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 8,
+   "y": 4,
+   "z": 13,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 8,
+   "y": 4,
+   "z": 14,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 9,
+   "y": 0,
+   "z": 0,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 9,
+   "y": 0,
+   "z": 1,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 9,
+   "y": 0,
+   "z": 2,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 9,
+   "y": 0,
+   "z": 3,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 9,
+   "y": 0,
+   "z": 4,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 9,
+   "y": 0,
+   "z": 5,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 9,
+   "y": 0,
+   "z": 10,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 9,
+   "y": 0,
+   "z": 11,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 9,
+   "y": 0,
+   "z": 12,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 9,
+   "y": 0,
+   "z": 13,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 9,
+   "y": 0,
+   "z": 14,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 9,
+   "y": 1,
+   "z": -1,
+   "kind": "block",
+   "id": "engine"
+  },
+  {
+   "x": 9,
+   "y": 1,
+   "z": 0,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 9,
+   "y": 1,
+   "z": 5,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 9,
+   "y": 1,
+   "z": 10,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 9,
+   "y": 1,
+   "z": 14,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 9,
+   "y": 2,
+   "z": -1,
+   "kind": "block",
+   "id": "engine"
+  },
+  {
+   "x": 9,
+   "y": 2,
+   "z": 0,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 9,
+   "y": 2,
+   "z": 5,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 9,
+   "y": 2,
+   "z": 10,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 9,
+   "y": 2,
+   "z": 14,
+   "kind": "block",
+   "id": "glass"
+  },
+  {
+   "x": 9,
+   "y": 2,
+   "z": 15,
+   "kind": "block",
+   "id": "light"
+  },
+  {
+   "x": 9,
+   "y": 3,
+   "z": 0,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 9,
+   "y": 3,
+   "z": 5,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 9,
+   "y": 3,
+   "z": 10,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 9,
+   "y": 3,
+   "z": 14,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 9,
+   "y": 4,
+   "z": 0,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 9,
+   "y": 4,
+   "z": 1,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 9,
+   "y": 4,
+   "z": 2,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 9,
+   "y": 4,
+   "z": 3,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 9,
+   "y": 4,
+   "z": 4,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 9,
+   "y": 4,
+   "z": 5,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 9,
+   "y": 4,
+   "z": 10,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 9,
+   "y": 4,
+   "z": 11,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 9,
+   "y": 4,
+   "z": 12,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 9,
+   "y": 4,
+   "z": 13,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 9,
+   "y": 4,
+   "z": 14,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 10,
+   "y": 0,
+   "z": 0,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 10,
+   "y": 0,
+   "z": 1,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 10,
+   "y": 0,
+   "z": 2,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 10,
+   "y": 0,
+   "z": 3,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 10,
+   "y": 0,
+   "z": 4,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 10,
+   "y": 0,
+   "z": 5,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 10,
+   "y": 0,
+   "z": 10,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 10,
+   "y": 0,
+   "z": 11,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 10,
+   "y": 0,
+   "z": 12,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 10,
+   "y": 0,
+   "z": 13,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 10,
+   "y": 0,
+   "z": 14,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 10,
+   "y": 1,
+   "z": 0,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 10,
+   "y": 1,
+   "z": 5,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 10,
+   "y": 1,
+   "z": 10,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 10,
+   "y": 1,
+   "z": 14,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 10,
+   "y": 2,
+   "z": 0,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 10,
+   "y": 2,
+   "z": 5,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 10,
+   "y": 2,
+   "z": 10,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 10,
+   "y": 2,
+   "z": 14,
+   "kind": "block",
+   "id": "glass"
+  },
+  {
+   "x": 10,
+   "y": 3,
+   "z": 0,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 10,
+   "y": 3,
+   "z": 5,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 10,
+   "y": 3,
+   "z": 10,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 10,
+   "y": 3,
+   "z": 14,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 10,
+   "y": 4,
+   "z": 0,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 10,
+   "y": 4,
+   "z": 1,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 10,
+   "y": 4,
+   "z": 2,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 10,
+   "y": 4,
+   "z": 3,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 10,
+   "y": 4,
+   "z": 4,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 10,
+   "y": 4,
+   "z": 5,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 10,
+   "y": 4,
+   "z": 10,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 10,
+   "y": 4,
+   "z": 11,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 10,
+   "y": 4,
+   "z": 12,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 10,
+   "y": 4,
+   "z": 13,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 10,
+   "y": 4,
+   "z": 14,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 11,
+   "y": 0,
+   "z": 0,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 11,
+   "y": 0,
+   "z": 1,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 11,
+   "y": 0,
+   "z": 2,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 11,
+   "y": 0,
+   "z": 3,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 11,
+   "y": 0,
+   "z": 4,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 11,
+   "y": 0,
+   "z": 5,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 11,
+   "y": 0,
+   "z": 10,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 11,
+   "y": 0,
+   "z": 11,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 11,
+   "y": 0,
+   "z": 12,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 11,
+   "y": 0,
+   "z": 13,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 11,
+   "y": 0,
+   "z": 14,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 11,
+   "y": 1,
+   "z": -1,
+   "kind": "block",
+   "id": "engine"
+  },
+  {
+   "x": 11,
+   "y": 1,
+   "z": 0,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 11,
+   "y": 1,
+   "z": 1,
+   "kind": "station",
+   "id": "quarters"
+  },
+  {
+   "x": 11,
+   "y": 1,
+   "z": 4,
+   "kind": "station",
+   "id": "medbay"
+  },
+  {
+   "x": 11,
+   "y": 1,
+   "z": 5,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 11,
+   "y": 1,
+   "z": 10,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 11,
+   "y": 1,
+   "z": 14,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 11,
+   "y": 2,
+   "z": 0,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 11,
+   "y": 2,
+   "z": 5,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 11,
+   "y": 2,
+   "z": 10,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 11,
+   "y": 2,
+   "z": 14,
+   "kind": "block",
+   "id": "glass"
+  },
+  {
+   "x": 11,
+   "y": 3,
+   "z": 0,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 11,
+   "y": 3,
+   "z": 5,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 11,
+   "y": 3,
+   "z": 10,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 11,
+   "y": 3,
+   "z": 14,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 11,
+   "y": 4,
+   "z": 0,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 11,
+   "y": 4,
+   "z": 1,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 11,
+   "y": 4,
+   "z": 2,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 11,
+   "y": 4,
+   "z": 3,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 11,
+   "y": 4,
+   "z": 4,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 11,
+   "y": 4,
+   "z": 5,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 11,
+   "y": 4,
+   "z": 10,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 11,
+   "y": 4,
+   "z": 11,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 11,
+   "y": 4,
+   "z": 12,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 11,
+   "y": 4,
+   "z": 13,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 11,
+   "y": 4,
+   "z": 14,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 12,
+   "y": 0,
+   "z": 0,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 12,
+   "y": 0,
+   "z": 1,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 12,
+   "y": 0,
+   "z": 2,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 12,
+   "y": 0,
+   "z": 3,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 12,
+   "y": 0,
+   "z": 4,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 12,
+   "y": 0,
+   "z": 5,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 12,
+   "y": 0,
+   "z": 10,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 12,
+   "y": 0,
+   "z": 11,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 12,
+   "y": 0,
+   "z": 12,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 12,
+   "y": 0,
+   "z": 13,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 12,
+   "y": 0,
+   "z": 14,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 12,
+   "y": 1,
+   "z": 0,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 12,
+   "y": 1,
+   "z": 5,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 12,
+   "y": 1,
+   "z": 10,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 12,
+   "y": 1,
+   "z": 11,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 12,
+   "y": 1,
+   "z": 12,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 12,
+   "y": 1,
+   "z": 13,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 12,
+   "y": 1,
+   "z": 14,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 12,
+   "y": 2,
+   "z": 0,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 12,
+   "y": 2,
+   "z": 5,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 12,
+   "y": 2,
+   "z": 10,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 12,
+   "y": 2,
+   "z": 11,
+   "kind": "block",
+   "id": "glass"
+  },
+  {
+   "x": 12,
+   "y": 2,
+   "z": 12,
+   "kind": "block",
+   "id": "glass"
+  },
+  {
+   "x": 12,
+   "y": 2,
+   "z": 13,
+   "kind": "block",
+   "id": "glass"
+  },
+  {
+   "x": 12,
+   "y": 2,
+   "z": 14,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 12,
+   "y": 3,
+   "z": 0,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 12,
+   "y": 3,
+   "z": 5,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 12,
+   "y": 3,
+   "z": 10,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 12,
+   "y": 3,
+   "z": 11,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 12,
+   "y": 3,
+   "z": 12,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 12,
+   "y": 3,
+   "z": 13,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 12,
+   "y": 3,
+   "z": 14,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 12,
+   "y": 4,
+   "z": 0,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 12,
+   "y": 4,
+   "z": 1,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 12,
+   "y": 4,
+   "z": 2,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 12,
+   "y": 4,
+   "z": 3,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 12,
+   "y": 4,
+   "z": 4,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 12,
+   "y": 4,
+   "z": 5,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 12,
+   "y": 4,
+   "z": 10,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 12,
+   "y": 4,
+   "z": 11,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 12,
+   "y": 4,
+   "z": 12,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 12,
+   "y": 4,
+   "z": 13,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 12,
+   "y": 4,
+   "z": 14,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 13,
+   "y": 0,
+   "z": 0,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 13,
+   "y": 0,
+   "z": 1,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 13,
+   "y": 0,
+   "z": 2,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 13,
+   "y": 0,
+   "z": 3,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 13,
+   "y": 0,
+   "z": 4,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 13,
+   "y": 0,
+   "z": 5,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 13,
+   "y": 1,
+   "z": 0,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 13,
+   "y": 1,
+   "z": 1,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 13,
+   "y": 1,
+   "z": 2,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 13,
+   "y": 1,
+   "z": 3,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 13,
+   "y": 1,
+   "z": 4,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 13,
+   "y": 1,
+   "z": 5,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 13,
+   "y": 2,
+   "z": 0,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 13,
+   "y": 2,
+   "z": 1,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 13,
+   "y": 2,
+   "z": 2,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 13,
+   "y": 2,
+   "z": 3,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 13,
+   "y": 2,
+   "z": 4,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 13,
+   "y": 2,
+   "z": 5,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 13,
+   "y": 2,
+   "z": 12,
+   "kind": "block",
+   "id": "light_green"
+  },
+  {
+   "x": 13,
+   "y": 3,
+   "z": 0,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 13,
+   "y": 3,
+   "z": 1,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 13,
+   "y": 3,
+   "z": 2,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 13,
+   "y": 3,
+   "z": 3,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 13,
+   "y": 3,
+   "z": 4,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 13,
+   "y": 3,
+   "z": 5,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 13,
+   "y": 4,
+   "z": 0,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 13,
+   "y": 4,
+   "z": 1,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 13,
+   "y": 4,
+   "z": 2,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 13,
+   "y": 4,
+   "z": 3,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 13,
+   "y": 4,
+   "z": 4,
+   "kind": "block",
+   "id": "iron_wall"
+  },
+  {
+   "x": 13,
+   "y": 4,
+   "z": 5,
+   "kind": "block",
+   "id": "iron_wall"
+  }
+ ]
+}

--- a/data/ships.json
+++ b/data/ships.json
@@ -35,5 +35,15 @@
     "requiredBlueprint": "ship_corvette",
     "craftCost": [ { "item": "titanium_plate", "count": 30 }, { "item": "iron_plate", "count": 30 }, { "item": "cable", "count": 18 }, { "item": "energy_cell_1", "count": 5 }, { "item": "steel", "count": 5 }, { "item": "light_alloy", "count": 4 }, { "item": "circuit_board", "count": 3 } ],
     "startModules": [ "cockpit", "reactor", "life_support", "medbay", "quarters", "cargo_hold_basic", "ship_laser_basic" ]
+  },
+  {
+    "key": "hammerhead", "nameKey": "ship.hammerhead.name", "descriptionKey": "ship.hammerhead.desc",
+    "baseHull": 220, "baseShield": 60,
+    "flightSpeed": 0.9, "handling": 0.75,
+    "interiorWidth": 14, "interiorLength": 15, "height": 4, "cargoSlots": 72,
+    "layout": "ship_hammerhead",
+    "requiredBlueprint": "ship_hammerhead",
+    "craftCost": [ { "item": "titanium_plate", "count": 60 }, { "item": "iron_plate", "count": 80 }, { "item": "cable", "count": 30 }, { "item": "energy_cell_1", "count": 8 }, { "item": "steel", "count": 12 }, { "item": "glass", "count": 10 }, { "item": "circuit_board", "count": 6 } ],
+    "startModules": [ "cockpit", "reactor", "life_support", "workshop", "medbay", "quarters", "cargo_hold_basic", "ship_cannon_1" ]
   }
 ]

--- a/src/BlocksBeyondTheStars.GameServer/GameServerDoors.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerDoors.cs
@@ -104,10 +104,16 @@ public sealed partial class GameServer
             {
                 // The ship's doors are energy doors (item 35): a slide door with a passable blue energy field
                 // shown in the opening while open. Auto-open like a slide door (handled above). The hatch is the
-                // wide gap in the ship's front (-Z) wall, which runs along X → force the door across X so it sits
-                // parallel to the opening, not lengthwise in the cabin (B41a).
+                // wide gap in the ship's rear (-Z) wall, which runs along X → force that door across X so it
+                // sits parallel to the opening, not lengthwise in the cabin (B41a; a ±1 jamb probe at the
+                // centre of a wide gap is ambiguous). Only the rear-wall hatch gets the forced axis: interior
+                // doors of a multi-room layout (hammerhead) can face ±X, and their narrower openings make the
+                // jamb probe unambiguous — let it decide.
                 var ship = rec;
-                _doors.Add(MakeDoor("energy", pos, ShipHatchOpenRange, forceAxisX: true,
+                var local = ship.ToLocal(new Vector3i(
+                    (int)System.Math.Floor(pos.X), (int)System.Math.Floor(pos.Y), (int)System.Math.Floor(pos.Z)),
+                    _world.Circumference);
+                _doors.Add(MakeDoor("energy", pos, ShipHatchOpenRange, forceAxisX: local.Z == 0 ? true : (bool?)null,
                     solid: (x, y, z) => !ship.Structure.Get(ship.ToLocal(new Vector3i(x, y, z), _world.Circumference)).IsAir));
             }
         }

--- a/src/BlocksBeyondTheStars.GameServer/GameServerSpaceStructure.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerSpaceStructure.cs
@@ -201,12 +201,25 @@ public sealed partial class GameServer
             }
 
             // Guarantee a flush, solid floor across the footprint (fills layout gaps) so the player never
-            // falls out of the walkable interior — mirrors the old stamped-ship floor guarantee.
+            // falls out of the walkable interior — mirrors the old stamped-ship floor guarantee. Only
+            // columns the hull actually encloses (a floor or roof cell) get filled: a non-rectangular plan
+            // (the hammerhead's T-shape) must not grow floating floor tiles in the notches of its bounding
+            // rect, and an exterior attachment (a nav light on a flank) must not grow one under itself.
+            var footprint = new HashSet<(int X, int Z)>();
+            foreach (var cell in layout.Cells)
+            {
+                if ((cell.Y == 0 || cell.Y == layout.Height) &&
+                    cell.X >= 0 && cell.X < layout.Width && cell.Z >= 0 && cell.Z < layout.Length)
+                {
+                    footprint.Add((cell.X, cell.Z));
+                }
+            }
+
             for (int fx = 0; fx < layout.Width; fx++)
                 for (int fz = 0; fz < layout.Length; fz++)
                 {
                     var fp = new Vector3i(fx, 0, fz);
-                    if (s.Get(fp).IsAir)
+                    if (footprint.Contains((fx, fz)) && s.Get(fp).IsAir)
                     {
                         s.Set(fp, wall);
                     }

--- a/tests/BlocksBeyondTheStars.Tests/HammerheadShipTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/HammerheadShipTests.cs
@@ -1,0 +1,137 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using System.Text.Json;
+using BlocksBeyondTheStars.Networking.Transport;
+using BlocksBeyondTheStars.Persistence;
+using BlocksBeyondTheStars.Shared.Configuration;
+using BlocksBeyondTheStars.Shared.Content;
+using BlocksBeyondTheStars.Shared.Definitions;
+using BlocksBeyondTheStars.Shared.Geometry;
+using Xunit;
+using SvGameServer = BlocksBeyondTheStars.GameServer.GameServer;
+
+namespace BlocksBeyondTheStars.Tests;
+
+/// <summary>
+/// The hammerhead is the first multi-room ship layout: a T-shaped hull (wide bridge, central corridor,
+/// two flanking rooms) with interior doors. Its structure must keep the T-shape — in particular the
+/// floor-fill guarantee must not grow floor tiles in the notches of the bounding rect — and all four
+/// doors and six stations must register.
+/// </summary>
+public sealed class HammerheadShipTests : IDisposable
+{
+    private readonly string _root;
+    private readonly string _dataDir;
+
+    public HammerheadShipTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "bbts_hammer_" + Guid.NewGuid().ToString("N"));
+        _dataDir = Path.Combine(_root, "data");
+        CopyDir(TestPaths.DataDir(), _dataDir);
+
+        // Give the (free) starter ship the real hammerhead layout so the served player's structure
+        // builds from it without needing the blueprint/craft flow.
+        var shipsPath = Path.Combine(_dataDir, "ships.json");
+        var ships = JsonSerializer.Deserialize<List<ShipDefinition>>(File.ReadAllText(shipsPath), ContentLoader.JsonOptions)!;
+        ships.First(s => s.Key == "starter").Layout = "ship_hammerhead";
+        File.WriteAllText(shipsPath, JsonSerializer.Serialize(ships, ContentLoader.JsonOptions));
+    }
+
+    private SvGameServer Started(out SqliteWorldRepository repo)
+    {
+        var content = ContentLoader.LoadFromDirectory(_dataDir);
+        repo = new SqliteWorldRepository(new SaveGamePaths(_root, "hammer"));
+        var st = new LoopbackServerTransport(new LoopbackLink());
+        var config = new ServerConfig { WorldName = "hammer", Seed = 1, AutoSaveIntervalMinutes = 9999, PlaceStarterShip = true };
+        var server = new SvGameServer(config, content, st, repo);
+        server.Start();
+        server.AddLocalPlayer("Host");
+        return server;
+    }
+
+    [Fact]
+    public void HammerheadStructure_KeepsTheTShape_NoFloorInTheBoundingRectNotches()
+    {
+        var server = Started(out var repo);
+        using (repo)
+        {
+            var s = server.BuildShipStructureForTest("Host");
+            Assert.Equal(14, s.Width);
+            Assert.Equal(15, s.Length);
+
+            // Floor exists across the real footprint: workshop, corridor and bridge.
+            Assert.False(s.Get(new Vector3i(2, 0, 2)).IsAir);   // workshop
+            Assert.False(s.Get(new Vector3i(6, 0, 7)).IsAir);   // corridor
+            Assert.False(s.Get(new Vector3i(6, 0, 12)).IsAir);  // bridge
+            Assert.False(s.Get(new Vector3i(11, 0, 3)).IsAir);  // sleeping cabins
+
+            // The notches of the bounding rect (beside the corridor, beside the bridge) stay empty —
+            // the floor-fill guarantee must not stamp floating tiles there.
+            foreach (var (x, z) in new[] { (0, 8), (2, 7), (4, 9), (9, 9), (11, 7), (13, 8), (0, 14), (13, 14) })
+            {
+                for (int y = 0; y <= s.Height; y++)
+                {
+                    Assert.True(s.Get(new Vector3i(x, y, z)).IsAir, $"notch cell ({x},{y},{z}) should be air");
+                }
+            }
+
+            // The nav lights hang on the bridge flanks as pure attachments: the light cell itself is
+            // solid, but no floor tile may grow underneath it.
+            Assert.False(s.Get(new Vector3i(0, 2, 12)).IsAir);
+            Assert.True(s.Get(new Vector3i(0, 0, 12)).IsAir);
+            Assert.False(s.Get(new Vector3i(13, 2, 12)).IsAir);
+            Assert.True(s.Get(new Vector3i(13, 0, 12)).IsAir);
+        }
+    }
+
+    [Fact]
+    public void HammerheadStructure_RegistersFourDoors_AndAllRoomStations()
+    {
+        var server = Started(out var repo);
+        using (repo)
+        {
+            var s = server.BuildShipStructureForTest("Host");
+
+            // Stern airlock + bridge door + workshop door + sleeping-cabin door.
+            Assert.Equal(4, s.DoorCells.Count);
+            Assert.Contains(new Vector3i(6, 1, 0), s.DoorCells);   // stern (rear wall — the forced-X hatch)
+            Assert.Contains(new Vector3i(6, 1, 10), s.DoorCells);  // corridor -> bridge (faces Z)
+            Assert.Contains(new Vector3i(5, 1, 2), s.DoorCells);   // corridor -> workshop (faces X)
+            Assert.Contains(new Vector3i(8, 1, 3), s.DoorCells);   // corridor -> sleeping cabins (faces X)
+
+            // Every drawn room got its jobs; the medbay in the sleeping cabins is the spawn/heal anchor.
+            var stationTypes = s.StationCells.Select(c => c.Type).ToHashSet();
+            foreach (var type in new[] { "cockpit", "console", "workshop", "cargo", "quarters", "medbay" })
+            {
+                Assert.Contains(type, stationTypes);
+            }
+
+            Assert.NotNull(s.MedbayCell);
+        }
+    }
+
+    private static void CopyDir(string src, string dst)
+    {
+        Directory.CreateDirectory(dst);
+        foreach (var file in Directory.GetFiles(src))
+        {
+            File.Copy(file, Path.Combine(dst, Path.GetFileName(file)), overwrite: true);
+        }
+
+        foreach (var dir in Directory.GetDirectories(src))
+        {
+            CopyDir(dir, Path.Combine(dst, Path.GetFileName(dir)));
+        }
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+            if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true);
+        }
+        catch { }
+    }
+}

--- a/tests/BlocksBeyondTheStars.Tests/ShipStructureTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/ShipStructureTests.cs
@@ -381,21 +381,38 @@ public sealed class ShipStructureTests : IDisposable
 
             foreach (var door in layout.Cells.Where(c => c.Id == "door_slide" || c.Id == "door_hinge"))
             {
-                foreach (var gx in DoorwayGapColumns(x => solid.Contains((x, door.Y, door.Z)), door.X))
+                // Mirror the server's axis choice (RegisterDoors/MakeDoor): the rear-wall (z=0) hatch is
+                // forced across X; an interior door of a multi-room layout (hammerhead) resolves its wall
+                // axis from the jamb probe. Gap columns run along the wall axis; the walk corridor that must
+                // stay clear runs along the other. The stern hatch checks one row outside (open space) and
+                // two inside; an interior door is approached from both sides, so both get two rows.
+                bool xJamb = solid.Contains((door.X - 1, door.Y, door.Z)) || solid.Contains((door.X + 1, door.Y, door.Z));
+                bool zJamb = solid.Contains((door.X, door.Y, door.Z - 1)) || solid.Contains((door.X, door.Y, door.Z + 1));
+                bool axisX = door.Z == 0 || (xJamb && !zJamb ? true : (zJamb && !xJamb ? false : xJamb));
+                var walkOffsets = door.Z == 0 ? new[] { -1, 0, 1, 2 } : new[] { -2, -1, 0, 1, 2 };
+
+                bool SolidAtGap(int g) => axisX
+                    ? solid.Contains((g, door.Y, door.Z))
+                    : solid.Contains((door.X, door.Y, g));
+
+                foreach (var g in DoorwayGapColumns(SolidAtGap, axisX ? door.X : door.Z))
                 {
-                    foreach (int dz in new[] { -1, 0, 1, 2 })
+                    foreach (int dw in walkOffsets)
                     {
                         for (int dy = 0; dy <= 2; dy++)
                         {
-                            Assert.False(solid.Contains((gx, door.Y + dy, door.Z + dz)),
-                                $"{ship.Key}: doorway corridor blocked, x={gx} dy={dy} dz={dz}");
+                            var probe = axisX
+                                ? (g, door.Y + dy, door.Z + dw)
+                                : (door.X + dw, door.Y + dy, g);
+                            Assert.False(solid.Contains(probe),
+                                $"{ship.Key}: doorway corridor blocked, gap={g} dy={dy} dw={dw} axisX={axisX}");
                         }
                     }
                 }
             }
         }
 
-        Assert.True(layoutsChecked >= 3, "expected the scout/corvette/hauler layouts to be checked");
+        Assert.True(layoutsChecked >= 4, "expected the scout/corvette/hauler/hammerhead layouts to be checked");
     }
 
     /// <summary>The X columns of a doorway's contiguous air gap around a door marker, scanned like the

--- a/tools/gen_ship_layouts.py
+++ b/tools/gen_ship_layouts.py
@@ -27,7 +27,13 @@ def build(width, height, length, builder):
     def put(x, y, z, id_, kind="block"):
         cells[(x, y, z)] = (kind, id_)
 
-    builder(put, width, height, length)
+    def cut(x, y, z):
+        cells.pop((x, y, z), None)
+
+    if builder.__code__.co_argcount >= 5:
+        builder(put, width, height, length, cut)
+    else:
+        builder(put, width, height, length)
     ordered = sorted(cells.items())
     return {
         "width": width, "height": height, "length": length,
@@ -149,6 +155,62 @@ def hauler(put, W, H, L):   # 7 x 4 x 9 — big boxy freighter with deck cargo +
             put(cx - 1, H + 1, z, "iron_wall"); put(cx + 1, H + 1, z, "iron_wall")
 
 
+def room_box(put, x0, z0, x1, z1, H):
+    """A closed sub-room: floor + roof over the rect, perimeter walls in between (inclusive bounds).
+    Abutting rooms share wall cells (the cell dict dedupes overlapping writes)."""
+    for x in range(x0, x1 + 1):
+        for z in range(z0, z1 + 1):
+            put(x, 0, z, "iron_wall")   # floor
+            put(x, H, z, "iron_wall")   # roof
+            if x in (x0, x1) or z in (z0, z1):
+                for y in range(1, H):
+                    put(x, y, z, "iron_wall")
+
+
+def doorway(put, cut, cells_xz, door_at, H):
+    """Punch a full-height (3-tall, y=1..H-1) opening through a wall and hang one slide door in it."""
+    for (x, z) in cells_xz:
+        for y in range(1, H):
+            cut(x, y, z)
+    put(door_at[0], 1, door_at[1], "door_slide", "element")
+
+
+def hammerhead(put, W, H, L, cut):  # 14 x 4 x 15 — the first multi-room hull: a T-shaped heavy gunship
+    """Hammerhead floor plan: a wide bridge up front (the "hammer head"), a long central
+    corridor running aft, and a workshop (port) + sleeping cabins (starboard) flanking the
+    corridor behind their own doors. Three engines aft, stern airlock between them."""
+    # -- hull: four abutting closed rooms (shared walls), then door openings punched through --
+    room_box(put, 1, 10, 12, L - 1, H)   # bridge/control room, 12 wide x 5 long, full width up front
+    room_box(put, 5, 0, 8, 10, H)        # central corridor, 4 wide x 11 long (front wall = bridge rear wall)
+    room_box(put, 0, 0, 5, 5, H)         # workshop area 5x5 + shared east wall with the corridor
+    room_box(put, 8, 0, 13, 5, H)        # sleeping cabins 5x5 + shared west wall with the corridor
+    doorway(put, cut, [(6, 0), (7, 0)], (6, 0), H)      # stern airlock into the corridor
+    doorway(put, cut, [(6, 10), (7, 10)], (6, 10), H)   # corridor -> bridge
+    doorway(put, cut, [(5, 2), (5, 3)], (5, 2), H)      # corridor -> workshop
+    doorway(put, cut, [(8, 2), (8, 3)], (8, 3), H)      # corridor -> sleeping cabins
+    # -- windows: full-width bridge windscreen + side portholes on the head --
+    for x in range(2, 12):
+        put(x, 2, L - 1, "glass")
+    for z in (11, 12, 13):
+        put(1, 2, z, "glass")
+        put(12, 2, z, "glass")
+    # -- stations: each of the drawn rooms gets its jobs --
+    stations(put, [
+        (7, L - 2, "cockpit"), (4, L - 2, "console"),      # bridge: helm + systems console
+        (2, 1, "workshop"), (2, 4, "cargo"),               # workshop area
+        (11, 1, "quarters"), (11, 4, "medbay"),            # sleeping cabins (medbay = spawn/heal)
+    ])
+    # -- exterior: main engine block aft (split around the airlock: its exit corridor must stay clear,
+    # the #211 rule), plus one side engine behind each room --
+    for x in (4, 5, 8, 9):                                 # stacked main nozzles flanking the stern airlock
+        put(x, 1, -1, "engine"); put(x, 2, -1, "engine")
+    put(2, 1, -1, "engine"); put(11, 1, -1, "engine")      # side engines behind the rooms
+    put(0, 2, 12, "light_red"); put(13, 2, 12, "light_green")  # nav lights on the head flanks
+    put(4, 2, L, "light"); put(9, 2, L, "light")           # headlights off the windscreen
+    for x in (6, 7):                                       # raised glass canopy over the bridge
+        put(x, H + 1, 12, "glass"); put(x, H + 1, 13, "glass")
+
+
 # NOTE: the starter intentionally keeps the parametric box hull (its silhouette is added in the box fallback,
 # and the box interior is what the ship-interior tests + energy hatch rely on). Only the unlockable ships get
 # bespoke voxel layouts here. (The starter() builder is kept for reference / future use.)
@@ -156,6 +218,7 @@ SHIPS = {
     "ship_scout": (5, 4, 5, scout),
     "ship_corvette": (6, 4, 7, corvette),
     "ship_hauler": (7, 4, 9, hauler),
+    "ship_hammerhead": (14, 4, 15, hammerhead),
 }
 
 


### PR DESCRIPTION
## Summary

Adds the **Hammerhead** (DE: *Hammerhai*) as a fifth ship type — a heavy combat-tier ship built from a hand-drawn floor plan, and the first ship in the game with a **multi-room interior**: a wide 12-block bridge up front (the "hammer head"), a central corridor running aft, and a workshop (port) + sleeping cabins (starboard), each behind its own interior door. Stern airlock sits between the split main engine block.

Closes #723

## Changes

- **Layout generator** (`tools/gen_ship_layouts.py`): new composite `room_box`/`doorway` helpers + the `hammerhead` builder → `data/ship_layouts/ship_hammerhead.json` (14×4×15, 560+ cells, 4 doors, 6 stations). The committed scout/corvette/hauler layouts have drifted from the generator (hand-tuned after generation) — they are deliberately left untouched; only the new file is added.
- **Server — floor-fill guarantee** (`GameServerSpaceStructure`): fills only columns the hull encloses (a floor or roof cell) instead of the whole Width×Length bounding rect, so a T-shaped plan gets no floating floor tiles in its notches, and exterior attachments (nav lights) don''t grow a tile underneath.
- **Server — door axis** (`GameServerDoors`): `forceAxisX: true` (B41a) now applies only to the rear-wall (z=0) hatch; interior doors of multi-room layouts resolve their wall axis via the jamb probe (their narrow openings make it unambiguous).
- **Data**: `ships.json` entry (hull 220 / shield 60, speed 0.9 / handling 0.75, cargo 72, `ship_cannon_1` as a start module — heavy cannon damage, cosy interior), `blueprints.json` unlock (prereqs `ship_corvette` + `ship_cannon_1`), DE+EN locale strings.
- **Tests**: new `HammerheadShipTests` (T-footprint floor fill, notches stay empty, no floor under nav lights, 4 doors + all room stations register, medbay set); `DesignedShipLayouts_ExitCorridorIsClear` is now door-axis-aware (mirrors the server''s axis choice) and covers all four layouts. Doorways keep the 3-tall rule; the stern exit corridor is engine-free (#211 rule).

## Verification

- Full fast-tier suite: **1400 passed, 0 failed** (Release).
- Clean Release build, 0 warnings.
- No client/Assets changes (data + server + tools only).
- NPC traders enumerate ship types automatically — Hammerheads will appear as NPC ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)