### PR TITLE
fix(ui): wrap the bandit demand line and grow the panel to fit

### DIFF
--- a/client/Assets/BlocksBeyondTheStars/Scripts/BanditDemandUi.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/BanditDemandUi.cs
@@ -32,6 +32,12 @@ namespace BlocksBeyondTheStars.Client
         private float _unlockAt;           // Time.unscaledTime the buttons arm
         private bool _subscribed;
         private bool _answered;            // sent our answer — keep showing the countdown until the result lands
+        private string _laidOutLine;       // the demand line the current row layout was measured for
+
+        // Base row layout (1920×1080 reference units). The speech line row grows with its measured
+        // wrapped height; every row below it and the panel shift down by the same delta.
+        private const float PanelW = 520f, PanelBaseH = 240f, RowW = 480f, LineBaseH = 44f;
+        private const float ItemsY = 96f, CountdownY = 126f, ButtonsY = 160f, HintY = 206f;
 
         private void Update()
         {
@@ -124,6 +130,10 @@ namespace BlocksBeyondTheStars.Client
 
             // The demand line: an LLM-authored line wins; otherwise the localized static key.
             _line.text = "“" + (!string.IsNullOrEmpty(_demand.Text) ? _demand.Text : L(_demand.LineKey)) + "”";
+            if (_line.text != _laidOutLine)
+            {
+                ReflowForLine();
+            }
 
             var sb = new System.Text.StringBuilder();
             foreach (var it in _demand.Demanded)
@@ -152,6 +162,45 @@ namespace BlocksBeyondTheStars.Client
 
         private string L(string key) => Game?.Localizer?.Get(key) ?? key;
 
+        private static readonly TextGenerator Measurer = new TextGenerator();
+
+        /// <summary>
+        /// Sizes the speech-line row to its wrapped height and shifts every row below it (and the panel
+        /// bottom) by the same amount, so long hail lines — the localized ones as much as LLM-authored
+        /// ones — stay inside the panel instead of spilling past its edges. Measured with an explicit
+        /// scaleFactor of 1 so the height comes back in the same reference units the rows are placed in
+        /// (the UiWhatsNew pattern).
+        /// </summary>
+        private void ReflowForLine()
+        {
+            var settings = new TextGenerationSettings
+            {
+                font = UiKit.Font,
+                fontSize = 18,
+                fontStyle = FontStyle.Italic,
+                richText = false,
+                scaleFactor = 1f,
+                lineSpacing = 1f,
+                horizontalOverflow = HorizontalWrapMode.Wrap,
+                verticalOverflow = VerticalWrapMode.Overflow,
+                generationExtents = new Vector2(RowW, 0f),
+                textAnchor = TextAnchor.UpperLeft,
+                pivot = new Vector2(0f, 1f),
+                color = Color.white,
+            };
+            float lineH = Mathf.Max(LineBaseH, Measurer.GetPreferredHeight(_line.text, settings) + 4f);
+            float delta = lineH - LineBaseH;
+
+            _line.rectTransform.sizeDelta = new Vector2(RowW, lineH);
+            _items.rectTransform.anchoredPosition = new Vector2(20f, -(ItemsY + delta));
+            _countdown.rectTransform.anchoredPosition = new Vector2(20f, -(CountdownY + delta));
+            ((RectTransform)_comply.transform).anchoredPosition = new Vector2(20f, -(ButtonsY + delta));
+            ((RectTransform)_refuse.transform).anchoredPosition = new Vector2(270f, -(ButtonsY + delta));
+            _hint.rectTransform.anchoredPosition = new Vector2(20f, -(HintY + delta));
+            ((RectTransform)_panel.transform).sizeDelta = new Vector2(PanelW, PanelBaseH + delta);
+            _laidOutLine = _line.text;
+        }
+
         private void EnsureBuilt()
         {
             if (_canvas != null)
@@ -167,7 +216,7 @@ namespace BlocksBeyondTheStars.Client
             _panel.transform.SetParent(root, false);
             var rt = _panel.GetComponent<RectTransform>();
             rt.anchorMin = rt.anchorMax = rt.pivot = new Vector2(0.5f, 0.5f);
-            rt.sizeDelta = new Vector2(520f, 240f);
+            rt.sizeDelta = new Vector2(PanelW, PanelBaseH);
             rt.anchoredPosition = new Vector2(0f, 60f);
             var img = _panel.AddComponent<Image>();
             img.sprite = UiKit.PanelSprite;
@@ -175,17 +224,18 @@ namespace BlocksBeyondTheStars.Client
             img.color = UiKit.PanelFill;
 
             var t = _panel.transform;
-            _title = UiKit.AddText(t, 20f, 12f, 480f, 26f, string.Empty, 22, new Color(1f, 0.55f, 0.3f), TextAnchor.MiddleLeft, FontStyle.Bold);
-            _line = UiKit.AddText(t, 20f, 44f, 480f, 44f, string.Empty, 18, UiKit.TextCol, TextAnchor.UpperLeft, FontStyle.Italic);
-            _items = UiKit.AddText(t, 20f, 96f, 480f, 26f, string.Empty, 20, UiKit.Cyan, TextAnchor.MiddleLeft, FontStyle.Bold);
-            _countdown = UiKit.AddText(t, 20f, 126f, 480f, 24f, string.Empty, 18, UiKit.TextCol, TextAnchor.MiddleLeft, FontStyle.Bold);
+            _title = UiKit.AddText(t, 20f, 12f, RowW, 26f, string.Empty, 22, new Color(1f, 0.55f, 0.3f), TextAnchor.MiddleLeft, FontStyle.Bold);
+            _line = UiKit.AddText(t, 20f, 44f, RowW, LineBaseH, string.Empty, 18, UiKit.TextCol, TextAnchor.UpperLeft, FontStyle.Italic);
+            _line.horizontalOverflow = HorizontalWrapMode.Wrap; // hail lines wrap; ReflowForLine grows the row
+            _items = UiKit.AddText(t, 20f, ItemsY, RowW, 26f, string.Empty, 20, UiKit.Cyan, TextAnchor.MiddleLeft, FontStyle.Bold);
+            _countdown = UiKit.AddText(t, 20f, CountdownY, RowW, 24f, string.Empty, 18, UiKit.TextCol, TextAnchor.MiddleLeft, FontStyle.Bold);
 
-            _comply = UiKit.AddButton(t, 20f, 160f, 230f, 40f, string.Empty, () => Answer(true));
+            _comply = UiKit.AddButton(t, 20f, ButtonsY, 230f, 40f, string.Empty, () => Answer(true));
             _complyLabel = _comply.GetComponentInChildren<Text>();
-            _refuse = UiKit.AddButton(t, 270f, 160f, 230f, 40f, string.Empty, () => Answer(false));
+            _refuse = UiKit.AddButton(t, 270f, ButtonsY, 230f, 40f, string.Empty, () => Answer(false));
             _refuseLabel = _refuse.GetComponentInChildren<Text>();
 
-            _hint = UiKit.AddText(t, 20f, 206f, 480f, 22f, string.Empty, 14, UiKit.CyanDim, TextAnchor.MiddleCenter);
+            _hint = UiKit.AddText(t, 20f, HintY, RowW, 22f, string.Empty, 14, UiKit.CyanDim, TextAnchor.MiddleCenter);
 
             _panel.SetActive(false);
         }


### PR DESCRIPTION
## Summary

During a bandit hold-up, long hail lines (e.g. the German "Wegzoll" lines, and LLM-authored lines) rendered on a single line and stuck out past both edges of the dialog panel — `UiKit.AddText` defaults to horizontal `Overflow` and `BanditDemandUi` gave the speech line a fixed 480×44 slot.

## Fix

- Enable `HorizontalWrapMode.Wrap` on the speech line.
- Measure its wrapped height with a `TextGenerator` at `scaleFactor = 1` (the proven `UiWhatsNew` pattern) and shift the item/countdown/button/hint rows and the panel bottom down by the delta, so the full line stays inside the dialog for any line length.
- Re-measure only when the line text changes (Refresh runs per frame).

## Verification

- Local Unity client build (scripts/build-client.ps1): success, no new warnings. PR CI does not build Unity.
- No .NET (src/) code touched.

closes #734

🤖 Generated with [Claude Code](https://claude.com/claude-code)