### PR TITLE
fix(enemies): slow post-cap machine refills + opt-in space waves (#740, #741)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,22 @@ the richer, screenshot-laden versions live there. `(#123)` references the pull r
 
 ## [Unreleased]
 
+### 🤖 Enemy pacing — machines stop streaming in, space combat is opt-in again (#740, #741)
+
+- **No more instant reinforcements on planets**: destroying a robot or scan-drone used to summon its
+  replacement within a fraction of a second (the spawn timer silently banked time while the population
+  was full). Refills now wait a slow, varied 20–45 s (plus a breather after each kill), so machine
+  fights are encounters with quiet in between — not an endless stream.
+- **Machines let go when you leave**: hostiles far from every player despawn instead of trailing you
+  across the planet forever.
+- **Space hostiles wait for you to come to them**: drones and UFOs could see farther than their own
+  spawn distance, so the UFO started hunting your ship the moment you launched — every single flight.
+  Their detection ranges now match the "you choose to fly out to them" design; park at the launch
+  point and nobody bothers you.
+- **Every flight stops replaying the same wave**: destroyed drones/UFOs stay gone across relaunches
+  until the sector re-arms (~8 minutes), the wave sits on a different bearing each launch, and every
+  4th flight runs quieter.
+
 ### ⚔️ Bounty missions — quest givers put a price on the bandits (#730, #731)
 
 - **Camp bounty**: a settlement mission board on a planet with an uncleared bandit camp now offers a

--- a/TODO.md
+++ b/TODO.md
@@ -7148,6 +7148,30 @@ is **pre-approved** (keys in `tools/ai-assets/.env`, run via `uv`).
 
 ---
 
+## ✅ Done (2026-08-05): enemy spawn pacing — no instant machine refills, space combat is opt-in again (#740/#741)
+
+Two long-standing pacing bugs that made hostiles feel relentless:
+
+- **Planet machines (#740)** — the spawn timer kept accumulating while the population sat at its cap
+  and only reset on an actual spawn, so the moment a machine died its replacement appeared on the
+  *next tick* — fighting back turned the spawner into a zero-gap stream. Now: the timer holds at zero
+  at the cap; once a world has filled to its cap, refills switch from the 5 s fill cadence to a slow
+  **jittered 20–45 s interval** (deterministic per world, `EnemySpawnOrdinal`-seeded); a kill adds a
+  further 10 s grace; and machines farther than **150 blocks** from every surface player despawn
+  (creature parity) — walking away finally ends the encounter.
+- **Space waves (#741)** — the ambient hostiles' aggro radii exceeded their spawn distances (UFO:
+  spawn ~227u < aggro 240u; drone 0's ±18u patrol ring dipped under its 190u aggro), so the UFO hunted
+  the ship the instant it launched, every flight — defeating the documented "combat is opt-in" spawn
+  design. Aggro reduced to Drone 120 / UFO 150 / Cruiser 170 (bandit ships keep 280 by design; the
+  finale gauntlet becomes genuinely opt-in too). Plus session-scoped **wave memory per location**
+  (`AmbientWave`): destroyed drones/UFOs stay dead across relaunches until the sector re-arms (~8 min),
+  bearings rotate golden-angle per flight ordinal, and every 4th flight runs one drone quieter — so
+  repeat launches stop replaying the identical hard-coded wave.
+
+Tests: `EnemySpawnPacingTests` (5) — no instant refill + eventual slow refill, far-despawn, hostiles
+hold off the launch point for a full minute, cleared drone stays cleared until re-arm, wave varies
+between flights + quiet 4th flight. Analysis first (root causes verified in code before the fix).
+
 ## ✅ Done (2026-08-04): Courier, Thunderbolt, Deathblock — three ships from hand-drawn floor plans (#727/#728/#729)
 
 Three more ship types built from Justus' pencil floor plans, following the hammerhead multi-room

--- a/src/BlocksBeyondTheStars.GameServer/GameServerEnemies.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerEnemies.cs
@@ -16,7 +16,14 @@ namespace BlocksBeyondTheStars.GameServer;
 /// </summary>
 public sealed partial class GameServer
 {
-    private const double EnemySpawnInterval = 5.0;
+    private const double EnemySpawnInterval = 5.0;      // initial fill cadence while a fresh world ramps to its cap
+    private const double EnemyRefillMinInterval = 20.0; // #740: once the cap was reached, refills come slow…
+    private const double EnemyRefillMaxInterval = 45.0; //       …and jittered, so machine encounters read as events
+    private const double EnemyKillSpawnGrace = 10.0;    // #740: extra breather added when a machine is destroyed
+    // #740: machines far from every player despawn (like creatures, which prune at 70). The leash is wide
+    // enough that ambient wander (≈0.5 b/s net with pauses) can't plausibly cross it — only a player
+    // actually LEAVING (walking 4-5 b/s) does, so the count-neutral wreck-coupling guarantee stays intact.
+    private const float EnemyFarDespawnRange = 150f;
     private const float EnemyProximityRange = 4f;
     private const float EnemyAttackReach = 6f;
 
@@ -66,10 +73,24 @@ public sealed partial class GameServer
         }
 
         int cap = ActivityCount(Rules.PlanetEnemies) * targets.Count;
-        _enemySpawnTimer += dt;
-        if (_enemySpawnTimer >= EnemySpawnInterval && _planetEnemies.Count < cap)
+        if (_planetEnemies.Count >= cap)
+        {
+            // At the cap the timer must not bank time (#740): it used to keep accumulating here, so the
+            // moment a machine died its replacement spawned on the very next tick — fighting back turned
+            // the spawner into a zero-gap stream. Holding it at zero makes every refill wait its interval,
+            // and reaching the cap for the first time switches the world to the slow jittered refill pace.
+            if (!_worlds.Active.EnemyCapSeen)
+            {
+                _worlds.Active.EnemyCapSeen = true;
+                _worlds.Active.EnemyNextSpawnIn = RollEnemyRefillInterval();
+            }
+
+            _enemySpawnTimer = 0;
+        }
+        else if ((_enemySpawnTimer += dt) >= (_worlds.Active.EnemyCapSeen ? _worlds.Active.EnemyNextSpawnIn : EnemySpawnInterval))
         {
             _enemySpawnTimer = 0;
+            _worlds.Active.EnemyNextSpawnIn = RollEnemyRefillInterval();
             // A fraction (~2 in 5) of the population spawns as the flying scan-drone variant (P4), the rest as
             // walking three-eyed ground robots — both within the same PlanetEnemies cap (count unchanged).
             // Key the mix off how many drones are ALREADY alive, not the raw spawn count: keying off the count
@@ -84,6 +105,37 @@ public sealed partial class GameServer
             }
             bool asDrone = Rules.PlanetDrones && droneCount * 5 < (_planetEnemies.Count + 1) * 2;
             SpawnPlanetEnemyNear(targets[_planetEnemies.Count % targets.Count].State, asDrone);
+            BroadcastPlanetEnemies();
+        }
+
+        // #740: machines that ended up far from every surface player despawn — walking away from a fight
+        // actually ends it instead of leaving a pack trailing you forever. Freed slots refill near the
+        // players on the normal (post-cap: slow) cadence.
+        bool pruned = false;
+        for (int i = _planetEnemies.Count - 1; i >= 0; i--)
+        {
+            var e = _planetEnemies[i];
+            bool near = false;
+            foreach (var s in targets)
+            {
+                if (WrapDistSq(s.State.Position, e.Position) <= EnemyFarDespawnRange * EnemyFarDespawnRange)
+                {
+                    near = true;
+                    break;
+                }
+            }
+
+            if (!near)
+            {
+                _planetEnemies.RemoveAt(i);
+                _enemyWander.Remove(e.Id);
+                _enemySightSeenAt.Remove(e.Id);
+                pruned = true;
+            }
+        }
+
+        if (pruned)
+        {
             BroadcastPlanetEnemies();
         }
 
@@ -148,6 +200,14 @@ public sealed partial class GameServer
             _enemySyncTimer = 0;
             BroadcastPlanetEnemies();
         }
+    }
+
+    /// <summary>Rolls the next post-cap refill interval (#740): 20–45 s, jittered deterministically from the
+    /// world id + a per-world spawn ordinal so the cadence varies without wall-clock randomness.</summary>
+    private double RollEnemyRefillInterval()
+    {
+        uint h = (uint)StableStringHash(_worlds.Active.LocationId + ":" + _worlds.Active.EnemySpawnOrdinal++);
+        return EnemyRefillMinInterval + (h % 1000) / 999.0 * (EnemyRefillMaxInterval - EnemyRefillMinInterval);
     }
 
     private const float EnemyHuntRange = 28f;   // detection radius — inside it the fiend stalks the player
@@ -574,6 +634,9 @@ public sealed partial class GameServer
             {
                 RecordStoryMachineKill(); // planet machine destroyed → advances the story (P4: combat-as-progress)
                 TryDropPlayerMemory(session); // a chance to release a personal memory (P4)
+                // #740: a destroyed machine buys an extra breather on top of the refill interval — the
+                // negative timer delays the freed slot, so a fight is followed by quiet, not reinforcements.
+                _enemySpawnTimer = System.Math.Min(_enemySpawnTimer, -EnemyKillSpawnGrace);
             }
 
             BroadcastPlanetEnemies();

--- a/src/BlocksBeyondTheStars.GameServer/GameServerSpaceCombat.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerSpaceCombat.cs
@@ -599,8 +599,24 @@ public sealed partial class GameServer
                     drones = System.Math.Min(4, drones + 1);
                 }
 
+                // #741: per-location wave memory — repeat launches stop replaying the identical wave. The
+                // flight ordinal rotates every bearing (so the wave sits somewhere new each launch), every
+                // 4th flight runs quieter, and hostiles destroyed here stay dead until the sector re-arms.
+                var wave = AmbientWaveFor(instanceId);
+                int flight = wave.FlightOrdinal++;
+                if (flight % 4 == 3 && drones > 1)
+                {
+                    drones--;
+                }
+
+                drones = System.Math.Max(0, drones - wave.DronesKilled);
+
                 for (int i = 0; i < drones; i++)
                 {
+                    // Bearings fan out golden-angle-rotated per flight; the radius stays far outside the
+                    // drone's (reduced) aggro range so its patrol drift can never reach the launch point.
+                    float ang = -0.71f + flight * 2.39996f + i * 0.35f;
+                    float rad = 205f + (i % 3) * 18f;
                     instance.Entities.Add(new CombatEntity
                     {
                         Id = NextEntityId(),
@@ -608,14 +624,18 @@ public sealed partial class GameServer
                         Hostile = true,
                         Hull = 40f,
                         HullMax = 40f,
-                        Position = new Vector3f(150f + i * 16f, 10f, -130f - i * 20f),
+                        Position = new Vector3f(rad * (float)System.Math.Cos(ang),
+                            10f + ((i + flight) % 3 - 1) * 8f,
+                            rad * (float)System.Math.Sin(ang)),
                         DamagePerSecond = 5f,
                         Loot = { new ItemAmount("data_fragment", 1) },
                     });
                 }
 
-                if (Rules.AlienUfos != AlienActivity.Off && archetype != SystemArchetype.Desolate)
+                if (Rules.AlienUfos != AlienActivity.Off && archetype != SystemArchetype.Desolate
+                    && wave.UfosKilled == 0)
                 {
+                    float uang = 2.42f + flight * 2.39996f; // roughly opposite the drone fan, rotating per flight
                     instance.Entities.Add(new CombatEntity
                     {
                         Id = NextEntityId(),
@@ -625,7 +645,7 @@ public sealed partial class GameServer
                         // ~12s and took a long time to down. Now closer to a drone so UFOs read as a light threat.
                         Hull = 40f,
                         HullMax = 40f,
-                        Position = new Vector3f(-170f, 14f, 150f),
+                        Position = new Vector3f(230f * (float)System.Math.Cos(uang), 14f, 230f * (float)System.Math.Sin(uang)),
                         DamagePerSecond = 4f,
                         Loot = { new ItemAmount("data_fragment", 3) },
                     });
@@ -634,6 +654,63 @@ public sealed partial class GameServer
         }
 
         return instance;
+    }
+
+    /// <summary>#741: session-scoped ambient-wave memory for one location — how many launches happened here
+    /// (varies the wave layout per flight) and which ambient hostiles were destroyed (kept dead until the
+    /// sector re-arms). Survives the instance teardown on landing, so relaunching doesn't reset the fight.</summary>
+    private sealed class AmbientWave
+    {
+        public int FlightOrdinal;
+        public int DronesKilled;
+        public int UfosKilled;
+        public double ReplenishAt; // uptime at which the destroyed hostiles return (rolls from the last kill)
+    }
+
+    private readonly Dictionary<string, AmbientWave> _ambientWaves = new(); // instanceId → wave memory
+    private const double AmbientReplenishSeconds = 480.0; // destroyed ambient hostiles return after ~8 min
+
+    private AmbientWave AmbientWaveFor(string instanceId)
+    {
+        if (!_ambientWaves.TryGetValue(instanceId, out var wave))
+        {
+            wave = new AmbientWave();
+            _ambientWaves[instanceId] = wave;
+        }
+
+        if (wave.ReplenishAt > 0 && _uptime >= wave.ReplenishAt)
+        {
+            wave.DronesKilled = 0; // the sector re-arms — the next launch faces a full wave again
+            wave.UfosKilled = 0;
+            wave.ReplenishAt = 0;
+        }
+
+        return wave;
+    }
+
+    /// <summary>Records a destroyed ambient hostile in its location's wave memory (#741) so the next launch
+    /// doesn't replay it. Finale-gauntlet instances never rolled a wave record, so they are unaffected.</summary>
+    private void RecordAmbientHostileKill(SpaceInstance instance, CombatEntity target)
+    {
+        if (!_ambientWaves.TryGetValue(instance.Id, out var wave))
+        {
+            return;
+        }
+
+        if (target.Kind == CombatEntityKind.Drone)
+        {
+            wave.DronesKilled++;
+        }
+        else if (target.Kind == CombatEntityKind.Ufo)
+        {
+            wave.UfosKilled++;
+        }
+        else
+        {
+            return;
+        }
+
+        wave.ReplenishAt = _uptime + AmbientReplenishSeconds;
     }
 
     private const int DenseAsteroidFieldTarget = 9;  // launch-field rocks when anchored at an asteroid (#683 S1)
@@ -849,6 +926,7 @@ public sealed partial class GameServer
         else if (target.Hostile)
         {
             RecordStoryMachineKill(); // space machine (drone/UFO) destroyed → advances the story (P4)
+            RecordAmbientHostileKill(instance, target); // #741: stays dead across relaunches for a while
             if (session is not null)
             {
                 TryDropPlayerMemory(session); // a chance to release a personal memory (P4)
@@ -1477,12 +1555,15 @@ public sealed partial class GameServer
     }
 
     /// <summary>Per-kind movement profile for hostile space NPCs: how far they notice the ship, how close
-    /// they press in, and how fast they fly.</summary>
+    /// they press in, and how fast they fly. Aggro MUST stay well below the ambient spawn distances
+    /// (~200-230u; gauntlet ≥150u) (#741): the old radii (drone 190 / UFO 240 / cruiser 260) exceeded them,
+    /// so the UFO hunted the ship the instant it launched and every flight auto-started the same fight —
+    /// the "combat is opt-in, you fly out to them" spawn design only holds when they can't see that far.</summary>
     private static (float Aggro, float MinDist, float Speed) HostileProfile(CombatEntityKind kind) => kind switch
     {
-        CombatEntityKind.Drone => (190f, 16f, 9f),
-        CombatEntityKind.Ufo => (240f, 24f, 7f),
-        CombatEntityKind.Cruiser => (260f, 36f, 4f),
+        CombatEntityKind.Drone => (120f, 16f, 9f),
+        CombatEntityKind.Ufo => (150f, 24f, 7f),
+        CombatEntityKind.Cruiser => (170f, 36f, 4f),
         CombatEntityKind.BanditShip => (280f, 20f, 8f), // once hostile it presses in hard (it already knows you)
         _ => (0f, 0f, 0f),
     };

--- a/src/BlocksBeyondTheStars.GameServer/WorldManager.cs
+++ b/src/BlocksBeyondTheStars.GameServer/WorldManager.cs
@@ -180,6 +180,12 @@ internal sealed class LoadedWorld
     public int CreatureSpawnRotor { get; set; }
     public int CreatureRingRotor { get; set; } // #470: ring slot counter, SEPARATE from the species rotor
     public double EnemySpawnTimer { get; set; }
+    // #740 enemy-spawn pacing: once a world has filled to its machine cap, refills switch from the quick
+    // initial cadence to a slow jittered interval — the fields carry the "seen the cap" flag, the rolled
+    // current interval and the ordinal that seeds the next roll (deterministic per world).
+    public bool EnemyCapSeen { get; set; }
+    public double EnemyNextSpawnIn { get; set; }
+    public int EnemySpawnOrdinal { get; set; }
     public double SinceBanditSync { get; set; }  // bandit movement stream throttle (per-world, like SinceEnemySync)
     public double SinceFluid { get; set; }
     public double SinceFire { get; set; }

--- a/tests/BlocksBeyondTheStars.Tests/EnemySpawnPacingTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/EnemySpawnPacingTests.cs
@@ -1,0 +1,261 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using System;
+using System.Linq;
+using BlocksBeyondTheStars.GameServer;
+using BlocksBeyondTheStars.Networking.Transport;
+using BlocksBeyondTheStars.Persistence;
+using BlocksBeyondTheStars.Shared.Configuration;
+using BlocksBeyondTheStars.Shared.Content;
+using BlocksBeyondTheStars.Shared.Geometry;
+using Xunit;
+using SvGameServer = BlocksBeyondTheStars.GameServer.GameServer;
+
+namespace BlocksBeyondTheStars.Tests;
+
+/// <summary>
+/// Enemy spawn pacing (#740, #741). Planet machines: no instant refill after a kill (the timer used to
+/// bank time at the cap), far-from-everyone machines despawn. Space: ambient hostiles must not engage
+/// the launch point on their own (aggro stays below the spawn distances), destroyed hostiles stay dead
+/// across relaunches until the sector re-arms, and repeat launches vary the wave instead of replaying it.
+/// </summary>
+public sealed class EnemySpawnPacingTests : IDisposable
+{
+    private readonly string _root;
+    private readonly GameContent _content;
+
+    public EnemySpawnPacingTests()
+    {
+        _root = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "bbts_pacing_" + Guid.NewGuid().ToString("N"));
+        _content = ContentLoader.LoadFromDirectory(TestPaths.DataDir());
+    }
+
+    public void Dispose()
+    {
+        try { System.IO.Directory.Delete(_root, recursive: true); } catch { /* best effort */ }
+    }
+
+    private SvGameServer Started(string world, Action<GameRules> configure, out SqliteWorldRepository repo)
+    {
+        repo = new SqliteWorldRepository(new SaveGamePaths(_root, world));
+        var st = new LoopbackServerTransport(new LoopbackLink());
+        var config = new ServerConfig
+        {
+            WorldName = world,
+            Seed = 9,
+            StartPlanet = "rocky",
+            AutoSaveIntervalMinutes = 9999,
+            PlaceStarterShip = false,
+            PlaceSettlements = false,
+            PlaceWrecks = false,
+            ViewDistanceChunks = 1,
+        };
+        configure(config.Rules);
+        var server = new SvGameServer(config, _content, st, repo);
+        server.Start();
+        return server;
+    }
+
+    // ---------------- Planet machines (#740) ----------------
+
+    [Fact]
+    public void PlanetMachineKill_IsNotRefilledInstantly()
+    {
+        var server = Started("norefill", r => { }, out var repo); // default rules: Survival + PlanetEnemies Normal
+        using (repo)
+        {
+            var pilot = server.AddLocalPlayer("Fighter");
+            pilot.State.AboardShip = false;
+
+            // Fill to the cap (Normal + solo = 2) on the quick initial cadence.
+            for (int i = 0; i < 60 && server.PlanetEnemies.Count < 2; i++)
+            {
+                server.Tick(0.5);
+            }
+
+            Assert.Equal(2, server.PlanetEnemies.Count);
+
+            // Sit at the cap for a while — the OLD bug banked spawn-timer time here, which made the next
+            // kill refill on the very next tick.
+            for (int i = 0; i < 30; i++)
+            {
+                server.Tick(0.5);
+            }
+
+            // Kill one machine with bare fists (teleport onto it between swings; it may be moving).
+            var victim = server.PlanetEnemies[0];
+            for (int i = 0; i < 15 && server.PlanetEnemies.Any(e => e.Id == victim.Id); i++)
+            {
+                var cur = server.PlanetEnemies.FirstOrDefault(e => e.Id == victim.Id);
+                if (cur is null)
+                {
+                    break;
+                }
+
+                pilot.State.Position = cur.Position;
+                server.AttackEntity("Fighter", victim.Id);
+                server.Tick(2.0);
+            }
+
+            Assert.DoesNotContain(server.PlanetEnemies, e => e.Id == victim.Id);
+
+            // No instant replacement: refills wait for the post-kill grace plus the slow jittered
+            // interval (>= 30 s in total), so 10 s after the kill the slot must still be free.
+            for (int i = 0; i < 20; i++)
+            {
+                server.Tick(0.5);
+            }
+
+            Assert.True(server.PlanetEnemies.Count < 2,
+                "a killed machine must not be refilled within seconds — refills wait for the slow interval");
+
+            // …but the spawner is only slowed, not dead: the population finds its way back to the cap.
+            for (int i = 0; i < 400 && server.PlanetEnemies.Count < 2; i++)
+            {
+                server.Tick(0.5);
+            }
+
+            Assert.Equal(2, server.PlanetEnemies.Count);
+        }
+    }
+
+    [Fact]
+    public void PlanetMachines_FarFromEveryPlayer_Despawn()
+    {
+        var server = Started("farprune", r => { }, out var repo);
+        using (repo)
+        {
+            var pilot = server.AddLocalPlayer("Wanderer");
+            pilot.State.AboardShip = false;
+
+            for (int i = 0; i < 40 && server.PlanetEnemies.Count == 0; i++)
+            {
+                server.Tick(0.5);
+            }
+
+            Assert.NotEmpty(server.PlanetEnemies);
+            var enemy = server.PlanetEnemies[0];
+
+            // Walk far away (well past the 150-block leash): the machine must despawn instead of
+            // trailing the player across the planet forever.
+            var p = pilot.State.Position;
+            pilot.State.Position = new Vector3f(p.X + 200f, p.Y, p.Z);
+            server.Tick(0.5);
+            server.Tick(0.5);
+
+            Assert.DoesNotContain(server.PlanetEnemies, e => e.Id == enemy.Id);
+        }
+    }
+
+    // ---------------- Space waves (#741) ----------------
+
+    [Fact]
+    public void SpaceHostiles_DoNotEngageTheLaunchPoint()
+    {
+        var server = Started("optin", r =>
+        {
+            r.FreeSpaceFlight = true;
+            r.SpaceCombat = SpaceCombatMode.PvE;
+            r.SpaceNpcEnemies = AlienActivity.Normal;
+            r.AlienUfos = AlienActivity.Normal;
+        }, out var repo);
+        using (repo)
+        {
+            server.AddLocalPlayer("Pilot");
+            server.EnterSpace("Pilot");
+            float hullBefore = server.Ship.Hull;
+
+            Assert.Contains(server.SpaceEntitiesFor("Pilot"), e => e.Hostile); // drones + UFO are out there
+
+            // Park at the launch point for a minute. The old aggro radii exceeded the spawn distances
+            // (UFO: spawn ~227 < aggro 240), so the UFO hunted the ship the moment it launched.
+            for (int i = 0; i < 120; i++)
+            {
+                server.Tick(0.5);
+            }
+
+            Assert.True(server.InSpace("Pilot"));
+            foreach (var e in server.SpaceEntitiesFor("Pilot").Where(e => e.Hostile))
+            {
+                double d = Math.Sqrt((e.Position.X * e.Position.X) + (e.Position.Y * e.Position.Y)
+                    + (e.Position.Z * e.Position.Z));
+                Assert.True(d > 100, $"an unprovoked ambient hostile must stay away from the launch point (was {d:F0}u)");
+            }
+
+            Assert.Equal(hullBefore, server.Ship.Hull); // nobody shot at the parked ship
+        }
+    }
+
+    [Fact]
+    public void SpaceWave_ClearedDrone_StaysCleared_UntilTheSectorRearms()
+    {
+        var server = Started("cleared", r =>
+        {
+            r.FreeSpaceFlight = true;
+            r.SpaceCombat = SpaceCombatMode.PvE;
+            r.SpaceNpcEnemies = AlienActivity.Rare; // 1 drone, hull 40
+            r.ShipWeapons = ShipWeaponMode.NpcsOnly;
+        }, out var repo);
+        using (repo)
+        {
+            server.AddLocalPlayer("Pilot");
+            server.Ship.Modules.Add("ship_cannon_1"); // 20 dmg
+            server.Ship.Modules.Remove("tractor_beam");
+            server.EnterSpace("Pilot");
+
+            var drone = server.SpaceEntitiesFor("Pilot").First(e => e.Kind == CombatEntityKind.Drone);
+            server.ShipMove("Pilot", drone.Position.X, drone.Position.Y, drone.Position.Z);
+            server.FireWeapon("Pilot", "ship_cannon_1", drone.Id); // 40 -> 20
+            server.TickForTest(1.1); // let the cannon's server-enforced cooldown cycle (#694)
+            server.FireWeapon("Pilot", "ship_cannon_1", drone.Id); // destroyed
+            Assert.DoesNotContain(server.SpaceEntitiesFor("Pilot"), e => e.Kind == CombatEntityKind.Drone);
+
+            // Land and relaunch: the cleared drone must NOT be back at its post.
+            server.LeaveSpace("Pilot");
+            server.EnterSpace("Pilot");
+            Assert.DoesNotContain(server.SpaceEntitiesFor("Pilot"), e => e.Kind == CombatEntityKind.Drone);
+
+            // After the replenish window the sector re-arms and the next launch faces a drone again.
+            server.LeaveSpace("Pilot");
+            server.Tick(250.0);
+            server.Tick(250.0); // past the ~8 min replenish window
+            server.EnterSpace("Pilot");
+            Assert.Contains(server.SpaceEntitiesFor("Pilot"), e => e.Kind == CombatEntityKind.Drone);
+        }
+    }
+
+    [Fact]
+    public void SpaceWave_VariesBetweenFlights_AndRunsQuietSometimes()
+    {
+        var server = Started("variety", r =>
+        {
+            r.FreeSpaceFlight = true;
+            r.SpaceCombat = SpaceCombatMode.PvE;
+            r.SpaceNpcEnemies = AlienActivity.Normal; // 2 drones baseline
+        }, out var repo);
+        using (repo)
+        {
+            server.AddLocalPlayer("Pilot");
+
+            server.EnterSpace("Pilot"); // flight 0
+            var first = server.SpaceEntitiesFor("Pilot")
+                .Where(e => e.Kind == CombatEntityKind.Drone).Select(e => e.Position).ToList();
+            Assert.Equal(2, first.Count);
+            server.LeaveSpace("Pilot");
+
+            server.EnterSpace("Pilot"); // flight 1 — the wave must sit somewhere else now
+            var second = server.SpaceEntitiesFor("Pilot")
+                .Where(e => e.Kind == CombatEntityKind.Drone).Select(e => e.Position).ToList();
+            Assert.Equal(2, second.Count);
+            Assert.DoesNotContain(second, p => first.Any(q => q.Equals(p)));
+            server.LeaveSpace("Pilot");
+
+            server.EnterSpace("Pilot"); // flight 2
+            server.LeaveSpace("Pilot");
+
+            server.EnterSpace("Pilot"); // flight 3 — every 4th flight runs quieter (one drone fewer)
+            Assert.Equal(1, server.SpaceEntitiesFor("Pilot").Count(e => e.Kind == CombatEntityKind.Drone));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the two enemy-pacing complaints from playtesting: planet machines that stream in faster and faster once you fight back, and space drones/UFOs that attack on every single flight.

### Planet machines (closes #740)

- **Root cause**: the spawn timer kept accumulating while the population sat at its cap and only reset on an actual spawn — so the moment a machine died, its replacement spawned on the *next tick* (~66 ms).
- The timer now holds at zero while at the cap; a kill is never refilled instantly.
- Once a world has filled to its cap once, refills switch from the 5 s fill cadence to a **jittered 20-45 s interval** (deterministic: seeded from world id + per-world spawn ordinal — no wall-clock randomness).
- A destroyed machine adds a further **10 s post-kill grace** (negative timer), so a fight is followed by quiet, not reinforcements.
- Machines farther than **150 blocks** from every surface player **despawn** (parity with creatures, which prune at 70) — walking away from a fight finally ends it. The leash is wide enough that ambient wander cannot plausibly cross it, so the count-neutral wreck-coupling guarantee is unaffected.

### Space waves (closes #741)

- **Root cause**: aggro radii exceeded the spawn distances (UFO: spawn ~227u < aggro 240u; drone 0''s +/-18u patrol ring dipped under its 190u aggro) — the UFO hunted the ship the instant it launched, every flight, defeating the documented "combat is opt-in, you fly out to them" spawn design.
- Aggro reduced: Drone 190 → **120**, UFO 240 → **150**, Cruiser 260 → **170**. Bandit ships keep 280 by design (they already know you). The finale gauntlet''s approach becomes genuinely opt-in too.
- **Session-scoped wave memory per location** (`AmbientWave`): destroyed drones/UFOs stay dead across relaunches until the sector re-arms (~8 min after the last kill).
- Wave bearings rotate golden-angle per flight ordinal and every 4th flight runs one drone quieter — repeat launches stop replaying the identical hard-coded wave. The first flight from a location keeps the classic full complement (existing count assertions unchanged).

## Tests

- New `EnemySpawnPacingTests` (5): no instant refill + eventual slow refill, far-despawn, hostiles hold off the launch point for a full minute, cleared drone stays cleared until re-arm + returns after, wave varies between flights + quiet 4th flight.
- Full fast tier green locally: 1420 server + 161 client. Affected suites (EnemyMovement, SpaceCombat, StoryCombat, Coupling incl. Slow, AimValidation, Equipment, Bandit, BountyMission) run explicitly: 86/86.
- Docs: TODO.md work-log entry + CHANGELOG Unreleased section.

closes #740
closes #741

🤖 Generated with [Claude Code](https://claude.com/claude-code)