### PR TITLE
feat(ui): pickup feed + hotbar stack counts (#744, #745)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7148,6 +7148,24 @@ is **pre-approved** (keys in `tools/ai-assets/.env`, run via `uv`).
 
 ---
 
+## ✅ Done (2026-08-05): pickup feed + hotbar stack counts (#744/#745)
+
+You can finally SEE what you collected. Two HUD gaps closed:
+
+- **Hotbar stack counts (#744)** — every hotbar cell shows its stack size top-right (the free
+  corner: hotkey number top-left, name caption bottom). Only for stacks > 1, so tools stay clean.
+  New `UiKit.QuickSlot.Count` label (the flight ship-systems bar shares the widget and simply
+  leaves it empty) + `GameBootstrap.CountInSlot`.
+- **Pickup feed (#745)** — an unobtrusive column just above the hotbar's right end announces what
+  an inventory update ADDED: `icon  +n item name` (localized), max 4 rows, newest at the bottom,
+  each fading after ~2.5 s; repeat pickups of the same item merge and count up instead of
+  stacking rows. Fully client-side: `InventoryDiff.Gains` (Client.Core, unit-tested) diffs the
+  wholesale `InventoryUpdate` snapshots per BASE item key (dyed/shaped variants merge; slot moves
+  and losses are silent). The first update after a join is the baseline; gains while a menu is
+  open are dropped (craft/trade have their own in-menu feedback); gains while the hotbar is
+  hidden (piloting/driving/observer) are dropped, not saved up. Reduced-motion holds full alpha
+  until removal instead of fading.
+
 ## ✅ Done (2026-08-05): enemy spawn pacing — no instant machine refills, space combat is opt-in again (#740/#741)
 
 Two long-standing pacing bugs that made hostiles feel relentless:

--- a/client/Assets/BlocksBeyondTheStars/Scripts/GameBootstrap.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/GameBootstrap.cs
@@ -714,6 +714,14 @@ namespace BlocksBeyondTheStars.Client
         public NetItemStack[] Personal { get; private set; } = System.Array.Empty<NetItemStack>();
         public NetItemStack[] Cargo { get; private set; } = System.Array.Empty<NetItemStack>();
 
+        /// <summary>Item gains since the last HUD drain, aggregated per inventory update — the HUD
+        /// pickup feed (#745) consumes these. Base item key + amount gained.</summary>
+        public readonly Queue<(string Item, int Gained)> PickupGains = new Queue<(string, int)>();
+
+        /// <summary>False until the first InventoryUpdate after a join landed — that one is the
+        /// baseline snapshot, not a pickup (#745).</summary>
+        private bool _inventoryBaselined;
+
         /// <summary>Total slots in the ship's cargo hold (capacity), so the cargo tab can show "used/total". 0
         /// when not aboard (the cargo list is empty then).</summary>
         public int CargoSlots { get; private set; }
@@ -1028,6 +1036,20 @@ namespace BlocksBeyondTheStars.Client
             return string.Empty;
         }
 
+        /// <summary>The stack size in a personal inventory slot, or 0 if the slot is empty (#744).</summary>
+        public int CountInSlot(int slot)
+        {
+            foreach (var s in Personal)
+            {
+                if (s.Slot == slot)
+                {
+                    return s.Count;
+                }
+            }
+
+            return 0;
+        }
+
         /// <summary>A loaded chunk's GameObject plus its cached components, so the per-block-move reposition pass
         /// (RepositionChunks) never calls GetComponent on every loaded chunk — at a large view distance that loop
         /// runs over ~1700 chunks each time the player crosses a block, and GetComponent there was a real cost.
@@ -1219,6 +1241,8 @@ namespace BlocksBeyondTheStars.Client
             }
             Network.JoinAccepted += m =>
             {
+                _inventoryBaselined = false; // next InventoryUpdate is the join baseline, not a pickup (#745)
+                PickupGains.Clear();
                 LocalPlayerId = m.PlayerId;
                 LocationName = string.IsNullOrEmpty(m.SystemName)
                     ? m.PlanetName
@@ -1248,6 +1272,22 @@ namespace BlocksBeyondTheStars.Client
             Network.PlayerStateUpdated += OnPlayerState;
             Network.InventoryUpdated += m =>
             {
+                // Pickup feed (#745): surface what this update ADDED. The first update after a join is
+                // the baseline (the whole inventory is "new" then, not a pickup), and gains while a
+                // menu is open are dropped on purpose — craft/trade results have their own in-menu
+                // feedback, and re-announcing them after the menu closes would double up.
+                if (!_inventoryBaselined)
+                {
+                    _inventoryBaselined = true;
+                }
+                else if (!MenuOpen)
+                {
+                    foreach (var (item, gained) in InventoryDiff.Gains(Personal, m.Personal))
+                    {
+                        PickupGains.Enqueue((item, gained));
+                    }
+                }
+
                 Personal = m.Personal;
                 Cargo = m.Cargo;
                 CargoSlots = m.CargoSlotCount;

--- a/client/Assets/BlocksBeyondTheStars/Scripts/HudUi.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/HudUi.cs
@@ -98,6 +98,25 @@ namespace BlocksBeyondTheStars.Client
 
         private int _lastSelSlot = -1; // hotbar selection tick state
 
+        // Pickup feed (#745): a short right-aligned column just above the hotbar's right end, one row per
+        // collected item ("icon  +n name"). Repeat pickups of the same item merge and count up instead of
+        // stacking rows; each row fades out after a couple of seconds. Rows live under the hotbar root so
+        // flying/driving hides the feed together with the bar.
+        private sealed class PickupRow
+        {
+            public string Item;
+            public int Count;
+            public float Ttl;
+            public GameObject Go;
+            public CanvasGroup Fade;
+            public Text Label;
+        }
+
+        private readonly System.Collections.Generic.List<PickupRow> _pickupRows = new System.Collections.Generic.List<PickupRow>();
+        private const int PickupMaxRows = 4;
+        private const float PickupRowH = 26f, PickupRowW = 300f, PickupLife = 2.5f, PickupFadeTime = 0.5f;
+        private float _pickupRightX, _pickupAnchorY; // right edge + top of the hotbar backplate
+
         // Perf: the text-heavy HUD refresh runs at ~10 Hz, not every frame — rebuilding dozens of strings
         // per frame is pure GC churn and the readouts (vitals, clock, prompts) don't change faster than
         // that anyway. Motion-coupled elements (compass blips) still update per frame, and a hotbar
@@ -128,6 +147,10 @@ namespace BlocksBeyondTheStars.Client
             {
                 _canvas.enabled = show;
             }
+
+            // Even while a menu hides the canvas: rows must keep aging (a closed menu must not resurrect
+            // stale pickups) and gains queued during the hidden-hotbar states must keep draining away.
+            UpdatePickupFeed(Time.deltaTime);
 
             // While the binocular optic is raised its own reticle takes over — two crosshairs stacked on top of
             // each other read as a rendering bug (BinocularOptic owns the flag and always clears it).
@@ -404,6 +427,11 @@ namespace BlocksBeyondTheStars.Client
             {
                 _hotbar[i] = UiKit.MakeQuickSlot(hbParent, x0 + i * pitch, hy, sw);
             }
+
+            // Pickup feed anchors (#745): rows sit flush with the backplate's right edge, stacking upward
+            // from just above it.
+            _pickupRightX = x0 + total + 12f;
+            _pickupAnchorY = hy - 14f;
 
             // Compass (round).
             var comp = new GameObject("Compass", typeof(RectTransform));
@@ -750,8 +778,13 @@ namespace BlocksBeyondTheStars.Client
                 {
                     s.Icon.enabled = false;
                     s.Name.text = string.Empty;
+                    s.Count.text = string.Empty;
                     continue;
                 }
+
+                // Stack size top-right (#744): only for real stacks, so tools (max stack 1) stay clean.
+                int count = Game.CountInSlot(i);
+                s.Count.text = count > 1 ? count.ToString() : string.Empty;
 
                 var blockDef = Game.Content?.GetBlock(item);
                 if (blockDef == null && Game.Content?.GetItem(item)?.PlacesBlock is string pb && pb.Length > 0)
@@ -795,6 +828,134 @@ namespace BlocksBeyondTheStars.Client
                 s.Name.text = sel ? name : (name.Length > 10 ? name.Substring(0, 9) + "…" : name);
                 s.Name.color = sel ? UiKit.Cyan : UiKit.TextCol;
             }
+        }
+
+        // --- pickup feed (#745) ---
+
+        /// <summary>Drains the queued inventory gains into the feed rows and ages/fades them. While the
+        /// hotbar is hidden (piloting/driving/observer) gains are dropped, not saved up — announcing a
+        /// pile of stale pickups after landing would be noise, not feedback.</summary>
+        private void UpdatePickupFeed(float dt)
+        {
+            if (_hotbarRoot == null || !_hotbarRoot.activeSelf)
+            {
+                Game.PickupGains.Clear();
+                if (_pickupRows.Count > 0)
+                {
+                    foreach (var row in _pickupRows)
+                    {
+                        Destroy(row.Go);
+                    }
+
+                    _pickupRows.Clear();
+                }
+
+                return;
+            }
+
+            bool changed = false;
+            while (Game.PickupGains.Count > 0)
+            {
+                var (item, gained) = Game.PickupGains.Dequeue();
+                var row = _pickupRows.Find(r => r.Item == item);
+                if (row == null)
+                {
+                    if (_pickupRows.Count >= PickupMaxRows)
+                    {
+                        Destroy(_pickupRows[0].Go); // full: the oldest row yields
+                        _pickupRows.RemoveAt(0);
+                    }
+
+                    row = MakePickupRow(item);
+                    _pickupRows.Add(row);
+                }
+
+                row.Count += gained;
+                row.Ttl = PickupLife;
+                row.Label.text = $"+{row.Count} {Game.Localizer.Get($"item.{item}.name")}";
+                changed = true;
+            }
+
+            for (int i = _pickupRows.Count - 1; i >= 0; i--)
+            {
+                var row = _pickupRows[i];
+                row.Ttl -= dt;
+                if (row.Ttl <= 0f)
+                {
+                    Destroy(row.Go);
+                    _pickupRows.RemoveAt(i);
+                    changed = true;
+                    continue;
+                }
+
+                // Steady, then a short fade-out at the end; reduced motion holds full alpha until removal.
+                row.Fade.alpha = UiKit.ReducedMotion ? 1f : Mathf.Clamp01(row.Ttl / PickupFadeTime);
+            }
+
+            if (changed)
+            {
+                // Stack upward from the backplate: newest row sits closest to the hotbar.
+                for (int i = 0; i < _pickupRows.Count; i++)
+                {
+                    float y = _pickupAnchorY - (_pickupRows.Count - i) * PickupRowH;
+                    UiKit.Place(_pickupRows[i].Go, _pickupRightX - PickupRowW, y, PickupRowW, PickupRowH);
+                }
+            }
+        }
+
+        /// <summary>One feed row: right-aligned "+n name" text with the item's icon at the far right.</summary>
+        private PickupRow MakePickupRow(string item)
+        {
+            var go = new GameObject("pickup_row", typeof(RectTransform));
+            go.transform.SetParent(_hotbarRoot.transform, false);
+            var fade = go.AddComponent<CanvasGroup>();
+            fade.blocksRaycasts = false;
+            fade.interactable = false;
+
+            var iconGo = new GameObject("icon", typeof(RectTransform));
+            iconGo.transform.SetParent(go.transform, false);
+            UiKit.Place(iconGo, PickupRowW - 24f, 3f, 20f, 20f);
+            var raw = iconGo.AddComponent<RawImage>();
+            raw.raycastTarget = false;
+            SetItemIcon(raw, item);
+
+            var label = UiKit.AddText(go.transform, 0f, 3f, PickupRowW - 30f, 20f, string.Empty, 15,
+                UiKit.TextCol, TextAnchor.MiddleRight, FontStyle.Bold);
+            UiKit.AddOutline(label);
+
+            return new PickupRow { Item = item, Go = go, Fade = fade, Label = label };
+        }
+
+        /// <summary>Resolves an item key to its icon the same way the hotbar does (atlas tile for blocks
+        /// and seeds, generated PNG or procedural fallback for pure items) — minus the shaped-block special
+        /// case, since drops in the feed are plain base items.</summary>
+        private void SetItemIcon(RawImage img, string item)
+        {
+            var blockDef = Game.Content?.GetBlock(item);
+            if (blockDef == null && Game.Content?.GetItem(item)?.PlacesBlock is string pb && pb.Length > 0)
+            {
+                blockDef = Game.Content?.GetBlock(pb);
+            }
+
+            Texture2D itemTex;
+            if (blockDef != null && Game.Atlas != null)
+            {
+                img.texture = Game.Atlas.Texture;
+                img.uvRect = Game.Atlas.TileUv(blockDef.NumericId.Value);
+            }
+            else if ((itemTex = IconResolver.ItemTexture(item)) != null)
+            {
+                img.texture = itemTex;
+                img.uvRect = new Rect(0, 0, 1, 1);
+            }
+            else
+            {
+                var kind = Game.Content?.GetItem(item)?.Tool?.Kind ?? BlocksBeyondTheStars.Shared.Definitions.ToolKind.None;
+                img.texture = IconFactory.ForItem(item, kind);
+                img.uvRect = new Rect(0, 0, 1, 1);
+            }
+
+            img.color = IconResolver.Tint(item, Game);
         }
 
         // --- compass ---

--- a/client/Assets/BlocksBeyondTheStars/Scripts/UiKit.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/UiKit.cs
@@ -688,6 +688,7 @@ namespace BlocksBeyondTheStars.Client
             public Image Ring;           // bright selection outline (toggled on the active slot)
             public RawImage Icon;        // the block-atlas / item texture
             public Text Num, Name;
+            public Text Count;           // stack size, top-right (#744) — left empty by the ship-systems bar
         }
 
         /// <summary>Builds a quick-bar cell at a top-left anchored rect. The icon nearly fills the box (only a thin
@@ -712,8 +713,11 @@ namespace BlocksBeyondTheStars.Client
             AddOutline(num);
             var name = AddText(box.transform, 2f, size - 17f, size - 4f, 16f, string.Empty, 12, TextCol, TextAnchor.MiddleCenter, FontStyle.Bold);
             AddOutline(name);
+            // Stack size in the free corner: the hotkey number owns top-left, the caption owns the bottom edge.
+            var count = AddText(box.transform, 5f, 2f, size - 10f, 18f, string.Empty, 13, TextCol, TextAnchor.UpperRight, FontStyle.Bold);
+            AddOutline(count);
 
-            return new QuickSlot { Rt = box.rectTransform, Border = box, Ring = ring, Icon = icon, Num = num, Name = name };
+            return new QuickSlot { Rt = box.rectTransform, Border = box, Ring = ring, Icon = icon, Num = num, Name = name, Count = count };
         }
 
         /// <summary>Applies the selected/idle look to a quick-bar cell: a bright fill + a cyan outline ring on the

--- a/src/BlocksBeyondTheStars.Client.Core/InventoryDiff.cs
+++ b/src/BlocksBeyondTheStars.Client.Core/InventoryDiff.cs
@@ -1,0 +1,74 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+
+using System.Collections.Generic;
+using BlocksBeyondTheStars.Networking.Messages;
+using BlocksBeyondTheStars.Shared.State;
+
+namespace BlocksBeyondTheStars.Client
+{
+    /// <summary>
+    /// Unity-free diff over two personal-inventory snapshots, feeding the HUD pickup feed (#745).
+    /// The server sends the whole inventory wholesale on every change, so "what did I just collect?"
+    /// is the per-item total AFTER minus BEFORE — positive deltas only. Losses (placing, eating,
+    /// selling) are not pickups and never surface. Lives here (not in the MonoBehaviour) so the
+    /// aggregation rules are covered by plain .NET tests.
+    /// </summary>
+    public static class InventoryDiff
+    {
+        /// <summary>
+        /// Aggregated item gains between two inventory snapshots, in first-seen slot order of the new
+        /// snapshot. Totals are summed per BASE item key (<see cref="ItemKey.Base"/>), so a dyed or
+        /// shaped variant counts toward its plain item and a pure slot move never reads as a pickup.
+        /// </summary>
+        public static List<(string Item, int Gained)> Gains(
+            IReadOnlyList<NetItemStack?>? before, IReadOnlyList<NetItemStack?>? after)
+        {
+            var beforeTotals = Totals(before, order: null);
+            var order = new List<string>();
+            var afterTotals = Totals(after, order);
+
+            var gains = new List<(string, int)>();
+            foreach (string key in order)
+            {
+                beforeTotals.TryGetValue(key, out int had);
+                int delta = afterTotals[key] - had;
+                if (delta > 0)
+                {
+                    gains.Add((key, delta));
+                }
+            }
+
+            return gains;
+        }
+
+        /// <summary>Per-base-item totals of one snapshot; records first-seen key order when asked.</summary>
+        private static Dictionary<string, int> Totals(IReadOnlyList<NetItemStack?>? stacks, List<string>? order)
+        {
+            var totals = new Dictionary<string, int>();
+            if (stacks == null)
+            {
+                return totals;
+            }
+
+            foreach (var s in stacks)
+            {
+                if (s == null || string.IsNullOrEmpty(s.Item) || s.Count <= 0)
+                {
+                    continue;
+                }
+
+                string key = ItemKey.Base(s.Item);
+                if (!totals.TryGetValue(key, out int n))
+                {
+                    order?.Add(key);
+                }
+
+                totals[key] = n + s.Count;
+            }
+
+            return totals;
+        }
+    }
+}

--- a/tests/BlocksBeyondTheStars.Client.Tests/InventoryDiffTests.cs
+++ b/tests/BlocksBeyondTheStars.Client.Tests/InventoryDiffTests.cs
@@ -1,0 +1,106 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using BlocksBeyondTheStars.Networking.Messages;
+using Xunit;
+
+namespace BlocksBeyondTheStars.Client.Tests;
+
+/// <summary>
+/// The aggregation rules behind the HUD pickup feed (#745): only positive per-item deltas surface,
+/// slot moves and losses stay silent, and modifier variants merge into their base item.
+/// </summary>
+public sealed class InventoryDiffTests
+{
+    private static NetItemStack S(int slot, string item, int count) =>
+        new() { Slot = slot, Item = item, Count = count };
+
+    [Fact]
+    public void Pickup_SurfacesTheGainedAmount()
+    {
+        var before = new[] { S(0, "berries", 5) };
+        var after = new[] { S(0, "berries", 8) };
+        var gains = InventoryDiff.Gains(before, after);
+
+        Assert.Single(gains);
+        Assert.Equal(("berries", 3), gains[0]);
+    }
+
+    [Fact]
+    public void NewItem_SurfacesItsFullCount()
+    {
+        var before = new[] { S(0, "berries", 5) };
+        var after = new[] { S(0, "berries", 5), S(7, "mud", 2) };
+        var gains = InventoryDiff.Gains(before, after);
+
+        Assert.Single(gains);
+        Assert.Equal(("mud", 2), gains[0]);
+    }
+
+    [Fact]
+    public void Loss_IsNotAPickup()
+    {
+        var before = new[] { S(0, "berries", 5), S(1, "mud", 4) };
+        var after = new[] { S(0, "berries", 2) }; // ate berries, placed all the mud
+        Assert.Empty(InventoryDiff.Gains(before, after));
+    }
+
+    [Fact]
+    public void SlotMove_IsNotAPickup()
+    {
+        var before = new[] { S(0, "berries", 5) };
+        var after = new[] { S(8, "berries", 5) };
+        Assert.Empty(InventoryDiff.Gains(before, after));
+    }
+
+    [Fact]
+    public void SplitStack_IsNotAPickup()
+    {
+        var before = new[] { S(0, "mud", 10) };
+        var after = new[] { S(0, "mud", 4), S(1, "mud", 6) };
+        Assert.Empty(InventoryDiff.Gains(before, after));
+    }
+
+    [Fact]
+    public void ModifierVariants_MergeIntoTheBaseItem()
+    {
+        // A dyed/shaped variant (key#modifier) counts toward its plain item.
+        var before = new[] { S(0, "planks", 3) };
+        var after = new[] { S(0, "planks", 3), S(1, "planks#ff0000", 2) };
+        var gains = InventoryDiff.Gains(before, after);
+
+        Assert.Single(gains);
+        Assert.Equal(("planks", 2), gains[0]);
+    }
+
+    [Fact]
+    public void MultipleGains_KeepFirstSeenSlotOrder()
+    {
+        var before = System.Array.Empty<NetItemStack>();
+        var after = new[] { S(2, "stone", 4), S(5, "berries", 1) };
+        var gains = InventoryDiff.Gains(before, after);
+
+        Assert.Equal(2, gains.Count);
+        Assert.Equal(("stone", 4), gains[0]);
+        Assert.Equal(("berries", 1), gains[1]);
+    }
+
+    [Fact]
+    public void NullOrEmptySnapshots_AreSafe()
+    {
+        Assert.Empty(InventoryDiff.Gains(null, null));
+        Assert.Empty(InventoryDiff.Gains(System.Array.Empty<NetItemStack>(), null));
+
+        var gains = InventoryDiff.Gains(null, new[] { S(0, "mud", 2) });
+        Assert.Single(gains);
+        Assert.Equal(("mud", 2), gains[0]);
+    }
+
+    [Fact]
+    public void EmptyAndZeroCountStacks_AreIgnored()
+    {
+        var before = new[] { S(0, string.Empty, 5), S(1, "mud", 0) };
+        var after = new NetItemStack?[] { S(0, string.Empty, 9), S(1, "mud", 0), null };
+        Assert.Empty(InventoryDiff.Gains(before, after));
+    }
+}


### PR DESCRIPTION
## Summary

You can finally SEE what you collected — two HUD gaps closed:

- **Hotbar stack counts (#744)**: every hotbar cell shows its stack size in the top-right corner for stacks > 1 (hotkey number owns top-left, name caption the bottom edge — tools with max stack 1 stay clean). New `Count` label on the shared `UiKit.QuickSlot`; the flight ship-systems bar simply leaves it empty. New `GameBootstrap.CountInSlot` accessor.
- **Pickup feed (#745)**: an unobtrusive column just above the hotbar's right end announces what an inventory update ADDED — `icon  +n item name` (localized), max 4 rows, newest at the bottom, ~2.5 s lifetime. Repeat pickups of the same item merge and count up ("+7 berries") instead of stacking rows.

## Approach

Fully client-side, no protocol change. `InventoryDiff.Gains` (Client.Core, Unity-free) diffs the wholesale `InventoryUpdate` snapshots per BASE item key: slot moves and stack splits are silent, losses (placing, eating, selling) are not pickups, dyed/shaped variants merge into their plain item. The first update after a join is the baseline; gains while a menu is open are dropped (craft/trade feedback already lives in-menu); gains while the hotbar is hidden (piloting/driving/observer) are dropped rather than saved up. Reduced-motion holds full alpha until removal instead of fading.

## Testing

- 9 new `InventoryDiffTests` covering gain/new-item/loss/slot-move/split/variant-merge/order/null-safety.
- Full fast-tier suite green: 1415 server + 170 client, 0 failures; clean Release rebuild with 0 warnings.
- Local Unity Windows build succeeded (client/Assets changed; PR CI does not build Unity).

closes #744
closes #745

🤖 Generated with [Claude Code](https://claude.com/claude-code)