### PR TITLE
feat(hud): research toast — knowledge that unlocks new tech announces itself (#763)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7190,6 +7190,26 @@ Tests: `ScanMicroFauna_GrantsKnowledgeOnce_RejectsUnknownKind_AndListsInLedger`,
 `MicroFaunaCatalog_KeysAreDistinct_AndKnownLookupWorks` (ScanningTests). NEEDS Unity build (client
 HUD/VEGA/SpaceView/micro-fauna changes).
 
+## ✅ Done (2026-08-05): research toast — knowledge that unlocks new tech announces itself (#763)
+
+Crossing a blueprint's `knowledgeCost` used to be invisible outside the Tech tab (only its dot
+badge, visible with the menu already open). Now a HUD toast top-centre celebrates the moment:
+
+- **Trigger** — client-side diff of `KnowledgePoints` in the inventory snapshot
+  (`GameBootstrap.ResearchAvailable` queue, mirroring the pickup-feed pattern): every still-locked
+  blueprint whose threshold the gain crossed queues a toast, threshold-only on purpose
+  (prerequisites may still be missing — advertising deeper tree nodes is the point). The join
+  snapshot baselines silently; a huge jump (admin grant) is capped at 6 queued toasts. Queued keys
+  survive menus/flight and play sequentially (~3.5 s each) once the HUD is visible.
+- **Toast** (`HudUi`) — blueprint icon (item resolution like the pickup feed; module blueprints
+  fall back to their tech-category sprite) + "New research available!" + blueprint name in cyan;
+  scale-pop in with overshoot, pulsing glow disc behind the icon, one diagonal shine sweep
+  (clipped by a RectMask2D), then fade. Reduced motion: plain fade, no pop/pulse/sweep.
+- **Sound** — new `research_available` ProceduralAudio chime (two soft bell notes + shimmer),
+  deliberately calmer than the `tech_unlock` fanfare. Drive-by: `Cue("ui_success")` on the
+  achievement toast was a silent no-op (clip never existed) — achievements are audible now.
+- Locale key `ui.tech.research_available` (DE+EN).
+
 ## ✅ Done (2026-08-05): pickup feed + hotbar stack counts (#744/#745)
 
 You can finally SEE what you collected. Two HUD gaps closed:

--- a/client/Assets/BlocksBeyondTheStars/Scripts/GameBootstrap.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/GameBootstrap.cs
@@ -718,6 +718,11 @@ namespace BlocksBeyondTheStars.Client
         /// pickup feed (#745) consumes these. Base item key + amount gained.</summary>
         public readonly Queue<(string Item, int Gained)> PickupGains = new Queue<(string, int)>();
 
+        /// <summary>Blueprint keys whose knowledge threshold a knowledge gain just crossed — the HUD
+        /// research toast (#763) consumes these. Unlike pickups they survive menus and flight: newly
+        /// being ABLE to research something is rare enough to announce a little late rather than drop.</summary>
+        public readonly Queue<string> ResearchAvailable = new Queue<string>();
+
         /// <summary>False until the first InventoryUpdate after a join landed — that one is the
         /// baseline snapshot, not a pickup (#745).</summary>
         private bool _inventoryBaselined;
@@ -1303,6 +1308,7 @@ namespace BlocksBeyondTheStars.Client
             {
                 _inventoryBaselined = false; // next InventoryUpdate is the join baseline, not a pickup (#745)
                 PickupGains.Clear();
+                ResearchAvailable.Clear();
                 LocalPlayerId = m.PlayerId;
                 LocationName = string.IsNullOrEmpty(m.SystemName)
                     ? m.PlanetName
@@ -1336,7 +1342,8 @@ namespace BlocksBeyondTheStars.Client
                 // the baseline (the whole inventory is "new" then, not a pickup), and gains while a
                 // menu is open are dropped on purpose — craft/trade results have their own in-menu
                 // feedback, and re-announcing them after the menu closes would double up.
-                if (!_inventoryBaselined)
+                bool baseline = !_inventoryBaselined;
+                if (baseline)
                 {
                     _inventoryBaselined = true;
                 }
@@ -1352,6 +1359,32 @@ namespace BlocksBeyondTheStars.Client
                 Cargo = m.Cargo;
                 CargoSlots = m.CargoSlotCount;
                 UnlockedBlueprints = new System.Collections.Generic.HashSet<string>(m.UnlockedBlueprints ?? System.Array.Empty<string>());
+
+                // Research toast (#763): a knowledge gain that crosses a still-locked blueprint's
+                // threshold makes it newly researchable — queue it for the HUD. Threshold-only on
+                // purpose (prerequisites may still be missing): "you now know enough for X" is true
+                // either way, and advertising deeper tree nodes is the point. The join snapshot
+                // baselines silently, and a huge jump (admin grant) is capped so the HUD doesn't
+                // announce toasts for minutes.
+                if (!baseline && m.KnowledgePoints > Knowledge && Content != null)
+                {
+                    var crossed = new List<Shared.Definitions.BlueprintDefinition>();
+                    foreach (var bp in Content.Blueprints.Values)
+                    {
+                        if (bp.KnowledgeCost > Knowledge && bp.KnowledgeCost <= m.KnowledgePoints
+                            && !UnlockedBlueprints.Contains(bp.Key))
+                        {
+                            crossed.Add(bp);
+                        }
+                    }
+
+                    crossed.Sort((a, b) => a.KnowledgeCost.CompareTo(b.KnowledgeCost));
+                    for (int i = 0; i < crossed.Count && ResearchAvailable.Count < 6; i++)
+                    {
+                        ResearchAvailable.Enqueue(crossed[i].Key);
+                    }
+                }
+
                 Knowledge = m.KnowledgePoints;
             };
             Network.ShipPlacementReceived += m => ShipPosition = new Vector3(m.X, m.Y, m.Z);

--- a/client/Assets/BlocksBeyondTheStars/Scripts/HudUi.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/HudUi.cs
@@ -118,6 +118,19 @@ namespace BlocksBeyondTheStars.Client
         private const float PickupRowH = 26f, PickupRowW = 300f, PickupLife = 2.5f, PickupFadeTime = 0.5f;
         private float _pickupRightX, _pickupAnchorY; // right edge + top of the hotbar backplate
 
+        // Research toast (#763): "New research available!" with the blueprint's icon, top-centre under
+        // the IN SPACE/observer lines. One toast at a time; further keys wait in Game.ResearchAvailable.
+        private GameObject _researchGo;
+        private RectTransform _researchRect;
+        private CanvasGroup _researchFade;
+        private RawImage _researchIcon;
+        private Image _researchGlow;
+        private RectTransform _researchShine;
+        private Text _researchHead, _researchName;
+        private float _researchAge = -1f; // <0 = idle, no toast up
+        private const float ResearchW = 480f, ResearchH = 86f, ResearchY = 64f;
+        private const float ResearchPop = 0.25f, ResearchHold = 3.0f, ResearchFade = 0.5f;
+
         // Perf: the text-heavy HUD refresh runs at ~10 Hz, not every frame — rebuilding dozens of strings
         // per frame is pure GC churn and the readouts (vitals, clock, prompts) don't change faster than
         // that anyway. Motion-coupled elements (compass blips) still update per frame, and a hotbar
@@ -152,6 +165,7 @@ namespace BlocksBeyondTheStars.Client
             // Even while a menu hides the canvas: rows must keep aging (a closed menu must not resurrect
             // stale pickups) and gains queued during the hidden-hotbar states must keep draining away.
             UpdatePickupFeed(Time.deltaTime);
+            UpdateResearchToast(Time.deltaTime);
 
             // While the binocular optic is raised its own reticle takes over — two crosshairs stacked on top of
             // each other read as a rendering bug (BinocularOptic owns the flag and always clears it).
@@ -997,6 +1011,163 @@ namespace BlocksBeyondTheStars.Client
             }
 
             img.color = IconResolver.Tint(item, Game);
+        }
+
+        // --- research toast (#763) ---
+
+        /// <summary>Drives the "new research available" toast: pops the next queued blueprint when idle
+        /// and the HUD is visible, animates the pop/glow/shine, then fades out. Queued keys survive
+        /// menus and flight — the announcement is rare enough to arrive late rather than be dropped.</summary>
+        private void UpdateResearchToast(float dt)
+        {
+            if (_researchAge >= 0f && _researchGo == null)
+            {
+                _researchAge = -1f; // the canvas (and toast) got torn down mid-toast, e.g. on a world change
+            }
+
+            if (_researchAge < 0f)
+            {
+                if (Game.ResearchAvailable.Count == 0 || _canvas == null || !_canvas.enabled)
+                {
+                    return;
+                }
+
+                StartResearchToast(Game.ResearchAvailable.Dequeue());
+            }
+
+            _researchAge += dt;
+            if (_researchAge >= ResearchHold + ResearchFade)
+            {
+                _researchAge = -1f;
+                _researchGo.SetActive(false);
+                return;
+            }
+
+            float alpha = _researchAge >= ResearchHold
+                ? 1f - (_researchAge - ResearchHold) / ResearchFade
+                : (UiKit.ReducedMotion ? Mathf.Clamp01(_researchAge / 0.2f) : 1f);
+            _researchFade.alpha = alpha;
+
+            if (UiKit.ReducedMotion)
+            {
+                _researchRect.localScale = Vector3.one;
+                _researchGlow.color = new Color(0.4f, 0.82f, 1f, 0.22f * alpha);
+                _researchShine.gameObject.SetActive(false);
+                return;
+            }
+
+            // Pop-in: overshoot past 1.0 and settle by the end of the pop window (sin term ends at 0).
+            float p = Mathf.Clamp01(_researchAge / ResearchPop);
+            _researchRect.localScale = Vector3.one * (Mathf.Lerp(0.75f, 1f, p) + Mathf.Sin(p * Mathf.PI) * 0.08f);
+
+            // Soft glow pulsing behind the icon for the toast's whole life.
+            float pulse = Mathf.Sin(_researchAge * 4.2f) * 0.5f + 0.5f;
+            _researchGlow.color = new Color(0.4f, 0.82f, 1f, (0.14f + pulse * 0.24f) * alpha);
+            float gs = 1f + pulse * 0.18f;
+            _researchGlow.rectTransform.localScale = new Vector3(gs, gs, 1f);
+
+            // One diagonal shine sweep across the panel just after the pop (clipped by the RectMask2D).
+            float sweep = (_researchAge - 0.15f) / 0.6f;
+            bool sweeping = sweep >= 0f && sweep <= 1f;
+            _researchShine.gameObject.SetActive(sweeping);
+            if (sweeping)
+            {
+                var ap = _researchShine.anchoredPosition;
+                ap.x = Mathf.Lerp(-80f, ResearchW + 40f, sweep);
+                _researchShine.anchoredPosition = ap;
+            }
+        }
+
+        /// <summary>Fills and shows the toast for one blueprint key and plays the discovery chime.</summary>
+        private void StartResearchToast(string bpKey)
+        {
+            EnsureResearchToast();
+            var loc = Game.Localizer;
+            _researchHead.text = loc.Get("ui.tech.research_available").ToUpperInvariant();
+            _researchName.text = loc.Get($"blueprint.{bpKey}.name");
+            SetBlueprintIcon(_researchIcon, bpKey);
+            _researchGo.SetActive(true);
+            _researchAge = 0f;
+            _researchFade.alpha = UiKit.ReducedMotion ? 0f : 1f;
+            _researchRect.localScale = UiKit.ReducedMotion ? Vector3.one : Vector3.one * 0.75f;
+            ClientAudio.Instance?.Cue("research_available", 0.9f);
+        }
+
+        /// <summary>Builds the toast hierarchy once: panel + glow disc + icon + two text lines + the
+        /// shine bar. Center-pivoted (unlike the usual top-left Place) so the pop scales in place.</summary>
+        private void EnsureResearchToast()
+        {
+            if (_researchGo != null)
+            {
+                return;
+            }
+
+            _researchGo = new GameObject("research_toast", typeof(RectTransform));
+            _researchGo.transform.SetParent(_canvas.transform, false);
+            _researchRect = UiKit.Place(_researchGo, (W - ResearchW) / 2f, ResearchY, ResearchW, ResearchH);
+            _researchRect.pivot = new Vector2(0.5f, 0.5f);
+            _researchRect.anchoredPosition += new Vector2(ResearchW / 2f, -ResearchH / 2f);
+            _researchFade = _researchGo.AddComponent<CanvasGroup>();
+            _researchFade.blocksRaycasts = false;
+            _researchFade.interactable = false;
+
+            var bg = _researchGo.AddComponent<Image>();
+            bg.sprite = UiKit.PanelSprite;
+            bg.type = Image.Type.Sliced;
+            bg.color = new Color(0.05f, 0.12f, 0.24f, 0.9f);
+            bg.raycastTarget = false;
+            _researchGo.AddComponent<RectMask2D>(); // clips the shine sweep to the panel
+
+            _researchGlow = UiKit.AddImage(_researchGo.transform, 8f, 8f, 70f, 70f, UiKit.DiscSprite, new Color(0.4f, 0.82f, 1f, 0.3f));
+            var glowRt = _researchGlow.rectTransform; // centre-pivot so the pulse grows around the icon
+            glowRt.pivot = new Vector2(0.5f, 0.5f);
+            glowRt.anchoredPosition += new Vector2(35f, -35f);
+            var iconGo = new GameObject("icon", typeof(RectTransform));
+            iconGo.transform.SetParent(_researchGo.transform, false);
+            UiKit.Place(iconGo, 15f, 15f, 56f, 56f);
+            _researchIcon = iconGo.AddComponent<RawImage>();
+            _researchIcon.raycastTarget = false;
+
+            _researchHead = UiKit.AddText(_researchGo.transform, 92f, 16f, ResearchW - 104f, 22f, string.Empty, 15, UiKit.CyanDim, TextAnchor.MiddleLeft, FontStyle.Bold);
+            _researchName = UiKit.AddText(_researchGo.transform, 92f, 40f, ResearchW - 104f, 30f, string.Empty, 20, UiKit.Cyan, TextAnchor.MiddleLeft, FontStyle.Bold);
+            UiKit.AddOutline(_researchHead);
+            UiKit.AddOutline(_researchName);
+
+            var shine = UiKit.AddImage(_researchGo.transform, -80f, -20f, 46f, ResearchH + 40f, UiKit.SolidSprite, new Color(1f, 1f, 1f, 0.16f));
+            shine.transform.localRotation = Quaternion.Euler(0f, 0f, 18f);
+            _researchShine = shine.rectTransform;
+            _researchShine.gameObject.SetActive(false);
+
+            _researchGo.SetActive(false);
+        }
+
+        /// <summary>Icon for a blueprint key: most blueprint keys ARE item keys (heal_tank, binoculars…)
+        /// and reuse the item resolution; module/expansion blueprints fall back to their tech-category
+        /// sprite, tinted cyan like the tech tree's own nodes.</summary>
+        private void SetBlueprintIcon(RawImage img, string bpKey)
+        {
+            if (Game.Content?.GetItem(bpKey) != null || Game.Content?.GetBlock(bpKey) != null)
+            {
+                SetItemIcon(img, bpKey);
+                return;
+            }
+
+            string cat = Game.Content != null && Game.Content.Blueprints.TryGetValue(bpKey, out var bp) && bp.Category == "ShipExpansion"
+                ? "cat_modules"
+                : "cat_tech";
+            var sprite = UiKit.Icon(cat);
+            if (sprite != null)
+            {
+                img.texture = sprite.texture;
+                img.uvRect = new Rect(0, 0, 1, 1);
+                img.color = UiKit.Cyan;
+            }
+            else
+            {
+                img.texture = IconFactory.ForItem(bpKey, BlocksBeyondTheStars.Shared.Definitions.ToolKind.None);
+                img.uvRect = new Rect(0, 0, 1, 1);
+                img.color = Color.white;
+            }
         }
 
         // --- compass ---

--- a/client/Assets/BlocksBeyondTheStars/Scripts/ProceduralAudio.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/ProceduralAudio.cs
@@ -27,7 +27,7 @@ namespace BlocksBeyondTheStars.Client
             "thunder_1", "thunder_2", "thunder_3",
             // ui / vitals
             "ui_hover", "ui_click", "ui_confirm", "ui_back", "o2_warning", "tech_unlock", "hull_alarm",
-            "vitals_warning",
+            "vitals_warning", "research_available", "ui_success",
             // ship / space
             "hyperspace_jump", "station_board", "scan_ping", "lamp_toggle", "teleport",
             "ship_launch", "ship_landing",
@@ -60,6 +60,8 @@ namespace BlocksBeyondTheStars.Client
             "ui_back" => Arp("ui_back", 0.20f, 0.22f, up: false),
             "o2_warning" => Alarm("o2_warning", 950f, 0.5f),
             "tech_unlock" => Arp("tech_unlock", 0.45f, 0.30f, up: true), // longer rising fanfare than ui_confirm
+            "research_available" => Chime("research_available"), // "you can research something new" ping (#763)
+            "ui_success" => Arp("ui_success", 0.30f, 0.26f, up: true), // achievement toast — was a silent no-op (#763)
             "hull_alarm" => Alarm("hull_alarm", 640f, 0.45f), // deeper than the O₂ warning
             "vitals_warning" => Alarm("vitals_warning", 780f, 0.4f), // below-10 % vitals blink (#753), between the two
             "hyperspace_jump" => Warp("hyperspace_jump"),
@@ -152,6 +154,22 @@ namespace BlocksBeyondTheStars.Client
                 int n = Mathf.Min(notes.Length - 1, i / seg);
                 float lt = (i - n * seg) / (float)Rate;
                 d[i] = Mathf.Sin(2f * Mathf.PI * notes[n] * (i / (float)Rate)) * Mathf.Exp(-lt * 16f) * vol;
+            }
+        });
+
+        /// <summary>Two soft bell notes a fifth apart plus a faint high shimmer — the "new research
+        /// available" discovery ping (#763): brighter than ui_confirm, calmer than the tech_unlock fanfare.</summary>
+        private static AudioClip Chime(string name) => Buf(name, 0.55f, d =>
+        {
+            for (int i = 0; i < d.Length; i++)
+            {
+                float t = i / (float)Rate;
+                float a = Mathf.Sin(2f * Mathf.PI * 1046.5f * t) * Mathf.Exp(-t * 7f);              // C6
+                float b = t > 0.16f
+                    ? Mathf.Sin(2f * Mathf.PI * 1568f * (t - 0.16f)) * Mathf.Exp(-(t - 0.16f) * 6f) // G6
+                    : 0f;
+                float shimmer = Mathf.Sin(2f * Mathf.PI * 3135f * t) * Mathf.Exp(-t * 12f) * 0.15f;
+                d[i] = (a * 0.55f + b * 0.6f + shimmer) * 0.3f;
             }
         });
 

--- a/data/locales/de.json
+++ b/data/locales/de.json
@@ -843,6 +843,7 @@
   "ui.tech.locked": "Gesperrt",
   "ui.tech.materials_missing": "Material fehlt",
   "ui.tech.unlockable": "Freischaltbar",
+  "ui.tech.research_available": "Neue Forschung verfügbar!",
   "ui.tech.tier": "Stufe",
   "ui.tech.cat_production": "Produktion",
   "ui.tech.cat_ship": "Schiff",

--- a/data/locales/en.json
+++ b/data/locales/en.json
@@ -842,6 +842,7 @@
   "ui.tech.locked": "Locked",
   "ui.tech.materials_missing": "Materials missing",
   "ui.tech.unlockable": "Unlockable",
+  "ui.tech.research_available": "New research available!",
   "ui.tech.tier": "Tier",
   "ui.tech.cat_production": "Production",
   "ui.tech.cat_ship": "Ship",


### PR DESCRIPTION
## What

Closes #763.

When a knowledge gain crosses a still-locked blueprint's `knowledgeCost`, the HUD now celebrates it top-centre: the blueprint's icon + **"New research available!"** + the blueprint name in cyan, with a scale-pop (slight overshoot), a pulsing glow disc behind the icon and one diagonal shine sweep, then a fade-out — and a new soft two-note `research_available` chime. Under reduced motion: plain fade, no pop/pulse/sweep, chime unchanged.

## How

- **`GameBootstrap`** — client-side diff of `KnowledgePoints` on the inventory snapshot into a new `ResearchAvailable` queue (mirrors the pickup-feed pattern; no protocol/server change). Threshold-only on purpose — prerequisites may still be missing; advertising deeper tree nodes is the point. The join snapshot baselines silently; a huge jump (admin grant) caps at 6 queued toasts.
- **`HudUi`** — lazily built `research_toast` element (centre-pivoted so the pop scales in place), driven from `LateUpdate` like the pickup feed. Queued keys survive menus/flight and play sequentially (~3.5 s each) once the HUD is visible; torn-down-canvas mid-toast resets cleanly. Icon resolution reuses the pickup feed's item path (atlas / generated PNG / procedural fallback); module/expansion blueprints fall back to their tech-category sprite tinted cyan.
- **`ProceduralAudio`** — new `Chime` primitive (C6 + G6 bells + faint shimmer), calmer than the `tech_unlock` fanfare. **Drive-by:** `Cue("ui_success")` on the achievement toast was a silent no-op (the clip never existed and the id wasn't in `KnownIds`) — achievements now get a rising arp.
- **Locales** — `ui.tech.research_available` in DE + EN.

## Verification

- `dotnet build -c Release`: 0 warnings, 0 errors
- Fast-tier tests: **1422/1422 green**
- Local Unity client build (worktree): **OK**, `ScriptAssemblies/BlocksBeyondTheStars.Client.dll` rebuilt

🤖 Generated with [Claude Code](https://claude.com/claude-code)