### PR TITLE
feat(balance): research pacing — stretch the knowledge ladder, cap the faucets

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7148,6 +7148,33 @@ is **pre-approved** (keys in `tools/ai-assets/.env`, run via `uv`).
 
 ---
 
+## ✅ Done (2026-08-05): research pacing — blueprints no longer unlock in a rush (#767)
+
+Knowledge is a lifetime threshold (never spent), but the whole tech tree topped out at `knowledgeCost`
+24 while normal first-hour play banked ~50–70 knowledge — every blueprint was instantly researchable
+and the research toast (#763) fired in bursts. Five levers, server + data only (no client change):
+
+- **Minigame faucet capped** — `HandleMinigameResult` now pays 5 knowledge per star **newly earned on
+  that game** (per-player best-rating ledger in `PlayerState.Milestones`, `arcade:<game>:star:N`);
+  replays and worse runs pay nothing, improving 1★→3★ pays the +10 difference. Was 5/10/15 per
+  completed run, unbounded — the dominant faucet.
+- **Knowledge ladder stretched wide** (`data/blueprints.json`) — every blueprint now carries a cost:
+  early ~3–10, mid ~15–40, late 60–120 (`ship_deathblock` 100, `ai_core_mk3` 90, `matter_resynth` 80).
+  Previously ~half the tree (all ships, ship weapons/defense, refinery chain) had no knowledge cost.
+- **Prerequisites deepened** — ships sit behind `docking_module` (+ `cargo_expansion_1` for the
+  hauler), ship cannons behind `hull_plating`, heal tank behind `field_medkit`, terrain blaster behind
+  `titanium_drill`, advanced scanner behind `terrain_scanner`, tractor beam behind `docking_module`,
+  jump generator behind `radar_array`, stealth suit/jetpack behind `suit_liner_2`, station vendor
+  behind `station_container`.
+- **Story-beat knowledge trimmed** — B1–B12 pay +1 each (was +3; 36 total out-earned the old ceiling).
+- **Repeat-tame trickle removed** — first tame of a species per world still pays full research;
+  repeats pay nothing (was +1, unbounded).
+
+Existing saves keep their banked knowledge and unlocked blueprints; the higher tiers now sit above
+most veterans' totals again. Tests: minigame star-ledger, blueprint graph guard (prereqs resolve, no
+cycles, no cost inversions along chains, every blueprint costs knowledge); taming/detoxifier/heal-tank
+tests updated. Open: playtest the new pacing curve.
+
 ## ✅ Done (2026-08-05): intro cinematic, staged VEGA prologue, VEGA voice chatter, memory flashbacks (#759–#762)
 
 The game gained a watchable intro plus cinematic story dressing — all real-time in-engine (no video

--- a/data/blueprints.json
+++ b/data/blueprints.json
@@ -1,337 +1,337 @@
 [
   {
     "key": "oxygen_tank_1", "nameKey": "blueprint.oxygen_tank_1.name", "descriptionKey": "blueprint.oxygen_tank_1.desc",
-    "category": "Suit", "prerequisites": [],
+    "category": "Suit", "prerequisites": [], "knowledgeCost": 3,
     "unlockCost": [ { "item": "data_fragment", "count": 1 }, { "item": "iron_plate", "count": 5 } ]
   },
   {
     "key": "titanium_drill", "nameKey": "blueprint.titanium_drill.name", "descriptionKey": "blueprint.titanium_drill.desc",
-    "category": "Tools", "prerequisites": [],
+    "category": "Tools", "prerequisites": [], "knowledgeCost": 6,
     "unlockCost": [ { "item": "data_fragment", "count": 2 }, { "item": "iron_plate", "count": 10 } ]
   },
   {
     "key": "field_medkit", "nameKey": "blueprint.field_medkit.name", "descriptionKey": "blueprint.field_medkit.desc",
-    "category": "Tools", "prerequisites": [],
+    "category": "Tools", "prerequisites": [], "knowledgeCost": 5,
     "unlockCost": [ { "item": "data_fragment", "count": 2 }, { "item": "iron_plate", "count": 6 } ]
   },
   {
     "key": "heal_tank", "nameKey": "blueprint.heal_tank.name", "descriptionKey": "blueprint.heal_tank.desc",
-    "category": "Tools", "prerequisites": [], "knowledgeCost": 4,
+    "category": "Tools", "prerequisites": [ "field_medkit" ], "knowledgeCost": 12,
     "unlockCost": [ { "item": "data_fragment", "count": 3 }, { "item": "titanium_plate", "count": 4 }, { "item": "glass", "count": 4 } ]
   },
   {
     "key": "stasis_projector", "nameKey": "blueprint.stasis_projector.name", "descriptionKey": "blueprint.stasis_projector.desc",
-    "category": "Tools", "prerequisites": [],
+    "category": "Tools", "prerequisites": [], "knowledgeCost": 14,
     "unlockCost": [ { "item": "data_fragment", "count": 3 }, { "item": "titanium_plate", "count": 4 } ]
   },
   {
     "key": "terrain_blaster", "nameKey": "blueprint.terrain_blaster.name", "descriptionKey": "blueprint.terrain_blaster.desc",
-    "category": "Tools", "prerequisites": [],
+    "category": "Tools", "prerequisites": [ "titanium_drill" ], "knowledgeCost": 20,
     "unlockCost": [ { "item": "data_fragment", "count": 4 }, { "item": "titanium_plate", "count": 6 }, { "item": "carbide", "count": 2 } ]
   },
   {
     "key": "terrain_scanner", "nameKey": "blueprint.terrain_scanner.name", "descriptionKey": "blueprint.terrain_scanner.desc",
-    "category": "Tools", "prerequisites": [],
+    "category": "Tools", "prerequisites": [], "knowledgeCost": 8,
     "unlockCost": [ { "item": "data_fragment", "count": 3 }, { "item": "titanium_plate", "count": 3 } ]
   },
   {
     "key": "creature_translator", "nameKey": "blueprint.creature_translator.name", "descriptionKey": "blueprint.creature_translator.desc",
-    "category": "Tools", "prerequisites": [], "knowledgeCost": 4,
+    "category": "Tools", "prerequisites": [], "knowledgeCost": 12,
     "unlockCost": [ { "item": "data_fragment", "count": 2 }, { "item": "titanium_plate", "count": 3 }, { "item": "cable", "count": 2 } ]
   },
   {
     "key": "radio_beacon", "nameKey": "blueprint.radio_beacon.name", "descriptionKey": "blueprint.radio_beacon.desc",
-    "category": "Tools", "prerequisites": [],
+    "category": "Tools", "prerequisites": [], "knowledgeCost": 6,
     "unlockCost": [ { "item": "data_fragment", "count": 2 }, { "item": "iron_plate", "count": 5 }, { "item": "cable", "count": 2 } ]
   },
   {
     "key": "beam_block", "nameKey": "blueprint.beam_block.name", "descriptionKey": "blueprint.beam_block.desc",
-    "category": "Tools", "prerequisites": [],
+    "category": "Tools", "prerequisites": [], "knowledgeCost": 18,
     "unlockCost": [ { "item": "data_fragment", "count": 4 }, { "item": "titanium_plate", "count": 4 }, { "item": "cable", "count": 3 } ]
   },
   {
     "key": "speeder", "nameKey": "blueprint.speeder.name", "descriptionKey": "blueprint.speeder.desc",
-    "category": "Tools", "prerequisites": [], "knowledgeCost": 12,
+    "category": "Tools", "prerequisites": [], "knowledgeCost": 30,
     "unlockCost": [ { "item": "data_fragment", "count": 5 }, { "item": "titanium_plate", "count": 10 }, { "item": "cable", "count": 8 }, { "item": "energy_cell_1", "count": 3 } ]
   },
   {
     "key": "camera", "nameKey": "blueprint.camera.name", "descriptionKey": "blueprint.camera.desc",
-    "category": "Tools", "prerequisites": [], "knowledgeCost": 2,
+    "category": "Tools", "prerequisites": [], "knowledgeCost": 4,
     "unlockCost": [ { "item": "data_fragment", "count": 1 }, { "item": "iron_plate", "count": 3 }, { "item": "glass", "count": 1 } ]
   },
   {
     "key": "binoculars", "nameKey": "blueprint.binoculars.name", "descriptionKey": "blueprint.binoculars.desc",
-    "category": "Tools", "prerequisites": [], "knowledgeCost": 1,
+    "category": "Tools", "prerequisites": [], "knowledgeCost": 3,
     "unlockCost": [ { "item": "data_fragment", "count": 1 }, { "item": "iron_plate", "count": 4 }, { "item": "glass", "count": 2 } ]
   },
   {
     "key": "thermal_binoculars", "nameKey": "blueprint.thermal_binoculars.name", "descriptionKey": "blueprint.thermal_binoculars.desc",
-    "category": "Tools", "prerequisites": [ "binoculars" ], "knowledgeCost": 4,
+    "category": "Tools", "prerequisites": [ "binoculars" ], "knowledgeCost": 15,
     "unlockCost": [ { "item": "data_fragment", "count": 3 }, { "item": "titanium_plate", "count": 3 }, { "item": "circuit_board", "count": 1 }, { "item": "crystal", "count": 1 } ]
   },
   {
     "key": "cargo_expansion_1", "nameKey": "blueprint.cargo_expansion_1.name", "descriptionKey": "blueprint.cargo_expansion_1.desc",
-    "category": "ShipExpansion", "prerequisites": [],
+    "category": "ShipExpansion", "prerequisites": [], "knowledgeCost": 6,
     "unlockCost": [ { "item": "data_fragment", "count": 1 }, { "item": "iron_ingot", "count": 20 }, { "item": "cable", "count": 5 } ]
   },
   {
     "key": "refinery", "nameKey": "blueprint.refinery.name", "descriptionKey": "blueprint.refinery.desc",
-    "category": "ShipExpansion", "prerequisites": [ "cargo_expansion_1" ],
+    "category": "ShipExpansion", "prerequisites": [ "cargo_expansion_1" ], "knowledgeCost": 15,
     "unlockCost": [ { "item": "data_fragment", "count": 3 }, { "item": "iron_plate", "count": 15 }, { "item": "cable", "count": 8 } ]
   },
   {
     "key": "detoxifier", "nameKey": "blueprint.detoxifier.name", "descriptionKey": "blueprint.detoxifier.desc",
-    "category": "ShipExpansion", "prerequisites": [], "knowledgeCost": 6,
+    "category": "ShipExpansion", "prerequisites": [], "knowledgeCost": 16,
     "unlockCost": [ { "item": "data_fragment", "count": 2 }, { "item": "iron_plate", "count": 12 }, { "item": "cable", "count": 4 } ]
   },
   {
     "key": "matter_forge", "nameKey": "blueprint.matter_forge.name", "descriptionKey": "blueprint.matter_forge.desc",
-    "category": "ShipExpansion", "prerequisites": [ "refinery" ], "knowledgeCost": 10,
+    "category": "ShipExpansion", "prerequisites": [ "refinery" ], "knowledgeCost": 35,
     "unlockCost": [ { "item": "data_fragment", "count": 4 }, { "item": "titanium_plate", "count": 8 }, { "item": "circuit_board", "count": 3 }, { "item": "cable", "count": 8 } ]
   },
   {
     "key": "matter_resynth", "nameKey": "blueprint.matter_resynth.name", "descriptionKey": "blueprint.matter_resynth.desc",
-    "category": "ShipExpansion", "prerequisites": [ "matter_forge" ], "knowledgeCost": 18,
+    "category": "ShipExpansion", "prerequisites": [ "matter_forge" ], "knowledgeCost": 80,
     "unlockCost": [ { "item": "data_fragment", "count": 6 }, { "item": "circuit_board", "count": 4 }, { "item": "power_cell", "count": 2 } ]
   },
   {
     "key": "tractor_beam", "nameKey": "blueprint.tractor_beam.name", "descriptionKey": "blueprint.tractor_beam.desc",
-    "category": "ShipExpansion", "prerequisites": [], "knowledgeCost": 8,
+    "category": "ShipExpansion", "prerequisites": [ "docking_module" ], "knowledgeCost": 25,
     "unlockCost": [ { "item": "data_fragment", "count": 3 }, { "item": "titanium_plate", "count": 8 }, { "item": "cable", "count": 6 } ]
   },
   {
     "key": "oxygen_generator", "nameKey": "blueprint.oxygen_generator.name", "descriptionKey": "blueprint.oxygen_generator.desc",
-    "category": "ShipExpansion", "prerequisites": [],
+    "category": "ShipExpansion", "prerequisites": [], "knowledgeCost": 10,
     "unlockCost": [ { "item": "data_fragment", "count": 2 }, { "item": "ice", "count": 20 }, { "item": "cable", "count": 5 } ]
   },
   {
     "key": "docking_module", "nameKey": "blueprint.docking_module.name", "descriptionKey": "blueprint.docking_module.desc",
-    "category": "ShipExpansion", "prerequisites": [],
+    "category": "ShipExpansion", "prerequisites": [], "knowledgeCost": 8,
     "unlockCost": [ { "item": "data_fragment", "count": 2 }, { "item": "iron_plate", "count": 10 } ]
   },
   {
     "key": "jump_generator", "nameKey": "blueprint.jump_generator.name", "descriptionKey": "blueprint.jump_generator.desc",
-    "category": "ShipExpansion", "prerequisites": [], "knowledgeCost": 12,
+    "category": "ShipExpansion", "prerequisites": [ "radar_array" ], "knowledgeCost": 35,
     "unlockCost": [ { "item": "data_fragment", "count": 4 }, { "item": "titanium_plate", "count": 12 }, { "item": "energy_cell_1", "count": 6 } ]
   },
   {
     "key": "radar_array", "nameKey": "blueprint.radar_array.name", "descriptionKey": "blueprint.radar_array.desc",
-    "category": "ShipExpansion", "prerequisites": [], "knowledgeCost": 5,
+    "category": "ShipExpansion", "prerequisites": [], "knowledgeCost": 18,
     "unlockCost": [ { "item": "data_fragment", "count": 2 }, { "item": "titanium_plate", "count": 6 }, { "item": "cable", "count": 6 } ]
   },
   {
     "key": "hull_plating", "nameKey": "blueprint.hull_plating.name", "descriptionKey": "blueprint.hull_plating.desc",
-    "category": "ShipDefense", "prerequisites": [],
+    "category": "ShipDefense", "prerequisites": [], "knowledgeCost": 10,
     "unlockCost": [ { "item": "data_fragment", "count": 2 }, { "item": "titanium_plate", "count": 10 } ]
   },
   {
     "key": "shield_generator", "nameKey": "blueprint.shield_generator.name", "descriptionKey": "blueprint.shield_generator.desc",
-    "category": "ShipDefense", "prerequisites": [ "hull_plating" ],
+    "category": "ShipDefense", "prerequisites": [ "hull_plating" ], "knowledgeCost": 20,
     "unlockCost": [ { "item": "data_fragment", "count": 3 }, { "item": "titanium_plate", "count": 8 }, { "item": "cable", "count": 6 } ]
   },
   {
     "key": "asteroid_breaker", "nameKey": "blueprint.asteroid_breaker.name", "descriptionKey": "blueprint.asteroid_breaker.desc",
-    "category": "ShipWeapon", "prerequisites": [],
+    "category": "ShipWeapon", "prerequisites": [], "knowledgeCost": 12,
     "unlockCost": [ { "item": "data_fragment", "count": 2 }, { "item": "titanium_plate", "count": 6 } ]
   },
   {
     "key": "ship_cannon_1", "nameKey": "blueprint.ship_cannon_1.name", "descriptionKey": "blueprint.ship_cannon_1.desc",
-    "category": "ShipWeapon", "prerequisites": [],
+    "category": "ShipWeapon", "prerequisites": [ "hull_plating" ], "knowledgeCost": 15,
     "unlockCost": [ { "item": "data_fragment", "count": 3 }, { "item": "titanium_plate", "count": 10 }, { "item": "cable", "count": 4 } ]
   },
   {
     "key": "laser_cannon_2", "nameKey": "blueprint.laser_cannon_2.name", "descriptionKey": "blueprint.laser_cannon_2.desc",
-    "category": "ShipWeapon", "prerequisites": [ "ship_cannon_1" ],
+    "category": "ShipWeapon", "prerequisites": [ "ship_cannon_1" ], "knowledgeCost": 30,
     "unlockCost": [ { "item": "data_fragment", "count": 4 }, { "item": "titanium_plate", "count": 15 }, { "item": "cable", "count": 8 } ]
   },
   {
     "key": "ship_hauler", "nameKey": "blueprint.ship_hauler.name", "descriptionKey": "blueprint.ship_hauler.desc",
-    "category": "Ship", "prerequisites": [ "cargo_expansion_1" ],
+    "category": "Ship", "prerequisites": [ "cargo_expansion_1", "docking_module" ], "knowledgeCost": 25,
     "unlockCost": [ { "item": "data_fragment", "count": 4 }, { "item": "titanium_plate", "count": 12 } ]
   },
   {
     "key": "ship_scout", "nameKey": "blueprint.ship_scout.name", "descriptionKey": "blueprint.ship_scout.desc",
-    "category": "Ship", "prerequisites": [],
+    "category": "Ship", "prerequisites": [ "docking_module" ], "knowledgeCost": 20,
     "unlockCost": [ { "item": "data_fragment", "count": 4 }, { "item": "titanium_plate", "count": 10 }, { "item": "cable", "count": 6 } ]
   },
   {
     "key": "ship_corvette", "nameKey": "blueprint.ship_corvette.name", "descriptionKey": "blueprint.ship_corvette.desc",
-    "category": "Ship", "prerequisites": [],
+    "category": "Ship", "prerequisites": [ "docking_module" ], "knowledgeCost": 25,
     "unlockCost": [ { "item": "data_fragment", "count": 4 }, { "item": "titanium_plate", "count": 11 }, { "item": "cable", "count": 5 } ]
   },
   {
     "key": "ship_hammerhead", "nameKey": "blueprint.ship_hammerhead.name", "descriptionKey": "blueprint.ship_hammerhead.desc",
-    "category": "Ship", "prerequisites": [ "ship_corvette", "ship_cannon_1" ],
+    "category": "Ship", "prerequisites": [ "ship_corvette", "ship_cannon_1" ], "knowledgeCost": 60,
     "unlockCost": [ { "item": "data_fragment", "count": 6 }, { "item": "titanium_plate", "count": 18 }, { "item": "steel", "count": 4 } ]
   },
   {
     "key": "ship_courier", "nameKey": "blueprint.ship_courier.name", "descriptionKey": "blueprint.ship_courier.desc",
-    "category": "Ship", "prerequisites": [ "ship_scout" ],
+    "category": "Ship", "prerequisites": [ "ship_scout" ], "knowledgeCost": 35,
     "unlockCost": [ { "item": "data_fragment", "count": 4 }, { "item": "titanium_plate", "count": 10 }, { "item": "light_alloy", "count": 4 } ]
   },
   {
     "key": "ship_thunderbolt", "nameKey": "blueprint.ship_thunderbolt.name", "descriptionKey": "blueprint.ship_thunderbolt.desc",
-    "category": "Ship", "prerequisites": [ "ship_corvette", "ship_cannon_1" ],
+    "category": "Ship", "prerequisites": [ "ship_corvette", "ship_cannon_1" ], "knowledgeCost": 70,
     "unlockCost": [ { "item": "data_fragment", "count": 5 }, { "item": "titanium_plate", "count": 14 }, { "item": "cable", "count": 6 } ]
   },
   {
     "key": "ship_deathblock", "nameKey": "blueprint.ship_deathblock.name", "descriptionKey": "blueprint.ship_deathblock.desc",
-    "category": "Ship", "prerequisites": [ "ship_hammerhead" ],
+    "category": "Ship", "prerequisites": [ "ship_hammerhead" ], "knowledgeCost": 100,
     "unlockCost": [ { "item": "data_fragment", "count": 8 }, { "item": "titanium_plate", "count": 20 }, { "item": "steel", "count": 6 } ]
   },
   {
     "key": "stealth_suit", "nameKey": "blueprint.stealth_suit.name", "descriptionKey": "blueprint.stealth_suit.desc",
-    "category": "Suit", "prerequisites": [], "knowledgeCost": 14,
+    "category": "Suit", "prerequisites": [ "suit_liner_2" ], "knowledgeCost": 40,
     "unlockCost": [ { "item": "data_fragment", "count": 4 }, { "item": "titanium_plate", "count": 8 }, { "item": "cable", "count": 8 } ]
   },
   {
     "key": "jetpack", "nameKey": "blueprint.jetpack.name", "descriptionKey": "blueprint.jetpack.desc",
-    "category": "Suit", "prerequisites": [], "knowledgeCost": 16,
+    "category": "Suit", "prerequisites": [ "suit_liner_2" ], "knowledgeCost": 60,
     "unlockCost": [ { "item": "data_fragment", "count": 4 }, { "item": "titanium_plate", "count": 8 }, { "item": "energy_cell_1", "count": 2 } ]
   },
   {
     "key": "advanced_scanner", "nameKey": "blueprint.advanced_scanner.name", "descriptionKey": "blueprint.advanced_scanner.desc",
-    "category": "Tools", "prerequisites": [], "knowledgeCost": 10,
+    "category": "Tools", "prerequisites": [ "terrain_scanner" ], "knowledgeCost": 25,
     "unlockCost": [ { "item": "data_fragment", "count": 3 }, { "item": "titanium_plate", "count": 5 }, { "item": "cable", "count": 4 } ]
   },
   {
     "key": "mining_beam", "nameKey": "blueprint.mining_beam.name", "descriptionKey": "blueprint.mining_beam.desc",
-    "category": "Tools", "prerequisites": [ "titanium_drill" ], "knowledgeCost": 14,
+    "category": "Tools", "prerequisites": [ "titanium_drill" ], "knowledgeCost": 35,
     "unlockCost": [ { "item": "data_fragment", "count": 4 }, { "item": "titanium_plate", "count": 10 }, { "item": "cable", "count": 6 } ]
   },
   {
     "key": "diamond_drill", "nameKey": "blueprint.diamond_drill.name", "descriptionKey": "blueprint.diamond_drill.desc",
-    "category": "Tools", "prerequisites": [ "titanium_drill" ], "knowledgeCost": 18,
+    "category": "Tools", "prerequisites": [ "titanium_drill" ], "knowledgeCost": 70,
     "unlockCost": [ { "item": "data_fragment", "count": 5 }, { "item": "titanium_plate", "count": 8 }, { "item": "diamond", "count": 1 } ]
   },
   {
     "key": "armor_chest", "nameKey": "blueprint.armor_chest.name", "descriptionKey": "blueprint.armor_chest.desc",
-    "category": "Suit", "prerequisites": [], "knowledgeCost": 4,
+    "category": "Suit", "prerequisites": [], "knowledgeCost": 8,
     "unlockCost": [ { "item": "data_fragment", "count": 1 }, { "item": "iron_plate", "count": 12 } ]
   },
   {
     "key": "armor_legs", "nameKey": "blueprint.armor_legs.name", "descriptionKey": "blueprint.armor_legs.desc",
-    "category": "Suit", "prerequisites": [], "knowledgeCost": 3,
+    "category": "Suit", "prerequisites": [], "knowledgeCost": 6,
     "unlockCost": [ { "item": "data_fragment", "count": 1 }, { "item": "iron_plate", "count": 9 } ]
   },
   {
     "key": "helmet", "nameKey": "blueprint.helmet.name", "descriptionKey": "blueprint.helmet.desc",
-    "category": "Suit", "prerequisites": [], "knowledgeCost": 3,
+    "category": "Suit", "prerequisites": [], "knowledgeCost": 6,
     "unlockCost": [ { "item": "data_fragment", "count": 1 }, { "item": "iron_plate", "count": 8 }, { "item": "glass", "count": 3 } ]
   },
   {
     "key": "oxygen_tank_2", "nameKey": "blueprint.oxygen_tank_2.name", "descriptionKey": "blueprint.oxygen_tank_2.desc",
-    "category": "Suit", "prerequisites": [ "oxygen_tank_1" ], "knowledgeCost": 6,
+    "category": "Suit", "prerequisites": [ "oxygen_tank_1" ], "knowledgeCost": 10,
     "unlockCost": [ { "item": "data_fragment", "count": 2 }, { "item": "iron_plate", "count": 10 }, { "item": "glass", "count": 4 } ]
   },
   {
     "key": "oxygen_tank_3", "nameKey": "blueprint.oxygen_tank_3.name", "descriptionKey": "blueprint.oxygen_tank_3.desc",
-    "category": "Suit", "prerequisites": [ "oxygen_tank_2" ], "knowledgeCost": 8,
+    "category": "Suit", "prerequisites": [ "oxygen_tank_2" ], "knowledgeCost": 20,
     "unlockCost": [ { "item": "data_fragment", "count": 3 }, { "item": "titanium_plate", "count": 4 }, { "item": "glass", "count": 5 } ]
   },
   {
     "key": "suit_lamp", "nameKey": "blueprint.suit_lamp.name", "descriptionKey": "blueprint.suit_lamp.desc",
-    "category": "Suit", "prerequisites": [], "knowledgeCost": 2,
+    "category": "Suit", "prerequisites": [], "knowledgeCost": 4,
     "unlockCost": [ { "item": "iron_plate", "count": 4 }, { "item": "glass", "count": 2 } ]
   },
   {
     "key": "suit_liner_1", "nameKey": "blueprint.suit_liner_1.name", "descriptionKey": "blueprint.suit_liner_1.desc",
-    "category": "Suit", "prerequisites": [], "knowledgeCost": 3,
+    "category": "Suit", "prerequisites": [], "knowledgeCost": 6,
     "unlockCost": [ { "item": "data_fragment", "count": 1 }, { "item": "polymer", "count": 2 } ]
   },
   {
     "key": "suit_liner_2", "nameKey": "blueprint.suit_liner_2.name", "descriptionKey": "blueprint.suit_liner_2.desc",
-    "category": "Suit", "prerequisites": [ "suit_liner_1" ], "knowledgeCost": 6,
+    "category": "Suit", "prerequisites": [ "suit_liner_1" ], "knowledgeCost": 15,
     "unlockCost": [ { "item": "data_fragment", "count": 2 }, { "item": "carbon_composite", "count": 2 } ]
   },
   {
     "key": "suit_liner_3", "nameKey": "blueprint.suit_liner_3.name", "descriptionKey": "blueprint.suit_liner_3.desc",
-    "category": "Suit", "prerequisites": [ "suit_liner_2" ], "knowledgeCost": 8,
+    "category": "Suit", "prerequisites": [ "suit_liner_2" ], "knowledgeCost": 25,
     "unlockCost": [ { "item": "data_fragment", "count": 3 }, { "item": "titanium_plate", "count": 2 } ]
   },
   {
     "key": "comm_radio", "nameKey": "blueprint.comm_radio.name", "descriptionKey": "blueprint.comm_radio.desc",
-    "category": "Production", "prerequisites": [], "knowledgeCost": 2,
+    "category": "Production", "prerequisites": [], "knowledgeCost": 4,
     "unlockCost": [ { "item": "copper_wire", "count": 4 }, { "item": "data_fragment", "count": 1 } ]
   },
   {
     "key": "system_radio", "nameKey": "blueprint.system_radio.name", "descriptionKey": "blueprint.system_radio.desc",
-    "category": "Production", "prerequisites": [ "comm_radio" ], "knowledgeCost": 6,
+    "category": "Production", "prerequisites": [ "comm_radio" ], "knowledgeCost": 15,
     "unlockCost": [ { "item": "titanium_plate", "count": 4 }, { "item": "data_fragment", "count": 2 } ]
   },
   {
     "key": "galaxy_radio", "nameKey": "blueprint.galaxy_radio.name", "descriptionKey": "blueprint.galaxy_radio.desc",
-    "category": "Production", "prerequisites": [ "system_radio" ], "knowledgeCost": 14,
+    "category": "Production", "prerequisites": [ "system_radio" ], "knowledgeCost": 40,
     "unlockCost": [ { "item": "titanium_plate", "count": 8 }, { "item": "data_fragment", "count": 5 }, { "item": "cable", "count": 6 } ]
   },
   {
     "key": "radar_scanner", "nameKey": "blueprint.radar_scanner.name", "descriptionKey": "blueprint.radar_scanner.desc",
-    "category": "Tools", "prerequisites": [], "knowledgeCost": 8,
+    "category": "Tools", "prerequisites": [], "knowledgeCost": 20,
     "unlockCost": [ { "item": "data_fragment", "count": 3 }, { "item": "titanium_plate", "count": 5 }, { "item": "cable", "count": 4 } ]
   },
   {
     "key": "suit_teleporter", "nameKey": "blueprint.suit_teleporter.name", "descriptionKey": "blueprint.suit_teleporter.desc",
-    "category": "Suit", "prerequisites": [], "knowledgeCost": 12,
+    "category": "Suit", "prerequisites": [], "knowledgeCost": 40,
     "unlockCost": [ { "item": "data_fragment", "count": 4 }, { "item": "titanium_plate", "count": 8 }, { "item": "cable", "count": 6 } ]
   },
   {
     "key": "oxygen_extractor", "nameKey": "blueprint.oxygen_extractor.name", "descriptionKey": "blueprint.oxygen_extractor.desc",
-    "category": "Suit", "prerequisites": [], "knowledgeCost": 8,
+    "category": "Suit", "prerequisites": [], "knowledgeCost": 18,
     "unlockCost": [ { "item": "data_fragment", "count": 3 }, { "item": "iron_plate", "count": 10 }, { "item": "cable", "count": 5 } ]
   },
   {
     "key": "machete", "nameKey": "blueprint.machete.name", "descriptionKey": "blueprint.machete.desc",
-    "category": "Weapon", "prerequisites": [],
+    "category": "Weapon", "prerequisites": [], "knowledgeCost": 3,
     "unlockCost": [ { "item": "iron_plate", "count": 3 } ]
   },
   {
     "key": "vibro_knife", "nameKey": "blueprint.vibro_knife.name", "descriptionKey": "blueprint.vibro_knife.desc",
-    "category": "Weapon", "prerequisites": [ "machete" ],
+    "category": "Weapon", "prerequisites": [ "machete" ], "knowledgeCost": 8,
     "unlockCost": [ { "item": "data_fragment", "count": 1 }, { "item": "iron_plate", "count": 6 }, { "item": "cable", "count": 3 } ]
   },
   {
     "key": "plasma_sword", "nameKey": "blueprint.plasma_sword.name", "descriptionKey": "blueprint.plasma_sword.desc",
-    "category": "Weapon", "prerequisites": [ "vibro_knife" ],
+    "category": "Weapon", "prerequisites": [ "vibro_knife" ], "knowledgeCost": 25,
     "unlockCost": [ { "item": "data_fragment", "count": 3 }, { "item": "titanium_plate", "count": 8 }, { "item": "cable", "count": 6 } ]
   },
   {
     "key": "gauss_pistol", "nameKey": "blueprint.gauss_pistol.name", "descriptionKey": "blueprint.gauss_pistol.desc",
-    "category": "Weapon", "prerequisites": [],
+    "category": "Weapon", "prerequisites": [], "knowledgeCost": 4,
     "unlockCost": [ { "item": "data_fragment", "count": 1 }, { "item": "iron_plate", "count": 6 } ]
   },
   {
     "key": "laser_pistol", "nameKey": "blueprint.laser_pistol.name", "descriptionKey": "blueprint.laser_pistol.desc",
-    "category": "Weapon", "prerequisites": [ "gauss_pistol" ], "knowledgeCost": 10,
+    "category": "Weapon", "prerequisites": [ "gauss_pistol" ], "knowledgeCost": 25,
     "unlockCost": [ { "item": "data_fragment", "count": 3 }, { "item": "titanium_plate", "count": 6 }, { "item": "cable", "count": 5 } ]
   },
   {
     "key": "plasma_blaster", "nameKey": "blueprint.plasma_blaster.name", "descriptionKey": "blueprint.plasma_blaster.desc",
-    "category": "Weapon", "prerequisites": [ "laser_pistol" ], "knowledgeCost": 16,
+    "category": "Weapon", "prerequisites": [ "laser_pistol" ], "knowledgeCost": 60,
     "unlockCost": [ { "item": "data_fragment", "count": 4 }, { "item": "titanium_plate", "count": 12 }, { "item": "cable", "count": 8 } ]
   },
   {
     "key": "ai_core_mk2", "nameKey": "blueprint.ai_core_mk2.name", "descriptionKey": "blueprint.ai_core_mk2.desc",
-    "category": "ShipExpansion", "prerequisites": [], "knowledgeCost": 8,
+    "category": "ShipExpansion", "prerequisites": [], "knowledgeCost": 25,
     "unlockCost": [ { "item": "data_fragment", "count": 3 }, { "item": "cable", "count": 6 } ]
   },
   {
     "key": "ai_core_mk3", "nameKey": "blueprint.ai_core_mk3.name", "descriptionKey": "blueprint.ai_core_mk3.desc",
-    "category": "ShipExpansion", "prerequisites": [ "ai_core_mk2" ], "knowledgeCost": 24,
+    "category": "ShipExpansion", "prerequisites": [ "ai_core_mk2" ], "knowledgeCost": 90,
     "unlockCost": [ { "item": "data_fragment", "count": 10 }, { "item": "titanium_plate", "count": 8 }, { "item": "cable", "count": 12 } ]
   },
   {
     "key": "station_vendor", "nameKey": "blueprint.station_vendor.name", "descriptionKey": "blueprint.station_vendor.desc",
-    "category": "Station", "prerequisites": [], "knowledgeCost": 6,
+    "category": "Station", "prerequisites": [ "station_container" ], "knowledgeCost": 15,
     "unlockCost": [ { "item": "data_fragment", "count": 2 }, { "item": "circuit_board", "count": 2 }, { "item": "metal_panel", "count": 6 } ]
   },
   {
     "key": "station_mission_board", "nameKey": "blueprint.station_mission_board.name", "descriptionKey": "blueprint.station_mission_board.desc",
-    "category": "Station", "prerequisites": [], "knowledgeCost": 4,
+    "category": "Station", "prerequisites": [], "knowledgeCost": 8,
     "unlockCost": [ { "item": "data_fragment", "count": 2 }, { "item": "circuit_board", "count": 1 }, { "item": "glass", "count": 3 } ]
   },
   {
     "key": "station_container", "nameKey": "blueprint.station_container.name", "descriptionKey": "blueprint.station_container.desc",
-    "category": "Station", "prerequisites": [],
+    "category": "Station", "prerequisites": [], "knowledgeCost": 5,
     "unlockCost": [ { "item": "data_fragment", "count": 1 }, { "item": "iron_plate", "count": 6 } ]
   }
 ]

--- a/docs/developer/MINIGAMES_AND_WIKI.md
+++ b/docs/developer/MINIGAMES_AND_WIKI.md
@@ -46,7 +46,9 @@ Menu "Codex"/"DataQubes" button
   `<DataDir>/minigames/catalog.json`).
 - Net messages (`MinigameMessages.cs`, registered in `NetCodec` tags 118–121): `DataCubeList`,
   `UnlockGameIntent`, `GameUnlocks`, `MinigameResultIntent` (finished run → server grants knowledge points,
-  rating-scaled, repeatable, in `GameServerDataCubes.HandleMinigameResult`).
+  5 per star newly earned on that game — a per-player best-rating ledger in `PlayerState.Milestones`
+  (`arcade:<game>:star:N`) stops replays from farming research (#767), in
+  `GameServerDataCubes.HandleMinigameResult`).
 - Gated by `ServerConfig.PlaceDataCubes` (default on). A Creative world (`CreativeUnlockAllBlueprints`) also
   unlocks every minigame via `UnlockAllGames`.
 

--- a/src/BlocksBeyondTheStars.GameServer/GameServerDataCubes.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerDataCubes.cs
@@ -191,9 +191,11 @@ public sealed partial class GameServer
         }
     }
 
-    /// <summary>A minigame run finished — grant a small knowledge reward scaled by the reported rating. Repeatable
-    /// (the player can re-run a fragment for more research), but each grant is small + capped, and the rating is
-    /// clamped server-side. Knowledge feeds the tech tree; the client reads it back from the inventory sync.</summary>
+    /// <summary>A minigame run finished — grant knowledge for stars newly earned on this game. Analysing the
+    /// same fragment twice teaches nothing (#767): each star pays 5 knowledge once per player per game
+    /// (best-rating ledger in <c>PlayerState.Milestones</c>), so the first 3-star run pays 15, replays pay
+    /// nothing, and improving a 1-star best to 3 stars pays the +10 difference. The rating is clamped
+    /// server-side. Knowledge feeds the tech tree; the client reads it back from the inventory sync.</summary>
     private void HandleMinigameResult(PlayerSession session, MinigameResultIntent intent)
     {
         if (!intent.Completed)
@@ -201,11 +203,39 @@ public sealed partial class GameServer
             return; // only completed runs reward
         }
 
+        string key = (intent.GameKey ?? string.Empty).Trim();
+        if (key.Length == 0 || key.Length > 64)
+        {
+            return; // missing/implausible key — no ledger to credit against
+        }
+
         int rating = System.Math.Clamp(intent.Rating, 1, 3);
-        int reward = rating * 5; // 1/2/3 stars -> 5/10/15 knowledge
+        int reward = 0;
+        for (int star = 1; star <= rating; star++)
+        {
+            if (session.State.Milestones.Add("arcade:" + key + ":star:" + star))
+            {
+                reward += 5;
+            }
+        }
+
+        if (reward == 0)
+        {
+            return; // every star already banked — this fragment holds nothing new
+        }
+
         session.State.KnowledgePoints += reward;
         SendInventory(session); // carries KnowledgePoints to the client
         Send(session, new ServerMessage { Text = $"+{reward} knowledge — data fragment analysed." });
+    }
+
+    /// <summary>Test hook: report a finished minigame run (mirrors the client's <see cref="MinigameResultIntent"/>).</summary>
+    public void ReportMinigameResultForTest(string playerId, string gameKey, int rating, bool completed = true)
+    {
+        if (FindSessionByPlayerId(playerId) is { } session)
+        {
+            HandleMinigameResult(session, new MinigameResultIntent { GameKey = gameKey, Rating = rating, Completed = completed });
+        }
     }
 
     private List<string>? _minigameKeys;

--- a/src/BlocksBeyondTheStars.GameServer/GameServerTaming.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerTaming.cs
@@ -202,18 +202,10 @@ public sealed partial class GameServer
         };
         p.TamedCreatures.Add(tc);
 
-        // First tame of this species (per world) pays full research knowledge; later ones a small trickle.
+        // First tame of this species (per world) pays research knowledge; repeats pay nothing — the old
+        // +1 trickle was an unbounded knowledge faucet that helped trivialise the research gate (#767).
         string signature = body + ":" + creature.SpeciesId;
-        int reward;
-        if (p.TamedSpecies.Add(signature))
-        {
-            reward = TameKnowledgeReward(sp, creature.SizeScale);
-        }
-        else
-        {
-            reward = 1;
-        }
-
+        int reward = p.TamedSpecies.Add(signature) ? TameKnowledgeReward(sp, creature.SizeScale) : 0;
         p.KnowledgePoints += reward;
 
         // The wild animal becomes the companion in place.

--- a/src/BlocksBeyondTheStars.Shared/Story/StoryRegistry.cs
+++ b/src/BlocksBeyondTheStars.Shared/Story/StoryRegistry.cs
@@ -61,21 +61,23 @@ public static class StoryRegistry
         KillWeight = 1,
         MilestoneWeight = 2,
         KillContributionCap = 40,
+        // Beats pay +1 knowledge each (was +3): the arc alone used to out-earn the whole research
+        // ladder's knowledge ceiling, trivialising the blueprint gate (#767).
         Beats = new List<StoryBeat>
         {
             Beat(0,  "Systems online",        0,   0),
-            Beat(1,  "A familiar signature",  6,   3),
-            Beat(2,  "The Service",           14,  3),
-            Beat(3,  "Not scattered — erased", 24, 3),
-            Beat(4,  "Ours, once",            36,  3),
-            Beat(5,  "The Guardian",          50,  3),
-            Beat(6,  "The verdict",           66,  3),
-            Beat(7,  "Her stand",             84,  3),
-            Beat(8,  "The thought-arcs",      104, 3),
-            Beat(9,  "What you are",          126, 3),  // the clone reveal
-            Beat(10, "Many minds",            150, 3),
-            Beat(11, "It still sleeps",       176, 3),  // locates the dormant Guardian system
-            Beat(12, "The choice",            204, 3),  // finale opens
+            Beat(1,  "A familiar signature",  6,   1),
+            Beat(2,  "The Service",           14,  1),
+            Beat(3,  "Not scattered — erased", 24, 1),
+            Beat(4,  "Ours, once",            36,  1),
+            Beat(5,  "The Guardian",          50,  1),
+            Beat(6,  "The verdict",           66,  1),
+            Beat(7,  "Her stand",             84,  1),
+            Beat(8,  "The thought-arcs",      104, 1),
+            Beat(9,  "What you are",          126, 1),  // the clone reveal
+            Beat(10, "Many minds",            150, 1),
+            Beat(11, "It still sleeps",       176, 1),  // locates the dormant Guardian system
+            Beat(12, "The choice",            204, 1),  // finale opens
         },
     };
 

--- a/tests/BlocksBeyondTheStars.Tests/CraftingConsistencyTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/CraftingConsistencyTests.cs
@@ -197,4 +197,43 @@ public sealed class CraftingConsistencyTests
         // Lab / MachineRoom were dead (no module, no recipe); ensure no recipe references them either.
         Assert.DoesNotContain(_c.Recipes.Values, r => r.Station.ToString() is "Lab" or "MachineRoom");
     }
+
+    [Fact]
+    public void BlueprintGraph_PrereqsResolve_NoCycles_CostsClimbAlongChains()
+    {
+        // Every prerequisite must be a real blueprint.
+        var badRefs = _c.Blueprints.Values
+            .SelectMany(bp => bp.Prerequisites.Select(pre => (bp.Key, pre)))
+            .Where(x => _c.GetBlueprint(x.pre) is null)
+            .Select(x => $"{x.Key}:{x.pre}")
+            .ToList();
+        Assert.True(badRefs.Count == 0, "blueprint prerequisites referencing non-existent blueprints: " + string.Join(", ", badRefs));
+
+        // The prerequisite graph must be acyclic, or a chain could never be researched.
+        var visiting = new HashSet<string>();
+        var done = new HashSet<string>();
+        bool HasCycle(string key)
+        {
+            if (done.Contains(key)) return false;
+            if (!visiting.Add(key)) return true;
+            bool cycle = _c.GetBlueprint(key) is { } bp && bp.Prerequisites.Any(HasCycle);
+            visiting.Remove(key);
+            done.Add(key);
+            return cycle;
+        }
+
+        Assert.DoesNotContain(_c.Blueprints.Keys, k => HasCycle(k));
+
+        // Research pacing (#767): every blueprint carries a knowledge cost, and a blueprint is never
+        // cheaper than what it builds on — the ladder must climb along every prerequisite chain.
+        var free = _c.Blueprints.Values.Where(bp => bp.KnowledgeCost <= 0).Select(bp => bp.Key).ToList();
+        Assert.True(free.Count == 0, "blueprints without a knowledge cost: " + string.Join(", ", free));
+
+        var inverted = _c.Blueprints.Values
+            .SelectMany(bp => bp.Prerequisites.Select(pre => (Child: bp, Parent: _c.GetBlueprint(pre)!)))
+            .Where(x => x.Child.KnowledgeCost < x.Parent.KnowledgeCost)
+            .Select(x => $"{x.Child.Key}({x.Child.KnowledgeCost}) < {x.Parent.Key}({x.Parent.KnowledgeCost})")
+            .ToList();
+        Assert.True(inverted.Count == 0, "blueprints cheaper than their prerequisites: " + string.Join(", ", inverted));
+    }
 }

--- a/tests/BlocksBeyondTheStars.Tests/CreatureTamingTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/CreatureTamingTests.cs
@@ -118,7 +118,7 @@ public sealed class CreatureTamingTests : IDisposable
     }
 
     [Fact]
-    public void Taming_AwardsKnowledge_FullFirstTime_TrickleAfterPerSpecies()
+    public void Taming_AwardsKnowledge_FullFirstTime_NothingAfterPerSpecies()
     {
         var server = Started(out var repo);
         using (repo)
@@ -146,7 +146,7 @@ public sealed class CreatureTamingTests : IDisposable
             int gain2 = p.State.KnowledgePoints - k1;
 
             Assert.True(gain1 >= 2, $"first tame of a species should pay a full research bonus (got {gain1})");
-            Assert.Equal(1, gain2); // a second of the same species pays only the small trickle
+            Assert.Equal(0, gain2); // a second of the same species teaches nothing new (#767)
         }
     }
 

--- a/tests/BlocksBeyondTheStars.Tests/HealTankTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/HealTankTests.cs
@@ -78,13 +78,15 @@ public sealed class HealTankTests : IDisposable
             server.Craft("Builder", "heal_tank");
             Assert.Equal(0, p.State.Inventory.CountOf("heal_tank"));
 
-            // Research it (materials + knowledge threshold), then the same craft succeeds.
+            // Research it (materials + knowledge threshold), then the same craft succeeds. The heal tank
+            // sits behind the medical chain now — treat the field medkit as already researched (#767).
             var bp = _content.GetBlueprint("heal_tank")!;
             foreach (var cost in bp.UnlockCost)
             {
                 p.State.Inventory.Add(cost.Item, cost.Count, 99);
             }
 
+            p.State.UnlockedBlueprints.Add("field_medkit");
             p.State.KnowledgePoints = bp.KnowledgeCost;
             server.UnlockBlueprint(p.State.PlayerId, "heal_tank");
             Assert.Contains("heal_tank", p.State.UnlockedBlueprints);

--- a/tests/BlocksBeyondTheStars.Tests/ScanningTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/ScanningTests.cs
@@ -336,7 +336,7 @@ public sealed class ScanningTests : IDisposable
         using (repo)
         {
             var p = server.AddLocalPlayer("Eng");
-            // detoxifier unlockCost: data_fragment x2, iron_plate x12, cable x4; knowledgeCost 6.
+            // detoxifier unlockCost: data_fragment x2, iron_plate x12, cable x4; knowledgeCost 16.
             p.State.Inventory.Add("data_fragment", 2, 99);
             p.State.Inventory.Add("iron_plate", 12, 99);
             p.State.Inventory.Add("cable", 4, 99);
@@ -347,11 +347,41 @@ public sealed class ScanningTests : IDisposable
 
             // Research enough, then it unlocks. Knowledge is a permanent THRESHOLD (item 11): it gates the
             // unlock but is NOT spent — only the research materials are consumed.
-            p.State.KnowledgePoints = 6;
+            p.State.KnowledgePoints = 16;
             server.UnlockBlueprint("Eng", "detoxifier");
             Assert.Contains("detoxifier", p.State.UnlockedBlueprints);
-            Assert.Equal(6, p.State.KnowledgePoints);              // knowledge never goes away
+            Assert.Equal(16, p.State.KnowledgePoints);             // knowledge never goes away
             Assert.Equal(0, p.State.Inventory.CountOf("cable"));   // but the materials are spent
+        }
+    }
+
+    [Fact]
+    public void MinigameKnowledge_PaysPerStarOncePerGame()
+    {
+        var server = Started("rocky", out var repo);
+        using (repo)
+        {
+            var p = server.AddLocalPlayer("Gamer");
+
+            // First 2-star run pays 10; replaying the same game at the same rating teaches nothing (#767).
+            server.ReportMinigameResultForTest("Gamer", "asteroid_dodger", rating: 2);
+            Assert.Equal(10, p.State.KnowledgePoints);
+            server.ReportMinigameResultForTest("Gamer", "asteroid_dodger", rating: 2);
+            Assert.Equal(10, p.State.KnowledgePoints);
+
+            // Improving the best rating pays only the newly-earned star; a worse re-run pays nothing.
+            server.ReportMinigameResultForTest("Gamer", "asteroid_dodger", rating: 3);
+            Assert.Equal(15, p.State.KnowledgePoints);
+            server.ReportMinigameResultForTest("Gamer", "asteroid_dodger", rating: 1);
+            Assert.Equal(15, p.State.KnowledgePoints);
+
+            // A different game has its own ledger; incomplete runs and missing keys never pay.
+            server.ReportMinigameResultForTest("Gamer", "star_racer", rating: 1);
+            Assert.Equal(20, p.State.KnowledgePoints);
+            server.ReportMinigameResultForTest("Gamer", "star_racer", rating: 3, completed: false);
+            Assert.Equal(20, p.State.KnowledgePoints);
+            server.ReportMinigameResultForTest("Gamer", "", rating: 3);
+            Assert.Equal(20, p.State.KnowledgePoints);
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes the "build options unlock too quickly" pacing problem in five moves (analysis in #767). Server + data only — no client change, no save migration.

1. **Minigame faucet capped** — `HandleMinigameResult` pays 5 knowledge per star **newly earned on that game** via a per-player best-rating ledger in `PlayerState.Milestones` (`arcade:<game>:star:N`). First 3★ run pays 15, replays pay 0, improving 1★→3★ pays the +10 difference. Previously 5/10/15 per completed run, repeatable without cap.
2. **Knowledge ladder stretched wide** (`data/blueprints.json`) — every blueprint now carries a `knowledgeCost`: early ~3–10, mid ~15–40, late 60–120 (deathblock 100, AI core Mk3 90, matter resynth 80). Previously the whole tree topped out at 24 and ~half the blueprints (all ships, ship weapons/defense, refinery chain) had no cost at all.
3. **Prerequisites deepened** — ships behind `docking_module` (+ cargo for the hauler), cannons behind `hull_plating`, heal tank behind `field_medkit`, terrain blaster behind `titanium_drill`, advanced scanner behind `terrain_scanner`, tractor beam behind `docking_module`, jump generator behind `radar_array`, stealth suit/jetpack behind `suit_liner_2`, station vendor behind `station_container`.
4. **Story-beat knowledge trimmed** — B1–B12 pay +1 each (was +3; the arc alone out-earned the old tree ceiling). Story progression itself is never gated by knowledge, so the arc pacing is untouched.
5. **Repeat-tame trickle removed** — first tame of a species per world still pays the full research bonus; repeats pay nothing (was +1, unbounded).

Existing saves keep their banked knowledge and unlocked blueprints; the new upper tiers sit above most veterans'"'"' totals again, so the research tab reveals in waves instead of all at once.

## Tests

- New: minigame star-ledger behaviour (pay once, difference on improvement, per-game, incomplete/keyless runs pay nothing).
- New: blueprint graph guard — prerequisites resolve, no cycles, no cost inversions along chains, every blueprint costs knowledge.
- Updated: taming (repeat pays 0), detoxifier threshold (16), heal tank (medical chain prereq).
- Full non-Slow suite locally green: **1424 server + 177 client**, 0 failures.

closes #767

🤖 Generated with [Claude Code](https://claude.com/claude-code)