### PR TITLE
fix(client): browser singleplayer waits for its in-process server (#771)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7148,6 +7148,28 @@ is **pre-approved** (keys in `tools/ai-assets/.env`, run via `uv`).
 
 ---
 
+## ✅ Done (2026-08-06): browser singleplayer entered the world before its server existed (#771)
+
+Clicking **Singleplayer** in the browser build (glitch.fun) showed the loading screen and then bounced
+back to the menu with "Could not connect to the server" after ~13 s — the in-browser world never
+started for the player. The loading screen handed off to `AppShell.LaunchGame` on a 1.2 s timer while
+`BootBrowserSingleplayer` was still awaiting the cloud-save lookup (a relay round trip measured at
+2.1–2.9 s live), so `WorldRig.Build` captured **no** loopback wire, the client fell back to the
+WebSocket transport, and it dialed the `"loopback"` placeholder host until its six retries ran out.
+
+- **The boot gates the launch** — `AppShell.BrowserWorldBooting` is set when the browser world starts
+  booting and cleared when the in-process server is up (or failed); `LoadingScreen` treats `MinShow`
+  as a minimum display time again instead of a deadline the world start has to beat.
+- **Fail fast instead of dialing a placeholder** — `GameBootstrap` recognises the loopback host without
+  a wire and reports `ui.sp.browser_failed` immediately, rather than spending ~12 s of retries and then
+  blaming the player's server address.
+- **Bounded cloud lookup** — the boot-blocking cloud-save GET times out after 10 s instead of 20; the
+  locally persisted world blob is a complete world on its own.
+
+Browser/WebGL only — desktop singleplayer launches the bundled child-process server on a different
+path and was unaffected. Verified alongside: glitch.fun arcade multiplayer and the hosted official
+worlds were both healthy.
+
 ## ✅ Done (2026-08-05): research pacing — blueprints no longer unlock in a rush (#767)
 
 Knowledge is a lifetime threshold (never spent), but the whole tech tree topped out at `knowledgeCost`

--- a/client/Assets/BlocksBeyondTheStars/Scripts/AppShell.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/AppShell.cs
@@ -86,6 +86,16 @@ namespace BlocksBeyondTheStars.Client
         /// <summary>The in-process singleplayer host (browser builds; usable in the editor for testing).
         /// Null until the first browser-singleplayer start; survives returns to the menu stopped.</summary>
         public BrowserLocalServer BrowserServer { get; private set; }
+
+        /// <summary>Placeholder host for the in-process browser world: it is never resolved or dialed —
+        /// the rig recognises it and takes the in-memory wire instead. Nothing listens on this name.</summary>
+        public const string BrowserLoopbackHost = "loopback";
+
+        /// <summary>True while <see cref="BootBrowserSingleplayer"/> is still bringing the in-process world
+        /// up. The loading screen must not hand off to <see cref="LaunchGame"/> before this clears: the rig
+        /// captures the loopback wire once, and a launch that beats the boot ends up with no wire at all,
+        /// dialing the "loopback" placeholder host over WebSocket until it gives up (#771).</summary>
+        public bool BrowserWorldBooting { get; private set; }
         private bool _serverPending;                          // prepared, waiting to spawn once the screen is up
         private System.Threading.Tasks.Task<bool> _serverLaunch; // the off-thread spawn (so Process.Start can't freeze us)
         private GameObject _gameRoot;
@@ -652,8 +662,9 @@ namespace BlocksBeyondTheStars.Client
             HostInfo = "";
             _hostLocal = false;
             _serverPending = false;
-            Host = "loopback"; // GameBootstrap picks the loopback transport off shell.BrowserServer.Link
+            Host = BrowserLoopbackHost; // GameBootstrap picks the loopback transport off shell.BrowserServer.Link
             _loading.MinShow = 1.2f;
+            BrowserWorldBooting = true; // MinShow is a minimum, not a deadline — the boot gates the launch
             Phase = ShellPhase.Loading;
             StartCoroutine(BootBrowserSingleplayer());
         }
@@ -694,12 +705,14 @@ namespace BlocksBeyondTheStars.Client
             long freshSeed = (long)UnityEngine.Random.Range(1, int.MaxValue) << 16 ^ System.DateTime.UtcNow.Ticks;
             if (!BrowserServer.StartServer(Content, blob, freshSeed))
             {
+                BrowserWorldBooting = false;
                 ReturnToMenu();
                 MenuNotice = L("ui.sp.browser_failed");
                 yield break;
             }
 
             GlitchCloudSaves.Attach(this, BrowserServer); // upload each durable save (no-op off glitch.fun)
+            BrowserWorldBooting = false; // the wire exists — the loading screen may hand off now
         }
 
         /// <summary>The machine's LAN IPv4 (the address friends on the same network join), or loopback.</summary>

--- a/client/Assets/BlocksBeyondTheStars/Scripts/GameBootstrap.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/GameBootstrap.cs
@@ -1300,6 +1300,20 @@ namespace BlocksBeyondTheStars.Client
                 // in-memory loopback pair replaces every socket, on WebGL and in the editor alike.
                 Network = new NetworkClient(new BlocksBeyondTheStars.Networking.Transport.LoopbackClientTransport(Loopback));
             }
+            else if (string.Equals(Host, AppShell.BrowserLoopbackHost, System.StringComparison.OrdinalIgnoreCase))
+            {
+                // The shell asked for the in-process world but handed over no wire — the browser host
+                // failed to start (or was torn down mid-boot). "loopback" is a placeholder, not a
+                // reachable address, so dialing it would burn ~12 s of retries and then blame the
+                // player's server address; say what actually happened instead (#771).
+                Debug.LogError("Browser singleplayer was requested without a running in-process server — aborting the world entry.");
+                var shell = FindAnyObjectByType<AppShell>();
+                ConnectFailedReason = shell != null && shell.Localizer != null
+                    ? shell.L("ui.sp.browser_failed")
+                    : "The world could not be started in this browser.";
+                enabled = false;
+                return;
+            }
             else
             {
 #if UNITY_WEBGL && !UNITY_EDITOR

--- a/client/Assets/BlocksBeyondTheStars/Scripts/GlitchCloudSaves.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/GlitchCloudSaves.cs
@@ -70,7 +70,10 @@ namespace BlocksBeyondTheStars.Client
             using (var request = UnityWebRequest.Get(
                 $"{GlitchIntegration.PortalUrl}/api/glitch/save?installId={UnityWebRequest.EscapeURL(GlitchIntegration.ArcadeInstallId)}"))
             {
-                request.timeout = 20;
+                // This blocks the world boot (the loading screen waits for it since #771), so bound it
+                // tighter than the upload: the locally persisted blob is a complete world on its own,
+                // and a relay this slow is better skipped than waited out.
+                request.timeout = 10;
                 yield return request.SendWebRequest();
 
                 if (request.responseCode == 403)

--- a/client/Assets/BlocksBeyondTheStars/Scripts/LoadingScreen.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/LoadingScreen.cs
@@ -36,8 +36,12 @@ namespace BlocksBeyondTheStars.Client
                 return;
             }
 
+            // The browser singleplayer host boots asynchronously (cloud-save lookup, then worldgen) and
+            // hands its in-memory wire to the rig at launch. Launching on the timer alone raced that boot
+            // and left the rig without a wire, so the browser world "could not connect" (#771) — MinShow
+            // is the minimum time the screen shows, never a deadline the world start has to beat.
             _elapsed += Time.deltaTime;
-            if (_elapsed >= MinShow)
+            if (_elapsed >= MinShow && !_shell.BrowserWorldBooting)
             {
                 _elapsed = 0f;
                 _shell.LaunchGame();


### PR DESCRIPTION
## The bug

Clicking **Singleplayer** in the browser build (glitch.fun) showed the loading screen and then dropped back to the main menu with *"Could not connect to the server"* (`ui.connect.failed`) after roughly 13 seconds. The in-browser world never started for the player. Control-plane logs show a real visitor hitting this six times in a row on the night of 2026-08-05 before giving up and joining an arcade world instead.

## Why it happened

The loading screen launched the world on a **timer** while the in-process server was still booting:

1. `StartBrowserSingleplayer` sets `MinShow = 1.2f` and starts the `BootBrowserSingleplayer` coroutine.
2. That coroutine first awaits `GlitchCloudSaves.FetchLatest` — a relay round trip measured at a consistent **2.1–2.9 s** live (the save payload has grown to ~300 KB) — and only then starts the in-process server.
3. `LoadingScreen.Update` called `LaunchGame()` as soon as `MinShow` elapsed, gating only on `ContentReady`.
4. `WorldRig.Build` therefore captured `Loopback = null`, the client fell back to the WebSocket transport, and it dialed `Host`, which is the deliberate placeholder string `"loopback"` — not a resolvable address. Six retries × 2 s later the generic connect error appeared.

Once the cloud round trip exceeded 1.2 s the server lost that race every time, which is why this reads as "singleplayer is broken" rather than "flaky".

## The fix

- **The boot gates the launch.** `AppShell.BrowserWorldBooting` is set when the browser world starts booting and cleared once the in-process server is up — or has failed. `LoadingScreen` treats `MinShow` as a minimum display time again instead of a deadline the world start has to beat.
- **Fail fast instead of dialing a placeholder.** `GameBootstrap` recognises the loopback host arriving without a wire and reports `ui.sp.browser_failed` immediately, rather than spending ~12 s on doomed retries and then blaming the player's server address.
- **Bounded cloud lookup.** The boot-blocking cloud-save GET now times out after 10 s instead of 20 — the locally persisted world blob is a complete world on its own, so a relay that slow is better skipped than waited out.

## Scope and verification

Browser/WebGL only. Desktop singleplayer launches the bundled child-process server through `StartLocalWorld` and never touches this path.

- Local Unity Windows player build: succeeded (PR CI does not build Unity, so this was run locally).
- `BlocksBeyondTheStars.Client.Tests`: 177 passed, 0 failed.
- The changed files are Unity-only scripts, so no .NET behaviour changed; the server suite is unaffected.

Verified healthy alongside the investigation, and untouched by this PR: glitch.fun arcade multiplayer session grants and joins, and the hosted official worlds (control plane plus both world instances).

closes #771

🤖 Generated with [Claude Code](https://claude.com/claude-code)
