### PR TITLE
fix(client): joining players hover instead of falling through unstreamed terrain (#773)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7148,6 +7148,26 @@ is **pre-approved** (keys in `tools/ai-assets/.env`, run via `uv`).
 
 ---
 
+## ✅ Done (2026-08-06): joining players no longer fall through terrain that hasn't streamed yet (#773)
+
+A player joining a hosted world from the browser dropped into the void ~8 s after entering, was
+teleported by the server's void rescue, and fell again — the first ten seconds of a new player's
+session. `PlayerController` freezes the player at the spawn until the floor chunk's collider streams
+in, but that freeze had a hard 8 s cap that released control **even with no ground below**, trading
+the freeze for a free fall and leaving the server's rescue to clean up. Fast desktop clients win that
+race; browser clients over a slower link do not, so the safety net became the normal first join.
+
+- **Reveal and physics are decoupled** — the veil still lifts on the grace timer (`SettleGraceSeconds`),
+  but if there is no collider under the spawn the player enters a hover (`_awaitingFloor`) instead of
+  falling. They can look around and walk; they just don't drop through a world that isn't there yet.
+- **The hover ends by itself** — as soon as the controller is grounded or a collider streams in below
+  (`ColliderBelow`), gravity resumes normally. `AwaitFloorMaxSeconds` (30 s) hard-caps it, so a spawn
+  chunk that never arrives falls back to the old behaviour rather than hovering forever.
+- **Menus included** — the gravity-only path used while a panel or chat is open honours the same wait.
+
+Observed live on an arcade world: join at 22:51:53, first void rescue at 22:52:01 — exactly the 8 s
+cap. Browser-facing, but the fix applies to every platform (a slow desktop join behaves the same).
+
 ## ✅ Done (2026-08-06): browser singleplayer entered the world before its server existed (#771)
 
 Clicking **Singleplayer** in the browser build (glitch.fun) showed the loading screen and then bounced

--- a/client/Assets/BlocksBeyondTheStars/Scripts/PlayerController.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/PlayerController.cs
@@ -101,13 +101,22 @@ namespace BlocksBeyondTheStars.Client
         private bool _settling;
         private float _settleTimer; // how long we've been frozen at spawn waiting for the floor to stream
         private bool _worldRevealed; // settle: has the loading overlay been dismissed for this spawn yet
+        private bool _awaitingFloor;   // released on the grace timer with no floor yet — hover instead of falling
+        private float _awaitFloorTimer;
 
         // View-settle gate (#390): hold the reveal until the streamed view has finished arriving AND meshing, so
         // the world doesn't visibly assemble after the veil lifts. "No new chunk for this long" is the reliable
         // "server finished the frozen spawn view" signal (streaming keeps chunks arriving every tick); the backlog
-        // check confirms those last arrivals are meshed. The 8 s spawn grace below still hard-caps the wait.
+        // check confirms those last arrivals are meshed. The spawn grace below still hard-caps the wait.
         private const float ViewSettleQuietSeconds = 0.6f;
         private const int ViewSettleBacklog = 6; // ~a frame's worth of the mesh budget (MeshChunksPerFrame)
+
+        /// <summary>How long the spawn freeze may hold the veil up before the world is revealed regardless.</summary>
+        private const float SettleGraceSeconds = 8f;
+
+        /// <summary>Upper bound on hovering while waiting for a floor that never arrives (#773). Only reached
+        /// when the spawn chunk truly never streams; the server's void rescue then takes over as before.</summary>
+        private const float AwaitFloorMaxSeconds = 30f;
         private bool _wasGrounded = true;
         private bool _jetpackActive; // last reported jetpack thrust state (server drains energy on this)
         private float _stepTimer;
@@ -193,6 +202,7 @@ namespace BlocksBeyondTheStars.Client
                 _lastWorldEpoch = Game.WorldEpoch;
                 _spawned = false;
                 _settling = false;
+                _awaitingFloor = false;
             }
 
             // Snap to the server's authoritative spawn once it is known, then take over.
@@ -204,6 +214,7 @@ namespace BlocksBeyondTheStars.Client
                 _settling = true; // hold at spawn until the ground/ship chunk streams in
                 _settleTimer = 0f;
                 _worldRevealed = false;
+                _awaitingFloor = false; // the freeze owns us again; the release below re-decides
             }
 
             // On death the server respawns us at the ship's heal-tank — teleport the body there.
@@ -215,6 +226,7 @@ namespace BlocksBeyondTheStars.Client
                 _settling = true; // hold at the heal-tank until its chunk is streamed
                 _settleTimer = 0f;
                 _worldRevealed = false;
+                _awaitingFloor = false;
             }
 
             // Hold the player frozen at the spawn (no gravity, no control, no movement sent) until the
@@ -256,11 +268,13 @@ namespace BlocksBeyondTheStars.Client
                 bool viewSettled = Game.TimeSinceLastChunk >= ViewSettleQuietSeconds
                                    && Game.PendingMeshCount <= ViewSettleBacklog;
 
-                // Reveal the world + release control TOGETHER — once there is real ground under the spawn AND the
-                // view has settled, or after a short grace (then the server's void-rescue recovers a still-streaming
-                // spawn chunk by teleporting onto the ship). Tying reveal to release means you never see a "loaded"
-                // world you can't move in; the grace hard-caps the wait so the veil never lingers or feels stuck.
-                if (!awaitingConfirm && ((groundBelow && viewSettled) || _settleTimer > 8f))
+                // Reveal the world + release control once there is real ground under the spawn AND the view has
+                // settled, or after a short grace so the veil never lingers or feels stuck. Releasing on that
+                // grace alone used to hand the player straight into free fall through terrain that had not
+                // streamed yet — an 8-second drop into the void followed by the server's rescue teleports, which
+                // is what a slow (browser) client got on every first join (#773). Gravity is therefore held off
+                // separately until a floor actually exists: the veil lifts on time, the player just doesn't fall.
+                if (!awaitingConfirm && ((groundBelow && viewSettled) || _settleTimer > SettleGraceSeconds))
                 {
                     if (!_worldRevealed)
                     {
@@ -268,6 +282,8 @@ namespace BlocksBeyondTheStars.Client
                         Game.NotifyWorldReady();
                     }
 
+                    _awaitingFloor = !groundBelow;
+                    _awaitFloorTimer = 0f;
                     _settling = false;
                     _settleTimer = 0f;
                 }
@@ -1790,9 +1806,15 @@ namespace BlocksBeyondTheStars.Client
 
         private void ApplyGravityOnly()
         {
-            if (_controller.isGrounded)
+            bool grounded = _controller.isGrounded;
+            UpdateFloorWait(grounded);
+            if (grounded)
             {
                 _verticalVelocity = -1f;
+            }
+            else if (_awaitingFloor)
+            {
+                _verticalVelocity = 0f; // no floor streamed yet — a menu open at spawn must not drop us either
             }
             else
             {
@@ -1801,6 +1823,28 @@ namespace BlocksBeyondTheStars.Client
 
             _controller.Move(new Vector3(0f, _verticalVelocity, 0f) * Time.deltaTime);
         }
+
+        /// <summary>Ends the post-spawn hover (#773) as soon as there is something to stand on — the collider
+        /// under our feet, or one streaming in below us — and hard-caps it so a spawn chunk that never arrives
+        /// falls back to the old behaviour (drop, then the server's void rescue) instead of hovering forever.</summary>
+        private void UpdateFloorWait(bool grounded)
+        {
+            if (!_awaitingFloor)
+            {
+                return;
+            }
+
+            _awaitFloorTimer += Time.deltaTime;
+            if (grounded || _awaitFloorTimer > AwaitFloorMaxSeconds || ColliderBelow())
+            {
+                _awaitingFloor = false;
+            }
+        }
+
+        /// <summary>True when a streamed collider (terrain, ship deck, pad) sits within a short drop below us.</summary>
+        private bool ColliderBelow()
+            => Physics.Raycast(transform.position + Vector3.up * 0.5f, Vector3.down, out var hit, 10f)
+               && hit.collider != _controller;
 
         private void LookAround()
         {
@@ -2057,6 +2101,7 @@ namespace BlocksBeyondTheStars.Client
             bool grounded = _controller.isGrounded;
             bool inWater = IsSubmerged();
             bool onLadder = !inWater && OnLadder();
+            UpdateFloorWait(grounded);
             _moving = (inWater || grounded || onLadder) && (Mathf.Abs(h) + Mathf.Abs(v) > 0.1f);
 
             // Crouch/sneak: shrink the capsule + slow the walk while held on the ground.
@@ -2114,6 +2159,10 @@ namespace BlocksBeyondTheStars.Client
                 float lift = (InputMap.JumpHeld() ? SpaceFloatSpeed : 0f)
                            - ((InputMap.CrouchHeld()) ? SpaceFloatSpeed : 0f);
                 _verticalVelocity = Mathf.MoveTowards(_verticalVelocity, lift, SpaceFloatAccel * Time.deltaTime);
+            }
+            else if (_awaitingFloor)
+            {
+                _verticalVelocity = 0f; // the spawn floor hasn't streamed in yet — hold altitude, don't drop (#773)
             }
             else
             {


### PR DESCRIPTION
## The bug

A player joining a hosted world from the browser client fell through the not-yet-streamed terrain a few seconds after entering, got teleported by the server's void rescue, and fell again — their first ten seconds in the world.

Observed live on an arcade world (2026-08-05, real visitor):

```
22:51:53 [INFO] Player 'Explorer-4fd' joined (connection 2000001).
22:52:01 [WARN] Player 'Explorer-4fd' fell into the void; recovered to (0.5, 84, 0.5).
22:52:02 [WARN] Player 'Explorer-4fd' fell into the void; recovered to (0.5, 84, 0.5).
```

## Why it happened

`PlayerController` freezes the player at the spawn until the floor chunk's collider has streamed in — but that freeze had a hard 8 second cap that released control **even when no ground had arrived**, deliberately leaving the server's void rescue to clean up afterwards. The timing matches to the second: join at 22:51:53, first rescue at 22:52:01.

On a desktop client the chunks win that race, so the fallback almost never fires. On a browser client over a slower link they do not, which turns a rare safety net into the normal first-join experience — on exactly the platform the store points at.

## The fix

- **Reveal and physics are decoupled.** The veil still lifts on the grace timer (`SettleGraceSeconds`), so nothing lingers or feels stuck — but when there is no collider under the spawn, the player enters a hover (`_awaitingFloor`) instead of free fall. They can look around and walk; they just don't drop through a world that isn't there yet.
- **The hover ends by itself.** As soon as the character controller is grounded, or a collider streams in below (`ColliderBelow`), gravity resumes normally. `AwaitFloorMaxSeconds` (30 s) hard-caps it, so a spawn chunk that genuinely never arrives falls back to the previous behaviour rather than hovering forever.
- **Menus included.** The gravity-only path used while a panel or chat is open honours the same wait, so opening a menu at spawn can't drop the player either.

The hover state is cleared whenever a new spawn or respawn starts, and on a world-epoch change, so it can never leak into normal play. Fall damage is unaffected: the player never accumulates downward velocity during the wait.

## Scope and verification

Browser-facing in practice, but the change applies on every platform — a slow desktop join behaves the same way.

- Local Unity Windows player build: succeeded (PR CI does not build Unity).
- No .NET code changed, so the server suite is untouched; server-side spawn safety needed no change — it behaved correctly and rescued the player as designed.

closes #773

🤖 Generated with [Claude Code](https://claude.com/claude-code)
