### PR TITLE
fix(client): prologue orbit camera no longer clips through terrain

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7148,6 +7148,26 @@ is **pre-approved** (keys in `tools/ai-assets/.env`, run via `uv`).
 
 ---
 
+## ✅ Done (2026-08-06): prologue orbit camera no longer clips through terrain (#777)
+
+The first-spawn VEGA prologue orbited the camera around the landed ship on a blind parametric
+circle (radius 24→16, height 7–9, start angle `PlayerYaw + 160°`). A ship parked against a
+mountainside put part of that ring — sometimes the very first frame — inside the slope; voxel
+backfaces aren't rendered, so the player looked straight through the hill.
+
+**Terrain-aware staging** — new Unity-free `CinematicStageScan` (Client.Core, plain .NET tests):
+half-block line marches, camera spot clearance (cell + horizontal neighbours + above; ground below
+is fine) and a widest-clear-arc search over a 72-sample orbit ring. `PrologueCinematic.Begin()` now
+scans the ring first and picks the shot the terrain can carry: the classic orbit at height 7, else
+raised (12/18), restricted to the widest open arc when the full circle is blocked — the orbit then
+**ping-pongs across the open side** instead of passing through the mountain. Ships in craters get a
+high crane shot; no clear staging at all falls back to the pre-existing dim + panel prologue.
+A per-frame line-of-sight net (pull levels trading radius for height, smoothed so corrections read
+as camera moves) guards against late-streamed chunks and the page-2 push-in. Unloaded chunks count
+as **blocked** — `ClientWorld` grew `TryGetBlock` so the scan can tell "not streamed" from "air"
+(`GetBlock` still reads air, unchanged for existing callers). The landed ship's own hull is not part
+of the world grid, so the ship never occludes its own shot.
+
 ## ✅ Done (2026-08-06): glitch.fun can be redeployed without cutting a release
 
 Until now the store build could only be refreshed by tagging a version: the upload lives in

--- a/client/Assets/BlocksBeyondTheStars/Scripts/PrologueCinematic.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/PrologueCinematic.cs
@@ -14,6 +14,11 @@ namespace BlocksBeyondTheStars.Client
     /// others just see the player seated). <see cref="VegaPanel"/> drives it per prologue line; the
     /// panel itself keeps showing the text, subtitle-style.
     ///
+    /// The orbit is terrain-aware (#777): <see cref="CinematicStageScan"/> probes the voxel world at
+    /// Begin() to pick a clear height and open arc (ping-ponging across it when a mountainside blocks
+    /// the full circle), a per-frame line-of-sight net pulls the camera in/up out of late-streamed
+    /// terrain, and a ship with no clear shot at all falls back to the classic dim + panel prologue.
+    ///
     /// The camera override runs in LateUpdate at execution order 210, after every gameplay writer, and
     /// only while <see cref="GameBootstrap.CinematicCameraActive"/> also freezes on-foot control — the
     /// moment it is released, <see cref="PlayerController"/> re-asserts the normal eye pose next frame.
@@ -31,6 +36,15 @@ namespace BlocksBeyondTheStars.Client
         private const float LetterboxSeconds = 0.5f;
         private const float OrbitDegPerSecond = 8f;
 
+        // Terrain-aware staging (#777): the orbit ring is scanned against the voxel world before the
+        // shot, and a per-frame line-of-sight net keeps the camera out of late-streamed terrain.
+        private const int RingSamples = 72;      // 5° ring resolution for the pre-scan
+        private const float MinArcSweep = 110f;  // an orbit needs at least this much open sky to read as one
+        private const float ArcEdgeMargin = 10f; // ping-pong turnaround this far before the blocked edge
+        private const int MaxPull = 6;           // safety-net levels: each pulls the radius in and raises the camera
+        private const float PullRadiusStep = 0.13f;
+        private const float PullHeightStep = 1.5f;
+
         private WorldLoadingOverlay _overlay;
         private CinematicFrame _frame;
         private bool _active;
@@ -43,6 +57,17 @@ namespace BlocksBeyondTheStars.Client
         private float _radius, _height, _targetRadius, _targetHeight;
         private float _letter;
         private float _flash;
+
+        private CinematicStageScan.ClearSampler _sampler;
+        private float _stageRadius, _stageHeight; // page-1 settle orbit (chosen by the pre-scan)
+        private float _pushRadius, _pushHeight;   // page-2 push-in target
+        private bool _arcLimited;
+        private float _arcCenter, _arcHalf;       // degrees; only meaningful while _arcLimited
+        private float _orbitDir = 1f;
+        private float _safetyPull;                // smoothed 0..MaxPull terrain-avoidance blend
+        private Vector3 _lastPos;                 // last known-clear pose (held if everything is blocked)
+        private Quaternion _lastRot;
+        private bool _hasLastPose;
 
         private void Start() => _overlay = FindAnyObjectByType<WorldLoadingOverlay>();
 
@@ -72,8 +97,9 @@ namespace BlocksBeyondTheStars.Client
             }
         }
 
-        /// <summary>Tries to start the staged sequence. False only when the scene can't carry it at all
-        /// (space view active, camera missing) — the caller then keeps today's dim + panel behaviour.
+        /// <summary>Tries to start the staged sequence. False when the scene can't carry it at all
+        /// (space view active, camera missing) OR when the terrain pre-scan finds no clear shot around
+        /// the ship (#777) — the caller then keeps today's dim + panel behaviour.
         /// Deliberately NOT gated on the authoritative Aboard flag: that packet can trail WorldReady by
         /// several seconds (the ScreenshotDirector lesson) and silently downgraded the whole staging.</summary>
         public bool Begin()
@@ -90,6 +116,25 @@ namespace BlocksBeyondTheStars.Client
                       ?? (Game.PlayerPosition != Vector3.zero ? Game.PlayerPosition : Camera.transform.position);
             Debug.Log($"[Cinematic] Prologue staged around {(Game.ShipPosition.HasValue ? "ship" : "player")} at {_center} (aboard={Game.Aboard}).");
 
+            // Terrain-aware staging (#777): scan the orbit ring against the voxel world and pick a clear
+            // height/arc up front — a ship on a mountainside must not put the camera inside the slope.
+            // Unloaded chunks count as blocked, never as open space. No clear staging at all (crater,
+            // canyon, world missing) → the caller keeps today's dim + panel behaviour.
+            var world = Game.World;
+            if (world == null)
+            {
+                Debug.Log("[Cinematic] Prologue staging fallback: no world to scan the orbit against.");
+                return false;
+            }
+
+            _sampler = (x, y, z) => world.TryGetBlock(x, y, z, out var b) && b.IsAir;
+            if (!ChooseStaging())
+            {
+                Debug.Log("[Cinematic] Prologue staging fallback: no terrain-clear orbit around the ship.");
+                _sampler = null;
+                return false;
+            }
+
             // The first-person viewmodel rides the camera — a drill floating through an exterior orbit
             // shot breaks it. Hidden for the whole sequence, restored per camera mode on End().
             _viewmodel = Camera.GetComponent<Viewmodel>();
@@ -99,16 +144,75 @@ namespace BlocksBeyondTheStars.Client
             _ending = false;
             _letter = 0f;
             _flash = 0f;
-
-            // Start wide behind the current view and settle onto the orbit.
-            _angle = Game.PlayerYaw + 160f;
-            _radius = 24f;
-            _height = 9f;
-            _targetRadius = 16f;
-            _targetHeight = 7f;
+            _safetyPull = 0f;
+            _hasLastPose = false;
             _cameraOverride = true;
             Game.CinematicCameraActive = true;
             return true;
+        }
+
+        /// <summary>
+        /// Picks the shot the terrain can carry: the classic wide orbit settling to radius 16 (at rising
+        /// heights if the slope demands it), restricted to the widest open arc when a full circle is
+        /// blocked (the orbit then ping-pongs across the open side); else a high crane shot; else false.
+        /// </summary>
+        private bool ChooseStaging()
+        {
+            foreach (float h in new[] { 7f, 12f, 18f })
+            {
+                // Per angle BOTH rings must clear: the wide entry (radius 24) and the settle orbit
+                // (radius 16) — the camera damps from one to the other while sweeping.
+                var ring = CinematicStageScan.ScanRing(_sampler, _center.x, _center.y, _center.z,
+                    2f, 16f, h, RingSamples);
+                var entry = CinematicStageScan.ScanRing(_sampler, _center.x, _center.y, _center.z,
+                    2f, 24f, h + 2f, RingSamples);
+                for (int i = 0; i < RingSamples; i++)
+                {
+                    ring[i] &= entry[i];
+                }
+
+                if (CinematicStageScan.TryFindWidestClearArc(ring, MinArcSweep, out float arcCenter, out float sweep))
+                {
+                    ApplyStaging(24f, h + 2f, 16f, h, 8f, Mathf.Max(3.5f, h - 3.5f), arcCenter, sweep);
+                    Debug.Log($"[Cinematic] Prologue orbit staged at height {h} (arc {sweep:0}° around {arcCenter:0}°).");
+                    return true;
+                }
+            }
+
+            // Crane fallback: a slow near-top-down sweep for ships parked in craters/canyons.
+            var crane = CinematicStageScan.ScanRing(_sampler, _center.x, _center.y, _center.z,
+                2f, 6f, 26f, 36);
+            if (CinematicStageScan.TryFindWidestClearArc(crane, 60f, out float craneCenter, out float craneSweep))
+            {
+                ApplyStaging(6f, 26f, 6f, 26f, 4.5f, 18f, craneCenter, craneSweep);
+                Debug.Log($"[Cinematic] Prologue crane shot staged (arc {craneSweep:0}° around {craneCenter:0}°).");
+                return true;
+            }
+
+            return false;
+        }
+
+        private void ApplyStaging(float startRadius, float startHeight, float stageRadius, float stageHeight,
+            float pushRadius, float pushHeight, float arcCenter, float sweep)
+        {
+            _stageRadius = stageRadius;
+            _stageHeight = stageHeight;
+            _pushRadius = pushRadius;
+            _pushHeight = pushHeight;
+            _radius = startRadius;
+            _height = startHeight;
+            _targetRadius = stageRadius;
+            _targetHeight = stageHeight;
+
+            _arcLimited = sweep < 355f;
+            _arcCenter = arcCenter;
+            _arcHalf = sweep * 0.5f;
+            _orbitDir = 1f;
+            // Full circle: start wide behind the current view (the classic shot). Arc-limited: enter
+            // near one edge of the open side and sweep across it.
+            _angle = _arcLimited
+                ? arcCenter - Mathf.Max(0f, _arcHalf - ArcEdgeMargin) * 0.8f
+                : Game.PlayerYaw + 160f;
         }
 
         /// <summary>Advances the stage per prologue page: 0 = exterior orbit, 1 = push-in toward the
@@ -122,13 +226,13 @@ namespace BlocksBeyondTheStars.Client
 
             if (index <= 0)
             {
-                _targetRadius = 16f;
-                _targetHeight = 7f;
+                _targetRadius = _stageRadius;
+                _targetHeight = _stageHeight;
             }
             else if (index == 1)
             {
-                _targetRadius = 8f;
-                _targetHeight = 3.5f;
+                _targetRadius = _pushRadius;
+                _targetHeight = _pushHeight;
             }
             else
             {
@@ -209,15 +313,89 @@ namespace BlocksBeyondTheStars.Client
                 return;
             }
 
-            _angle += Time.deltaTime * OrbitDegPerSecond;
+            float step = Time.deltaTime * OrbitDegPerSecond;
+            if (_arcLimited)
+            {
+                // Ping-pong across the open arc instead of orbiting through the blocked side.
+                _angle += step * _orbitDir;
+                float half = Mathf.Max(ArcEdgeMargin, _arcHalf - ArcEdgeMargin);
+                float rel = Mathf.DeltaAngle(_arcCenter, _angle);
+                if (rel > half)
+                {
+                    _orbitDir = -1f;
+                }
+                else if (rel < -half)
+                {
+                    _orbitDir = 1f;
+                }
+            }
+            else
+            {
+                _angle += step;
+            }
+
             _radius = Damp(_radius, _targetRadius);
             _height = Damp(_height, _targetHeight);
 
-            float rad = _angle * Mathf.Deg2Rad;
-            Vector3 pos = _center + new Vector3(Mathf.Sin(rad) * _radius, _height, Mathf.Cos(rad) * _radius);
             Vector3 look = _center + new Vector3(0f, 2f, 0f);
-            Camera.transform.SetPositionAndRotation(pos, Quaternion.LookRotation(look - pos));
+
+            // Terrain safety net: the pre-scan staged the shot, but a late-streamed chunk or the page-2
+            // push-in can still put the ideal spot inside terrain. Each pull level trades radius for
+            // height until the view is clear; blend levels smoothly so the correction reads as a camera
+            // move, not a cut.
+            int needed = RequiredPull(look);
+            if (needed < 0)
+            {
+                // Nothing clear even fully pulled in — hold the last good pose rather than enter the rock.
+                if (_hasLastPose)
+                {
+                    Camera.transform.SetPositionAndRotation(_lastPos, _lastRot);
+                }
+
+                return;
+            }
+
+            _safetyPull = Mathf.MoveTowards(_safetyPull, needed, Time.deltaTime * 3f);
+            Vector3 pos = OrbitPos(_safetyPull);
+            if (!CameraClear(look, pos))
+            {
+                _safetyPull = needed; // the smooth blend crossed a wall — snap to the verified level
+                pos = OrbitPos(needed);
+            }
+
+            var rot = Quaternion.LookRotation(look - pos);
+            Camera.transform.SetPositionAndRotation(pos, rot);
+            _lastPos = pos;
+            _lastRot = rot;
+            _hasLastPose = true;
         }
+
+        private Vector3 OrbitPos(float pull)
+        {
+            float rad = _angle * Mathf.Deg2Rad;
+            float r = _radius * (1f - PullRadiusStep * pull);
+            float h = _height + PullHeightStep * pull;
+            return _center + new Vector3(Mathf.Sin(rad) * r, h, Mathf.Cos(rad) * r);
+        }
+
+        /// <summary>Smallest pull level whose camera spot is clear with line of sight to the ship, or
+        /// -1 when even the fully pulled-in spot is blocked.</summary>
+        private int RequiredPull(Vector3 look)
+        {
+            for (int k = 0; k <= MaxPull; k++)
+            {
+                if (CameraClear(look, OrbitPos(k)))
+                {
+                    return k;
+                }
+            }
+
+            return -1;
+        }
+
+        private bool CameraClear(Vector3 look, Vector3 pos)
+            => _sampler != null
+               && CinematicStageScan.CameraClear(_sampler, look.x, look.y, look.z, pos.x, pos.y, pos.z);
 
         /// <summary>Framerate-independent exponential approach (≈ settles in ~2 s).</summary>
         private static float Damp(float current, float target)

--- a/src/BlocksBeyondTheStars.Client.Core/CinematicStageScan.cs
+++ b/src/BlocksBeyondTheStars.Client.Core/CinematicStageScan.cs
@@ -1,0 +1,152 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+
+using System;
+
+namespace BlocksBeyondTheStars.Client
+{
+    /// <summary>
+    /// Unity-free terrain probing for the staged prologue orbit (#777): the camera used to fly a blind
+    /// parametric circle around the landed ship, which on a hillside put it inside the mountain (voxel
+    /// backfaces aren't rendered, so the player looked straight through the slope). These helpers let
+    /// <c>PrologueCinematic</c> scan the orbit ring against the client voxel world before the shot and
+    /// keep a cheap per-frame line-of-sight safety net while it runs. Lives here (not in the
+    /// MonoBehaviour) so the geometry rules are covered by plain .NET tests.
+    /// </summary>
+    public static class CinematicStageScan
+    {
+        /// <summary>True = the cell is KNOWN to be air. A cell in a chunk that has not streamed yet must
+        /// report false (blocked): mistaking not-yet-loaded terrain for open space is exactly the bug
+        /// this scan exists to prevent.</summary>
+        public delegate bool ClearSampler(int wx, int wy, int wz);
+
+        /// <summary>Sample spacing of the line march, in blocks. Half a block cannot skip a cell wall.</summary>
+        private const float MarchStep = 0.5f;
+
+        /// <summary>
+        /// Whether a camera can sit at a world position: its cell, the four horizontal neighbours and the
+        /// cell above must all be known air (near plane + foliage cross-billboard clearance). The cell
+        /// BELOW may be solid — hovering one block over the ground is fine.
+        /// </summary>
+        public static bool SpotClear(ClearSampler clear, float x, float y, float z)
+        {
+            int cx = Floor(x), cy = Floor(y), cz = Floor(z);
+            return clear(cx, cy, cz)
+                   && clear(cx + 1, cy, cz) && clear(cx - 1, cy, cz)
+                   && clear(cx, cy, cz + 1) && clear(cx, cy, cz - 1)
+                   && clear(cx, cy + 1, cz);
+        }
+
+        /// <summary>
+        /// Marches the segment in half-block steps; every touched cell must be known air. Start and end
+        /// cells are included, so a look target buried in terrain fails immediately.
+        /// </summary>
+        public static bool PathClear(ClearSampler clear,
+            float fromX, float fromY, float fromZ, float toX, float toY, float toZ)
+        {
+            float dx = toX - fromX, dy = toY - fromY, dz = toZ - fromZ;
+            float length = (float)Math.Sqrt(dx * dx + dy * dy + dz * dz);
+            int steps = Math.Max(1, (int)Math.Ceiling(length / MarchStep));
+            for (int i = 0; i <= steps; i++)
+            {
+                float t = (float)i / steps;
+                if (!clear(Floor(fromX + dx * t), Floor(fromY + dy * t), Floor(fromZ + dz * t)))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>Spot clearance at the camera position plus line of sight back to the look target —
+        /// the full per-position check both the pre-scan and the per-frame safety net use.</summary>
+        public static bool CameraClear(ClearSampler clear,
+            float lookX, float lookY, float lookZ, float camX, float camY, float camZ)
+            => SpotClear(clear, camX, camY, camZ)
+               && PathClear(clear, lookX, lookY, lookZ, camX, camY, camZ);
+
+        /// <summary>
+        /// Per-angle clearance of an orbit ring around (<paramref name="cx"/>, <paramref name="cy"/>,
+        /// <paramref name="cz"/>): sample i covers angle i·360/<paramref name="samples"/> degrees with the
+        /// orbit convention pos = center + (sin·r, camHeight, cos·r), looking at center + lookHeight.
+        /// </summary>
+        public static bool[] ScanRing(ClearSampler clear, float cx, float cy, float cz,
+            float lookHeight, float radius, float camHeight, int samples)
+        {
+            if (samples <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(samples));
+            }
+
+            var ring = new bool[samples];
+            for (int i = 0; i < samples; i++)
+            {
+                float rad = i * (360f / samples) * ((float)Math.PI / 180f);
+                float px = cx + (float)Math.Sin(rad) * radius;
+                float py = cy + camHeight;
+                float pz = cz + (float)Math.Cos(rad) * radius;
+                ring[i] = CameraClear(clear, cx, cy + lookHeight, cz, px, py, pz);
+            }
+
+            return ring;
+        }
+
+        /// <summary>
+        /// Finds the widest circular run of clear samples. True when its sweep reaches
+        /// <paramref name="minSweepDeg"/>; a fully clear ring reports a 360° sweep (callers treat that as
+        /// "no arc limit"). <paramref name="arcCenterDeg"/> is the run's middle angle in [0, 360).
+        /// </summary>
+        public static bool TryFindWidestClearArc(bool[] ring, float minSweepDeg,
+            out float arcCenterDeg, out float sweepDeg)
+        {
+            arcCenterDeg = 0f;
+            sweepDeg = 0f;
+            if (ring == null || ring.Length == 0)
+            {
+                return false;
+            }
+
+            int n = ring.Length;
+            float degPer = 360f / n;
+
+            int bestStart = -1, bestLen = 0;
+            int runStart = -1, runLen = 0;
+
+            // Walk twice around so a run wrapping 359°→0° is seen as one run (capped at n samples).
+            for (int i = 0; i < 2 * n; i++)
+            {
+                if (ring[i % n])
+                {
+                    if (runLen == 0)
+                    {
+                        runStart = i;
+                    }
+
+                    runLen = Math.Min(runLen + 1, n);
+                    if (runLen > bestLen)
+                    {
+                        bestLen = runLen;
+                        bestStart = runStart;
+                    }
+                }
+                else
+                {
+                    runLen = 0;
+                }
+            }
+
+            if (bestLen == 0)
+            {
+                return false;
+            }
+
+            sweepDeg = bestLen * degPer;
+            arcCenterDeg = ((bestStart + (bestLen - 1) * 0.5f) * degPer) % 360f;
+            return sweepDeg + 0.001f >= minSweepDeg;
+        }
+
+        private static int Floor(float v) => (int)Math.Floor(v);
+    }
+}

--- a/src/BlocksBeyondTheStars.Client.Core/ClientWorld.cs
+++ b/src/BlocksBeyondTheStars.Client.Core/ClientWorld.cs
@@ -112,15 +112,26 @@ namespace BlocksBeyondTheStars.Client
 
         public BlockId GetBlock(int wx, int wy, int wz)
         {
+            TryGetBlock(wx, wy, wz, out var block);
+            return block;
+        }
+
+        /// <summary>Like <see cref="GetBlock"/> but reports whether the cell's chunk has actually been
+        /// streamed: false = unknown (chunk not loaded), with <paramref name="block"/> = air. For callers
+        /// that must not mistake not-yet-streamed terrain for open space (the prologue stage scan).</summary>
+        public bool TryGetBlock(int wx, int wy, int wz, out BlockId block)
+        {
             var pos = WorldConstants.CanonicalBlock(new Vector3i(wx, wy, wz), _circumference);
             var coord = WorldConstants.WorldToChunk(pos);
             if (!_chunks.TryGetValue(coord, out var chunk))
             {
-                return BlockId.Air;
+                block = BlockId.Air;
+                return false;
             }
 
             var local = WorldConstants.WorldToLocal(pos);
-            return chunk.Get(local.X, local.Y, local.Z);
+            block = chunk.Get(local.X, local.Y, local.Z);
+            return true;
         }
 
         /// <summary>The packed shape descriptor (non-cube building form + orientation; 0 = plain cube) at a

--- a/tests/BlocksBeyondTheStars.Client.Tests/CinematicStageScanTests.cs
+++ b/tests/BlocksBeyondTheStars.Client.Tests/CinematicStageScanTests.cs
@@ -1,0 +1,129 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using System;
+using Xunit;
+
+namespace BlocksBeyondTheStars.Client.Tests;
+
+/// <summary>
+/// Terrain probing for the staged prologue orbit (#777): a ship parked against a mountainside must not
+/// stage the camera inside the slope, unloaded chunks must read as blocked (never as open space), and
+/// the widest-arc search must handle wrap-around and fully-clear rings.
+/// </summary>
+public sealed class CinematicStageScanTests
+{
+    /// <summary>Flat ground: everything at y &lt; 0 is solid, the rest is loaded air.</summary>
+    private static bool FlatGround(int x, int y, int z) => y >= 0;
+
+    [Fact]
+    public void PathClear_OpenAir_IsClear()
+    {
+        Assert.True(CinematicStageScan.PathClear(FlatGround, 0f, 2f, 0f, 16f, 9f, 16f));
+    }
+
+    [Fact]
+    public void PathClear_ThroughAHill_IsBlocked()
+    {
+        // A wall occupying x in [5, 8] at all heights sits between the look target and the camera.
+        bool Wall(int x, int y, int z) => y >= 0 && (x < 5 || x > 8);
+        Assert.False(CinematicStageScan.PathClear(Wall, 0f, 2f, 0f, 16f, 9f, 0f));
+    }
+
+    [Fact]
+    public void PathClear_BuriedLookTarget_IsBlocked()
+    {
+        // The start cell itself is solid — a look target inside terrain can never stage a shot.
+        Assert.False(CinematicStageScan.PathClear(FlatGround, 0f, -2f, 0f, 0f, 9f, 16f));
+    }
+
+    [Fact]
+    public void SpotClear_AllowsSolidGroundBelow_ButNotBeside()
+    {
+        // Hovering one block above flat ground is fine (the cell below may be solid) ...
+        Assert.True(CinematicStageScan.SpotClear(FlatGround, 8.5f, 1.5f, 8.5f));
+
+        // ... but a wall in a horizontal neighbour cell violates the near-plane clearance.
+        bool WallAtX2(int x, int y, int z) => y >= 0 && x != 2;
+        Assert.False(CinematicStageScan.SpotClear(WallAtX2, 1.5f, 1.5f, 0.5f));
+
+        // A solid ceiling directly above blocks too.
+        bool Ceiling(int x, int y, int z) => y >= 0 && y != 3;
+        Assert.False(CinematicStageScan.SpotClear(Ceiling, 0.5f, 2.5f, 0.5f));
+    }
+
+    [Fact]
+    public void UnloadedChunks_ReadAsBlocked()
+    {
+        // A sampler that knows nothing (nothing streamed yet) must stage nothing.
+        static bool Unknown(int x, int y, int z) => false;
+        Assert.False(CinematicStageScan.PathClear(Unknown, 0f, 2f, 0f, 4f, 2f, 0f));
+        Assert.False(CinematicStageScan.SpotClear(Unknown, 0f, 2f, 0f));
+
+        var ring = CinematicStageScan.ScanRing(Unknown, 0f, 0f, 0f, 2f, 16f, 7f, 72);
+        Assert.False(CinematicStageScan.TryFindWidestClearArc(ring, 60f, out _, out _));
+    }
+
+    [Fact]
+    public void ScanRing_FlatGround_IsFullyClear()
+    {
+        var ring = CinematicStageScan.ScanRing(FlatGround, 0.5f, 0.5f, 0.5f, 2f, 16f, 7f, 72);
+        Assert.All(ring, r => Assert.True(r));
+
+        Assert.True(CinematicStageScan.TryFindWidestClearArc(ring, 110f, out _, out float sweep));
+        Assert.Equal(360f, sweep, 1);
+    }
+
+    [Fact]
+    public void ScanRing_Mountainside_LeavesOnlyTheOpenArc()
+    {
+        // A mountain wall east of the ship: solid for x > 6 at every height. With the orbit convention
+        // pos = center + (sin·r, h, cos·r), east (+x) is angle 90° — that side must scan blocked.
+        bool Mountain(int x, int y, int z) => y >= 0 && x <= 6;
+
+        var ring = CinematicStageScan.ScanRing(Mountain, 0.5f, 0.5f, 0.5f, 2f, 16f, 7f, 72);
+        Assert.False(ring[18]); // 90°: camera inside the mountain
+        Assert.True(ring[54]);  // 270°: open side
+
+        Assert.True(CinematicStageScan.TryFindWidestClearArc(ring, 110f, out float center, out float sweep));
+        Assert.True(sweep < 360f);
+        // The open arc must face away from the mountain (west, around 270°).
+        float delta = Math.Abs(((center - 270f) % 360f + 540f) % 360f - 180f);
+        Assert.True(delta < 30f, $"arc center {center}° should face ~270°");
+    }
+
+    [Fact]
+    public void TryFindWidestClearArc_HandlesWrapAround()
+    {
+        // Clear samples wrap 350°..360°..40°: one 60° run crossing zero, plus a narrow decoy at 180°.
+        var ring = new bool[36];
+        for (int i = 35; i < 36 + 4; i++)
+        {
+            ring[i % 36] = true;
+        }
+
+        ring[18] = true;
+
+        Assert.True(CinematicStageScan.TryFindWidestClearArc(ring, 40f, out float center, out float sweep));
+        Assert.Equal(50f, sweep, 1);
+        // Run covers samples 35..39 (350°..30°) → its centre sits at 10°.
+        Assert.Equal(10f, center, 1);
+    }
+
+    [Fact]
+    public void TryFindWidestClearArc_BelowMinimumSweep_Fails()
+    {
+        var ring = new bool[36];
+        ring[0] = ring[1] = ring[2] = true; // 30° of open sky
+
+        Assert.False(CinematicStageScan.TryFindWidestClearArc(ring, 110f, out _, out float sweep));
+        Assert.Equal(30f, sweep, 1); // the sweep is still reported for logging
+    }
+
+    [Fact]
+    public void TryFindWidestClearArc_EmptyOrAllBlocked_Fails()
+    {
+        Assert.False(CinematicStageScan.TryFindWidestClearArc(Array.Empty<bool>(), 10f, out _, out _));
+        Assert.False(CinematicStageScan.TryFindWidestClearArc(new bool[12], 10f, out _, out _));
+    }
+}


### PR DESCRIPTION
## Problem

In story mode, the first-spawn VEGA prologue orbits the camera around the player's landed ship on a blind parametric circle (radius 24→16 m, height 7–9 m, start angle `PlayerYaw + 160°`). When the ship lands against a mountainside, part of that ring — sometimes the very first frame — sits inside the slope; voxel backfaces aren't rendered, so the player looks straight through the terrain.

## Fix

- **New Unity-free `CinematicStageScan` (Client.Core)**: half-block line marches, camera spot clearance (cell + horizontal neighbours + above; solid ground below is fine) and a widest-clear-arc search over a 72-sample orbit ring — covered by 10 plain .NET tests.
- **`ClientWorld.TryGetBlock`**: distinguishes not-yet-streamed chunks from air. The scan treats unloaded as **blocked**, never as open space; `GetBlock` behaviour is unchanged for existing callers.
- **`PrologueCinematic.Begin()` stages the shot the terrain can carry**: the classic orbit at height 7, else raised (12/18); when the full circle is blocked the orbit is restricted to the widest open arc and **ping-pongs across the open side** instead of passing through the mountain. Ships in craters/canyons get a high crane shot; no clear staging at all falls back to the pre-existing dim + panel prologue.
- **Per-frame line-of-sight safety net**: smoothed pull levels trade radius for height when a late-streamed chunk or the page-2 push-in would put the ideal spot inside terrain; if even fully pulled in nothing is clear, the camera holds its last good pose instead of entering the rock.

The landed ship's own hull is not part of the world block grid, so the ship never occludes its own shot.

## Verification

- 10 new `CinematicStageScanTests` (flat ground, mountainside arc, wrap-around arc, unloaded-chunk semantics, spot clearance) — green.
- Full client suite 187/187 green; Release build with `-warnaserror`: 0 warnings.
- Local Unity Windows build (batch): success.

closes #777

🤖 Generated with [Claude Code](https://claude.com/claude-code)