### PR TITLE
fix(ships): light every room — per-room ceiling lamps + light across chunk seams

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7148,6 +7148,44 @@ is **pre-approved** (keys in `tools/ai-assets/.env`, run via `uv`).
 
 ---
 
+## ✅ Done (2026-08-06): every room of every ship is lit (#776)
+
+Ships with more than one room were only lit in some of their rooms — on the Hammerhead the bridge was
+lit while the rear and side compartments stayed dark, and the Courier, Thunderbolt, Deathblock and
+Hauler interiors got no block light at all.
+
+**Root cause was the data, not the renderer.** Not one of the seven authored layouts held a single
+interior light: every `light*` cell in `data/ship_layouts/*.json` sits *outside* the hull as a
+navigation light. Real interior lighting existed only on the starter ship, which has no layout and is
+built as a code box. What made *some* rooms look lit was an accident — the mesher's light flood-fill
+is stopped by opaque blocks but passes through glass, so exterior nav lights bled inside wherever a
+window happened to be near one. Simulating that fill over each layout put eye-level interior coverage
+at 83 % (corvette) and 59 % (scout), 43 % on the hammerhead (bow only) and **0 %** on the courier,
+thunderbolt, deathblock and hauler. Everything else the interior got was the flat, directionless
+`_Sc_Indoor` shader fill, and windows never helped: `ChunkMesher.Top()` counts glass as blocking, so
+interior skylight is ~0 by construction.
+
+**Ceiling lamps per room, procedurally.** `FinishShipStructure` now runs `PlaceInteriorLights`
+alongside the existing `PaintStructureAccents` room pass: it hangs a `light_white` in the air cell
+below each station's ceiling. Station cells are the ship's room anchors — the accent pass keys off the
+same list — so this lights every authored layout, the code-box starter hull and any ship a player
+builds in the editor, without touching the hand-tuned layout JSON. It scans up to the ceiling rather
+than trusting the structure height (correct under a low wing or a raised canopy), only ever fills AIR,
+and skips a room too low to keep the 1.88 m walkway clear.
+
+**Second, independent defect: light did not cross ship chunk seams.** Ship hulls mesh one 16³ chunk at
+a time and called `ChunkMesher.Build` *without* a light-source list, so the mesher fell back to
+scanning only the chunk it was meshing — a lamp stopped dead at whatever seam it sat next to, cutting a
+14×15 hull's lighting along arbitrary planes. New shared `ShipMeshBuilder.LightSources` collects the
+whole hull's emitters, and the landed/walkable ship, the flight-view hull and the preview/transit build
+all pass it (range culling already happens inside the mesher). The planet path solved this long ago via
+`ClientWorld.LightSourcesNear`; the ship paths never did. The speeder is deliberately left alone — it is
+a single-chunk open hull with no interior.
+
+New `ShipInteriorLightingTests` guards both halves: a theory over all seven layouts plus the code box
+asserts every station's room carries a lamp, and a hammerhead fact asserts the walkway above each
+station stays clear and the formerly dark flanking rooms are lit.
+
 ## ✅ Done (2026-08-06): glitch.fun can be redeployed without cutting a release
 
 Until now the store build could only be refreshed by tagging a version: the upload lives in

--- a/client/Assets/BlocksBeyondTheStars/Scripts/LandedShipView.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/LandedShipView.cs
@@ -197,6 +197,8 @@ namespace BlocksBeyondTheStars.Client
             System.Func<int, int, int, int> WorldShape = m.Shapes == null ? null
                 : (x, y, z) => m.Shapes.TryGetValue(new Vector3i(x, y, z), out var s) ? s : 0;
 
+            // The whole hull's lamps, so interior lighting carries across this ship's chunk seams (#776).
+            var lights = ShipMeshBuilder.LightSources(Game.Content, m.Cells, m.Mods);
             int cs = WorldConstants.ChunkSize;
             int FloorDiv(int a, int b) => (a >= 0 ? a : a - (b - 1)) / b;
             for (int cx = FloorDiv(minX, cs); cx <= FloorDiv(maxX, cs); cx++)
@@ -219,7 +221,7 @@ namespace BlocksBeyondTheStars.Client
                     }
                 }
 
-                var (mesh, collider) = ChunkMesher.Build(chunk, Game.Content, CellAt, Game.Atlas, paintTint: paint, worldShape: WorldShape);
+                var (mesh, collider) = ChunkMesher.Build(chunk, Game.Content, CellAt, Game.Atlas, paintTint: paint, lights: lights, worldShape: WorldShape);
                 if (mesh.vertexCount == 0)
                 {
                     continue;

--- a/client/Assets/BlocksBeyondTheStars/Scripts/ShipMeshBuilder.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/ShipMeshBuilder.cs
@@ -85,6 +85,35 @@ namespace BlocksBeyondTheStars.Client
             return ship;
         }
 
+        /// <summary>Every light-emitting cell of a sparse ship/structure grid, as the mesher's light-source
+        /// list. Ship hulls are meshed one 16³ chunk at a time, and without this list <see cref="ChunkMesher"/>
+        /// falls back to scanning only the chunk it is currently meshing — so a lamp stopped dead at whatever
+        /// chunk seam it happened to sit next to, cutting a big hull's lighting along arbitrary planes (#776).
+        /// The planet path solves the same problem with ClientWorld.LightSourcesNear. Shared by every ship
+        /// voxel-build path. Range culling happens inside the mesher, so the whole hull's list is fine.</summary>
+        public static List<(Vector3i Pos, int Rgb)> LightSources(GameContent content,
+            IEnumerable<KeyValuePair<Vector3i, BlockId>> cells,
+            Dictionary<Vector3i, (int Tint, int Glow)> mods = null)
+        {
+            var lights = new List<(Vector3i Pos, int Rgb)>();
+            if (content == null || cells == null)
+            {
+                return lights;
+            }
+
+            foreach (var kv in cells)
+            {
+                int glow = mods != null && mods.TryGetValue(kv.Key, out var m) ? m.Glow : 0;
+                int rgb = ChunkMesher.BlockLightColor(content, kv.Value, glow);
+                if (rgb != 0)
+                {
+                    lights.Add((kv.Key, rgb));
+                }
+            }
+
+            return lights;
+        }
+
         /// <summary>Writes a cell's authored dye/glow + shape into a chunk so the shared mesher renders them
         /// (no-op for cells without modifiers). Shared by every ship/structure voxel-build path.</summary>
         public static void ApplyMods(ChunkData chunk, int lx, int ly, int lz, Vector3i worldCell,
@@ -123,6 +152,7 @@ namespace BlocksBeyondTheStars.Client
             System.Func<int, int, int, int> WorldShape = shapes == null ? null
                 : (x, y, z) => shapes.TryGetValue(new Vector3i(x, y, z), out var s) ? s : 0;
 
+            var lights = LightSources(content, cells, mods);
             int cs = WorldConstants.ChunkSize;
             int FloorDiv(int a, int b) => (a >= 0 ? a : a - (b - 1)) / b;
             var mats = chunkMatTransparent != null
@@ -149,7 +179,7 @@ namespace BlocksBeyondTheStars.Client
                     }
                 }
 
-                var (mesh, collider) = ChunkMesher.Build(chunk, content, WorldBlock, atlas, paintTint: paint, worldShape: WorldShape);
+                var (mesh, collider) = ChunkMesher.Build(chunk, content, WorldBlock, atlas, paintTint: paint, lights: lights, worldShape: WorldShape);
                 if (collider != null)
                 {
                     Object.Destroy(collider); // display-only build — the cooked collider mesh is never used (#423)

--- a/client/Assets/BlocksBeyondTheStars/Scripts/SpaceView.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/SpaceView.cs
@@ -3146,6 +3146,8 @@ namespace BlocksBeyondTheStars.Client
             System.Func<int, int, int, int> WorldShape = shapes == null ? null
                 : (x, y, z) => shapes.TryGetValue(new Vector3i(x, y, z), out var s) ? s : 0;
 
+            // The whole hull's lamps, so lighting carries across this hull's chunk seams (#776).
+            var lights = ShipMeshBuilder.LightSources(Game.Content, cells, mods);
             int cs = WorldConstants.ChunkSize;
             int FloorDiv(int a, int b) => (a >= 0 ? a : a - (b - 1)) / b;
             var mats = Game.ChunkMaterialTransparent != null
@@ -3172,7 +3174,7 @@ namespace BlocksBeyondTheStars.Client
                     }
                 }
 
-                var (mesh, collider) = ChunkMesher.Build(chunk, Game.Content, WorldBlock, Game.Atlas, paintTint: paint, worldShape: WorldShape);
+                var (mesh, collider) = ChunkMesher.Build(chunk, Game.Content, WorldBlock, Game.Atlas, paintTint: paint, lights: lights, worldShape: WorldShape);
                 if (mesh.vertexCount == 0)
                 {
                     continue;

--- a/src/BlocksBeyondTheStars.GameServer/GameServerSpaceStructure.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerSpaceStructure.cs
@@ -343,13 +343,15 @@ public sealed partial class GameServer
         return s;
     }
 
-    /// <summary>Common ship-structure finish: paints the per-room floor accents, snapshots the protected
-    /// design baseline (hull + modules — never minable on foot), then (for a player's own ship) applies the
-    /// player's persisted edits on top (added blocks; in-space EVA hull repairs/removals). NPC trader ships
-    /// pass <paramref name="persistEdits"/> = false: they have no owner and no per-cell deltas to load.</summary>
+    /// <summary>Common ship-structure finish: paints the per-room floor accents, hangs the per-room ceiling
+    /// lamps, snapshots the protected design baseline (hull + modules — never minable on foot), then (for a
+    /// player's own ship) applies the player's persisted edits on top (added blocks; in-space EVA hull
+    /// repairs/removals). NPC trader ships pass <paramref name="persistEdits"/> = false: they have no owner
+    /// and no per-cell deltas to load.</summary>
     private void FinishShipStructure(SpaceStructure s, bool persistEdits = true)
     {
         PaintStructureAccents(s);
+        PlaceInteriorLights(s);
         s.Baseline.Clear();
         s.Baseline.UnionWith(s.Cells.Keys);
         if (persistEdits)
@@ -389,6 +391,45 @@ public sealed partial class GameServer
                         s.Set(p, accent.NumericId);
                     }
                 }
+        }
+    }
+
+    /// <summary>Interior lighting pass: hangs a ceiling lamp over every station marker, so each room of a
+    /// multi-room ship carries its own light source. Before this, NO authored layout held a single interior
+    /// light — every light cell in the layouts is an exterior nav light — and a room only looked lit where
+    /// that nav-light glow happened to bleed in through a window (glass passes the mesher's propagated block
+    /// light), which is why the Hammerhead's bridge was lit and its rear compartments were not (#776).
+    /// Station cells are the ship's room anchors (the accent pass above keys off the same list), so this
+    /// covers every authored layout, the code-box starter hull and any ship a player builds in the editor,
+    /// without touching the hand-tuned layout JSON. Only ever fills AIR: hull, cargo and stations stay put.</summary>
+    private void PlaceInteriorLights(SpaceStructure s)
+    {
+        if (_content.GetBlock("light_white") is not { } lamp)
+        {
+            return;
+        }
+
+        const int MaxRoomHeight = 8; // bounds the ceiling scan on an open-topped or malformed hull
+
+        foreach (var (_, cell) in s.StationCells)
+        {
+            // Scan up to this room's ceiling and hang the lamp in the air cell right below it. Scanning beats
+            // using the structure height: it stays correct under a low wing, a raised canopy or a second deck.
+            int y = cell.Y;
+            while (y < cell.Y + MaxRoomHeight && s.Get(new Vector3i(cell.X, y + 1, cell.Z)).IsAir)
+            {
+                y++;
+            }
+
+            // Needs real headroom: the player capsule is 1.88 m, so a lamp at the station's own head height
+            // would sit in the walkway. A room that low simply keeps the flat indoor fill instead.
+            var lampCell = new Vector3i(cell.X, y, cell.Z);
+            if (y <= cell.Y + 1 || !s.Get(lampCell).IsAir)
+            {
+                continue;
+            }
+
+            s.Set(lampCell, lamp.NumericId);
         }
     }
 

--- a/tests/BlocksBeyondTheStars.Tests/ShipInteriorLightingTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/ShipInteriorLightingTests.cs
@@ -1,0 +1,132 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using System.Text.Json;
+using BlocksBeyondTheStars.Networking.Transport;
+using BlocksBeyondTheStars.Persistence;
+using BlocksBeyondTheStars.Shared.Configuration;
+using BlocksBeyondTheStars.Shared.Content;
+using BlocksBeyondTheStars.Shared.Definitions;
+using BlocksBeyondTheStars.Shared.Geometry;
+using Xunit;
+using SvGameServer = BlocksBeyondTheStars.GameServer.GameServer;
+
+namespace BlocksBeyondTheStars.Tests;
+
+/// <summary>
+/// Every room of every ship must carry its own light source (#776). No authored layout holds an interior
+/// light — all their light cells are exterior nav lights — so the rooms used to be lit only where that
+/// glow happened to bleed in through a window, which left the Hammerhead's rear compartments dark. The
+/// structure build now hangs a ceiling lamp over every station marker (the ship's room anchors).
+/// </summary>
+public sealed class ShipInteriorLightingTests : IDisposable
+{
+    private readonly string _root;
+    private readonly string _dataDir;
+
+    public ShipInteriorLightingTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "bbts_shiplight_" + Guid.NewGuid().ToString("N"));
+        _dataDir = Path.Combine(_root, "data");
+        CopyDir(TestPaths.DataDir(), _dataDir);
+    }
+
+    /// <summary>Starts a server whose (free) starter ship is built from <paramref name="layoutKey"/>, so the
+    /// structure builds without the blueprint/craft flow — the hammerhead-test pattern. A null key leaves the
+    /// starter on its layout-less code box.</summary>
+    private SvGameServer Started(string? layoutKey, out SqliteWorldRepository repo, out GameContent content)
+    {
+        var shipsPath = Path.Combine(_dataDir, "ships.json");
+        var ships = JsonSerializer.Deserialize<List<ShipDefinition>>(File.ReadAllText(shipsPath), ContentLoader.JsonOptions)!;
+        ships.First(s => s.Key == "starter").Layout = layoutKey;
+        File.WriteAllText(shipsPath, JsonSerializer.Serialize(ships, ContentLoader.JsonOptions));
+
+        content = ContentLoader.LoadFromDirectory(_dataDir);
+        repo = new SqliteWorldRepository(new SaveGamePaths(_root, "shiplight_" + (layoutKey ?? "box")));
+        var st = new LoopbackServerTransport(new LoopbackLink());
+        var config = new ServerConfig { WorldName = "shiplight", Seed = 1, AutoSaveIntervalMinutes = 9999, PlaceStarterShip = true };
+        var server = new SvGameServer(config, content, st, repo);
+        server.Start();
+        server.AddLocalPlayer("Host");
+        return server;
+    }
+
+    [Theory]
+    [InlineData(null)] // the layout-less code-box starter hull
+    [InlineData("ship_scout")]
+    [InlineData("ship_corvette")]
+    [InlineData("ship_hauler")]
+    [InlineData("ship_courier")]
+    [InlineData("ship_thunderbolt")]
+    [InlineData("ship_deathblock")]
+    [InlineData("ship_hammerhead")]
+    public void EveryRoomOfEveryShip_GetsItsOwnCeilingLamp(string? layoutKey)
+    {
+        var server = Started(layoutKey, out var repo, out var content);
+        using (repo)
+        {
+            var s = server.BuildShipStructureForTest("Host");
+            var lamp = content.GetBlock("light_white")!.NumericId;
+
+            Assert.NotEmpty(s.StationCells);
+            foreach (var (type, cell) in s.StationCells)
+            {
+                // Somewhere above this room's station anchor, clear of the walkway, hangs a lamp.
+                var lit = Enumerable.Range(cell.Y + 2, 8)
+                    .Any(y => s.Get(new Vector3i(cell.X, y, cell.Z)).Equals(lamp));
+                Assert.True(lit, $"{layoutKey ?? "box"}: no ceiling lamp above the {type} at {cell}");
+            }
+        }
+    }
+
+    [Fact]
+    public void Lamps_HangClearOfTheWalkway_AndNeverDisplaceTheHull()
+    {
+        var server = Started("ship_hammerhead", out var repo, out var content);
+        using (repo)
+        {
+            var s = server.BuildShipStructureForTest("Host");
+            var lamp = content.GetBlock("light_white")!.NumericId;
+
+            foreach (var (_, cell) in s.StationCells)
+            {
+                // Head height above a station stays open: the player capsule is 1.88 m, so a lamp may
+                // never land in the cell the player walks through.
+                Assert.True(s.Get(new Vector3i(cell.X, cell.Y + 1, cell.Z)).IsAir,
+                    $"walkway above the station at {cell} must stay clear");
+            }
+
+            // The previously dark rooms — the flanking workshop/cargo bay and the sleeping cabins — are lit,
+            // not just the bridge that the bow nav lights happened to reach through the front pane.
+            foreach (var (x, z) in new[] { (2, 1), (2, 4), (11, 1), (11, 4) })
+            {
+                var lit = Enumerable.Range(2, 8).Any(y => s.Get(new Vector3i(x, y, z)).Equals(lamp));
+                Assert.True(lit, $"flanking room column ({x},{z}) should carry a lamp");
+            }
+        }
+    }
+
+    private static void CopyDir(string src, string dst)
+    {
+        Directory.CreateDirectory(dst);
+        foreach (var file in Directory.GetFiles(src))
+        {
+            File.Copy(file, Path.Combine(dst, Path.GetFileName(file)), overwrite: true);
+        }
+
+        foreach (var dir in Directory.GetDirectories(src))
+        {
+            CopyDir(dir, Path.Combine(dst, Path.GetFileName(dir)));
+        }
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+            if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true);
+        }
+        catch { }
+    }
+}


### PR DESCRIPTION
Ships with more than one room were only lit in some of their rooms: the Hammerhead's bridge was lit while its rear and side compartments stayed dark, and the Courier, Thunderbolt, Deathblock and Hauler interiors got no block light at all.

## Root cause was the data, not the renderer

Not one of the seven authored layouts holds a single interior light — every `light*` cell in `data/ship_layouts/*.json` sits *outside* the hull as a navigation light. Real interior lighting existed only on the starter ship, which has no layout and is built as a code box.

What made *some* rooms look lit was an accident: the mesher's light flood-fill is stopped by opaque blocks but **passes through glass**, so the exterior nav lights bled inside wherever a window happened to be near one. Simulating that flood-fill over each layout gives the eye-level interior coverage:

| ship | interior lit | why |
| --- | --- | --- |
| corvette | 83 % | small enough that the flank nav lights reach through the side glass |
| scout | 59 % | same |
| hammerhead | 43 % | bow lit through the front pane; rear + side compartments 0 % |
| courier / thunderbolt / deathblock / hauler | **0 %** | no block light reaches the interior at all |

Everything else the interior received was the flat, directionless `_Sc_Indoor` shader fill. Windows never helped: `ChunkMesher.Top()` counts any non-air block as blocking skylight, glass included, so interior skylight is ~0 by construction.

## Fix 1 — ceiling lamps per room, procedurally

`FinishShipStructure` now runs `PlaceInteriorLights` alongside the existing `PaintStructureAccents` room pass, hanging a `light_white` in the air cell below each station's ceiling.

Station cells are the ship's room anchors — the accent pass keys off the same list — so this lights every authored layout, the code-box starter hull and any ship a player builds in the editor, **without touching the hand-tuned layout JSON**. It scans up to the ceiling rather than trusting the structure height (stays correct under a low wing or a raised canopy), only ever fills AIR, and skips a room too low to keep the 1.88 m walkway clear.

## Fix 2 — light now crosses ship chunk seams

Ship hulls are meshed one 16³ chunk at a time and called `ChunkMesher.Build` **without** a light-source list, so the mesher fell back to scanning only the chunk it was meshing: a lamp stopped dead at whatever seam it happened to sit next to, cutting a 14×15 hull's lighting along arbitrary planes.

New shared `ShipMeshBuilder.LightSources` collects the whole hull's emitters, and the landed/walkable ship, the flight-view hull and the preview/transit build all pass it (range culling already happens inside the mesher). The planet path solved this long ago via `ClientWorld.LightSourcesNear`; the ship paths never did.

The speeder is deliberately left alone — single-chunk open hull, no interior.

## Tests

New `ShipInteriorLightingTests`:
- a theory over all seven layouts **plus** the layout-less code box asserts every station's room carries a lamp;
- a hammerhead fact asserts the walkway above each station stays clear and the formerly dark flanking rooms (workshop/cargo bay, sleeping cabins) are lit.

Full fast tier green locally: **1433 server + 177 client**, and the existing ship-structure tests (hammerhead T-shape, drawn-ship notches, floor-fill guarantees) still pass unchanged. Windows client built locally to verify the Unity-side changes compile and ship.

closes #776

🤖 Generated with [Claude Code](https://claude.com/claude-code)
