### PR TITLE
feat(bases): a founded base always has air — the base zone is a life-support field

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -103,6 +103,26 @@ Per-item detail lives in the dated work log below. **Since 2026-07 versions are 
 
 ---
 
+### ★ A base always has air: the Grundstein projects a life-support field over its zone (#782, 2026-08-06, branch feat/base-oxygen)
+Founded bases now breathe. The oxygen loop's life-support boolean (ship cabin / boarded station /
+`OxygenEnabled` off) gains a fourth source: standing inside ANY founded base's protection cube
+(`InAnyBaseZone`, the same radius-8 Chebyshev zone as the build protection — one teachable rule: *where
+you can build is where you can breathe*). Ownership is deliberately ignored — visitors breathe too, the
+protection rules still keep them from editing. Life support now also wins over the `AboveAtmosphere`
+altitude line (a base founded on a peak past it still breathes; same for ship cabins, which previously
+drained up there despite B41b) and over the diving drain (an underwater base zone is a dome — consistent
+with diving inside the ship's cabin). Suit-ENERGY recharge intentionally stays ship/heal-tank-only. The
+radius constant moved to `WorldConstants.BaseZoneRadius` so the client's HUD mirror can never diverge:
+HudUi computes the zone from the already-streamed `BaseList` (no protocol change), fires a one-shot
+"Life support: <base>" toast on entry and suffixes the O2 bar with "(base life support)" — both only on
+worlds whose own air is NOT breathable (under a breathable sky the field adds nothing and the hint would
+be noise). New keys `ui.base.life_support` + `ui.hud.base_air` (DE+EN). No new game rule (avoids the
+save-baked RulesOverride lift); gated by the existing `OxygenEnabled`. Makes airless-world colonization
+actually playable: craft the base core aboard the ship (workshop), land, place — the pad is your air
+pocket (the `oxygen_extractor` is useless on airless worlds). Tests: 4 new (`BaseOxygenTests` — zone
+regen + outside drain on toxic rocky, unallied visitor breathes, mining the core kills the field same
+tick, submerged-in-zone dome). Manual: base section documents the air field.
+
 ### ★ VEGA reads better: paged speech, a re-readable tips log, and a first-spawn prologue (#736, #737, #738, 2026-08-05, branch feat/vega-hints-ux)
 Three tutorial/onboarding fixes in one pass. **Paged speech (#736)** — VEGA's speech panel fits ~4
 lines (~220–240 chars) but locale lines are unclamped (only LLM banter had the 240-char server clamp),

--- a/client/Assets/BlocksBeyondTheStars/Scripts/HudUi.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/HudUi.cs
@@ -1,6 +1,8 @@
 // Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using BlocksBeyondTheStars.Networking.Messages;
+using BlocksBeyondTheStars.Shared.World;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -140,6 +142,10 @@ namespace BlocksBeyondTheStars.Client
         private int _lastCompassDist = int.MinValue;
         private int _lastCompassWpDist = int.MinValue;
 
+        /// <summary>Edge detector for the base life-support field (#782): true while the last HUD refresh saw
+        /// the player inside some founded base's zone, so the "Life support: …" toast fires once on entry.</summary>
+        private bool _wasInBaseZone;
+
         /// <summary>Set while a HUD exists so world-side FX (MiningFx) can hand off pickup fly-ins.</summary>
         public static HudUi Instance { get; private set; }
         private Canvas _flyCanvas; // own overlay canvas so the visor distortion can't bend the fly-ins
@@ -191,6 +197,34 @@ namespace BlocksBeyondTheStars.Client
                     Refresh();
                 }
             }
+        }
+
+        /// <summary>The founded base whose zone contains the player right now, or null. Mirrors the server's
+        /// authoritative life-support check (same <see cref="WorldConstants.BaseZoneRadius"/> cube around the
+        /// base_core) against the already-streamed <see cref="GameBootstrap.Bases"/> — HUD feedback only.</summary>
+        private NetBase FindBaseZone()
+        {
+            var bases = Game.Bases;
+            if (bases == null || bases.Length == 0)
+            {
+                return null;
+            }
+
+            int px = Mathf.FloorToInt(Game.PlayerPosition.x);
+            int py = Mathf.FloorToInt(Game.PlayerPosition.y);
+            int pz = Mathf.FloorToInt(Game.PlayerPosition.z);
+            foreach (var b in bases)
+            {
+                // NetBase carries the core's block centre (X/Z at +0.5) — floor back to the cell.
+                if (Mathf.Abs(px - Mathf.FloorToInt(b.X)) <= WorldConstants.BaseZoneRadius
+                    && Mathf.Abs(py - Mathf.FloorToInt(b.Y)) <= WorldConstants.BaseZoneRadius
+                    && Mathf.Abs(pz - Mathf.FloorToInt(b.Z)) <= WorldConstants.BaseZoneRadius)
+                {
+                    return b;
+                }
+            }
+
+            return null;
         }
 
         /// <summary>Flashes the screen red + names the cause whenever the player's health drops (B21), so
@@ -606,9 +640,25 @@ namespace BlocksBeyondTheStars.Client
 
             // Vitals.
             SetVital(0, loc.Get("ui.hud.health"), Game.Health, Game.Health / 100f, Health, true);
+            // Base life-support field (#782): a founded base's zone (the shared radius cube around its
+            // base_core) always breathes. Client-side mirror of the server's check, HUD feedback only —
+            // announced once on entry and spelled out on the O2 bar, but only where it matters (worlds
+            // whose own air is NOT breathable; under a breathable sky the base adds nothing).
+            bool breathable = Game.Environment != null && Game.Environment.Breathable;
+            var zoneBase = FindBaseZone();
+            if (zoneBase != null && !_wasInBaseZone && !breathable)
+            {
+                string baseName = string.IsNullOrEmpty(zoneBase.Name) ? loc.Get("ui.base.default") : zoneBase.Name;
+                Game.ShowMessage(loc.Get("ui.base.life_support").Replace("{name}", baseName));
+            }
+            _wasInBaseZone = zoneBase != null;
+
             // Spell out "(breathable)" rather than a bare "*", so new players understand the full O2 bar isn't
             // draining because the air here is breathable — and that it will drain elsewhere (space, toxic worlds).
-            string oxy = loc.Get("ui.hud.oxygen") + (Game.Environment != null && Game.Environment.Breathable ? "  (" + loc.Get("ui.hud.breathable") + ")" : string.Empty);
+            string oxySuffix = breathable ? "  (" + loc.Get("ui.hud.breathable") + ")"
+                : zoneBase != null ? "  (" + loc.Get("ui.hud.base_air") + ")"
+                : string.Empty;
+            string oxy = loc.Get("ui.hud.oxygen") + oxySuffix;
             SetVital(1, oxy, Game.Oxygen, Game.Oxygen / 100f, Oxygen, true);
             // While climate control fights heat/cold/vacuum (#666) the energy bar turns stress-orange.
             SetVital(2, loc.Get("ui.hud.energy"), Game.SuitEnergy, Game.SuitEnergy / 100f,

--- a/data/locales/de.json
+++ b/data/locales/de.json
@@ -1965,6 +1965,8 @@
   "ui.base.placeholder": "z. B. Heimatbasis, Außenposten 1",
   "ui.base.rename_hint": "[E] Basis umbenennen",
   "ui.base.default": "Basis",
+  "ui.base.life_support": "Lebenserhaltung: {name}",
+  "ui.hud.base_air": "Basis-Lebenserhaltung",
   "ui.hud.stash": "Lager",
   "ui.hud.stash_keys": "G nehmen · H einlagern",
   "vega.prologue.1": "Du erwachst im Pilotensitz eines kleinen Raumschiffs, gelandet auf einer Welt, die du nicht kennst. Dein Helm liegt in deinem Schoß. Hinter der Scheibe glitzern Sterne. Du hast keine Ahnung, wie du hierhergekommen bist.",

--- a/data/locales/en.json
+++ b/data/locales/en.json
@@ -1964,6 +1964,8 @@
   "ui.base.placeholder": "e.g. Home Base, Outpost 1",
   "ui.base.rename_hint": "[E] Rename base",
   "ui.base.default": "Base",
+  "ui.base.life_support": "Life support: {name}",
+  "ui.hud.base_air": "base life support",
   "ui.hud.stash": "Stash",
   "ui.hud.stash_keys": "G take · H store",
   "vega.prologue.1": "You wake in the pilot seat of a small ship, parked on a world you don't recognize. Your helmet rests in your lap. Stars glitter beyond the canopy. You have no idea how you got here.",

--- a/docs/user/USER_MANUAL.md
+++ b/docs/user/USER_MANUAL.md
@@ -362,6 +362,12 @@ separate unlock; admins can still disable it through server world rules.
   stone is the base's **position marker on the planet map** (key **M**), shown as a teal **⌂** with its name.
 - **One base per world** per player. **Mining** the base core removes the base. Walk up and press **E** on the
   stone to **name or rename** it (only the owner can).
+- **A base always has air**: the base core projects a **life-support field** over its whole zone (the same
+  cube where the base protects your blocks — about 8 blocks in every direction from the stone). Inside it your
+  **oxygen refills** even on toxic or airless worlds — the HUD marks the O2 bar with *(base life support)* and
+  greets you with *"Life support: <base name>"* when you step in. **Anyone** may breathe at a base (guests
+  still can't build or mine there), and the field disappears with the base if the core is mined. It even works
+  under water — sink the zone and you've built a diving dome.
 - On **Tab → Map**, a world where you have a base (or a station orbiting it) is **marked** and its details note
   *"You have a base/station here"*; you can also rename the base from there.
 

--- a/src/BlocksBeyondTheStars.GameServer/GameServer.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServer.cs
@@ -1265,13 +1265,20 @@ public sealed partial class GameServer
             // Standing physically inside the landed ship's cabin counts as life support too — a sealed cabin
             // gives air even on an airless planet, so you never suffocate inside your own ship (B41b).
             bool insideShip = !p.InEva && ShipInteriorContains(p.Position);
-            bool lifeSupport = !p.InEva && (p.AboardShip || insideShip || InStation(p.PlayerId) || !Rules.OxygenEnabled);
+            // A founded base's zone is a life-support field (issue #782): the Grundstein projects air over
+            // its whole protection cube — the same hand-wave station interiors already use. Any base counts,
+            // not just your own: visitors breathe too, the protection rules still keep them from editing.
+            bool atBase = !p.InEva && InAnyBaseZone(new Vector3i(
+                (int)System.Math.Floor(p.Position.X), (int)System.Math.Floor(p.Position.Y), (int)System.Math.Floor(p.Position.Z)));
+            bool lifeSupport = !p.InEva && (p.AboardShip || insideShip || atBase || InStation(p.PlayerId) || !Rules.OxygenEnabled);
             // Submerged underwater the suit runs on its own air, even on a breathable world — diving spends
             // the oxygen tank just like a toxic/airless atmosphere does (the extractor can't pull from water).
+            // Life support overrides this (ship cabin, station, base zone): an underwater base is a dome.
             bool submerged = !lifeSupport && !p.InEva && HeadUnderwater(p);
             // Above the atmosphere (built a tower up into space) the air runs out too, even on a breathable
-            // world — the suit tank drains until the player descends back below the line.
-            if (!submerged && !p.AboveAtmosphere && (lifeSupport || (!p.InEva && AtmosphereBreathable)))
+            // world — the suit tank drains until the player descends back below the line. Life support wins
+            // over the altitude line as well, so a base founded on a peak above it still breathes.
+            if (!submerged && (lifeSupport || (!p.AboveAtmosphere && !p.InEva && AtmosphereBreathable)))
             {
                 // Aboard the ship (life support), boarded on a station (its life support), oxygen disabled
                 // by rules, or a breathable atmosphere: regenerate, no drain (up to the tank capacity).

--- a/src/BlocksBeyondTheStars.GameServer/GameServerBases.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerBases.cs
@@ -47,8 +47,9 @@ public sealed partial class GameServer
         => _bases.Any(b => b.OwnerId == ownerId && b.Planet == body);
 
     /// <summary>Half-extent (in blocks) of a base's protected build zone: a cube centred on the base_core. Owner +
-    /// allies build/mine freely inside it; everyone else is blocked (place + mine + area tools). Tunable.</summary>
-    private const int BaseProtectionRadius = 8;
+    /// allies build/mine freely inside it; everyone else is blocked (place + mine + area tools). The same cube is
+    /// the base's life-support field (see <see cref="InAnyBaseZone"/>); shared with the client's HUD hint.</summary>
+    private const int BaseProtectionRadius = WorldConstants.BaseZoneRadius;
 
     /// <summary>True if the cell falls inside some player base's protected zone on the current world AND the actor
     /// may not edit it there. Owner + allies + admins build freely; for anyone else the whole zone is read-only.
@@ -92,6 +93,24 @@ public sealed partial class GameServer
         => System.Math.Abs(pos.X - core.X) <= BaseProtectionRadius
            && System.Math.Abs(pos.Y - core.Y) <= BaseProtectionRadius
            && System.Math.Abs(pos.Z - core.Z) <= BaseProtectionRadius;
+
+    /// <summary>True if the cell lies inside ANY founded base's zone on the current world (serve the session
+    /// first). Ownership is deliberately ignored: the base's life-support field breathes for visitors too —
+    /// the protection rules still keep them from editing anything. Same cube as the build protection, so the
+    /// one rule to teach is "where you can build is where you can breathe".</summary>
+    private bool InAnyBaseZone(Vector3i cell)
+    {
+        string body = _world.LocationId;
+        foreach (var b in _bases)
+        {
+            if (b.Planet == body && WithinBaseZone(b.Cell, cell))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
 
     /// <summary>Loads every founded base from persistence at server start (the base_core blocks themselves return via
     /// the block-edit store). Idempotent — clears first.</summary>

--- a/src/BlocksBeyondTheStars.Shared/World/WorldConstants.cs
+++ b/src/BlocksBeyondTheStars.Shared/World/WorldConstants.cs
@@ -32,6 +32,11 @@ public static class WorldConstants
     /// finite instead of an infinite N–S strip. ≈ a sphere's pole-to-pole span (half the equator).</summary>
     public const int LatitudeLimit = Circumference / 4;
 
+    /// <summary>Half-extent (in blocks) of a founded base's zone: the cube around the base_core block that is
+    /// both the build-protection zone and the base's life-support field (air). Shared so the client's HUD
+    /// hint and the server's authoritative checks can never disagree about the zone size.</summary>
+    public const int BaseZoneRadius = 8;
+
     // --- Longitude wrap helpers ---
     // Each takes an explicit circumference so a world can be any size; the no-arg overloads use the default
     // Circumference (6000) so existing callers/tests are unaffected. ChunksAround/LatitudeLimit have per-circ

--- a/tests/BlocksBeyondTheStars.Tests/BaseOxygenTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/BaseOxygenTests.cs
@@ -1,0 +1,185 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using System;
+using BlocksBeyondTheStars.GameServer;
+using BlocksBeyondTheStars.Networking.Transport;
+using BlocksBeyondTheStars.Persistence;
+using BlocksBeyondTheStars.Shared.Configuration;
+using BlocksBeyondTheStars.Shared.Content;
+using BlocksBeyondTheStars.Shared.Geometry;
+using Xunit;
+using SvGameServer = BlocksBeyondTheStars.GameServer.GameServer;
+
+namespace BlocksBeyondTheStars.Tests;
+
+/// <summary>
+/// The base life-support field (#782): a founded base's zone (the shared radius-8 cube around its base_core)
+/// always breathes — oxygen regenerates for ANYONE standing inside it, even on a world whose own air is not
+/// breathable, and the field vanishes together with the base when the core is mined. Rocky (toxic atmosphere)
+/// makes oxygen matter; every test position stays below rocky's atmosphere line (190), so only the toxic air —
+/// not the altitude — is what the base has to overcome.
+/// </summary>
+public sealed class BaseOxygenTests : IDisposable
+{
+    // Mid-air on rocky (terrain tops out well below): the core cell is empty, in reach, below the atmosphere line.
+    private const int CoreX = 1, CoreY = 120, CoreZ = 0;
+
+    private readonly string _root;
+    private readonly GameContent _content;
+
+    public BaseOxygenTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "bbts_baseoxy_" + Guid.NewGuid().ToString("N"));
+        _content = ContentLoader.LoadFromDirectory(TestPaths.DataDir());
+    }
+
+    private SvGameServer Start(out SqliteWorldRepository repo, string name)
+    {
+        repo = new SqliteWorldRepository(new SaveGamePaths(_root, name));
+        var st = new LoopbackServerTransport(new LoopbackLink());
+        var config = new ServerConfig
+        {
+            WorldName = name,
+            Seed = 7,
+            StartPlanet = "rocky", // toxic atmosphere → oxygen drains outside a life-support field
+            AutoSaveIntervalMinutes = 9999,
+            PlaceStarterShip = false,
+            PlaceSettlements = false,
+            PlaceWrecks = false,
+        };
+        var server = new SvGameServer(config, _content, st, repo);
+        server.Start();
+        return server;
+    }
+
+    /// <summary>Adds a player on foot. With no physical ship placed, UpdateAboard keeps the spawn default
+    /// (aboard = life support everywhere), so the flag must be dropped explicitly for oxygen to matter.</summary>
+    private static PlayerSession OnFoot(SvGameServer server, string name)
+    {
+        var p = server.AddLocalPlayer(name);
+        p.State.AboardShip = false;
+        return p;
+    }
+
+    /// <summary>Adds "Builder" hovering next to the core cell and founds their base at (CoreX, CoreY, CoreZ).</summary>
+    private static PlayerSession Founder(SvGameServer server)
+    {
+        var p = OnFoot(server, "Builder");
+        p.State.Position = new Vector3f(CoreX - 1, CoreY, CoreZ);
+        p.State.Inventory.Add("base_core", 2, 16);
+        server.PlaceBlock("Builder", CoreX, CoreY, CoreZ, "base_core");
+        Assert.Single(server.BaseSnapshots);
+        return p;
+    }
+
+    /// <summary>Ticks the environment with the player pinned at <paramref name="at"/> (re-set every tick so
+    /// nothing that nudges positions can drift the player out of / into the zone mid-test).</summary>
+    private static void TickAt(SvGameServer server, PlayerSession p, Vector3f at, int halfSeconds = 6)
+    {
+        for (int i = 0; i < halfSeconds; i++)
+        {
+            p.State.Position = at;
+            server.TickForTest(0.5);
+        }
+    }
+
+    [Fact]
+    public void InsideBaseZone_OxygenRefills_OutsideItDrains()
+    {
+        var server = Start(out var repo, "baseoxy");
+        using (repo)
+        {
+            var p = Founder(server);
+            Assert.False(server.AtmosphereBreathable, "rocky should be toxic for this test");
+
+            // Inside the zone (well off-centre, still within the radius-8 cube): the base breathes.
+            float inside = p.State.Oxygen = 50f;
+            TickAt(server, p, new Vector3f(CoreX + 5.5f, CoreY + 3f, CoreZ + 2.5f));
+            Assert.True(p.State.Oxygen > inside, $"Oxygen should refill inside the base zone (was {p.State.Oxygen}).");
+
+            // One step past the cube: the toxic air wins again.
+            float outside = p.State.Oxygen = 80f;
+            TickAt(server, p, new Vector3f(CoreX + 30.5f, CoreY, CoreZ + 0.5f));
+            Assert.True(p.State.Oxygen < outside, $"Oxygen should drain outside the base zone (was {p.State.Oxygen}).");
+        }
+    }
+
+    [Fact]
+    public void StrangerInSomeoneElsesBaseZone_AlsoBreathes()
+    {
+        var server = Start(out var repo, "baseoxyguest");
+        using (repo)
+        {
+            Founder(server);
+
+            // A second, unallied player: the field is not ownership-gated — visitors breathe too
+            // (the build protection still keeps them from touching anything).
+            var guest = OnFoot(server, "Visitor");
+            float before = guest.State.Oxygen = 50f;
+            TickAt(server, guest, new Vector3f(CoreX - 4.5f, CoreY + 1f, CoreZ - 3.5f));
+            Assert.True(guest.State.Oxygen > before, $"A visitor should breathe in a stranger's base zone (was {guest.State.Oxygen}).");
+        }
+    }
+
+    [Fact]
+    public void MiningTheBaseCore_RemovesTheAirField()
+    {
+        var server = Start(out var repo, "baseoxygone");
+        using (repo)
+        {
+            var p = Founder(server);
+            var spot = new Vector3f(CoreX + 3.5f, CoreY + 1f, CoreZ + 0.5f);
+
+            float before = p.State.Oxygen = 50f;
+            TickAt(server, p, spot);
+            Assert.True(p.State.Oxygen > before, $"Sanity: the founded base should breathe (was {p.State.Oxygen}).");
+
+            // Pull the Grundstein: the base — and with it the air field — is gone the moment the core is.
+            p.State.Position = new Vector3f(CoreX - 1, CoreY, CoreZ);
+            server.MineBlock("Builder", CoreX, CoreY, CoreZ);
+            Assert.Empty(server.BaseSnapshots);
+
+            float after = p.State.Oxygen = 80f;
+            TickAt(server, p, spot);
+            Assert.True(p.State.Oxygen < after, $"Oxygen should drain again once the base is dissolved (was {p.State.Oxygen}).");
+        }
+    }
+
+    [Fact]
+    public void SubmergedInsideTheZone_StillBreathes_DomeBehavior()
+    {
+        var server = Start(out var repo, "baseoxydome");
+        using (repo)
+        {
+            var p = Founder(server);
+
+            // A pool inside the zone: stone floor + a deep body of water (mirrors OxygenTests' pool build).
+            var water = _content.GetBlock("water")!.NumericId;
+            var stone = _content.GetBlock("stone")!.NumericId;
+            int floorY = CoreY - 4;
+            for (int x = CoreX + 1; x <= CoreX + 7; x++)
+                for (int z = CoreZ - 3; z <= CoreZ + 3; z++)
+                {
+                    server.World.SetBlock(new Vector3i(x, floorY, z), stone);
+                    for (int y = floorY + 1; y <= floorY + 8; y++) server.World.SetBlock(new Vector3i(x, y, z), water);
+                }
+
+            // Head fully underwater, still inside the cube: life support overrides the diving drain —
+            // an underwater base is a dome (same rule as diving inside the ship's cabin).
+            float before = p.State.Oxygen = 50f;
+            TickAt(server, p, new Vector3f(CoreX + 4.5f, floorY + 2f, CoreZ + 0.5f));
+            Assert.True(p.State.Oxygen > before, $"Submerged inside the base zone the player should still breathe (was {p.State.Oxygen}).");
+        }
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+            if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true);
+        }
+        catch { }
+    }
+}


### PR DESCRIPTION
Closes #782

## What

Standing anywhere inside a founded base's protection cube (the radius-8 Chebyshev zone around the `base_core`) now counts as **life support** in the environment tick — oxygen regenerates there even on toxic/airless worlds. One teachable rule: *where you can build is where you can breathe.*

- **Any** base breathes for **anyone** (visitors included) — the build protection still keeps non-owners/non-allies from editing.
- Life support now also beats the `AboveAtmosphere` altitude drain (a base founded past the line still breathes; ship cabins get the same fix, they previously drained up there despite B41b) and the diving drain (an underwater base zone is a dome — consistent with diving inside the ship's cabin).
- Suit **energy** recharge intentionally stays ship/heal-tank-only.
- No new game rule (avoids the save-baked RulesOverride lift); gated by the existing `OxygenEnabled`.
- Radius constant moved to `WorldConstants.BaseZoneRadius` (shared) so the client mirror can't diverge.

## Client

HudUi computes the zone client-side from the already-streamed `BaseList` — **no protocol change**. On worlds whose own air is NOT breathable it fires a one-shot "Life support: <base name>" toast on zone entry and suffixes the O2 bar with "(base life support)". New locale keys `ui.base.life_support` + `ui.hud.base_air` (DE+EN).

## Why

Life support was a per-player boolean (ship / boarded station / breathable sky). A founded base gave zero air, so on airless worlds your own base suffocated you — and the `oxygen_extractor` is useless there (extractability 0). Now: craft the Grundstein aboard the ship, land, place it — the pad is your air pocket. Space stations already behaved this way; this closes the planet-side gap.

## Tests

- New `BaseOxygenTests` (4, on toxic rocky below its atmosphere line): zone regen + outside drain, unallied visitor breathes, mining the core removes the field, submerged-in-zone dome behavior.
- Full local suite green: **1437 server + 187 client**, 0 failures.
- Local Unity Windows batch build green (fresh `BlocksBeyondTheStars.Client.dll` verified).
- Docs: user manual base section + TODO.md entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)