### PR TITLE
docs: bring README, USER_MANUAL, DEVELOPER + doc index current

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Design your ship block by block, fly real system-scale routes, dock at space sta
 *   **The VEGA Protocol:** An optional story campaign narrated by your ship's AI companion.
 *   **Windows & Linux:** Native desktop clients — no Wine/Proton needed (an experimental macOS build exists too).
 *   **Keyboard, mouse & controller:** Play with keyboard + mouse or an Xbox/XInput gamepad — both work at once, and menus are pad-navigable (controller support is experimental).
+*   **Play in your language:** the whole game is localized in **English, German, French and Spanish** — and community translations are welcome (Italian is underway; see [docs/developer/TRANSLATION_GUIDE.md](docs/developer/TRANSLATION_GUIDE.md)).
 
 ## 🕹️ Ways to Play
 
@@ -144,7 +145,9 @@ Want to see your name here? See **[CONTRIBUTING.md](CONTRIBUTING.md)**.
 > [docs/developer/ARCHITECTURE.md](docs/developer/ARCHITECTURE.md) and every developer doc is indexed in
 > [docs/developer/README.md](docs/developer/README.md). (The original German requirement specs under `plans/`
 > were consolidated and removed.)
-> Docs and code comments are **English**. In-game text is **bilingual (German + English)**.
+> Docs and code comments are **English**. In-game text is **localized — English, German, French and
+> Spanish are complete; Italian is a community translation in progress**
+> (see [docs/developer/TRANSLATION_GUIDE.md](docs/developer/TRANSLATION_GUIDE.md)).
 
 ## Project Status
 
@@ -251,7 +254,7 @@ oxygen, damage, blueprints or travel.
 |---|---|
 | Client | Unity 6 LTS (6000.4.x), URP + C# (Windows, Linux, experimental macOS) — see [`client/`](client/) |
 | Server | .NET 10, standalone console host (no Unity runtime) |
-| Admin UI | ASP.NET Core 8 minimal API + HTML dashboard |
+| Admin UI | ASP.NET Core (.NET 10) minimal API + HTML dashboard |
 | Database | SQLite (default, portable); optional PostgreSQL for hosted realms |
 | Realtime net | LiteNetLib UDP + MessagePack for native clients; WebSocket + JSON envelope for WebGL |
 | Shared logic | `netstandard2.1` so the same code runs in Unity *and* the server |
@@ -275,7 +278,7 @@ client/                         Unity project (scripts + scaffold + Assets/Tests
 ai-backend/                     optional Python LLM service (mission/NPC/ship-AI text) — game runs without it
 tools/                          editor-export merge tools (Python) + AI asset generation (tools/ai-assets)
 data/                           data-driven content (blocks, items, recipes, blueprints, modules, planets)
-data/locales/                   localization (en.json, de.json)
+data/locales/                   localization (en, de, fr, es + community it)
 docs/user/                      player-facing manual (USER_MANUAL.md)
 docs/developer/                 architecture, design/how-it-works docs, ADRs (docs/developer/adr/) — see its README.md index
 scripts/                        build-client.ps1 (Windows) + build-client.sh (Linux) + publish scripts
@@ -394,24 +397,31 @@ changes are needed to add content. Player-facing names use localization keys res
 ## Status
 
 A fully playable client + server game: **multiple star systems** (each with its own sun, planets,
-moons and asteroid fields), procedurally generated worlds that wrap east–west (walk around the
-planet, seam-free), 18 planet types including exotic ones (skylands, fungal, corrupted, ocean,
-salt flats, …) with their own flora and fauna, swimming/diving, creature taming, a craftable hover
-speeder, mining → crafting → blueprints →
-ship building, real system-scale space flight (with jumps between systems) with stations,
-settlements and NPCs, peaceful NPC trader traffic, rare **factories** with roster-limited
+moons and **asteroid belts** you can mine from the ship or on an EVA), procedurally generated
+worlds that wrap east–west (walk around the planet, seam-free), 21 planet types including exotic
+ones (skylands, fungal, corrupted, ocean, salt flats, …) with their own flora and fauna,
+swimming/diving, a survival **temperature/climate system**, **fire** you can start and put out
+(vegetation-only — nothing built ever burns), creature taming, a craftable hover
+speeder, mining → crafting → blueprints (with **tiered gear upgrades** that consume their
+predecessor) → ship building, real system-scale space flight (with jumps between systems) with
+stations, settlements and NPCs, peaceful NPC trader traffic, **bounty missions** on bandit camps
+and raider ships, rare **factories** with roster-limited
 production terminals, fallen **ruins** and **treasure chests**, **access-code claiming** that
 turns a factory into your own editable base, the
 **"VEGA Protocol" story campaign** (a swappable, story-agnostic engine with lore fragments, three
-Guardian machine types and a two-route finale), multiplayer with per-player ships, **player
-alliances**, shared bases and trading, planet **bases + teleporter pads**, material dyeing and
-colored-light building, in-game customization (avatar pixel-face editor, content/ship/station
-editors), an in-game **Codex wiki + data-cube arcade minigames**, a built-in **music library**,
-the VEGA ship-AI onboarding/advisor companion, world-creation options, and an optional LLM backend
-for dynamic dialogue/mission text. Self-hostable dedicated server. **Native Windows and Linux**
+Guardian machine types and a two-route finale) opened by a watchable **intro cinematic** and a
+staged prologue, multiplayer with per-player ships, **player
+alliances**, shared bases and trading, planet **bases + teleporter pads** with a life-support
+field and **airtight sealed rooms** (energy door, shield dome, leak warnings), material dyeing and
+colored-light building, **low-tech furniture** (bed, campfire, chairs you can actually sit on) and
+**player-paintable 32×32 block designs**, in-game customization (avatar pixel-face editor,
+content/ship/station editors), an in-game **Codex wiki + data-cube arcade minigames**, a built-in
+**music library**, the VEGA ship-AI onboarding/advisor companion, world-creation options, and an
+optional LLM backend for dynamic dialogue/mission text — all of it playable in **English, German,
+French and Spanish**. Self-hostable dedicated server. **Native Windows and Linux**
 clients (no Wine/Proton; an experimental macOS build exists), and **opt-in automatic crash reporting**
 so problems get fixed faster.
-Currently **1364 xUnit tests pass** (1219 server/shared + 145 headless client<->server).
+Currently **1739 xUnit tests pass** (1545 server/shared + 194 headless client<->server).
 
 See [TODO.md](TODO.md) for the current Done/Open status, the
 [user manual](docs/user/USER_MANUAL.md) for controls/mechanics/commands, and [AGENTS.md](AGENTS.md)

--- a/TODO.md
+++ b/TODO.md
@@ -7,7 +7,7 @@ plans live under [docs/](docs/) (committed); the long-range direction is the str
 keep it current when controls/features change. Last consolidated 2026-06-04.
 
 **Build:** `scripts/build-client.ps1` (Windows) or `scripts/build-client.sh` (Linux) — publishes shared libs + bundled server + Unity player.
-**Test:** `./scripts/run-tests.sh` — currently **1466 server + 154 client passing** (2026-08-04). Locale parity (en/de) is enforced by a test.
+**Test:** `./scripts/run-tests.sh` — currently **1545 server + 194 client passing** (2026-08-08). Locale parity (en/de) is enforced by a test.
 CI runs two tiers: PRs skip the tests marked `[Trait("Category", "Slow")]`; pushes to `main` and the release workflow run the full suite. CI builds/runs
 tests in Release, and a per-test duration guardrail (`scripts/check-test-durations.py`, PRs only) fails the gate when a non-Slow test exceeds 120 s.
 The server suite is sharded across a 4-runner matrix (`scripts/partition-tests.py` + checked-in weights; `Tests passed` is the required fan-in check) — PR gate ~4½ min.
@@ -7284,6 +7284,23 @@ is **pre-approved** (keys in `tools/ai-assets/.env`, run via `uv`).
    footprint so nothing seeps up. Leave landing at the seabed (so it *can* land underwater) unless the user
    prefers dry-land preference (see questions). Tests: collider excludes fluids; fluid won't enter a stamped
    ship interior; ship interior is water-free after landing in a sea.
+
+---
+
+## ✅ Done (2026-08-08): docs refresh — README, USER_MANUAL, DEVELOPER + doc index brought current
+
+An accuracy pass over the four top-level docs after the v2026.8.x feature wave:
+
+- **README.md** — "bilingual DE/EN" → localized EN/DE/FR/ES (+ community IT), locales listing, planet-type
+  count 18 → 21, Admin-UI ".NET 8" → .NET 10, refreshed test count, and the Status paragraph now covers
+  temperature, fire, base life support/sealed rooms, bounty missions, intro cinematic, furniture,
+  paintable blocks, tiered upgrades and the four languages; new "Play in your language" feature bullet.
+- **USER_MANUAL.md** — fixed the stale "Last updated" line and DE/EN claims; documented the Settings
+  language picker (45 % gate), the intro cinematic + staged prologue, tiered upgrades consuming their
+  predecessor (#798/#799), and a new "Missions & bounties" section (#730/#731).
+- **DEVELOPER.md** — prerequisites said ".NET SDK 8.x"; the repo targets net10.0 (README already said 10).
+- **docs/developer/README.md** — indexed six previously missing docs (HOSTED_WORLDS, TRANSLATION_GUIDE,
+  FACTORIES_RUINS_AND_CLAIMING, VOICE_CHAT, PLAYER_FEEDBACK, REPORT_HOST) and ADR 0012 (CalVer).
 
 ---
 

--- a/docs/developer/DEVELOPER.md
+++ b/docs/developer/DEVELOPER.md
@@ -8,8 +8,8 @@ built player. Contributor rules (language, architecture, conventions) live in
 ## Prerequisites
 
 | Tool | Version | Notes |
-|---|---|---|---|
-| .NET SDK | 8.x | builds the server, shared libs, tests and tools |
+|---|---|---|
+| .NET SDK | 10.x | builds the server, shared libs, tests and tools (all projects target `net10.0` / `netstandard2.1`) |
 | Unity Editor | 6 LTS (6000.4.x) | required only for the client build; default paths: `C:\Program Files\Unity\Hub\Editor\6000.4.9f1\Editor\Unity.exe` (Windows) or `/opt/Unity/Hub/Editor/6000.4.9f1/Editor/Unity` (Linux) |
 | Windows | 10/11 | for the Windows client build; the dedicated server also publishes for Linux |
 | Linux | any modern distro | for the Linux client build and/or server hosting |

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -6,7 +6,8 @@ the hard contributor rules are in [../../AGENTS.md](../../AGENTS.md); the projec
 (vision · mission · roadmap) is in [../strategy/](../strategy/vision.md).
 
 These are *how it works* / *why it is built this way* references — not pre-implementation checklists (status
-belongs in TODO.md). Each doc states its own status near the top. Last reorganised 2026-06-19.
+belongs in TODO.md). Each doc states its own status near the top. Last reorganised 2026-06-19; index
+refreshed 2026-08-08.
 
 ## Start here
 
@@ -24,6 +25,10 @@ belongs in TODO.md). Each doc states its own status near the top. Last reorganis
   tests to copy from, the content/locale fixtures, what "meaningful" assertions look like, and the CI
   analyzer traps. Start here for a first test contribution (e.g. issue #571).
 - [SELF_HOSTING.md](SELF_HOSTING.md) — run and host a dedicated server, config keys, the web portal & updates.
+- [HOSTED_WORLDS.md](HOSTED_WORLDS.md) — the hosted-worlds ("Official Worlds") service: control plane
+  (WorldHost), one container per world, routing, portal and operations.
+- [TRANSLATION_GUIDE.md](TRANSLATION_GUIDE.md) — contributing a translation: locale files, coverage
+  tooling, the 45 % settings-picker gate, and the machine-first-pass workflow.
 
 ## World & worldgen
 
@@ -60,6 +65,9 @@ belongs in TODO.md). Each doc states its own status near the top. Last reorganis
 - [NPC_TRADER_SHIPS.md](NPC_TRADER_SHIPS.md) — peaceful ambient NPC trader traffic.
 - [MATTER_CONVERTER.md](MATTER_CONVERTER.md) — the Transmuter station: craft scarce ore from spare
   terrain (lossy `matter_dust` intermediate, no Tier-3 output).
+- [FACTORIES_RUINS_AND_CLAIMING.md](FACTORIES_RUINS_AND_CLAIMING.md) — factories with roster-limited
+  production terminals, ruins/treasure chests, and access-code claiming.
+- [VOICE_CHAT.md](VOICE_CHAT.md) — push-to-talk voice chat + the tiered radio reach (planet/system/galaxy).
 
 ## Story & content
 
@@ -76,6 +84,8 @@ belongs in TODO.md). Each doc states its own status near the top. Last reorganis
 - [STATION_SETTLEMENT_EDITOR.md](STATION_SETTLEMENT_EDITOR.md) — the station/settlement structure editor.
 - [EDITORS_WORLDGEN_AND_DEV_LABELLING_ANALYSIS.md](EDITORS_WORLDGEN_AND_DEV_LABELLING_ANALYSIS.md) —
   editor output → worldgen integration + dev/test labelling.
+- [PLAYER_FEEDBACK.md](PLAYER_FEEDBACK.md) — the in-game F1/F2 feedback + crash-report pipeline.
+- [REPORT_HOST.md](REPORT_HOST.md) — ReportHost, the bug-report inbox the feedback pipeline uploads to.
 
 ## Forward-looking
 
@@ -99,3 +109,4 @@ ones are marked, not deleted.
 - [0009 — Embedded browser for the in-game Wiki + Arcade](adr/0009-embedded-browser-wiki-arcade.md) — *superseded (now native UI)*
 - [0010 — Velopack distribution + self-host portal](adr/0010-velopack-distribution-and-self-host-portal.md)
 - [0011 — CodeQL code scanning strategy](adr/0011-codeql-security-scanning-strategy.md)
+- [0012 — CalVer date-based versioning](adr/0012-calver-date-based-versioning.md)

--- a/docs/user/USER_MANUAL.md
+++ b/docs/user/USER_MANUAL.md
@@ -6,9 +6,10 @@ chat/admin commands. This is a living document.
 > **Maintainers:** keep this file current. Whenever a control changes, a feature is added, or a command
 > is introduced, update the relevant section here in the same change. This manual is the single source of
 > truth for player-facing operation. (Written in English per project doc policy; in-game text itself is
-> bilingual DE/EN.)
+> localized — English, German, French and Spanish are complete, further community translations such as
+> Italian are in progress.)
 
-Last updated: 2026-07-04.
+Last updated: 2026-08-08.
 
 ---
 
@@ -49,8 +50,15 @@ Last updated: 2026-07-04.
 - **Window mode** (Settings tab): the **"Window mode" / "Fenstermodus"** option cycles **Windowed → Borderless →
   Exclusive** and applies immediately. The default is **Windowed** (a normal movable, maximizable window);
   Borderless fills whichever monitor the window currently sits on; Exclusive is classic full-screen.
+- **Language** (Settings tab): switch the whole game between **English, German, French and Spanish**.
+  Further languages appear in the picker automatically once their community translation clears **45 %
+  coverage** (Italian is underway — want to help? See `docs/developer/TRANSLATION_GUIDE.md` in the
+  repository).
+- On the **very first start** a short (~28 s) **intro cinematic** plays between the title splash and the
+  menu — any key skips it, and the Credits screen's **"Watch intro"** button replays it any time.
 - On a **new world**, the ship AI **VEGA** boots up and walks you through the first hour (see §5 →
-  VEGA). Veteran saves get a one-line "systems online" instead.
+  VEGA) — her opening narration is staged like a scene (letterbox, an orbit shot of your landed ship);
+  **Esc** skips it. Veteran saves get a one-line "systems online" instead.
 
 ---
 
@@ -295,6 +303,11 @@ separate unlock; admins can still disable it through server world rules.
   (sand, dirt, stone, …) into *matter dust* and synthesises it back into ore — a sink for surplus digging.
 - **Blueprints** gate advanced recipes — unlock them with **knowledge points** (earned by scanning) plus
   research materials; some require prerequisite blueprints.
+- **Tiered upgrades consume their predecessor:** where an item is a straight upgrade of another —
+  oxygen tanks II/III, the terrain scanner, weapon upgrade chains, the AI cores — the recipe **requires
+  and consumes the previous tier**, so you never end up carrying a redundant Mk1 after building the Mk2.
+  Fitting the `ai_core_mk3` module **replaces** the fitted Mk2 and returns half its materials as salvage.
+  (Your starter gear — basic drill, scrap pistol — is deliberately chain-free.)
 - **Disassemble** (at a workshop): break a crafted item back into ~50 % of its recipe inputs. In the
   Inventory detail pane, select the item and press **Disassemble** (shows what it recovers). Raw resources
   and refinery/transmuter-synthesised ore can't be disassembled.
@@ -333,7 +346,7 @@ separate unlock; admins can still disable it through server world rules.
   your past visits), **mission-board flavour text** (title/description written around the fixed job),
   occasional extra **VEGA banter**, and admin-generated missions (`/ai <prompt>`, see §7).
 - It is **off by default**, and the game is fully playable without it — every AI line has a localized
-  scripted fallback (DE+EN), so you simply see the standard text instead. AI text is flavour only;
+  scripted fallback in every supported language, so you simply see the standard text instead. AI text is flavour only;
   it never decides gameplay (the server validates everything).
 - Enabling it is a server-side setup: run the `ai-backend/` service and set `aiLevel` in the server
   config — see [SELF_HOSTING.md](../developer/SELF_HOSTING.md) §8.
@@ -510,6 +523,18 @@ separate unlock; admins can still disable it through server world rules.
   refuse or open fire and it fights. Raiders only appear where the rules let you shoot back.
 - The **"Bandits"** world option (world options / at creation) scales all three — Off disables them
   entirely (peaceful/family presets default to Off).
+
+### Missions & bounties
+- **Mission boards** stand in settlements and aboard space stations; vendors and board givers hand out
+  gather/delivery jobs. Accepted missions are tracked in the **Tab → Missions** tab; report back to the
+  giver for the reward.
+- **Camp bounty:** a settlement mission board on a planet with an uncleared **bandit camp** offers a
+  bounty to drive the bandits out. Accepting it marks the camp on your planet map (key **M**); clear the
+  camp — everyone holding the bounty gets credit, so it's co-op friendly — and report back for a reward
+  that beats the usual gather jobs.
+- **Raider bounty:** station mission boards in **pirate systems** put a price on the raider ship prowling
+  the sector. While you hold the bounty, the raider *will* show up on your next flight — destroy it and
+  report back. Bounties follow the world's **Bandits** option: no bandits, no bounty missions.
 
 ### Trade
 - **Player ↔ player:** press **T** near a player to open a modal trade. Each side stages an offer (+/−) and


### PR DESCRIPTION
## Summary

An accuracy pass over the four top-level docs after the v2026.8.x feature wave (analysis first, then everything in one go):

**README.md**
- "bilingual (German + English)" → localized **EN/DE/FR/ES** (+ community Italian in progress), repo-layout locales listing updated
- planet types **18 → 21** (counted from `data/planets.json`, spawnable non-asteroid types)
- Tech-stack table: Admin UI "ASP.NET Core 8" → **.NET 10** (matches `BlocksBeyondTheStars.Api.csproj`)
- test count **1364 → 1739** (1545 server/shared + 194 client — from the full-tier CI run on `main` @ d60d37e3)
- Status paragraph now covers: temperature/climate, fire, base life support + airtight sealed rooms, bounty missions, intro cinematic + staged prologue, low-tech furniture, paintable block designs, tiered upgrades, asteroid-belt/EVA mining, four languages
- new "Play in your language" feature bullet

**docs/user/USER_MANUAL.md**
- fixed the stale "Last updated: 2026-07-04" line (file was actually maintained through #824) and the DE/EN-only claims
- documented: Settings **language picker** (45 % coverage gate), **intro cinematic** + staged VEGA prologue, **tiered upgrades consume their predecessor** (#798/#799, incl. Mk3-replaces-Mk2 half salvage), new **"Missions & bounties"** section (#730/#731)

**docs/developer/DEVELOPER.md**
- prerequisites said ".NET SDK 8.x" — the repo targets net10.0 everywhere (README already required .NET 10); also fixes a malformed table separator row

**docs/developer/README.md (index)**
- indexed six existing-but-unlisted docs: HOSTED_WORLDS, TRANSLATION_GUIDE, FACTORIES_RUINS_AND_CLAIMING, VOICE_CHAT, PLAYER_FEEDBACK, REPORT_HOST
- added ADR 0012 (CalVer) to the ADR list

**TODO.md** — refreshed the test-count header line + Done entry for this pass.

Docs-only change — no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)