### PR TITLE
feat(ui): sort craft & ship-module lists by reachability

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7287,6 +7287,21 @@ is **pre-approved** (keys in `tools/ai-assets/.env`, run via `uv`).
 
 ---
 
+## ✅ Done (2026-08-08): craft & ship-module lists sorted by reachability (#826)
+
+The crafting list and the ship-module list used to show entries in `data/recipes.json` /
+`data/ship_modules.json` authoring order — locked entries buried the next thing a player could
+actually build. Both lists now sort into three tiers: **craftable now** → **blueprint unlocked but
+materials missing** → **blueprint locked**. Within a tier, simpler things come first: fewest distinct
+input materials, then lowest *craft depth* of the inputs (raw resource = 0, each crafting step +1 —
+computed once in `GameContent`, market barter excluded), then total unit count, then authored order
+(stable sort). The within-tier key is inventory-independent, so cards only move when they change tier
+(e.g. an item becomes craftable and jumps to the top). Station proximity deliberately stays out of the
+tier — the list must not reshuffle while walking around; it still gates the status colour and the
+craft button. Market, tech tree, colour and shape lists keep their existing order.
+
+---
+
 ## ✅ Done (2026-08-08): docs refresh — README, USER_MANUAL, DEVELOPER + doc index brought current
 
 An accuracy pass over the four top-level docs after the v2026.8.x feature wave:

--- a/client/Assets/BlocksBeyondTheStars/Scripts/CraftingTechShipUI.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/CraftingTechShipUI.cs
@@ -794,6 +794,7 @@ namespace BlocksBeyondTheStars.Client
             }
 
             float y = 0f;
+            var entries = new List<(RecipeDefinition r, string outItem, bool can)>();
             foreach (var r in Game.Content.Recipes.Values)
             {
                 var outItem = r.Outputs.FirstOrDefault();
@@ -822,8 +823,28 @@ namespace BlocksBeyondTheStars.Client
                     continue;
                 }
 
-                AddCard(y, ItemName(outItem.Item), IconFor(outItem.Item), can ? L("ui.craft.ready") : L("ui.craft.blocked"),
-                    can ? UiKit.Ok : new Color(1f, 0.5f, 0.5f), r.Key, () => { _selected = r.Key; RebuildDetail(); }, contentKey: outItem.Item);
+                entries.Add((r, outItem.Item, can));
+            }
+
+            // Reachability ordering (#826): craftable first, blueprint-unlocked-but-missing-materials in the
+            // middle, blueprint-locked last; within a tier simpler recipes first. The within-tier key is
+            // static (inventory-independent), so cards only move when they change tier. Market keeps the
+            // authored order — barter offers are a vendor's stall, not a progression list.
+            if (_category != "market")
+            {
+                entries = entries
+                    .OrderBy(e => ReachTier(e.r.RequiredBlueprint, e.r.Inputs))
+                    .ThenBy(e => e.r.Inputs.Count)
+                    .ThenBy(e => Game.Content.MaxInputDepth(e.r.Inputs))
+                    .ThenBy(e => e.r.Inputs.Sum(i => i.Count))
+                    .ToList();
+            }
+
+            foreach (var e in entries)
+            {
+                string key = e.r.Key;
+                AddCard(y, ItemName(e.outItem), IconFor(e.outItem), e.can ? L("ui.craft.ready") : L("ui.craft.blocked"),
+                    e.can ? UiKit.Ok : new Color(1f, 0.5f, 0.5f), key, () => { _selected = key; RebuildDetail(); }, contentKey: e.outItem);
                 y += 88f;
             }
 
@@ -1110,7 +1131,14 @@ namespace BlocksBeyondTheStars.Client
 
             if (_category == "all" || _category == "modules")
             {
-                foreach (var m in Game.Content.ShipModules.Values.Where(m => !m.Mandatory))
+                // Same reachability ordering as the craft list (#826): buildable → materials missing →
+                // blueprint locked, simpler modules first inside each tier.
+                var modules = Game.Content.ShipModules.Values.Where(m => !m.Mandatory)
+                    .OrderBy(m => ReachTier(m.RequiredBlueprint, m.BuildCost))
+                    .ThenBy(m => m.BuildCost.Count)
+                    .ThenBy(m => Game.Content.MaxInputDepth(m.BuildCost))
+                    .ThenBy(m => m.BuildCost.Sum(c => c.Count));
+                foreach (var m in modules)
                 {
                     if (!MatchesSearch(L($"module.{m.Key}.name")))
                     {
@@ -3300,6 +3328,20 @@ namespace BlocksBeyondTheStars.Client
 
             reason = string.Empty;
             return true;
+        }
+
+        /// <summary>Reachability tier for the list ordering (#826): 0 = craftable now (blueprint unlocked +
+        /// materials owned), 1 = blueprint unlocked but materials missing, 2 = blueprint locked. Station
+        /// proximity is deliberately NOT part of the tier — the order must not reshuffle while walking
+        /// around; the station only keeps gating the status colour and the craft button.</summary>
+        private int ReachTier(string requiredBlueprint, List<BlocksBeyondTheStars.Shared.Definitions.ItemAmount> cost)
+        {
+            if (!BlueprintOk(requiredBlueprint))
+            {
+                return 2;
+            }
+
+            return HasAll(cost) ? 0 : 1;
         }
 
         private bool BlueprintOk(string bp) => string.IsNullOrEmpty(bp) || Game.UnlockedBlueprints.Contains(bp);

--- a/src/BlocksBeyondTheStars.Shared/Content/GameContent.cs
+++ b/src/BlocksBeyondTheStars.Shared/Content/GameContent.cs
@@ -32,6 +32,7 @@ public sealed class GameContent
     private readonly Dictionary<string, MissionDefinition> _missions;
     private readonly BlockDefinition?[] _blocksById;
     private readonly Dictionary<GameLocale, Dictionary<string, string>> _locales;
+    private readonly Dictionary<string, int> _craftDepth = new(StringComparer.Ordinal);
 
     public IReadOnlyDictionary<string, BlockDefinition> Blocks => _blocks;
     public IReadOnlyDictionary<string, ItemDefinition> Items => _items;
@@ -246,6 +247,7 @@ public sealed class GameContent
         MarkShapeableDefaults();
         MarkFloraHostDefaults();
         MarkAirtightDefaults();
+        ComputeCraftDepths();
 
         // Palette lookup: index by numeric id (air at 0).
         ushort max = 0;
@@ -368,6 +370,86 @@ public sealed class GameContent
                     block.FloraHost = true;
                 }
             }
+        }
+    }
+
+    /// <summary>
+    /// How many crafting steps deep an item sits: 0 = raw resource (nothing produces it), otherwise
+    /// 1 + the deepest input of its shallowest producing recipe. Market (barter) trades are excluded —
+    /// they are exchanges, not production, and could form cycles. Computed once at load so the client's
+    /// craft-list ordering (#826) is deterministic across sessions.
+    /// </summary>
+    public int CraftDepth(string itemKey) => _craftDepth.TryGetValue(itemKey, out var d) ? d : 0;
+
+    /// <summary>The deepest <see cref="CraftDepth"/> across a recipe/build cost (0 for an empty cost).</summary>
+    public int MaxInputDepth(IEnumerable<ItemAmount> cost)
+    {
+        int max = 0;
+        foreach (var c in cost)
+        {
+            max = Math.Max(max, CraftDepth(c.Item));
+        }
+
+        return max;
+    }
+
+    private void ComputeCraftDepths()
+    {
+        var byOutput = new Dictionary<string, List<RecipeDefinition>>(StringComparer.Ordinal);
+        foreach (var r in _recipes.Values)
+        {
+            if (r.Station == CraftingStation.Market)
+            {
+                continue;
+            }
+
+            foreach (var o in r.Outputs)
+            {
+                if (!byOutput.TryGetValue(o.Item, out var list))
+                {
+                    byOutput[o.Item] = list = new List<RecipeDefinition>();
+                }
+
+                list.Add(r);
+            }
+        }
+
+        // Depth-first with a visiting set as cycle guard: an input currently being resolved counts as
+        // raw (depth 0), which keeps the result finite and deterministic even if recipes ever loop.
+        var visiting = new HashSet<string>(StringComparer.Ordinal);
+
+        int Depth(string item)
+        {
+            if (_craftDepth.TryGetValue(item, out var known))
+            {
+                return known;
+            }
+
+            if (!byOutput.TryGetValue(item, out var producers) || !visiting.Add(item))
+            {
+                return 0;
+            }
+
+            int best = int.MaxValue;
+            foreach (var r in producers)
+            {
+                int deepest = 0;
+                foreach (var input in r.Inputs)
+                {
+                    deepest = Math.Max(deepest, Depth(input.Item));
+                }
+
+                best = Math.Min(best, 1 + deepest);
+            }
+
+            visiting.Remove(item);
+            _craftDepth[item] = best;
+            return best;
+        }
+
+        foreach (var item in byOutput.Keys)
+        {
+            Depth(item);
         }
     }
 

--- a/tests/BlocksBeyondTheStars.Tests/CraftDepthTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/CraftDepthTests.cs
@@ -1,0 +1,120 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using BlocksBeyondTheStars.Shared.Content;
+using BlocksBeyondTheStars.Shared.Definitions;
+using BlocksBeyondTheStars.Shared.Localization;
+using Xunit;
+
+namespace BlocksBeyondTheStars.Tests;
+
+/// <summary>
+/// The craft-depth metric behind the reachability ordering of the crafting and ship-module
+/// lists (#826): raw resources are depth 0, each crafting step adds one, market barter never counts.
+/// </summary>
+public class CraftDepthTests
+{
+    private static GameContent Build(params RecipeDefinition[] recipes) => new(
+        blocks: Array.Empty<BlockDefinition>(),
+        items: new[]
+        {
+            new ItemDefinition { Key = "ore" },
+            new ItemDefinition { Key = "plate" },
+            new ItemDefinition { Key = "gadget" },
+        },
+        recipes: recipes,
+        blueprints: Array.Empty<BlueprintDefinition>(),
+        shipModules: Array.Empty<ShipModuleDefinition>(),
+        locales: new Dictionary<GameLocale, Dictionary<string, string>>());
+
+    private static RecipeDefinition Recipe(string key, string output, params string[] inputs) => new RecipeDefinition
+    {
+        Key = key,
+        Outputs = { new ItemAmount(output, 1) },
+    }.WithInputs(inputs);
+
+    [Fact]
+    public void RawResource_HasDepthZero_AndEachStepAddsOne()
+    {
+        var content = Build(
+            Recipe("plate", "plate", "ore"),
+            Recipe("gadget", "gadget", "plate"));
+
+        Assert.Equal(0, content.CraftDepth("ore"));
+        Assert.Equal(1, content.CraftDepth("plate"));
+        Assert.Equal(2, content.CraftDepth("gadget"));
+    }
+
+    [Fact]
+    public void SeveralProducers_TheShallowestRecipeWins()
+    {
+        // gadget can be crafted from raw ore directly OR from the deeper plate — depth is the cheap path.
+        var content = Build(
+            Recipe("plate", "plate", "ore"),
+            Recipe("gadget_deep", "gadget", "plate"),
+            Recipe("gadget_cheap", "gadget", "ore"));
+
+        Assert.Equal(1, content.CraftDepth("gadget"));
+    }
+
+    [Fact]
+    public void MarketBarter_DoesNotCountAsProduction()
+    {
+        var market = Recipe("barter", "plate", "ore");
+        market.Station = CraftingStation.Market;
+        var content = Build(market);
+
+        Assert.Equal(0, content.CraftDepth("plate"));
+    }
+
+    [Fact]
+    public void RecipeCycle_StaysFiniteAndDeterministic()
+    {
+        var content = Build(
+            Recipe("a", "plate", "gadget"),
+            Recipe("b", "gadget", "plate"));
+
+        // A loop must not hang or overflow; both sides resolve to a small finite depth.
+        Assert.InRange(content.CraftDepth("plate"), 1, 2);
+        Assert.InRange(content.CraftDepth("gadget"), 1, 2);
+    }
+
+    [Fact]
+    public void MaxInputDepth_TakesTheDeepestIngredient_AndZeroForEmptyCost()
+    {
+        var content = Build(
+            Recipe("plate", "plate", "ore"),
+            Recipe("gadget", "gadget", "plate"));
+
+        Assert.Equal(2, content.MaxInputDepth(new[] { new ItemAmount("ore", 5), new ItemAmount("gadget", 1) }));
+        Assert.Equal(0, content.MaxInputDepth(Array.Empty<ItemAmount>()));
+    }
+
+    [Fact]
+    public void ShippedContent_EveryCraftedOutputHasDepthAtLeastOne()
+    {
+        var content = ContentLoader.LoadFromDirectory(TestPaths.DataDir());
+
+        foreach (var recipe in content.Recipes.Values.Where(r => r.Station != CraftingStation.Market))
+        {
+            foreach (var output in recipe.Outputs)
+            {
+                Assert.True(content.CraftDepth(output.Item) >= 1,
+                    $"'{output.Item}' is produced by recipe '{recipe.Key}' but has craft depth 0");
+            }
+        }
+    }
+}
+
+internal static class RecipeDefinitionTestExtensions
+{
+    public static RecipeDefinition WithInputs(this RecipeDefinition r, params string[] inputs)
+    {
+        foreach (var item in inputs)
+        {
+            r.Inputs.Add(new ItemAmount(item, 1));
+        }
+
+        return r;
+    }
+}


### PR DESCRIPTION
closes #826

## What

The crafting list and the ship-module list showed entries in the authoring order of `data/recipes.json` / `data/ship_modules.json` — locked entries buried the next thing a player could actually build. Both lists now sort into three tiers:

1. **Craftable now** — blueprint unlocked + all materials owned
2. **Generally buildable** — blueprint unlocked, materials missing
3. **Blueprint locked**

Within a tier, simpler things come first: fewest distinct input materials → lowest *craft depth* of the inputs → total unit count → authored order (stable sort).

## How

- `GameContent.CraftDepth(item)`: raw resource (nothing produces it) = 0, otherwise 1 + the deepest input of the shallowest producing recipe. Computed once at load; market (barter) recipes are excluded (they are exchanges, not production, and could form cycles); a visiting-set cycle guard keeps the result finite either way. Plus `MaxInputDepth(cost)` for the UI.
- `CraftingTechShipUI`: `ReachTier()` (blueprint + materials only) + the OrderBy chain in `BuildCraftingList` and the ship-module list.
- Station proximity deliberately does NOT affect ordering — the list must not reshuffle while walking around; it still gates the status colour and the craft button. Since the within-tier key is inventory-independent, cards only move on tier changes (item becomes craftable → jumps to the top).
- Unchanged: market (a vendor's stall keeps its authored offer order), tech tree (tier + name), colour/shape lists.

## Verification

- `dotnet build -c Release`: 0 warnings
- Tests: 1497 server + 187 client passing, incl. 6 new `CraftDepthTests` (depth chain, shallowest-producer-wins, market exclusion, cycle guard, shipped-content invariant)
- `dotnet format --verify-no-changes`: clean
- Local Unity Windows build: success (client/Assets changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)