### PR TITLE
docs: bring the localization statements in README + contributor rules up to date

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,7 +11,7 @@
 ## Checklist
 
 - [ ] I built and ran the tests before pushing (`dotnet build BlocksBeyondTheStars.sln` and `dotnet test`) — they pass.
-- [ ] Player-facing text is localized (keys in `data/locales/{en,de}.json`), not hardcoded.
+- [ ] Player-facing text is localized, not hardcoded — new keys added to both `data/locales/en.json` and `de.json` (the mandatory pair; `fr`/`es`/`it` fall back to English per missing key).
 - [ ] The server stays authoritative — the client doesn't decide resources, inventory, crafting, ship state, oxygen, damage, blueprints or travel.
 - [ ] I updated `TODO.md` and any `docs/` that my change makes stale (if applicable).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,7 @@ client/                         Unity project (incl. Assets/Tests EditMode/PlayM
 ai-backend/                     optional Python LLM service (missions, NPC/ship-AI text); offline-safe
 tools/                          editor-export merge tools + AI asset generation (tools/ai-assets)
 data/                           data-driven JSON definitions (blocks, items, recipes, ...)
-data/locales/                   localization resource files (en.json, de.json + community locales, e.g. it.json)
+data/locales/                   localization resource files (mandatory en.json + de.json, community locales fr/es/it)
 docs/user/                      player-facing manual (USER_MANUAL.md)
 docs/developer/                 ARCHITECTURE.md + design/how-it-works docs + ADRs (docs/developer/adr/); see docs/developer/README.md index
 scripts/                        build-client.ps1 + publish scripts
@@ -67,10 +67,11 @@ Dependency direction (no cycles): `Shared` ← everything; `WorldGeneration`,
 1. **Language of text:**
    - *Documentation and code comments → English only.* Even though the spec docs
      and chat are German.
-   - *In-game player-facing text → bilingual (German + English).* Never hardcode
-     player-facing strings; use localization keys + `data/locales/*.json`. Default
-     fallback locale is English.
-   - *Community languages beyond DE/EN* (currently `it.json`) are translated
+   - *In-game player-facing text → localized, with German + English mandatory.* Never
+     hardcode player-facing strings; use localization keys + `data/locales/*.json`.
+     Default fallback locale is English.
+   - *Community languages beyond DE/EN* (`fr.json` and `es.json`, both complete since
+     the FR/ES pass; `it.json` still in progress) are translated
      incrementally and are deliberately allowed to be incomplete — English fills every
      missing key. So: add new keys to `en.json`+`de.json` only, never "helpfully" to a
      community locale, and never extend the DE/EN completeness tests to cover them

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,9 +68,11 @@ These mirror [AGENTS.md](AGENTS.md) (the deeper contributor guide — please ski
   is the truth of the game world. Never make the client decide resources, inventory,
   crafting, ship state, oxygen, damage, blueprints or travel.
 - **Text language.** Documentation and code comments are **English**. In-game player-facing
-  text is **bilingual (German + English)** via localization keys in `data/locales/{en,de}.json`
-  — never hardcode player-facing strings. Additional community languages are welcome on top of
-  that pair (see [Translating the game](#translating-the-game)); DE and EN must stay complete.
+  text is **localized** via localization keys in `data/locales/*.json` — never hardcode
+  player-facing strings. New keys go into `en.json` **and** `de.json`: that pair is mandatory
+  and must stay complete. Every other language sits on top of it and falls back to English per
+  missing key — French and Spanish are complete too, Italian is in progress
+  (see [Translating the game](#translating-the-game)).
 - **Data-driven content.** Blocks, items, recipes, ship modules, tech nodes and planets live
   in `data/*.json`; adding content should not require touching game logic.
 - **Keep `Shared`/`WorldGeneration` `netstandard2.1`-clean** so the Unity client can consume them.

--- a/README.md
+++ b/README.md
@@ -392,7 +392,8 @@ it is always bound to whoever serves its page.
 
 Blocks, items, recipes, blueprints, ship modules and planets are JSON in `data/`; no code
 changes are needed to add content. Player-facing names use localization keys resolved from
-`data/locales/{en,de}.json`. Validate with `BlocksBeyondTheStars.Tools validate`.
+`data/locales/{en,de,fr,es}.json` (plus the in-progress community `it.json`). Validate with
+`BlocksBeyondTheStars.Tools validate`.
 
 ## Status
 

--- a/docs/developer/ARCHITECTURE.md
+++ b/docs/developer/ARCHITECTURE.md
@@ -155,8 +155,9 @@ content should not require touching game logic. User-authored structure template
 a `usercontent/` dir by the in-game editors are merged into the pools automatically.
 
 In-game text is **never hardcoded**: it uses localization keys resolved against
-`data/locales/en.json` + `de.json` (`Shared/Localization`, English fallback). All docs/code
-comments are English; player-facing text is bilingual.
+`data/locales/*.json` (`Shared/Localization`, English fallback per missing key). `en.json` +
+`de.json` are the mandatory pair every new key must land in; `fr`/`es` are complete on top of
+them and `it` is in progress. All docs/code comments are English.
 
 ## Networking protocol (intents → state)
 
@@ -218,7 +219,7 @@ by the server. See [AI_MISSION_BACKEND.md](AI_MISSION_BACKEND.md) and
 5. **Atomic saves** (temp-then-swap), autosave + rotating backups, low CPU/RAM/disk for Pi.
 6. **Single-threaded, tick-driven server**; handlers must not crash the tick.
 7. **Append-only `NetCodec` ids**; new message classes must be `Register()`'d.
-8. **Docs/comments English; in-game text bilingual** via locale keys.
+8. **Docs/comments English; in-game text localized** via locale keys (`en`+`de` mandatory).
 
 ## Where to find what
 

--- a/docs/developer/DEVELOPER.md
+++ b/docs/developer/DEVELOPER.md
@@ -507,7 +507,7 @@ in [SELF_HOSTING.md](SELF_HOSTING.md).
 
 ## Related documents
 
-- [AGENTS.md](../../AGENTS.md) — contributor rules (English-only docs, bilingual in-game text,
+- [AGENTS.md](../../AGENTS.md) — contributor rules (English-only docs, localized in-game text,
   server-authoritative architecture, data-driven content)
 - [TODO.md](../../TODO.md) — single Done/Open status doc
 - [USER_MANUAL.md](../user/USER_MANUAL.md) — player-facing controls, mechanics and commands


### PR DESCRIPTION
## What

Docs-only. Several contributor-facing docs still described the game as **bilingual (German + English)** and pointed at `data/locales/{en,de}.json` — from before French and Spanish shipped (#822). Four languages are complete now (EN/DE/FR/ES) with Italian in progress, so those lines read as if FR/ES don't exist.

Reworded to the rule that is **actually enforced**, not to a new one:

- `en.json` + `de.json` are the mandatory pair every new key must land in (`ContentTests`)
- every other language sits on top and falls back to English **per missing key** (`CommunityLocaleTests` — deliberately not held to the completeness bar)

## Files

| File | Was |
|---|---|
| `README.md` | "Adding content" pointed at `data/locales/{en,de}.json` |
| `CONTRIBUTING.md` | "In-game text is **bilingual (German + English)**" |
| `AGENTS.md` | same rule + repo layout + "community languages (currently `it.json`)" |
| `.github/pull_request_template.md` | checklist item "keys in `data/locales/{en,de}.json`" |
| `docs/developer/ARCHITECTURE.md` | "player-facing text is bilingual" (×2) |
| `docs/developer/DEVELOPER.md` | AGENTS cross-reference "bilingual in-game text" |

## Deliberately not changed

- **`tools/merge_ship.py` / `merge_recipe.py` / `merge_material.py`** — their headers say `data/locales/{en,de}.json` and that is *correct*: all three loop over `("en", "de")` only.
- **`CHANGELOG.md`, `TODO.md`, `docs/developer/*ANALYSIS.md`, feature docs' file tables** — point-in-time records; `{en,de}` is still where those features' keys are mandatory.

No code, no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)