### PR TITLE
fix(webgl): localize the splash screens and intro from the first frame (#831)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ the richer, screenshot-laden versions live there. `(#123)` references the pull r
 
 ## [Unreleased]
 
+### Fixed
+
+- **Browser: the splash screens and the intro speak again (#831).** In the WebGL build the studio
+  splash, the title splash and the intro cinematic showed raw localization keys instead of their
+  texts, because the localizer waited for the entire content download (30+ files, fetched one at a
+  time, re-downloaded on every start) while those screens run on fixed timers. The locale files are
+  now fetched first and the localizer is published immediately, the remaining files download in
+  parallel, and an already-current cache is reused instead of refetched. The intro's voxel ship,
+  which the browser build silently skipped when content hadn't arrived yet, is now built as soon as
+  the content lands.
+
 ## [2026.8.7] — 2026-08-08
 
 The homestead release: the update that makes your base a home. Blocks take painted 32×32

--- a/TODO.md
+++ b/TODO.md
@@ -7287,6 +7287,35 @@ is **pre-approved** (keys in `tools/ai-assets/.env`, run via `uv`).
 
 ---
 
+## ✅ Done (2026-08-08): the browser's splash and intro are localized from the first frame (#831)
+
+In the WebGL build the studio splash, the title splash and the intro cinematic showed raw locale
+keys (`ui.splash.tagline`, `ui.intro.card1`, …) for as long as they were on screen; the main menu
+afterwards was fine. Cause: native builds load content synchronously in `AppShell.Awake`, the
+browser streams it — and the localizer was only built after the *last* of 30+ data files had
+arrived, fetched strictly one at a time (~1.6 MB) and re-downloaded from scratch on every single
+start. Meanwhile the shell screens run on fixed timers (studio 5 s → splash 3.2 s → intro 28 s) and
+start on frame one. Four changes:
+
+- **Locale-first bootstrap** — the startup coroutine now fetches `locales/en.json` plus the active
+  language *first* and publishes a localizer built from just those two tables; the full content load
+  swaps in the content-backed one when it lands. Two requests instead of thirty before the shell can
+  speak. `ContentLoader.ParseLocaleTable` is the shared parser both paths use.
+- **Parallel downloads** — the cache fetches up to 6 files at once (what a browser allows per host)
+  instead of paying a full round-trip per file.
+- **Cache versioning** — the cache is stamped with the build version plus a fingerprint of the
+  manifest and reused when it still matches (verifying every file is present), instead of being
+  deleted and re-downloaded on every start.
+- **The intro ship shows up in the browser** — `IntroCinematic` gave up on the voxel ship when the
+  content wasn't loaded yet and never retried, so the cinematic played without its centrepiece; it
+  now builds the ship the moment the content arrives.
+
+Also: the hard-coded `FallbackManifest` (used only when a deployment has no `manifest.json`) had
+drifted — it was missing `achievements.json` and four ship layouts, which such a build would have
+silently omitted. It is current again, and the WebGL build now warns when it drifts from `data/`.
+
+---
+
 ## ✅ Done (2026-08-08): craft & ship-module lists sorted by reachability (#826)
 
 The crafting list and the ship-module list used to show entries in `data/recipes.json` /

--- a/client/Assets/BlocksBeyondTheStars/Editor/BuildScript.cs
+++ b/client/Assets/BlocksBeyondTheStars/Editor/BuildScript.cs
@@ -242,6 +242,53 @@ namespace BlocksBeyondTheStars.Client.EditorTools
             File.WriteAllText(manifestPath, json.ToString());
             AssetDatabase.ImportAsset("Assets/StreamingAssets/data/manifest.json", ImportAssetOptions.ForceUpdate);
             Debug.Log($"WebGL StreamingAssets manifest written with {files.Count} files.");
+            WarnOnStaleFallbackManifest(files);
+        }
+
+        /// <summary>Compares the generated manifest with <c>StreamingAssetsCache.FallbackManifest</c>, the
+        /// hard-coded list used when a deployment has no <c>manifest.json</c>. Drift there is invisible at
+        /// runtime — such a build simply never fetches the missing files (a language, a ship, the
+        /// achievements) and reports no error — so the build says it out loud instead.</summary>
+        private static void WarnOnStaleFallbackManifest(List<string> files)
+        {
+            var generated = new HashSet<string>(files, StringComparer.Ordinal);
+            var fallback = new HashSet<string>(StreamingAssetsCache.FallbackManifestFiles, StringComparer.Ordinal);
+
+            var missing = new List<string>(files.Count);
+            foreach (string file in files)
+            {
+                if (!fallback.Contains(file))
+                {
+                    missing.Add(file);
+                }
+            }
+
+            var stale = new List<string>();
+            foreach (string file in StreamingAssetsCache.FallbackManifestFiles)
+            {
+                if (!generated.Contains(file))
+                {
+                    stale.Add(file);
+                }
+            }
+
+            if (missing.Count == 0 && stale.Count == 0)
+            {
+                return;
+            }
+
+            var message = new StringBuilder("StreamingAssetsCache.FallbackManifest is out of sync with data/.");
+            if (missing.Count > 0)
+            {
+                message.Append(" Missing: ").Append(string.Join(", ", missing.ToArray())).Append('.');
+            }
+
+            if (stale.Count > 0)
+            {
+                message.Append(" No longer present: ").Append(string.Join(", ", stale.ToArray())).Append('.');
+            }
+
+            Debug.LogWarning(message.ToString());
         }
 
         private static void RemoveAutoFullscreen(string outDir)

--- a/client/Assets/BlocksBeyondTheStars/Scripts/AppShell.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/AppShell.cs
@@ -250,6 +250,13 @@ namespace BlocksBeyondTheStars.Client
 
         private IEnumerator LoadContentForStartup()
         {
+            // Locale files first (#831): the shell screens run on fixed timers — studio splash 5 s, title
+            // splash 3.2 s, intro cinematic 28 s — and start on the first frame, while the full content
+            // cache is 30+ files / ~1.6 MB of HTTP. Waiting for all of it means they render raw "ui.*"
+            // keys for their whole visible window. Two locale files are all they need, so fetch those and
+            // publish a bootstrap localizer immediately; LoadLocalizer swaps in the content-backed one.
+            yield return BootstrapLocalizer();
+
             System.Exception failure = null;
             yield return StreamingAssetsCache.EnsureReady(ex => failure = ex);
             if (failure != null)
@@ -264,6 +271,42 @@ namespace BlocksBeyondTheStars.Client
 
             LoadLocalizer();
             EnsureMenuBackground();
+        }
+
+        /// <summary>Builds a localizer from just the locale tables (active language + the English fallback),
+        /// so the browser's shell screens are localized seconds before the content cache is complete. Purely
+        /// best-effort — a failed fetch leaves <see cref="Localizer"/> null and the normal load takes over.</summary>
+        private IEnumerator BootstrapLocalizer()
+        {
+            var locale = GameLocaleExtensions.Parse(Settings.Language);
+            System.Collections.Generic.Dictionary<string, string> english = null, active = null;
+
+            yield return StreamingAssetsCache.FetchDataText("locales/en.json", text => english = ParseLocaleTable(text));
+            if (locale != GameLocale.English)
+            {
+                yield return StreamingAssetsCache.FetchDataText($"locales/{locale.Code()}.json", text => active = ParseLocaleTable(text));
+            }
+
+            if (english == null && active == null)
+            {
+                yield break; // offline/404 — the keys stay visible until the full load succeeds or errors out
+            }
+
+            Localizer = new Localizer(locale, active ?? english, english ?? active);
+            Debug.Log($"Bootstrap localizer ready for '{locale.Code()}' before the content cache.");
+        }
+
+        private static System.Collections.Generic.Dictionary<string, string> ParseLocaleTable(string json)
+        {
+            try
+            {
+                return ContentLoader.ParseLocaleTable(json);
+            }
+            catch (System.Exception e)
+            {
+                Debug.LogWarning($"Bootstrap locale parse failed: {e.Message}");
+                return null;
+            }
         }
 
         /// <summary>

--- a/client/Assets/BlocksBeyondTheStars/Scripts/IntroCinematic.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/IntroCinematic.cs
@@ -37,6 +37,7 @@ namespace BlocksBeyondTheStars.Client
         private readonly AppShell _shell;
         private bool _replay;
         private float _elapsed;
+        private bool _shipBuildAttempted;
 
         private GameObject _root;
         private Camera _cam;
@@ -67,6 +68,16 @@ namespace BlocksBeyondTheStars.Client
             }
 
             EnsureBuilt();
+
+            // The browser streams its content in, so the rig is usually built before the ship design
+            // exists — pick it up as soon as it lands instead of playing the cinematic without its
+            // centrepiece (#831). One attempt per rig: content is either there by then or never.
+            if (!_shipBuildAttempted && _shell.Content != null)
+            {
+                _shipBuildAttempted = true;
+                BuildShip();
+            }
+
             _elapsed += Time.deltaTime;
             Animate(_elapsed);
 
@@ -217,6 +228,7 @@ namespace BlocksBeyondTheStars.Client
 
             BuildSun();
             BuildPlanet();
+            _shipBuildAttempted = _shell.Content != null; // else Update retries once the content lands
             BuildShip();
 
             if (UnityEngine.Rendering.GraphicsSettings.currentRenderPipeline != null)
@@ -307,7 +319,8 @@ namespace BlocksBeyondTheStars.Client
         }
 
         /// <summary>The voxel fighter through the real atlas mesher (menu recipe), with a simple engine
-        /// glow; hidden until its leg. Content not ready (early WebGL) → no ship, the sky carries the shot.</summary>
+        /// glow; hidden until its leg. Content not ready yet (the browser streams it) → no ship for now;
+        /// <see cref="Update"/> calls this again the moment the content lands.</summary>
         private void BuildShip()
         {
             var content = _shell.Content;
@@ -418,6 +431,7 @@ namespace BlocksBeyondTheStars.Client
             _root = null;
             _cam = null;
             _ship = null;
+            _shipBuildAttempted = false;
             _planet = null;
             _clouds = null;
 

--- a/client/Assets/BlocksBeyondTheStars/Scripts/StreamingAssetsCache.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/StreamingAssetsCache.cs
@@ -3,6 +3,7 @@
 // This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.IO;
 using UnityEngine;
 using UnityEngine.Networking;
@@ -17,13 +18,21 @@ namespace BlocksBeyondTheStars.Client
     {
         private const string DataFolder = "data";
         private const string CacheFolder = "streaming-assets-cache";
+        private const string StampFile = "cache.stamp";
+
+        /// <summary>How many data files are fetched at once. The browser caps concurrent requests per host
+        /// at ~6 anyway, and the old one-at-a-time loop paid a full round-trip per file — with 30+ files
+        /// that pushed the localizer past the splash/intro screens, which then showed raw keys (#831).</summary>
+        private const int MaxConcurrentDownloads = 6;
 
         /// <summary>Used only when <c>data/manifest.json</c> is missing — the real list is generated at build
         /// time by <c>BuildScript.EnsureStreamingAssetsManifest</c>, which enumerates the folder and therefore
-        /// picks up new locale files on its own. Keep locale entries here in sync anyway: a build without the
-        /// manifest would otherwise silently ship a language the client can never fetch.</summary>
+        /// picks up new locale files on its own. Keep this list in sync anyway: a build without the manifest
+        /// would otherwise silently ship content the client can never fetch (a language, a ship, the
+        /// achievements). <c>EnsureStreamingAssetsManifest</c> compares the two and warns when they drift.</summary>
         private static readonly string[] FallbackManifest =
         {
+            "achievements.json",
             "blocks.json",
             "blueprints.json",
             "items.json",
@@ -38,8 +47,12 @@ namespace BlocksBeyondTheStars.Client
             "recipes.json",
             "settlement_templates.json",
             "ship_layouts/ship_corvette.json",
+            "ship_layouts/ship_courier.json",
+            "ship_layouts/ship_deathblock.json",
+            "ship_layouts/ship_hammerhead.json",
             "ship_layouts/ship_hauler.json",
             "ship_layouts/ship_scout.json",
+            "ship_layouts/ship_thunderbolt.json",
             "ship_modules.json",
             "ships.json",
             "station_templates.json",
@@ -66,6 +79,9 @@ namespace BlocksBeyondTheStars.Client
         public static bool UsesRemoteStreamingAssets => IsHttpUrl(Application.streamingAssetsPath);
         public static bool IsReady => _ready;
         public static int RemoteFileCount => _remoteFileCount;
+
+        /// <summary>The built-in file list, for the build-time staleness check in <c>BuildScript</c>.</summary>
+        public static IReadOnlyList<string> FallbackManifestFiles => FallbackManifest;
 
         public static string DataDir
         {
@@ -144,16 +160,77 @@ namespace BlocksBeyondTheStars.Client
             _loading = false;
         }
 
+        /// <summary>
+        /// Fetches ONE data file as text, ahead of (or independently of) the full cache. Used by the
+        /// browser startup to pull the locale tables first, so the splash/intro screens localize while the
+        /// rest of the content is still streaming in (#831). Best-effort: <paramref name="onText"/> simply
+        /// isn't invoked when the file is missing or the request fails — the caller keeps its fallback.
+        /// </summary>
+        public static IEnumerator FetchDataText(string relativePath, Action<string> onText)
+        {
+            string file = NormalizeRelativePath(relativePath);
+            if (string.IsNullOrEmpty(file) || onText == null)
+            {
+                yield break;
+            }
+
+            // Cache (or a native install) already on disk: read it instead of re-fetching.
+            if (_ready)
+            {
+                string path = Path.Combine(DataDir, file.Replace('/', Path.DirectorySeparatorChar));
+                string text = null;
+                try
+                {
+                    if (File.Exists(path))
+                    {
+                        text = File.ReadAllText(path);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Debug.LogWarning($"Could not read '{path}': {ex.Message}");
+                }
+
+                if (text != null)
+                {
+                    onText(text);
+                }
+
+                yield break;
+            }
+
+            if (!UsesRemoteStreamingAssets)
+            {
+                yield break; // native, but not prepared yet — the caller's own load path handles it
+            }
+
+            string url = JoinUrl(Application.streamingAssetsPath, DataFolder + "/" + file);
+            using (var request = UnityWebRequest.Get(url))
+            {
+                yield return request.SendWebRequest();
+                if (RequestSucceeded(request))
+                {
+                    onText(request.downloadHandler.text);
+                }
+                else
+                {
+                    Debug.LogWarning($"Could not fetch '{url}': {RequestError(request)}");
+                }
+            }
+        }
+
         private static IEnumerator DownloadRemoteData(string cacheDir, Action<Exception> onFailure)
         {
             string[] files = null;
+            string manifestText = null;
             string manifestUrl = JoinUrl(Application.streamingAssetsPath, DataFolder + "/manifest.json");
             using (var request = UnityWebRequest.Get(manifestUrl))
             {
                 yield return request.SendWebRequest();
                 if (RequestSucceeded(request))
                 {
-                    files = ParseManifest(request.downloadHandler.text);
+                    manifestText = request.downloadHandler.text;
+                    files = ParseManifest(manifestText);
                 }
                 else
                 {
@@ -164,10 +241,39 @@ namespace BlocksBeyondTheStars.Client
             if (files == null || files.Length == 0)
             {
                 files = FallbackManifest;
+                manifestText = null; // stamp the built-in list, not a half-read response
+            }
+
+            var wanted = new List<string>(files.Length);
+            foreach (string rawFile in files)
+            {
+                string file = NormalizeRelativePath(rawFile);
+                if (!string.IsNullOrEmpty(file))
+                {
+                    wanted.Add(file);
+                }
+            }
+
+            // The content only changes with a new build, so a cache that already matches this build is
+            // reused as-is. Before that every startup deleted and re-downloaded the whole ~1.6 MB tree.
+            string stamp = BuildStamp(manifestText, wanted);
+            if (CacheMatches(cacheDir, stamp, wanted))
+            {
+                _remoteFileCount = wanted.Count;
+                Debug.Log($"StreamingAssets cache reused ({wanted.Count} files, stamp {stamp}).");
+                yield break;
             }
 
             try
             {
+                // Drop the stamp first: a download that dies halfway must not leave a stamp claiming a
+                // complete cache (the per-file existence check would catch it, but this is the honest state).
+                string stampPath = StampPath(cacheDir);
+                if (File.Exists(stampPath))
+                {
+                    File.Delete(stampPath);
+                }
+
                 if (Directory.Exists(cacheDir))
                 {
                     Directory.Delete(cacheDir, true);
@@ -182,42 +288,155 @@ namespace BlocksBeyondTheStars.Client
             }
 
             _remoteFileCount = 0;
-            foreach (string rawFile in files)
+            Exception failure = null;
+            yield return DownloadFiles(wanted, cacheDir, ex => failure = ex);
+            if (failure != null)
             {
-                string file = NormalizeRelativePath(rawFile);
-                if (string.IsNullOrEmpty(file))
-                {
-                    continue;
-                }
+                onFailure(failure);
+                yield break;
+            }
 
-                string sourceUrl = JoinUrl(Application.streamingAssetsPath, DataFolder + "/" + file);
-                string targetPath = Path.Combine(cacheDir, file.Replace('/', Path.DirectorySeparatorChar));
-                using (var request = UnityWebRequest.Get(sourceUrl))
+            WriteStamp(cacheDir, stamp);
+        }
+
+        /// <summary>Downloads the manifest's files, up to <see cref="MaxConcurrentDownloads"/> at a time.</summary>
+        private static IEnumerator DownloadFiles(List<string> files, string cacheDir, Action<Exception> onFailure)
+        {
+            var inFlight = new List<UnityWebRequest>();
+            var targets = new List<string>();
+            Exception failure = null;
+            int next = 0;
+
+            try
+            {
+                while (failure == null && (next < files.Count || inFlight.Count > 0))
                 {
-                    yield return request.SendWebRequest();
-                    if (!RequestSucceeded(request))
+                    while (failure == null && inFlight.Count < MaxConcurrentDownloads && next < files.Count)
                     {
-                        onFailure(new IOException($"Could not download '{sourceUrl}': {RequestError(request)}"));
-                        yield break;
+                        string file = files[next++];
+                        var request = UnityWebRequest.Get(JoinUrl(Application.streamingAssetsPath, DataFolder + "/" + file));
+                        request.SendWebRequest();
+                        inFlight.Add(request);
+                        targets.Add(Path.Combine(cacheDir, file.Replace('/', Path.DirectorySeparatorChar)));
                     }
 
-                    try
+                    yield return null;
+
+                    for (int i = inFlight.Count - 1; i >= 0 && failure == null; i--)
                     {
-                        string parent = Path.GetDirectoryName(targetPath);
-                        if (!string.IsNullOrEmpty(parent))
+                        var request = inFlight[i];
+                        if (!request.isDone)
                         {
-                            Directory.CreateDirectory(parent);
+                            continue;
                         }
 
-                        File.WriteAllBytes(targetPath, request.downloadHandler.data);
-                        _remoteFileCount++;
-                    }
-                    catch (Exception ex)
-                    {
-                        onFailure(ex);
-                        yield break;
+                        if (!RequestSucceeded(request))
+                        {
+                            failure = new IOException($"Could not download '{request.url}': {RequestError(request)}");
+                            break;
+                        }
+
+                        try
+                        {
+                            string parent = Path.GetDirectoryName(targets[i]);
+                            if (!string.IsNullOrEmpty(parent))
+                            {
+                                Directory.CreateDirectory(parent);
+                            }
+
+                            File.WriteAllBytes(targets[i], request.downloadHandler.data);
+                            _remoteFileCount++;
+                        }
+                        catch (Exception ex)
+                        {
+                            failure = ex;
+                            break;
+                        }
+
+                        request.Dispose();
+                        inFlight.RemoveAt(i);
+                        targets.RemoveAt(i);
                     }
                 }
+            }
+            finally
+            {
+                // Whatever is still open when we stop (failure, or the caller stopping the coroutine)
+                // must not leak a native request handle.
+                foreach (var request in inFlight)
+                {
+                    request.Abort();
+                    request.Dispose();
+                }
+            }
+
+            if (failure != null)
+            {
+                onFailure(failure);
+            }
+        }
+
+        /// <summary>Identifies the cached content: build version plus the manifest itself, so a rebuilt
+        /// player (or edited content served under the same version) invalidates the cache.</summary>
+        private static string BuildStamp(string manifestText, List<string> files)
+        {
+            string source = manifestText ?? string.Join("\n", files.ToArray());
+            return Application.version + "-" + files.Count + "-" + Fnv1a(source).ToString("x8");
+        }
+
+        /// <summary>FNV-1a over the manifest text — a content fingerprint, not a security hash;
+        /// hand-rolled so it needs no crypto assembly in a stripped WebGL build.</summary>
+        private static uint Fnv1a(string value)
+        {
+            uint hash = 2166136261;
+            foreach (char c in value)
+            {
+                hash = (hash ^ c) * 16777619;
+            }
+
+            return hash;
+        }
+
+        private static string StampPath(string cacheDir)
+            => Path.Combine(Path.GetDirectoryName(cacheDir) ?? cacheDir, StampFile);
+
+        private static bool CacheMatches(string cacheDir, string stamp, List<string> files)
+        {
+            try
+            {
+                string stampPath = StampPath(cacheDir);
+                if (!File.Exists(stampPath) || File.ReadAllText(stampPath).Trim() != stamp)
+                {
+                    return false;
+                }
+
+                foreach (string file in files)
+                {
+                    if (!File.Exists(Path.Combine(cacheDir, file.Replace('/', Path.DirectorySeparatorChar))))
+                    {
+                        return false; // a partial cache (interrupted download) re-downloads in full
+                    }
+                }
+
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Debug.LogWarning($"StreamingAssets cache check failed: {ex.Message}");
+                return false;
+            }
+        }
+
+        private static void WriteStamp(string cacheDir, string stamp)
+        {
+            try
+            {
+                File.WriteAllText(StampPath(cacheDir), stamp);
+            }
+            catch (Exception ex)
+            {
+                // A missing stamp only costs one extra download next time.
+                Debug.LogWarning($"Could not write the StreamingAssets cache stamp: {ex.Message}");
             }
         }
 

--- a/src/BlocksBeyondTheStars.Shared/Content/ContentLoader.cs
+++ b/src/BlocksBeyondTheStars.Shared/Content/ContentLoader.cs
@@ -167,11 +167,15 @@ public static class ContentLoader
     }
 
     private static Dictionary<string, string> LoadObject(string path)
-    {
-        var json = File.ReadAllText(path);
-        return JsonSerializer.Deserialize<Dictionary<string, string>>(json, JsonOptions)
-               ?? new Dictionary<string, string>();
-    }
+        => ParseLocaleTable(File.ReadAllText(path));
+
+    /// <summary>Parses one locale table (a flat key→text JSON object) from an in-memory string. Public
+    /// because the browser client fetches <c>locales/*.json</c> over HTTP before its content cache is
+    /// complete — the shell screens must localize without waiting for the full load — and has to use the
+    /// exact same parser/options as the filesystem path.</summary>
+    public static Dictionary<string, string> ParseLocaleTable(string json)
+        => JsonSerializer.Deserialize<Dictionary<string, string>>(json, JsonOptions)
+           ?? new Dictionary<string, string>();
 
     /// <summary>Loads pluggable story packs from <c>data/stories/&lt;id&gt;/story.json</c> and merges each
     /// pack's optional <c>locales/&lt;code&gt;.json</c> into the shared locale tables. An absent directory

--- a/tests/BlocksBeyondTheStars.Tests/ContentTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/ContentTests.cs
@@ -187,4 +187,23 @@ public class ContentTests
 
         Assert.Contains(ex.Problems, p => p.Contains("nonexistent_item"));
     }
+
+    /// <summary>The browser client parses locale files it fetched over HTTP with this entry point, before
+    /// its content cache exists, so the splash/intro screens can localize (#831). It must read a real
+    /// shipped locale file exactly like the filesystem path does.</summary>
+    [Fact]
+    public void ParseLocaleTable_ReadsAShippedLocaleFile()
+    {
+        var path = Path.Combine(TestPaths.DataDir(), "locales", "en.json");
+        var table = ContentLoader.ParseLocaleTable(File.ReadAllText(path));
+
+        Assert.NotEmpty(table);
+        Assert.Equal(Load().CreateLocalizer(GameLocale.English).Get("ui.splash.tagline"), table["ui.splash.tagline"]);
+    }
+
+    [Fact]
+    public void ParseLocaleTable_EmptyObjectYieldsEmptyTable()
+    {
+        Assert.Empty(ContentLoader.ParseLocaleTable("{}"));
+    }
 }


### PR DESCRIPTION
@
Fixes the browser build showing raw locale keys (`ui.splash.tagline`, `ui.intro.card1`, …) in the
studio splash, the title splash and the intro cinematic. The main menu afterwards was already
correct — this is purely a startup-order problem, WebGL only.

## Why it happened

Native builds load content synchronously in `AppShell.Awake`; the browser streams it. The localizer
was only built once the **last** of 30+ data files had arrived — fetched strictly one at a time
(~1.6 MB, of which ~890 KB are locale files), and deleted plus re-downloaded from scratch on *every*
start. The shell screens meanwhile run on fixed timers (studio 5 s → title splash 3.2 s → intro
28 s) and start on frame one, so `AppShell.L()` returned the key for their whole visible window.
The intro only plays on the very first launch, i.e. exactly when the browser cache is cold.

## What changed

- **Locale-first bootstrap** — `LoadContentForStartup` now fetches `locales/en.json` plus the active
  language first and publishes a localizer built from those two tables; `LoadLocalizer` swaps in the
  content-backed one when the cache completes. Two requests instead of thirty before the shell can
  speak. Best-effort: a failed fetch simply leaves the old behaviour.
  `ContentLoader.ParseLocaleTable` is the shared parser both paths use (the client asmdef has no
  `System.Text.Json` reference of its own).
- **Parallel downloads** — up to 6 files in flight, which is what a browser allows per host, instead
  of paying a full round-trip per file.
- **Cache versioning** — the cache is stamped with the build version plus an FNV-1a fingerprint of
  the manifest and reused when it still matches, after verifying every manifest entry is actually
  present (so an interrupted download still refetches). The stamp is dropped before a fresh download
  so a half-written cache never looks complete.
- **The intro ship shows up in the browser** — `IntroCinematic.BuildShip` bailed out when
  `Content` was still null and `EnsureBuilt` runs only once, so the cinematic played without its
  centrepiece. It now builds the ship the moment the content lands, once per rig.
- **`FallbackManifest` refreshed** — it had drifted and was missing `achievements.json` and four ship
  layouts; a deployment without `manifest.json` would have omitted them silently. The WebGL build
  now compares the generated manifest against the built-in list and warns on drift.

## Verification

- `dotnet build -c Release`: 0 warnings, 0 errors.
- `dotnet test`: 1499 server/shared + 187 client passing (2 new tests for `ParseLocaleTable`).
- `dotnet format --verify-no-changes`: clean.
- Local Unity Windows player build (client scripts changed).
- Browser-side behaviour still needs a playtest on the deployed build: splash/intro localized from
  the first frame with a cold cache, and the intro showing the voxel ship.

closes #831

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@