### PR TITLE
fix(save): keep the ship after leaving and reloading a world (#848)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7287,6 +7287,32 @@ is **pre-approved** (keys in `tools/ai-assets/.env`, run via `uv`).
 
 ---
 
+## ✅ Done (2026-08-08): the ship is still there after leaving and reloading a world (#848)
+
+"I start a world, leave the game, load it again — and my ship is gone." Two save-game gaps, both
+data loss:
+
+- **The landing pad a player holds was session-only.** `AssignedPadIndex` lived on the session and
+  had no counterpart in the save, so a reload re-parked the ship on the *first free* pad — pad 0 in
+  singleplayer — while the player was restored at their persisted position on the pad they actually
+  landed on. Pads are spread across the whole globe, so the ship ended up thousands of blocks away.
+  The pad is now part of `PlayerState` (the session mirrors it, like `CurrentLocationId`), and the
+  join revalidates it: an out-of-range pad, or one another player is standing on, is released and
+  the first free pad handed out as before — pads stay communal and finite.
+- **Only the ACTIVE ship was persisted.** The join cleared the fleet and installed a single ship
+  under the fixed id `default`, and the saves wrote only `session.Ships[ActiveShipId]`, so every
+  ship a player crafted or claimed from a wreck was silently deleted by the next load — materials
+  included. Each ship now has its own save row (`ship_<playerId>#<shipId>`; the `ship` table is a
+  generic key→JSON store, so no schema migration), the player record carries the fleet index plus
+  the active ship id, and craft / wreck-claim / ship-switch persist immediately instead of riding on
+  the next autosave. The active ship is still mirrored to the legacy `ship_<playerId>` key, and a
+  save without a fleet index migrates through that key — an existing ship is never lost.
+
+Follow-up, deliberately out of scope: ship hull edits are keyed `ship:<playerId>`, i.e. per *player*
+rather than per *ship*, so edits bleed between ships of one fleet (pre-existing, now more visible).
+
+---
+
 ## ✅ Done (2026-08-08): the browser's splash and intro are localized from the first frame (#831)
 
 In the WebGL build the studio splash, the title splash and the intro cinematic showed raw locale

--- a/src/BlocksBeyondTheStars.GameServer/GameServer.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServer.cs
@@ -821,20 +821,25 @@ public sealed partial class GameServer
         }
     }
 
-    /// <summary>Persistence key for a player's saved ship (one persisted ship per player; extra owned
-    /// ships in the fleet live in-memory per session for now).</summary>
+    /// <summary>Persistence key for a player's ACTIVE ship. Kept as the legacy single-ship key (#848): every
+    /// save still mirrors the active ship here, so a save written by this build stays loadable by an older one
+    /// and the pre-fleet write sites need no change. The other ships use <see cref="FleetShipSaveKey"/>.</summary>
     private static string ShipSaveKey(string playerId) => "ship_" + playerId;
 
-    /// <summary>Sets up a freshly-joined player's ship: points the cursor at them, loads or creates their
-    /// own ship, registers it as their active ship, and parks it on their (active) world. A player owns
-    /// their own fleet (multiple ships possible via crafting/wreck-claim) with exactly one active ship.</summary>
+    /// <summary>Persistence key for one ship of a player's fleet (#848). The `ship` table is a generic
+    /// key→JSON store, so per-ship rows need no schema change; <c>PlayerState.FleetShipIds</c> is the index.</summary>
+    private static string FleetShipSaveKey(string playerId, string shipId) => "ship_" + playerId + "#" + shipId;
+
+    /// <summary>Sets up a freshly-joined player's ship: points the cursor at them, restores their whole fleet
+    /// and the ship they were flying, and parks it on their (active) world. A player owns their own fleet
+    /// (multiple ships via crafting/wreck-claim) with exactly one active ship.</summary>
     private void SetupPlayerShip(PlayerSession session)
     {
         SetActiveWorld(session.CurrentLocationId);
         SetCurrent(session);
         MarkArrivedOnBody(session, session.CurrentLocationId); // the home body is a quick-travel target from the start
-        var ship = _repo.LoadShip(ShipSaveKey(session.State.PlayerId)) ?? CreateStarterShip();
-        RegisterActiveShip(session, ship);
+        RestoreFleet(session);
+        RestoreLandingPad(session);
         RecomputeShipCombatStats();
         if (_config.PlaceStarterShip)
         {
@@ -842,7 +847,84 @@ public sealed partial class GameServer
             session.State.RespawnPoint = _healTank;
         }
 
-        _repo.SaveShip(ShipSaveKey(session.State.PlayerId), ship);
+        PersistFleet(session);
+    }
+
+    /// <summary>Restores a joining player's fleet from the save (#848). Every owned ship is loaded from its own
+    /// row and the active ship is the one they were last flying. A save from before per-ship persistence has no
+    /// fleet index — it migrates through the legacy single-ship key, so an existing ship is never lost — and a
+    /// brand-new player gets a starter ship.</summary>
+    private void RestoreFleet(PlayerSession session)
+    {
+        var p = session.State;
+        session.Ships.Clear();
+        foreach (var id in p.FleetShipIds)
+        {
+            if (!string.IsNullOrEmpty(id) && !session.Ships.ContainsKey(id)
+                && _repo.LoadShip(FleetShipSaveKey(p.PlayerId, id)) is { } stored)
+            {
+                session.Ships[id] = stored;
+            }
+        }
+
+        if (session.Ships.Count == 0)
+        {
+            // Pre-#848 save (or a first join): the single persisted ship becomes the fleet's starter entry.
+            session.Ships[ShipId] = _repo.LoadShip(ShipSaveKey(p.PlayerId)) ?? CreateStarterShip();
+        }
+
+        if (!session.Ships.ContainsKey(session.ActiveShipId))
+        {
+            session.ActiveShipId = session.Ships.Keys.First(); // a dropped/unknown active id falls back to ship one
+        }
+    }
+
+    /// <summary>Revalidates the landing pad restored from the save (#848). Pads are communal and finite, so a
+    /// persisted pad that is out of range for this body, or already held by another player standing on it, is
+    /// released — the next <c>PlayerPad</c> call then hands out the first free one, as before this existed.</summary>
+    private void RestoreLandingPad(PlayerSession session)
+    {
+        int idx = session.AssignedPadIndex;
+        if (idx < 0)
+        {
+            return;
+        }
+
+        if (_landingPads.Count == 0)
+        {
+            BuildLandingPads(); // the pad set is recomputed per world load; make sure it's there to validate against
+        }
+
+        if (idx >= _landingPads.Count || PadOccupiedByOther(session.CurrentLocationId, idx, session.State.PlayerId))
+        {
+            session.AssignedPadIndex = -1;
+        }
+    }
+
+    /// <summary>Writes a player's whole fleet to the save (#848): every owned ship under its own key, the
+    /// active one additionally under the legacy key, and the fleet index onto the player record. The caller
+    /// persists the player state itself (or calls <see cref="PersistFleet"/>, which does both).</summary>
+    private void SaveFleet(PlayerSession session)
+    {
+        var p = session.State;
+        p.FleetShipIds = session.Ships.Keys.ToList();
+        foreach (var (id, ship) in session.Ships)
+        {
+            _repo.SaveShip(FleetShipSaveKey(p.PlayerId, id), ship);
+        }
+
+        if (session.Ships.TryGetValue(session.ActiveShipId, out var active))
+        {
+            _repo.SaveShip(ShipSaveKey(p.PlayerId), active); // legacy key: still the active ship
+        }
+    }
+
+    /// <summary>Persists a fleet change (craft, wreck claim, ship switch) immediately, rather than leaving a
+    /// bought-and-paid-for ship riding on the next autosave.</summary>
+    private void PersistFleet(PlayerSession session)
+    {
+        SaveFleet(session);
+        _repo.SavePlayer(session.State); // carries the fleet index + active ship id
     }
 
     private ShipState CreateStarterShip()
@@ -2005,12 +2087,9 @@ public sealed partial class GameServer
             LeaveSpace(session.State.PlayerId);
             LeaveStation(session.State.PlayerId);
             CancelTradesFor(session.State.PlayerId);
-            _repo.SavePlayer(session.State);
             SetCurrent(session);
-            if (session.Ships.TryGetValue(session.ActiveShipId, out var theirShip))
-            {
-                _repo.SaveShip(ShipSaveKey(session.State.PlayerId), theirShip);
-            }
+            SaveFleet(session); // the whole fleet + the fleet index on the state, before it is written below
+            _repo.SavePlayer(session.State);
 
             string loc = session.CurrentLocationId;
             _sessions.Remove(connectionId);
@@ -2525,7 +2604,9 @@ public sealed partial class GameServer
         int spawnX = 0, spawnZ = 0;
         if (Rules.PersonalLandingZones && _landingPads.Count > 0)
         {
-            // First spawn: drop the new player on the first free landing pad of the home body (item 38).
+            // First spawn: drop the new player on the first free landing pad of the home body (item 38). The pad
+            // is NOT claimed here — occupancy is live, and a pad is only held once the player's ship is parked
+            // on it (PlayerPad), which is also where the claim starts being persisted (#848).
             int idx = FirstFreePadIndex(_world.LocationId, _landingPads.Count, name);
             var pad = _landingPads[idx >= 0 ? idx : 0];
             spawnX = pad.CenterX;
@@ -2660,7 +2741,7 @@ public sealed partial class GameServer
             _meta.CreativeKitGranted = true;
             _repo.SaveMetadata(_meta);
             _repo.SavePlayer(p); // persist the granted kit so a reload keeps it (and the one-time flag holds)
-            _repo.SaveShip(ShipSaveKey(p.PlayerId), _ship); // the kit lives in the hold now — persist it with the flag
+            SaveFleet(session); // the kit lives in the hold now — persist the fleet with the flag
             SendInventory(session);
         }
     }
@@ -4097,7 +4178,7 @@ public sealed partial class GameServer
                         _ship.Modules.Add(key);
                         ResizeCargo(_ship);
                         RecomputeShipCombatStats();
-                        _repo.SaveShip(ShipSaveKey(p.PlayerId), _ship);
+                        SaveFleet(session); // through the fleet, so the per-ship row and the legacy key agree (#848)
                         SendShipCombatStatus(session);
                         SendPlayerState(session);
                     }
@@ -4320,11 +4401,8 @@ public sealed partial class GameServer
                     continue;
                 }
 
+                SaveFleet(session); // each player's own ships; also refreshes the fleet index on their state
                 _repo.SavePlayer(session.State);
-                if (session.Ships.TryGetValue(session.ActiveShipId, out var ship))
-                {
-                    _repo.SaveShip(ShipSaveKey(session.State.PlayerId), ship); // each player's own ship
-                }
             }
 
             _repo.SaveMetadata(_meta);

--- a/src/BlocksBeyondTheStars.GameServer/GameServerShips.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerShips.cs
@@ -13,8 +13,9 @@ namespace BlocksBeyondTheStars.GameServer;
 /// craft new ship types, owns multiple ships, and switches which one is **active** (the active
 /// ship is the one flown and stamped into the world). Server-authoritative.
 ///
-/// Slice scope: owned ships beyond the starter live in-memory for the session; the active ship
-/// persists as today. Full per-ship persistence is a follow-up.
+/// The whole fleet is persisted (#848): each ship has its own save row and the player record carries the
+/// fleet index plus the active ship id, so a crafted ship or a claimed wreck survives a reload. See
+/// <c>GameServer.RestoreFleet</c>/<c>SaveFleet</c>.
 /// </summary>
 public sealed partial class GameServer
 {
@@ -32,14 +33,6 @@ public sealed partial class GameServer
 
     public IReadOnlyDictionary<string, ShipState> OwnedShips => _ships;
     public string ActiveShipId => _activeShipId;
-
-    /// <summary>Installs a player's starter/loaded ship as their initial active ship (called on join).</summary>
-    private void RegisterActiveShip(PlayerSession session, ShipState ship)
-    {
-        session.Ships.Clear();
-        session.Ships[ShipId] = ship;
-        session.ActiveShipId = ShipId;
-    }
 
     private ShipState BuildShipFromDefinition(ShipDefinition def)
     {
@@ -69,6 +62,11 @@ public sealed partial class GameServer
         string safePrefix = string.IsNullOrWhiteSpace(idPrefix) ? def.Key : idPrefix;
         string id = $"{safePrefix}_{def.Key}_{_ships.Count}";
         _ships[id] = BuildShipFromDefinition(def);
+        if (CurrentOrFirst() is { } owner)
+        {
+            PersistFleet(owner); // a ship that was paid for is saved now, not on the next autosave (#848)
+        }
+
         BroadcastOwnedShips();
         return id;
     }
@@ -158,6 +156,11 @@ public sealed partial class GameServer
                     SendShipDesign(s, rebuilt);
                 }
             }
+        }
+
+        if (CurrentOrFirst() is { } owner)
+        {
+            PersistFleet(owner); // remember which ship they fly, so a reload hands back the same one (#848)
         }
 
         BroadcastOwnedShips();

--- a/src/BlocksBeyondTheStars.GameServer/PlayerSession.cs
+++ b/src/BlocksBeyondTheStars.GameServer/PlayerSession.cs
@@ -33,8 +33,14 @@ public sealed class PlayerSession
 
     /// <summary>The fixed landing pad this player currently holds on their body (item 38), or -1 if none. Pads
     /// are communal + occupancy is live: a pad counts as taken only while its holder is on the body (not in
-    /// space). Set when landing; superseded on the next landing; ignored once the player is in space/elsewhere.</summary>
-    public int AssignedPadIndex { get; set; } = -1;
+    /// space). Set when landing; superseded on the next landing; ignored once the player is in space/elsewhere.
+    /// Mirrors <see cref="State"/>.<c>LandingPadIndex</c> so it is persisted (#848) — the pad is where the ship
+    /// is parked, so a reload that forgot it left the ship on the far side of the planet.</summary>
+    public int AssignedPadIndex
+    {
+        get => State.LandingPadIndex;
+        set => State.LandingPadIndex = value;
+    }
 
     /// <summary>Fleet admin: the operator of this hosting installation, as opposed to the owner of one world
     /// (issue #487). Granted on join from <see cref="Shared.Configuration.ServerConfig.FleetAdminPlayers"/> and
@@ -87,8 +93,13 @@ public sealed class PlayerSession
     /// <summary>This player's owned ships, keyed by ship id.</summary>
     public Dictionary<string, ShipState> Ships { get; } = new();
 
-    /// <summary>The id of this player's active ship (the one flown + stamped).</summary>
-    public string ActiveShipId { get; set; } = string.Empty;
+    /// <summary>The id of this player's active ship (the one flown + stamped). Mirrors
+    /// <see cref="State"/>.<c>ActiveShipId</c> so a reload hands back the ship they were flying (#848).</summary>
+    public string ActiveShipId
+    {
+        get => State.ActiveShipId;
+        set => State.ActiveShipId = value;
+    }
 
     // Avatar colours (packed 0xRRGGBB) relayed to other players. Sensible defaults until set.
     public int SkinColor { get; set; } = 0xD9AE8C;

--- a/src/BlocksBeyondTheStars.Persistence/Snapshots.cs
+++ b/src/BlocksBeyondTheStars.Persistence/Snapshots.cs
@@ -91,6 +91,16 @@ public sealed class PlayerSnapshot
 
     /// <summary>Deployed hover speeders (packable surface vehicles) — bound to their home body, restored on reload.</summary>
     public List<DeployedSpeeder> DeployedSpeeders { get; set; } = new();
+
+    /// <summary>The landing pad held on <see cref="CurrentLocationId"/> (#848), or -1 for none. Absent in
+    /// pre-#848 saves, which then fall back to the first free pad exactly as before.</summary>
+    public int LandingPadIndex { get; set; } = -1;
+
+    /// <summary>The fleet index (#848): the ids of every owned ship, each stored under its own
+    /// <c>ship_&lt;playerId&gt;#&lt;shipId&gt;</c> row, plus which one was active. Empty in pre-#848 saves,
+    /// which migrate through the legacy single-ship key.</summary>
+    public List<string> FleetShipIds { get; set; } = new();
+    public string ActiveShipId { get; set; } = string.Empty;
 }
 
 public sealed class ShipSnapshot
@@ -186,6 +196,9 @@ public static class StateMapper
         TamedCreatures = p.TamedCreatures.Select(CloneTamed).ToList(),
         TamedSpecies = p.TamedSpecies.ToList(),
         DeployedSpeeders = p.DeployedSpeeders.Select(CloneSpeeder).ToList(),
+        LandingPadIndex = p.LandingPadIndex,
+        FleetShipIds = new List<string>(p.FleetShipIds),
+        ActiveShipId = p.ActiveShipId,
         FacePixels = p.FacePixels,
     };
 
@@ -289,6 +302,9 @@ public static class StateMapper
         TamedCreatures = (s.TamedCreatures ?? new List<TamedCreature>()).Select(CloneTamed).ToList(),
         TamedSpecies = new HashSet<string>(s.TamedSpecies ?? new List<string>()),
         DeployedSpeeders = (s.DeployedSpeeders ?? new List<DeployedSpeeder>()).Select(CloneSpeeder).ToList(),
+        LandingPadIndex = s.LandingPadIndex,
+        FleetShipIds = new List<string>(s.FleetShipIds ?? new List<string>()),
+        ActiveShipId = s.ActiveShipId ?? string.Empty,
         FacePixels = s.FacePixels ?? string.Empty,
     };
 

--- a/src/BlocksBeyondTheStars.Shared/State/PlayerState.cs
+++ b/src/BlocksBeyondTheStars.Shared/State/PlayerState.cs
@@ -33,6 +33,13 @@ public sealed class PlayerState
     /// there — not always the home world. The session mirrors this via <c>PlayerSession.CurrentLocationId</c>.</summary>
     public string CurrentLocationId { get; set; } = string.Empty;
 
+    /// <summary>The landing pad this player holds on <see cref="CurrentLocationId"/>, or -1 for none. Persisted
+    /// (#848): the pad is where the ship is parked, and pads are scattered across the whole globe — without it a
+    /// reload re-parked the ship on the first free pad (pad 0 in singleplayer) while the player was restored at
+    /// their saved position on the pad they actually landed on, i.e. "my ship is gone". The session mirrors this
+    /// via <c>PlayerSession.AssignedPadIndex</c>; the join revalidates it against live occupancy.</summary>
+    public int LandingPadIndex { get; set; } = -1;
+
     /// <summary>Where the player respawns — the heal-tank in their ship's Medbay.</summary>
     public Vector3f RespawnPoint { get; set; } = Vector3f.Zero;
 
@@ -207,6 +214,16 @@ public sealed class PlayerState
     /// <summary>Runtime only: the id of the speeder this player is currently piloting (empty = on foot). Cleared
     /// on (re)join so a reload never starts the player "inside" a speeder; never meaningfully persisted.</summary>
     public string InSpeeder { get; set; } = string.Empty;
+
+    /// <summary>The ids of every ship in this player's fleet, in order — the index over the per-ship save rows
+    /// (#848). Before this, only the ACTIVE ship was saved and the fleet was rebuilt from scratch on every join,
+    /// so a crafted ship or a claimed wreck was silently deleted by the next load. Empty in pre-#848 saves,
+    /// which then migrate through the legacy single-ship key. Server-authoritative, persisted.</summary>
+    public List<string> FleetShipIds { get; set; } = new();
+
+    /// <summary>Which ship of <see cref="FleetShipIds"/> the player was flying, so a reload hands back the ship
+    /// they chose rather than always the first one. Empty (or unknown) falls back to the first ship in the fleet.</summary>
+    public string ActiveShipId { get; set; } = string.Empty;
 
     /// <summary>The player's custom pixel face, drawn in the in-game face editor and shown on this player's
     /// avatar to everyone (cosmetic). Encoded as a compact string of 16×16 palette indices (one hex char per

--- a/tests/BlocksBeyondTheStars.Tests/ShipReloadPersistenceTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/ShipReloadPersistenceTests.cs
@@ -1,0 +1,197 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using System;
+using System.Linq;
+using BlocksBeyondTheStars.Networking.Transport;
+using BlocksBeyondTheStars.Persistence;
+using BlocksBeyondTheStars.Shared.Configuration;
+using BlocksBeyondTheStars.Shared.Content;
+using BlocksBeyondTheStars.Shared.State;
+using Xunit;
+using SvGameServer = BlocksBeyondTheStars.GameServer.GameServer;
+
+namespace BlocksBeyondTheStars.Tests;
+
+/// <summary>
+/// #848 — "my ship is gone after I leave the world and load it again". Two save-game gaps caused it: the
+/// landing pad a player holds was session-only (so a reload re-parked the ship on the first free pad, i.e. on
+/// the far side of the planet from where the player was restored), and only the ACTIVE ship was persisted (so
+/// crafted ships and claimed wrecks were deleted by the next load). Both are covered here across a real
+/// server restart on the same save.
+/// </summary>
+public sealed class ShipReloadPersistenceTests : IDisposable
+{
+    private readonly string _root;
+    private readonly GameContent _content;
+
+    public ShipReloadPersistenceTests()
+    {
+        _root = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "bbts_reload_" + Guid.NewGuid().ToString("N"));
+        _content = ContentLoader.LoadFromDirectory(TestPaths.DataDir());
+    }
+
+    /// <summary>Opens (or re-opens) the save under <paramref name="tag"/> and starts a server on it — calling
+    /// this twice with the same tag is a "quit the game and load the world again".</summary>
+    private SvGameServer Start(string tag, out SqliteWorldRepository repo, bool placeShip = false)
+    {
+        repo = new SqliteWorldRepository(new SaveGamePaths(_root, tag));
+        var transport = new LoopbackServerTransport(new LoopbackLink());
+        var config = new ServerConfig
+        {
+            WorldName = tag,
+            Seed = 1,
+            AutoSaveIntervalMinutes = 9999,
+            PlaceStarterShip = placeShip,
+        };
+        var server = new SvGameServer(config, _content, transport, repo);
+        server.Start();
+        return server;
+    }
+
+    [Fact]
+    public void CraftedShip_AndActiveChoice_SurviveAReload()
+    {
+        string craftedId;
+        var first = Start("fleet", out var repo1);
+        using (repo1)
+        {
+            var pilot = first.AddLocalPlayer("Pilot");
+            pilot.State.InstantBuild = true; // skip the material cost; this test is about persistence
+            pilot.State.UnlockedBlueprints.Add("ship_hauler");
+
+            var (ok, id) = first.CraftShip("Pilot", "hauler");
+            Assert.True(ok);
+            craftedId = id;
+            Assert.True(first.SwitchShip(craftedId));
+            first.Stop(); // saves like a normal shutdown
+        }
+
+        var reloaded = Start("fleet", out var repo2);
+        using (repo2)
+        {
+            reloaded.AddLocalPlayer("Pilot");
+
+            Assert.Equal(2, reloaded.OwnedShips.Count);       // the starter AND the ship that was paid for
+            Assert.Equal(craftedId, reloaded.ActiveShipId);   // still flying the one they switched to
+            Assert.Equal("hauler", reloaded.Ship.ShipType);
+            Assert.Contains(reloaded.OwnedShips.Values, s => s.ShipType == "starter");
+        }
+    }
+
+    [Fact]
+    public void ShipCargo_SurvivesAReload_PerShip()
+    {
+        var first = Start("cargo", out var repo1);
+        using (repo1)
+        {
+            var pilot = first.AddLocalPlayer("Pilot");
+            pilot.State.InstantBuild = true;
+            pilot.State.UnlockedBlueprints.Add("ship_hauler");
+
+            var (ok, id) = first.CraftShip("Pilot", "hauler");
+            Assert.True(ok);
+            pilot.Ships[id].Cargo.Add("iron_ore", 7, 99); // load the NON-active ship's hold
+            first.Stop();
+        }
+
+        var reloaded = Start("cargo", out var repo2);
+        using (repo2)
+        {
+            reloaded.AddLocalPlayer("Pilot");
+            var hauler = reloaded.OwnedShips.Values.Single(s => s.ShipType == "hauler");
+            Assert.Equal(7, hauler.Cargo.CountOf("iron_ore"));
+        }
+    }
+
+    [Fact]
+    public void LegacySave_WithoutAFleetIndex_KeepsItsShip()
+    {
+        // A save written before per-ship persistence: one player row, one ship row under the legacy key.
+        using (var seed = new SqliteWorldRepository(new SaveGamePaths(_root, "legacy")))
+        {
+            seed.Initialize();
+            seed.SavePlayer(new PlayerState { PlayerId = "Pilot", Name = "Pilot" });
+            var ship = new ShipState { ShipType = "hauler", Hull = 42f };
+            ship.Cargo.Add("titanium_plate", 3, 99);
+            seed.SaveShip("ship_Pilot", ship);
+        }
+
+        var server = Start("legacy", out var repo);
+        using (repo)
+        {
+            server.AddLocalPlayer("Pilot");
+
+            Assert.Single(server.OwnedShips);
+            Assert.Equal("hauler", server.Ship.ShipType);       // migrated, not replaced by a fresh starter
+            Assert.Equal(3, server.Ship.Cargo.CountOf("titanium_plate"));
+        }
+    }
+
+    [Fact]
+    public void LandingPad_SurvivesAReload_SoTheShipIsWhereItWasLeft()
+    {
+        var first = Start("pad", out var repo1, placeShip: true);
+        int pad;
+        using (repo1)
+        {
+            var pilot = first.AddLocalPlayer("Pilot");
+            Assert.True(first.LandingPadCenters.Count > 2, "the home body should offer several pads");
+            pad = 2;
+            pilot.AssignedPadIndex = pad; // as landing on pad 2 would
+            first.Stop();
+        }
+
+        var reloaded = Start("pad", out var repo2, placeShip: true);
+        using (repo2)
+        {
+            var pilot = reloaded.AddLocalPlayer("Pilot");
+
+            Assert.Equal(pad, pilot.AssignedPadIndex);
+            var centre = reloaded.LandingPadCenters.Single(p => p.Index == pad);
+            var anchor = reloaded.ShipAnchorOf("Pilot");
+            Assert.Equal(centre.X, anchor.X); // the ship is parked on THAT pad, not back on pad 0
+            Assert.Equal(centre.Z, anchor.Z);
+        }
+    }
+
+    [Fact]
+    public void RestoredPad_IsReleased_WhenAnotherPlayerAlreadyHoldsIt()
+    {
+        var first = Start("shared", out var repo1, placeShip: true);
+        using (repo1)
+        {
+            var a = first.AddLocalPlayer("Ann");
+            var b = first.AddLocalPlayer("Ben");
+            a.AssignedPadIndex = 2;
+            b.AssignedPadIndex = 2; // a save that somehow recorded the same pad for both
+            first.Stop();
+        }
+
+        var reloaded = Start("shared", out var repo2, placeShip: true);
+        using (repo2)
+        {
+            var a = reloaded.AddLocalPlayer("Ann");
+            var b = reloaded.AddLocalPlayer("Ben");
+
+            Assert.Equal(2, a.AssignedPadIndex);          // first in keeps the pad
+            Assert.NotEqual(a.AssignedPadIndex, b.AssignedPadIndex); // the other is moved to a free one
+            Assert.NotEqual(reloaded.ShipAnchorOf("Ann"), reloaded.ShipAnchorOf("Ben"));
+        }
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+            if (System.IO.Directory.Exists(_root))
+            {
+                System.IO.Directory.Delete(_root, recursive: true);
+            }
+        }
+        catch
+        {
+        }
+    }
+}


### PR DESCRIPTION
"I start a world, leave the game, load it again — and my ship is gone." Two save-game gaps caused it, both data loss.

## The landing pad a player holds was session-only

`PlayerSession.AssignedPadIndex` had no counterpart in the save, so on join `PlayerPad` fell back to `FirstFreePadIndex` — pad 0 in singleplayer — and re-parked the ship there. The player's *position* **is** persisted, so they were restored on the pad they actually landed on. Pads are scattered across the whole globe (`baseX = (i / count) * circumference`), so the ship ended up thousands of blocks away. `EnsureSafeSpawn` doesn't catch it: the saved position is perfectly safe, just nowhere near the ship.

The pad now lives on `PlayerState` and the session mirrors it (same shape as `CurrentLocationId`), so every claim/release is saved without touching the landing code. The join revalidates the restored index: out of range for this body, or held by another player standing on it → released, and the first free pad is handed out exactly as before. Pads stay communal and finite, and two players can never be given the same one.

## Only the *active* ship was persisted

`RegisterActiveShip` cleared the fleet on every join and installed a single ship under the fixed id `default`, and both `SaveAll` and the disconnect path wrote only `session.Ships[ActiveShipId]`. Every ship a player crafted or claimed from a wreck was **silently deleted by the next load**, materials included — the "full per-ship persistence is a follow-up" note in `GameServerShips` was that follow-up.

Now each ship has its own save row (`ship_<playerId>#<shipId>` — the `ship` table is a generic key→JSON store, so no schema migration), the player record carries the fleet index plus the active ship id, and craft / wreck-claim / ship-switch persist immediately rather than riding on the next autosave. The active ship is still mirrored to the legacy `ship_<playerId>` key, and **every** write site now goes through `SaveFleet` so the two rows can't diverge (the creative-kit and `grant_module` paths used to write the legacy key alone).

**Migration:** a save with no fleet index loads its ship through the legacy key and becomes the fleet's starter entry — an existing ship is never lost, and the legacy key stays valid for older builds.

## Tests

Five reload tests that restart a real server on the same save: crafted ship + active choice survive, a non-active ship's cargo survives, a pre-#848 save keeps its ship, the pad is restored with the ship parked on it, and a pad claimed by two players is released for the second. **Four of the five fail on the unfixed server** (the fifth is the legacy-migration guard, which passes before and after by design).

Full fast suite: 1504 server + 187 client passing, clean rebuild with 0 warnings.

## Out of scope

Ship hull edits are keyed `ship:<playerId>`, i.e. per *player* rather than per *ship*, so edits bleed between ships of one fleet. Pre-existing, and more visible now that fleets survive reloads — noted in the issue as a follow-up.

closes #848

🤖 Generated with [Claude Code](https://claude.com/claude-code)
