### PR TITLE
fix(build): place blocks under water by displacing the fluid (#851)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,12 @@ the richer, screenshot-laden versions live there. `(#123)` references the pull r
 
 ### Fixed
 
+- **You can build under water (#851).** Every placement while swimming was refused with "Target is
+  not empty" — the cell you aim at under water holds water, and the server only accepted air. A block
+  now displaces water or lava, so underwater walls, pillars out of a lake and a dry room on the
+  seabed are possible at all; water only yields to a tier-3 mining beam, so before this there was no
+  way around it either. Doors and torches keep their refusal: a door lives in an air cell the water
+  would flow straight back into, and a torch is an open flame.
 - **Hovering scan-drones actually hurt now (#833).** A drone's own AI holds a 4–10 block standoff
   ring and floats 4 blocks up, so it never came within the server's 4-block damage aura — it circled
   you firing a laser and was mechanically harmless, exactly as a player reported. Ranged machines now

--- a/TODO.md
+++ b/TODO.md
@@ -104,6 +104,20 @@ Per-item detail lives in the dated work log below. **Since 2026-07 versions are 
 
 ---
 
+### ★ Building under water (#851, 2026-08-08, branch fix/underwater-block-placement)
+Under water **no** block could be placed: `HandlePlace` accepted an air target cell only, and the cell the
+client offers while you swim always holds water — the aim march deliberately passes *through* fluids (they
+have no collider), so the place cell in front of the seabed you aimed at is a water cell. With water mineable
+only by a tier-3 mining beam there was no way to clear it first either, so underwater building was simply
+impossible. A target cell is now free when it is air **or** a fluid: the placed block displaces water/lava.
+After `SetBlock` the cell's flowing state is dropped (`UntrackFluid` — the level row is *persisted*, so a stale
+one would reload as a fluid on top of the new block) and the neighbours are woken, so a cut-off tongue recedes
+and the body settles around a new wall. Two placeables keep their refusal, both *before* anything is consumed:
+a **door** (an entity in an air cell — water would just flow back around it; the four door keys moved into
+`IsDoorBlock`) and a **torch** in water (open flame, reusing the existing `@no_air` reason — no new locale
+keys anywhere). `DeriveShapeUpFace` no longer counts a fluid as a surface, so a stair placed against an
+underwater wall auto-orients the same way it does in air. Tests: `UnderwaterPlacementTests` (7).
+
 ### ★ Justus playtest batch: drone damage, entombed spawns, wall shots, creative flight, log end grain, finer face editor (#833–#841, 2026-08-08, branch fix/playtest-2026-08-08)
 Eleven F1 reports from one evening, triaged from the ReportHost inbox into nine issues and fixed in one
 sweep. **#833 scan-drones dealt zero damage, always** — the measured cause, not a guess: the drone AI holds a

--- a/src/BlocksBeyondTheStars.GameServer/GameServer.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServer.cs
@@ -3275,7 +3275,8 @@ public sealed partial class GameServer
         bool Solid(int dx, int dy, int dz)
         {
             var p = WorldConstants.CanonicalBlock(new Vector3i(pos.X + dx, pos.Y + dy, pos.Z + dz), _world.Circumference);
-            return !_world.GetBlock(p).IsAir;
+            var b = _world.GetBlock(p);
+            return !b.IsAir && !IsFluid(b.Value); // water/lava is no surface to build against (#851)
         }
 
         if (Solid(0, -1, 0)) return 0; // floor → +Y up (unchanged for ground placement)
@@ -3324,10 +3325,36 @@ public sealed partial class GameServer
             return;
         }
 
-        if (!_world.GetBlock(pos).IsAir)
+        // Building under water (#851): the target cell is free when it is air OR holds a fluid — a placed block
+        // DISPLACES water/lava, exactly like in every other voxel builder. Without this you can't build under
+        // water at all: the client's aim march passes THROUGH fluids (they have no collider — you swim into
+        // them), so the cell it offers while you're swimming always holds water, and water only yields to a
+        // tier-3 mining beam, so there was no way to clear it first either.
+        var existing = _world.GetBlock(pos);
+        bool intoFluid = IsFluid(existing.Value);
+        if (!existing.IsAir && !intoFluid)
         {
             Reject(session, "place", "@srv.place.not_empty");
             return;
+        }
+
+        if (intoFluid)
+        {
+            // Two placeables genuinely can't take a fluid cell, and both are refused before anything is
+            // consumed: a door is an ENTITY living in an air cell (the fluid would just flow back around it,
+            // leaving a door that holds nothing back), and a torch is an open flame — a submerged one would be
+            // the same mysterious dud the airless-body check above exists to prevent.
+            if (IsDoorBlock(blockDef.Key))
+            {
+                Reject(session, "place", "@srv.place.not_empty");
+                return;
+            }
+
+            if (blockDef.Key == "torch" && existing.Value == _waterId)
+            {
+                Reject(session, "place", "@no_air");
+                return;
+            }
         }
 
         // Don't let the player wall themselves in: refuse a block at HEAD height in their own column. The FEET
@@ -3430,8 +3457,7 @@ public sealed partial class GameServer
         }
 
         // A door isn't a voxel block — it fills the (air) cell as a server door entity (Task 5 Stage 3c).
-        if (blockDef.Key == "door_hinge" || blockDef.Key == "door_slide" || blockDef.Key == "door_wood"
-            || blockDef.Key == "door_energy")
+        if (IsDoorBlock(blockDef.Key))
         {
             PlaceDoor(session, pos, blockDef.Key switch
             {
@@ -3513,6 +3539,14 @@ public sealed partial class GameServer
         if (IsFluid(blockDef.NumericId.Value))
         {
             RegisterFluidSource(pos); // placed water/lava starts flowing
+        }
+        else if (intoFluid)
+        {
+            // The block displaced a fluid (#851): drop the cell's flowing state — memory AND the persisted level
+            // row — or a reload would resurrect the tongue on top of the new block, and wake the neighbours so a
+            // stream cut off here recedes (and the body around a new underwater wall settles again).
+            UntrackFluid(pos);
+            OnFluidRemoved(pos);
         }
 
         SendInventory(session);

--- a/src/BlocksBeyondTheStars.GameServer/GameServerDoors.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerDoors.cs
@@ -63,6 +63,12 @@ public sealed partial class GameServer
         _ => "slide",
     };
 
+    /// <summary>True for the placeable block keys that become a door ENTITY instead of a voxel block. Placement
+    /// treats them apart: they need a genuinely empty (air) cell — a door can't displace a fluid the way a solid
+    /// block does, the water would simply flow back around it (#851).</summary>
+    private static bool IsDoorBlock(string blockKey)
+        => blockKey is "door_hinge" or "door_slide" or "door_wood" or "door_energy";
+
     /// <summary>The item a door of this kind hands back when it is picked up again.</summary>
     private static string DoorItemFor(string kind) => kind switch
     {

--- a/tests/BlocksBeyondTheStars.Tests/UnderwaterPlacementTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/UnderwaterPlacementTests.cs
@@ -1,0 +1,223 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using System;
+using BlocksBeyondTheStars.Networking.Transport;
+using BlocksBeyondTheStars.Persistence;
+using BlocksBeyondTheStars.Shared.Configuration;
+using BlocksBeyondTheStars.Shared.Content;
+using BlocksBeyondTheStars.Shared.Geometry;
+using BlocksBeyondTheStars.Shared.Primitives;
+using Xunit;
+using SvGameServer = BlocksBeyondTheStars.GameServer.GameServer;
+
+namespace BlocksBeyondTheStars.Tests;
+
+/// <summary>
+/// Building under water (#851). A placed block DISPLACES water/lava instead of being refused as "not empty" —
+/// without this you cannot build under water at all, because the aim march passes through fluids (they have no
+/// collider) so the cell offered while swimming always holds water, and water only yields to a tier-3 beam.
+/// The two placeables that genuinely can't take a fluid cell stay refused: doors (an entity in an air cell) and
+/// torches (an open flame).
+/// </summary>
+public sealed class UnderwaterPlacementTests : IDisposable
+{
+    private readonly string _root;
+    private readonly GameContent _content;
+
+    public UnderwaterPlacementTests()
+    {
+        _root = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "bbts_uwplace_" + Guid.NewGuid().ToString("N"));
+        _content = ContentLoader.LoadFromDirectory(TestPaths.DataDir());
+    }
+
+    private SvGameServer NewServer(out SqliteWorldRepository repo)
+    {
+        repo = new SqliteWorldRepository(new SaveGamePaths(_root, "uwplace"));
+        var st = new LoopbackServerTransport(new LoopbackLink());
+        var config = new ServerConfig { WorldName = "uwplace", Seed = 1, AutoSaveIntervalMinutes = 9999, PlaceStarterShip = false, PlaceSettlements = false };
+        var server = new SvGameServer(config, _content, st, repo);
+        server.Start();
+        return server;
+    }
+
+    private const int PoolY = 180; // high above the terrain: an isolated basin, nothing else in reach
+
+    /// <summary>A stone basin filled with a 5x5x3 body of static "sea" water and a diver floating in it.</summary>
+    private BlocksBeyondTheStars.GameServer.PlayerSession Diver(SvGameServer server)
+    {
+        var stone = _content.GetBlock("stone")!.NumericId;
+        var water = _content.GetBlock("water")!.NumericId;
+        for (int x = -2; x <= 2; x++)
+        {
+            for (int z = -2; z <= 2; z++)
+            {
+                server.World.SetBlock(new Vector3i(x, PoolY, z), stone);
+                for (int y = PoolY + 1; y <= PoolY + 3; y++)
+                {
+                    server.World.SetBlock(new Vector3i(x, y, z), water);
+                }
+            }
+        }
+
+        var p = server.AddLocalPlayer("Diver");
+        p.State.AboardShip = false;
+        p.State.Position = new Vector3f(0.5f, PoolY + 2f, 0.5f);
+        return p;
+    }
+
+    [Fact]
+    public void Block_PlacedIntoWater_DisplacesTheFluid()
+    {
+        var server = NewServer(out var repo);
+        using (repo)
+        {
+            var p = Diver(server);
+            p.State.Inventory.Add("stone", 4, _content.MaxStackOf("stone"));
+
+            // The cell the client offers while swimming: the water cell in front of the seabed it aimed at.
+            var target = new Vector3i(1, PoolY + 1, 1);
+            Assert.Equal(_content.GetBlock("water")!.NumericId.Value, server.World.GetBlock(target).Value);
+
+            server.PlaceBlock("Diver", target.X, target.Y, target.Z, "stone");
+
+            Assert.Equal(_content.GetBlock("stone")!.NumericId.Value, server.World.GetBlock(target).Value);
+            Assert.Equal(3, p.State.Inventory.CountOf("stone")); // exactly one was consumed
+        }
+    }
+
+    [Fact]
+    public void PlacedBlock_IsNotFloodedAgainByTheSurroundingWater()
+    {
+        var server = NewServer(out var repo);
+        using (repo)
+        {
+            var p = Diver(server);
+            p.State.Inventory.Add("stone", 4, _content.MaxStackOf("stone"));
+
+            var target = new Vector3i(1, PoolY + 1, 1);
+            server.PlaceBlock("Diver", target.X, target.Y, target.Z, "stone");
+
+            // Displacing a cell wakes the body around it — it must settle around the new block, not swallow it.
+            for (int i = 0; i < 12; i++)
+            {
+                server.Tick(0.3);
+            }
+
+            Assert.Equal(_content.GetBlock("stone")!.NumericId.Value, server.World.GetBlock(target).Value);
+        }
+    }
+
+    [Fact]
+    public void PlacedBlock_SurvivesAReload_WithoutTheFluidComingBack()
+    {
+        var server = NewServer(out var repo);
+        var target = new Vector3i(1, PoolY + 1, 1);
+        using (repo)
+        {
+            var p = Diver(server);
+            p.State.Inventory.Add("stone", 4, _content.MaxStackOf("stone"));
+            server.PlaceBlock("Diver", target.X, target.Y, target.Z, "stone");
+            server.Stop();
+        }
+
+        // A stale flowing-level row for the displaced cell would reload as a fluid cell on top of the block.
+        var server2 = NewServer(out var repo2);
+        using (repo2)
+        {
+            Assert.Equal(_content.GetBlock("stone")!.NumericId.Value, server2.World.GetBlock(target).Value);
+            for (int i = 0; i < 12; i++)
+            {
+                server2.Tick(0.3);
+            }
+
+            Assert.Equal(_content.GetBlock("stone")!.NumericId.Value, server2.World.GetBlock(target).Value);
+            server2.Stop();
+        }
+    }
+
+    [Fact]
+    public void Door_IsStillRefusedInAFluidCell()
+    {
+        var server = NewServer(out var repo);
+        using (repo)
+        {
+            var p = Diver(server);
+            p.State.Inventory.Add("door_hinge", 1, 99);
+
+            var target = new Vector3i(1, PoolY + 1, 1);
+            server.PlaceBlock("Diver", target.X, target.Y, target.Z, "door_hinge");
+
+            // A door is an entity in an AIR cell — the water would just flow back around it.
+            Assert.Equal(0, server.DoorCount);
+            Assert.Equal(1, p.State.Inventory.CountOf("door_hinge")); // refused before anything was consumed
+            Assert.Equal(_content.GetBlock("water")!.NumericId.Value, server.World.GetBlock(target).Value);
+        }
+    }
+
+    [Fact]
+    public void Torch_IsStillRefusedUnderWater()
+    {
+        var server = NewServer(out var repo);
+        using (repo)
+        {
+            var p = Diver(server);
+            p.State.Inventory.Add("torch", 1, _content.MaxStackOf("torch"));
+
+            var target = new Vector3i(1, PoolY + 1, 1);
+            server.PlaceBlock("Diver", target.X, target.Y, target.Z, "torch");
+
+            Assert.Equal(_content.GetBlock("water")!.NumericId.Value, server.World.GetBlock(target).Value);
+            Assert.Equal(1, p.State.Inventory.CountOf("torch")); // an open flame stays in the pack
+        }
+    }
+
+    [Fact]
+    public void Block_PlacedIntoLava_DisplacesItToo()
+    {
+        var server = NewServer(out var repo);
+        using (repo)
+        {
+            var lava = _content.GetBlock("lava")!.NumericId;
+            var p = Diver(server);
+            p.State.Inventory.Add("stone", 4, _content.MaxStackOf("stone"));
+
+            var target = new Vector3i(1, PoolY + 1, 1);
+            server.World.SetBlock(target, lava);
+            server.PlaceBlock("Diver", target.X, target.Y, target.Z, "stone");
+
+            Assert.Equal(_content.GetBlock("stone")!.NumericId.Value, server.World.GetBlock(target).Value);
+        }
+    }
+
+    [Fact]
+    public void SolidCell_IsStillRefused()
+    {
+        var server = NewServer(out var repo);
+        using (repo)
+        {
+            var p = Diver(server);
+            p.State.Inventory.Add("stone", 4, _content.MaxStackOf("stone"));
+
+            var floor = new Vector3i(1, PoolY, 1); // the basin's stone floor — occupied, not a fluid
+            server.PlaceBlock("Diver", floor.X, floor.Y, floor.Z, "stone");
+
+            Assert.Equal(4, p.State.Inventory.CountOf("stone")); // nothing consumed, the cell was not empty
+        }
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (System.IO.Directory.Exists(_root))
+            {
+                System.IO.Directory.Delete(_root, recursive: true);
+            }
+        }
+        catch (System.IO.IOException)
+        {
+            // best effort — a locked save file must not fail the test run
+        }
+    }
+}


### PR DESCRIPTION
@
Under water **no** block could be placed at all — every attempt came back as *"Target is not empty"*.

`HandlePlace` accepted an **air** target cell only, and the cell the client offers while you swim always
holds water: the aim march deliberately passes **through** fluids (they have no collider — you swim into
them), so the place cell in front of the seabed you aimed at is a water cell. Water yields only to a tier-3
mining beam, so there was no way to clear it first either — underwater building was simply impossible.

## What changed

- A target cell is free when it is air **or** a fluid: the placed block **displaces** water/lava.
- After `SetBlock` the cells flowing state is dropped (`UntrackFluid`) and the neighbours are woken. The
  level row is *persisted*, so a stale one would reload as a fluid sitting on top of the new block; waking
  lets a stream cut off here recede and the body settle around a new underwater wall.
- Two placeables keep their refusal, both **before** anything is consumed: a **door** (an entity living in an
  air cell — the water would just flow back around it; the four door keys moved into a shared `IsDoorBlock`)
  and a **torch** in water (an open flame, refused with the existing `@no_air` reason). **No new locale keys.**
- `DeriveShapeUpFace` no longer counts a fluid as a surface, so a stair placed against an underwater wall
  auto-orients the same way it does in air.

## Tests

New `UnderwaterPlacementTests` (7): the fluid is displaced, the water does not flood the new block back,
it survives a reload, lava works the same, and door / torch / a genuinely solid cell stay refused.
Full fast tier green locally (1514 server + 187 client-core). Server-only change — no Unity assets touched.

closes #851

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@