### PR TITLE
Keep digging with a full pack: mined blocks fall as stacking ground drop packets (#853)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@ the richer, screenshot-laden versions live there. `(#123)` references the pull r
 
 ### Added
 
+- **A full backpack no longer stops the drill (#853).** Mining used to be refused outright once your
+  backpack and cargo hold were full — the block just would not break. Now it always breaks, and
+  whatever does not fit lands on the ground as a small block packet. Packets **stack**: further
+  overflow joins the bundle already lying there instead of littering one per block, and an area
+  drill's whole burst leaves a single packet. Walk near one with room to spare and it flows back into
+  your inventory by itself — no key, no prompt. Packets survive saving and reloading, and a dyed or
+  shaped block keeps its own stack inside the bundle. Defeated creatures drop their loot on the ground
+  the same way instead of it being lost. (Mining out in space keeps the old refusal: there is no ground
+  to drop onto, and the block simply stays put.)
+
 - **Creative and Sandbox worlds fly (#836).** Double-tap **Space** to lift off, Space to rise,
   Ctrl/C to sink; collision stays on, so you can still land on things and build against them.
   Flight was there all along as the admin command `/fly`, which nobody ever found — a young

--- a/TODO.md
+++ b/TODO.md
@@ -104,6 +104,50 @@ Per-item detail lives in the dated work log below. **Since 2026-07 versions are 
 
 ---
 
+### ★ Keep digging with a full pack: mined blocks fall as stacking ground packets (#853, 2026-08-09, branch feat/ground-drop-packets)
+Mining **stopped** once the backpack (and the cargo hold, when aboard) was full: `BreakBlockAt` priced the
+whole yield, asked `MaterialPool.CanFit` and left the block standing with an `@inventory_full` rejection. That
+was the right call in #600/#607 — a full inventory used to *destroy* drops silently, and refusing the break was
+the only lossless option while the world had nowhere to put the overflow. This adds the missing place, so the
+drill never stops again.
+
+**The packet.** A `StoredContainer` with the new kind `"drop"`. The container store is already generic over
+its kind in all three repositories (`id, planet, kind, x, y, z, json`), so packets persist across a reload with
+**no schema change and no save migration** — the same trick the salvage capsule and the storage crate use.
+They are filtered out of `ContainerList` (they would otherwise steal the crate/capsule loot prompt, and they
+collect themselves anyway) and travel on their own `DropPacketList`, NetCodec tag **194**.
+
+**Stacking, not littering.** `SpillToGround` merges into the nearest existing packet within 3.5 m by **exact
+item key**, so a dyed/glowing/shaped variant keeps its own stack instead of dissolving into the plain material
+(the composite `ItemKey` is what makes a mined blue wall come back blue). A packet holds 12 distinct keys —
+counts inside a stack are unbounded, which *is* the stacking requirement — and a body holds 64 packets; at that
+cap a spill pours into the nearest packet at any distance, so the count is bounded and **nothing is ever
+destroyed**. An area drill's whole burst spills once, at the end, from the shared pool: one bundle, not one per
+cell. `MaterialPool` grew `TakeLeftovers()` (merged per key, and cleared, so the same overflow cannot be
+spilled twice) next to the existing `Overflow` counter that feeds the warning path.
+
+**Automatic pickup.** `TickDropPackets` sweeps at 4 Hz per world: packets within 2.5 m of a joined player pour
+into their inventory, personal slots first and the cargo hold when aboard; the packet keeps whatever still does
+not fit and despawns once empty. A full pack standing on a packet is a deliberate no-op — no inventory push, no
+broadcast — so mining on with no room costs nothing. The collected items surface in the existing HUD pickup
+feed through the client's inventory diff, so no new UI was needed for the *taking*; the packet itself is a new
+`DropPacketView`, a small tumbling mini-block wearing its biggest stack's atlas tile (world containers have no
+3-D representation at all, so the capsule/crate path had nothing to reuse).
+
+**Also covered:** creature and bandit kills (`BankLoot` takes an optional spill cell — the kill already
+happened, so the loot could previously only be *reported* lost). **Deliberately not covered:** EVA and ship-hull
+mining in space, where containers have no body to belong to and there is no ground to spill onto — those keep
+the existing refusal, which is lossless because the block simply stays. Player-door pickup keeps its refusal
+too (the door stays standing; nothing is lost).
+
+Scope decisions with the owner: **no despawn timer** (a packet is not a countdown — the cap plus merging is the
+save-size guard), and **first player in range collects**, with no ownership tag. Tests: `DropPacketTests` (9) —
+digging four blocks on a full pack leaves one packet with all four stones, distant spills stay separate, dyed
+variants keep their own stack, the world cap merges without loss, pickup collects / partially collects / leaves
+out-of-reach packets alone, a full pack changes nothing, and packets survive a restart.
+`InventoryFullSafetyTests.Mining_WithNoRoomForTheDrop_LeavesTheBlockStanding` pinned the old refusal and was
+rewritten (same guarantee, new mechanism): the block breaks *and* the stone is on the ground.
+
 ### ★ Building under water (#851, 2026-08-08, branch fix/underwater-block-placement)
 Under water **no** block could be placed: `HandlePlace` accepted an air target cell only, and the cell the
 client offers while you swim always holds water — the aim march deliberately passes *through* fluids (they

--- a/client/Assets/BlocksBeyondTheStars/Scripts/DropPacketView.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/DropPacketView.cs
@@ -1,0 +1,205 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using System.Collections.Generic;
+using BlocksBeyondTheStars.Networking.Messages;
+using UnityEngine;
+
+namespace BlocksBeyondTheStars.Client
+{
+    /// <summary>
+    /// Renders the **ground drop packets** (#853): the little block bundles mining with a full backpack
+    /// leaves lying in the world. Each is a small tumbling mini-block wearing its biggest stack's texture,
+    /// so a pile of stone reads as stone from a distance.
+    /// <para>
+    /// Purely presentational — pickup is server-side and automatic (walk near it with room to spare), so
+    /// unlike <see cref="NetFragmentView"/> and <see cref="DataCubeView"/> there is no prompt and no key.
+    /// The collected items show up in the usual HUD pickup feed via the inventory diff; a packet
+    /// disappearing from the list simply pops here.
+    /// </para>
+    /// </summary>
+    public sealed class DropPacketView : MonoBehaviour
+    {
+        public GameBootstrap Game;
+
+        private sealed class Packet
+        {
+            public GameObject Go;
+            public Transform Spin;
+            public Vector3 World;
+            public float Phase;
+        }
+
+        private readonly Dictionary<string, Packet> _packets = new Dictionary<string, Packet>();
+        private bool _subscribed;
+
+        private const float Size = 0.42f;      // a mini block: clearly smaller than a real one
+        private const float HoverHeight = 0.3f;
+
+        private void Update()
+        {
+            if (!_subscribed && Game?.Network != null)
+            {
+                Game.Network.DropPacketsReceived += OnPackets;
+                _subscribed = true;
+            }
+
+            float t = Time.time;
+            foreach (var p in _packets.Values)
+            {
+                var basePos = Game != null ? Game.ScenePos(p.World.x, p.World.y, p.World.z) : p.World;
+                p.Go.transform.position = basePos + Vector3.up * (HoverHeight + Mathf.Sin(t * 1.8f + p.Phase) * 0.07f);
+                p.Spin.localRotation = Quaternion.Euler(18f, t * 45f + p.Phase * 20f, 10f);
+            }
+        }
+
+        private void OnPackets(DropPacketList m)
+        {
+            var seen = new HashSet<string>();
+            if (m.Packets != null)
+            {
+                foreach (var np in m.Packets)
+                {
+                    seen.Add(np.Id);
+                    if (_packets.TryGetValue(np.Id, out var existing))
+                    {
+                        existing.World = new Vector3(np.X + 0.5f, np.Y + 0.5f, np.Z + 0.5f);
+                    }
+                    else
+                    {
+                        _packets[np.Id] = Build(np);
+                    }
+                }
+            }
+
+            if (_packets.Count > seen.Count)
+            {
+                var stale = new List<string>();
+                foreach (var id in _packets.Keys)
+                {
+                    if (!seen.Contains(id)) stale.Add(id);
+                }
+
+                foreach (var id in stale)
+                {
+                    Destroy(_packets[id].Go);
+                    _packets.Remove(id);
+                }
+            }
+        }
+
+        private Packet Build(NetDropPacket np)
+        {
+            var go = new GameObject($"DropPacket {np.Id}");
+            go.transform.SetParent(transform, true);
+
+            var spin = new GameObject("Spin").transform;
+            spin.SetParent(go.transform, false);
+
+            // A stack of two offset mini-cubes so it reads as a *bundle* rather than a single lost block.
+            MakeCube(spin, Vector3.zero, Size, np.TopItem);
+            if (np.StackCount > 1 || np.TotalCount > 1)
+            {
+                MakeCube(spin, new Vector3(0.16f, 0.26f, -0.1f), Size * 0.72f, np.TopItem);
+            }
+
+            return new Packet
+            {
+                Go = go,
+                Spin = spin,
+                World = new Vector3(np.X + 0.5f, np.Y + 0.5f, np.Z + 0.5f),
+                Phase = (np.Id.GetHashCode() & 0x3ff) * 0.01f,
+            };
+        }
+
+        /// <summary>One mini-cube wearing the packet's material: the block's atlas tile where the item places
+        /// a block, otherwise a flat colour derived from the item key (tools, components, ...).</summary>
+        private void MakeCube(Transform parent, Vector3 offset, float size, string item)
+        {
+            var cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            var col = cube.GetComponent<Collider>();
+            if (col != null)
+            {
+                Destroy(col); // walked over, never bumped into — collecting is proximity, not physics
+            }
+
+            cube.transform.SetParent(parent, false);
+            cube.transform.localPosition = offset * size;
+            cube.transform.localScale = Vector3.one * size;
+
+            var def = BlockDefFor(item);
+            if (def != null && Game?.Atlas != null && Game.ChunkMaterial != null)
+            {
+                cube.GetComponent<Renderer>().sharedMaterial = Game.ChunkMaterial;
+                RemapToTile(cube.GetComponent<MeshFilter>(), Game.Atlas.TileUv(def.NumericId.Value));
+            }
+            else
+            {
+                if (_litShader == null)
+                {
+                    _litShader = Shader.Find("BlocksBeyondTheStars/LitColor") ?? Shader.Find("Unlit/Color");
+                }
+
+                var tint = HashTint(item);
+                cube.GetComponent<Renderer>().sharedMaterial = new Material(_litShader) { color = ShaderColor.Srgb(tint) };
+            }
+        }
+
+        /// <summary>The block an item key stands for — through <c>PlacesBlock</c> and past any dye/glow/shape
+        /// modifier, so a painted or shaped drop still shows its material rather than falling back to a swatch.</summary>
+        private BlocksBeyondTheStars.Shared.Definitions.BlockDefinition BlockDefFor(string item)
+        {
+            if (Game?.Content == null || string.IsNullOrEmpty(item))
+            {
+                return null;
+            }
+
+            string plain = BlocksBeyondTheStars.Shared.State.ItemKey.Base(item);
+            var def = Game.Content.GetBlock(plain);
+            if (def == null && Game.Content.GetItem(plain)?.PlacesBlock is string places && places.Length > 0)
+            {
+                def = Game.Content.GetBlock(places);
+            }
+
+            return def;
+        }
+
+        /// <summary>Rewrites the primitive cube's 0..1 UVs onto one atlas tile — the same trick the chunk
+        /// mesher does per face, minus the per-face variation a 0.4 m bundle would never show.</summary>
+        private static void RemapToTile(MeshFilter filter, Rect uv)
+        {
+            if (filter == null)
+            {
+                return;
+            }
+
+            var mesh = Instantiate(filter.sharedMesh); // never edit the shared primitive mesh
+            var uvs = mesh.uv;
+            for (int i = 0; i < uvs.Length; i++)
+            {
+                uvs[i] = new Vector2(uv.x + uvs[i].x * uv.width, uv.y + uvs[i].y * uv.height);
+            }
+
+            mesh.uv = uvs;
+            filter.sharedMesh = mesh;
+        }
+
+        private static Shader _litShader;
+
+        /// <summary>Stable pseudo-colour for a non-block item, so two packets of the same thing look alike.</summary>
+        private static Color HashTint(string item)
+        {
+            int h = string.IsNullOrEmpty(item) ? 0 : item.GetHashCode();
+            float hue = ((h & 0x7fffffff) % 360) / 360f;
+            return Color.HSVToRGB(hue, 0.35f, 0.75f);
+        }
+
+        private void OnDestroy()
+        {
+            if (_subscribed && Game?.Network != null)
+            {
+                Game.Network.DropPacketsReceived -= OnPackets;
+            }
+        }
+    }
+}

--- a/client/Assets/BlocksBeyondTheStars/Scripts/DropPacketView.cs.meta
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/DropPacketView.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c50d3c9879c644a8973326a16581959a

--- a/client/Assets/BlocksBeyondTheStars/Scripts/GameBootstrap.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/GameBootstrap.cs
@@ -950,6 +950,13 @@ namespace BlocksBeyondTheStars.Client
                     ?? "Backpack and cargo hold are full — anything else you pick up is lost.";
             }
 
+            // #853: mining with a full pack no longer stops — the overflow is lying on the ground.
+            if (text == "@dropped_on_ground")
+            {
+                return Localizer?.Get("ui.hint.dropped_on_ground")
+                    ?? "Backpack full — the rest is lying on the ground. Walk over it once you have room.";
+            }
+
             // #794: a base's sealed rooms just lost their air seal (a wall was mined, a door pulled …).
             if (text == "@base_air_lost")
             {

--- a/client/Assets/BlocksBeyondTheStars/Scripts/WorldRig.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/WorldRig.cs
@@ -263,6 +263,11 @@ namespace BlocksBeyondTheStars.Client
             var factories = root.AddComponent<FactoryView>();
             factories.Game = boot;
 
+            // Render ground drop packets (#853): what a full backpack left lying around while mining.
+            // Collected automatically by the server when the player walks near with room — no prompt.
+            var dropPackets = root.AddComponent<DropPacketView>();
+            dropPackets.Game = boot;
+
             // Render story "net fragments" scattered on the surface; press E to recover (text-only story finds).
             var netFragments = root.AddComponent<NetFragmentView>();
             netFragments.Game = boot;

--- a/data/locales/de.json
+++ b/data/locales/de.json
@@ -894,6 +894,7 @@
   "ui.inventory.discard_confirm": "Wirklich wegwerfen?",
   "ui.inventory.discard_warn": "Alle davon sind endgültig weg. Du bekommst sie nicht zurück.",
   "ui.hint.inventory_full": "Rucksack und Frachtraum sind voll — alles Weitere geht verloren.",
+  "ui.hint.dropped_on_ground": "Kein Platz mehr — der Rest liegt auf dem Boden. Lauf noch mal drüber, wenn du Platz hast.",
   "ui.cargo.title": "Frachtraum",
   "ui.cargo.capacity": "Kapazität",
   "ui.cargo.stow_all": "Alle Materialien einlagern",

--- a/data/locales/en.json
+++ b/data/locales/en.json
@@ -894,6 +894,7 @@
   "ui.inventory.discard_confirm": "Really throw away?",
   "ui.inventory.discard_warn": "Every one of these is destroyed for good. You can't get them back.",
   "ui.hint.inventory_full": "Backpack and cargo hold are full — anything else you pick up is lost.",
+  "ui.hint.dropped_on_ground": "No room left — the rest is lying on the ground. Walk over it again once you have space.",
   "ui.cargo.title": "Cargo Hold",
   "ui.cargo.capacity": "Capacity",
   "ui.cargo.stow_all": "Stow all materials in cargo",

--- a/data/locales/es.json
+++ b/data/locales/es.json
@@ -894,6 +894,7 @@
   "ui.inventory.discard_confirm": "¿Seguro que quieres tirar?",
   "ui.inventory.discard_warn": "Se destruyen para siempre. No podrás recuperarlos.",
   "ui.hint.inventory_full": "La mochila y la bodega están llenas — todo lo que recojas se perderá.",
+  "ui.hint.dropped_on_ground": "No queda sitio — el resto está en el suelo. Vuelve a pasar por encima cuando tengas espacio.",
   "ui.cargo.title": "Bodega",
   "ui.cargo.capacity": "Capacidad",
   "ui.cargo.stow_all": "Guardar todos los materiales en la bodega",

--- a/data/locales/fr.json
+++ b/data/locales/fr.json
@@ -894,6 +894,7 @@
   "ui.inventory.discard_confirm": "Vraiment jeter ?",
   "ui.inventory.discard_warn": "Chaque exemplaire est détruit définitivement. Tu ne pourras pas les récupérer.",
   "ui.hint.inventory_full": "Ton sac à dos et la soute sont pleins — tout ce que tu ramasses ensuite est perdu.",
+  "ui.hint.dropped_on_ground": "Plus de place — le reste est par terre. Repasse dessus quand tu auras de la place.",
   "ui.cargo.title": "Soute",
   "ui.cargo.capacity": "Capacité",
   "ui.cargo.stow_all": "Ranger tous les matériaux dans la soute",

--- a/docs/user/USER_MANUAL.md
+++ b/docs/user/USER_MANUAL.md
@@ -260,6 +260,12 @@ separate unlock; admins can still disable it through server world rules.
   the drill could mine directly (same tier rules).
 - Some powered drills (titanium drill, mining beam) **draw suit energy with every swing**; with an empty
   suit the swing is refused. The basic and diamond drills need no energy, so you can always keep mining.
+- **A full backpack does not stop you.** When neither your inventory nor (while aboard) the cargo hold has
+  room, the block still breaks and the drop lands at your feet as a small **block packet**. Packets stack —
+  everything you dig nearby joins the same bundle — and once you have space again, walking near one pours it
+  back into your inventory automatically. Packets stay where they are until collected, saving and reloading
+  included. Out in space (EVA, ship hulls) there is no ground to drop onto, so a full pack still refuses the
+  break there and the block stays where it is.
 - Ship hull, station, settlement and other players' protected landing zones cannot be mined — **except
   plants**: you may always pick flora, wherever it grows (that is what makes a settlement greenhouse worth
   visiting), you just cannot take the building apart.

--- a/src/BlocksBeyondTheStars.Client.Core/NetworkClient.cs
+++ b/src/BlocksBeyondTheStars.Client.Core/NetworkClient.cs
@@ -58,6 +58,10 @@ namespace BlocksBeyondTheStars.Client
         public event Action<PlanetEnemyDefeated>? PlanetEnemyDefeated;
         public event Action<CreatureList>? CreaturesReceived;
         public event Action<ContainerList>? ContainersReceived;
+
+        /// <summary>Ground drop packets on this body (#853) — the bundles a full inventory left lying around.
+        /// Rendered by <c>DropPacketView</c>; collected automatically by the server, so there is no intent.</summary>
+        public event Action<DropPacketList>? DropPacketsReceived;
         public event Action<ShipPlacement>? ShipPlacementReceived;
         public event Action<ShipStations>? ShipStationsReceived;
         public event Action<PlanetPoiList>? PlanetPoisReceived;
@@ -607,6 +611,7 @@ namespace BlocksBeyondTheStars.Client
                 case PlanetEnemyDefeated m: PlanetEnemyDefeated?.Invoke(m); break;
                 case CreatureList m: CreaturesReceived?.Invoke(m); break;
                 case ContainerList m: ContainersReceived?.Invoke(m); break;
+                case DropPacketList m: DropPacketsReceived?.Invoke(m); break;
                 case ShipPlacement m: ShipPlacementReceived?.Invoke(m); break;
                 case ShipStations m: ShipStationsReceived?.Invoke(m); break;
                 case PlanetPoiList m: PlanetPoisReceived?.Invoke(m); break;

--- a/src/BlocksBeyondTheStars.GameServer/GameServer.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServer.cs
@@ -1228,6 +1228,7 @@ public sealed partial class GameServer
             Guard("TickNpcs", deltaSeconds, TickNpcs);
             Guard("TickLandedTraders", deltaSeconds, TickLandedTraders); // P3: materialize/lift-off a peaceful trader parked on this surface
             Guard("TickDoors", deltaSeconds, TickDoors);
+            Guard("TickDropPackets", deltaSeconds, TickDropPackets); // #853: ground packets flow back into whoever walks over them
             Guard("TickHealTanks", deltaSeconds, TickHealTanks); // base/station regen field: heal + feed + suit recharge
             Guard("TickVoidRescue", deltaSeconds, TickVoidRescue);
             Guard("TickShipAi", deltaSeconds, TickShipAi); // VEGA advisor hints + memory-fragment redemption
@@ -3105,13 +3106,7 @@ public sealed partial class GameServer
         }
 
         var pool = new MaterialPool(_content, session.State, _ship);
-        if (!BreakBlockAt(session, pos, def, pool))
-        {
-            // Nothing was mined — say so instead of eating the drop. The accumulated progress is kept so the
-            // block breaks on the next swing once the player has made room.
-            Reject(session, "mine", "@inventory_full");
-            return;
-        }
+        BreakBlockAt(session, pos, def, pool);
 
         // Powerful drills clear a small area at once.
         if (tool.MiningRadius > 0)
@@ -3120,18 +3115,21 @@ public sealed partial class GameServer
         }
 
         SendInventory(session);
-        WarnIfPoolOverflowed(session, pool); // #600: a full backpack + hold used to eat the drops in silence
+
+        // #853: whatever found no room is now lying on the ground as a drop packet instead of blocking the
+        // swing. One spill call for the whole burst, so an area drill leaves one bundle, not one per cell.
+        SpillPoolOverflow(session, pool, pos);
     }
 
     /// <summary>Breaks one block: clears it, banks its drops in the pool, broadcasts the change,
     /// schedules flora regrowth and advances mining missions. Clears any accumulated mining progress.
     /// <para>
-    /// Returns <c>false</c> — changing nothing at all — when the drops would not fit in the player's
-    /// inventory (or cargo when aboard). Mining used to clear the cell and then silently destroy whatever
-    /// did not fit, so a full inventory quietly ate every drop; refusing the break is the only lossless
-    /// option while there are no ground items to spill onto.
+    /// Nothing is ever destroyed here, but nothing is refused either: what the player's inventory (and the
+    /// cargo hold, when aboard) cannot take stays in the pool's leftovers, and the caller spills it onto the
+    /// ground as a drop packet (#853). Mining used to be refused outright in that situation — correct while
+    /// there was no world container to spill into (#600/#607), and pure frustration once there is one.
     /// </para></summary>
-    private bool BreakBlockAt(PlayerSession session, Vector3i pos, BlockDefinition def, MaterialPool pool)
+    private void BreakBlockAt(PlayerSession session, Vector3i pos, BlockDefinition def, MaterialPool pool)
     {
         var current = _world.GetBlock(pos);
         var (dropTint, dropGlow) = _world.GetModifier(pos); // read the dye/glow BEFORE clearing, to recover it into the drop
@@ -3143,7 +3141,8 @@ public sealed partial class GameServer
             dropShape = 0;
         }
 
-        // Work out exactly what this break would yield, then make sure it all fits before touching the world.
+        // Work out exactly what this break yields. Nothing here can fail any more: what the player cannot
+        // carry ends up on the ground (see SpillPoolOverflow at the call sites), so the block always falls.
         var yield = new List<ItemAmount>();
         bool toxicFloraDrop = IsFlora(current.Value)
             && _floraSpeciesByBlock.TryGetValue(current.Value, out var toxSp) && toxSp.Toxic;
@@ -3161,11 +3160,6 @@ public sealed partial class GameServer
         if (IsContainerBlock(def.Key))
         {
             yield.AddRange(CrateContentsAt(pos)); // a mined crate/wood box hands its stored stacks back too
-        }
-
-        if (!pool.CanFit(yield))
-        {
-            return false;
         }
 
         // Attribution (issue #490): removing a block is an edit like any other, and it is the one that grief
@@ -3190,8 +3184,8 @@ public sealed partial class GameServer
             RemoveBeamAt(pos); // mining a beam block forgets its name/owner + map marker (teleporter pad)
         }
 
-        // Bank the yield computed (and capacity-checked) above. The crate case already handed its own stacks
-        // over in RemoveCrateContainer, so only the block's own drops are added here.
+        // Bank the yield computed above. The crate case already handed its own stacks over in
+        // RemoveCrateContainer, so only the block's own drops are added here.
         foreach (var drop in yield.Take(def.Drops.Count))
         {
             pool.Add(drop.Item, drop.Count);
@@ -3212,7 +3206,6 @@ public sealed partial class GameServer
 
         OnBlockMined(session, def.Key);
         ShipAiOnMine(session); // VEGA onboarding: the "mine a few blocks" stage counts every break
-        return true;
     }
 
     /// <summary>Area mining for powerful drills: breaks the mineable, unprotected blocks around a centre.
@@ -3243,23 +3236,34 @@ public sealed partial class GameServer
                         continue;
                     }
 
-                    // A block whose drops no longer fit is simply left standing (BreakBlockAt returns false
-                    // without changing anything) — the area sweep stops yielding rather than destroying loot.
+                    // A full inventory no longer stops the sweep: every block falls and the pool's leftovers
+                    // are spilled ONCE by the caller, so a burst leaves one ground packet, not one per cell.
                     BreakBlockAt(session, p, d, pool);
                 }
     }
 
     /// <summary>
     /// Banks loot from an event that cannot be refused after the fact — a creature is already dead, a wreck
-    /// already burst. Anything that does not fit is genuinely lost, so the player is TOLD instead of the drop
-    /// vanishing in silence (the complaint that started this: "Items futsch"). Prefer a capacity check up
-    /// front (<see cref="MaterialPool.CanFit"/>) wherever the action can still be refused.
+    /// already burst.
+    /// <para>
+    /// With a <paramref name="spillAt"/> cell the overflow lands on the ground as a drop packet (#853) and
+    /// nothing is lost. Without one — in space, where there is no ground to spill onto — what does not fit is
+    /// genuinely gone, so the player is at least TOLD instead of the drop vanishing in silence (the complaint
+    /// that started this: "Items futsch"). Prefer a capacity check up front
+    /// (<see cref="MaterialPool.CanFit"/>) wherever the action can still be refused.
+    /// </para>
     /// </summary>
-    private void BankLoot(PlayerSession session, MaterialPool pool, IEnumerable<ItemAmount> drops)
+    private void BankLoot(PlayerSession session, MaterialPool pool, IEnumerable<ItemAmount> drops, Vector3i? spillAt = null)
     {
         foreach (var drop in drops)
         {
             pool.Add(drop.Item, drop.Count);
+        }
+
+        if (spillAt is { } cell)
+        {
+            SpillPoolOverflow(session, pool, cell);
+            return;
         }
 
         // Reuses the same rate-limited "your pockets are full" hint as every other overflow site (#600), rather

--- a/src/BlocksBeyondTheStars.GameServer/GameServerContainers.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerContainers.cs
@@ -32,8 +32,10 @@ public sealed partial class GameServer
     /// so loot/stash/HUD treat them identically — the block key only decides capacity).</summary>
     private static bool IsContainerBlock(string key) => key is "crate" or "wood_crate";
 
-    /// <summary>Lootable containers on the current planet (salvage capsules / corpses).</summary>
-    public IReadOnlyList<StoredContainer> Containers => _containers;
+    /// <summary>Lootable containers on the current planet (salvage capsules / corpses / crates). Ground drop
+    /// packets share the same store but are not containers to the player — see <see cref="DropPackets"/>.</summary>
+    public IReadOnlyList<StoredContainer> Containers
+        => _containers.Where(c => c.Kind != DropPacketKind).ToList();
 
     private void LoadContainers()
     {
@@ -251,9 +253,21 @@ public sealed partial class GameServer
         ItemCount = c.Items.Count,
     };
 
-    private void BroadcastContainers()
-        => BroadcastToWorld(new ContainerList { Containers = _containers.Select(ToNetContainer).ToArray() });
+    /// <summary>The containers a client renders + loots. Ground drop packets share this store (and its free
+    /// persistence) but are NOT containers to the player: they collect themselves and would otherwise steal
+    /// the crate/capsule loot prompt, so they are filtered out here and travel on their own list (#853).</summary>
+    private ContainerList ContainerMessage() => new()
+    {
+        Containers = _containers.Where(c => c.Kind != DropPacketKind).Select(ToNetContainer).ToArray(),
+    };
 
+    private void BroadcastContainers() => BroadcastToWorld(ContainerMessage());
+
+    /// <summary>Sends this world's containers AND its ground drop packets — the two lists always travel
+    /// together, so every join/respawn/travel path stays in sync with one call.</summary>
     private void SendContainers(PlayerSession session)
-        => Send(session, new ContainerList { Containers = _containers.Select(ToNetContainer).ToArray() });
+    {
+        Send(session, ContainerMessage());
+        SendDropPackets(session);
+    }
 }

--- a/src/BlocksBeyondTheStars.GameServer/GameServerDropPackets.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerDropPackets.cs
@@ -1,0 +1,342 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using System.Collections.Generic;
+using System.Linq;
+using BlocksBeyondTheStars.Networking.Messages;
+using BlocksBeyondTheStars.Persistence;
+using BlocksBeyondTheStars.Shared.Definitions;
+using BlocksBeyondTheStars.Shared.Geometry;
+using BlocksBeyondTheStars.Shared.State;
+
+namespace BlocksBeyondTheStars.GameServer;
+
+/// <summary>
+/// Ground drop packets (#853): the small block bundles a full inventory leaves lying in the world.
+/// <para>
+/// Mining used to be <b>refused</b> outright once the backpack (and the cargo hold, when aboard) was full —
+/// <c>BreakBlockAt</c> checked <see cref="MaterialPool.CanFit"/> and left the block standing, because there
+/// was nowhere in the world to put the overflow without destroying it (#600/#607, "Items futsch"). This file
+/// is that missing place: the block always breaks, whatever does not fit spills onto the ground, and the
+/// player walks back over it later to get it back.
+/// </para>
+/// <para>
+/// Two rules make it bearable rather than a carpet of litter: packets <b>stack</b> (a nearby packet absorbs
+/// further overflow instead of a new one spawning per mined block), and they are collected
+/// <b>automatically</b> by <see cref="TickDropPackets"/> as soon as a player with room walks near.
+/// </para>
+/// <para>
+/// A packet is a <see cref="StoredContainer"/> with <see cref="DropPacketKind"/> — the container store is
+/// already generic over its kind in all three repositories, so packets persist across a reload with no
+/// schema change and no save migration. They are kept OUT of <c>ContainerList</c> (see
+/// <c>BroadcastContainers</c>) so they never hijack the crate/capsule loot prompt, and travel on their own
+/// <see cref="DropPacketList"/> message instead.
+/// </para>
+/// </summary>
+public sealed partial class GameServer
+{
+    /// <summary>Container kind that marks a ground drop packet (vs. "crate" / "salvage_capsule").</summary>
+    internal const string DropPacketKind = "drop";
+
+    /// <summary>How far a spill looks for an existing packet to merge into. Generous enough that a whole
+    /// tunnel section's overflow lands in one bundle rather than one per cell.</summary>
+    private const float DropMergeRadius = 3.5f;
+
+    /// <summary>How close a player has to be for a packet to flow back into their inventory by itself.</summary>
+    private const float DropPickupRadius = 2.5f;
+
+    /// <summary>Distinct item keys one packet holds before a spill starts a new packet. Counts within a stack
+    /// are unbounded — that IS the stacking requirement.</summary>
+    private const int MaxStacksPerDropPacket = 12;
+
+    /// <summary>Packets a single body may carry. At the cap a spill merges into the nearest packet whatever
+    /// the distance, so the count stays bounded and nothing is ever destroyed.</summary>
+    private const int MaxDropPacketsPerWorld = 64;
+
+    /// <summary>Seconds between auto-pickup sweeps (4 Hz). Fast enough to feel instant when walking over a
+    /// packet, cheap enough that a full inventory standing on one costs nothing.</summary>
+    private const double DropPacketSweepInterval = 0.25;
+
+    /// <summary>Ground drop packets on the active world (tests + inspection).</summary>
+    public IReadOnlyList<StoredContainer> DropPackets
+        => _containers.Where(c => c.Kind == DropPacketKind).ToList();
+
+    /// <summary>
+    /// Puts items that found no room anywhere onto the ground at <paramref name="origin"/>: merged into a
+    /// nearby packet when there is one, otherwise as a new packet. Merging is by <b>exact item key</b>, so a
+    /// dyed/glowing/shaped variant (composite <c>ItemKey</c>) keeps its own stack instead of dissolving into
+    /// the plain material.
+    /// </summary>
+    private void SpillToGround(Vector3i origin, IEnumerable<ItemAmount> items)
+    {
+        var pending = items.Where(i => i.Count > 0 && !string.IsNullOrEmpty(i.Item)).ToList();
+        if (pending.Count == 0)
+        {
+            return;
+        }
+
+        var cell = SettleDropCell(origin);
+        bool changed = false;
+        foreach (var amount in pending)
+        {
+            var packet = FindOrCreatePacket(cell, amount.Item);
+            var stack = packet.Items.FirstOrDefault(s => s.Item == amount.Item);
+            if (stack is null)
+            {
+                packet.Items.Add(new ItemStack(amount.Item, amount.Count));
+            }
+            else
+            {
+                stack.Count += amount.Count;
+            }
+
+            _repo.SaveContainer(packet);
+            changed = true;
+        }
+
+        if (changed)
+        {
+            BroadcastDropPackets();
+        }
+    }
+
+    /// <summary>Convenience overload for the single-item spill sites.</summary>
+    private void SpillToGround(Vector3i origin, string item, int count)
+        => SpillToGround(origin, new[] { new ItemAmount(item, count) });
+
+    /// <summary>
+    /// Spills whatever a pool could not store since its last spill — the overflow-aware companion to
+    /// <see cref="WarnIfPoolOverflowed"/> for events that cannot be refused after the fact (a creature is
+    /// already dead, a wreck already burst). Nothing is lost; the player is still told where it went.
+    /// </summary>
+    private void SpillPoolOverflow(PlayerSession session, MaterialPool pool, Vector3i origin)
+    {
+        var leftovers = pool.TakeLeftovers();
+        if (leftovers.Count == 0)
+        {
+            return;
+        }
+
+        SpillToGround(origin, leftovers);
+        NotifyDropped(session);
+    }
+
+    /// <summary>The throttled "it is on the ground, come back for it" toast — same cadence and channel as the
+    /// old "backpack full" hint it replaces (#600), because one drill swing can overflow on a dozen blocks.</summary>
+    private void NotifyDropped(PlayerSession session)
+    {
+        if (_uptime < session.NextInventoryFullHintAt)
+        {
+            return;
+        }
+
+        session.NextInventoryFullHintAt = _uptime + InventoryFullHintCooldown;
+        Send(session, new ServerMessage { Text = "@dropped_on_ground" });
+    }
+
+    /// <summary>The packet a spill of <paramref name="item"/> at <paramref name="cell"/> belongs in: the
+    /// nearest one within <see cref="DropMergeRadius"/> that already carries the key or still has a free
+    /// stack slot. Falls back to a new packet — or, at the world cap, to the nearest packet at ANY distance
+    /// (a bounded pile beats destroying the items).</summary>
+    private StoredContainer FindOrCreatePacket(Vector3i cell, string item)
+    {
+        var center = Center(cell);
+        StoredContainer? best = null;
+        double bestSq = DropMergeRadius * DropMergeRadius;
+        int count = 0;
+
+        foreach (var c in _containers)
+        {
+            if (c.Kind != DropPacketKind)
+            {
+                continue;
+            }
+
+            count++;
+            if (!HasRoomFor(c, item))
+            {
+                continue;
+            }
+
+            double sq = WrapDistSq(center, Center(c.Position));
+            if (sq <= bestSq)
+            {
+                bestSq = sq;
+                best = c;
+            }
+        }
+
+        if (best is not null)
+        {
+            return best;
+        }
+
+        if (count < MaxDropPacketsPerWorld)
+        {
+            var packet = new StoredContainer
+            {
+                Id = "drop_" + System.Guid.NewGuid().ToString("N"),
+                Planet = _world.LocationId,
+                Kind = DropPacketKind,
+                Position = cell,
+                Items = new List<ItemStack>(),
+            };
+
+            _containers.Add(packet);
+            return packet;
+        }
+
+        // At the cap: pour into the nearest packet regardless of distance and stack budget. Items are never
+        // destroyed — the world just stops growing new bundles.
+        return _containers
+            .Where(c => c.Kind == DropPacketKind)
+            .OrderBy(c => WrapDistSq(center, Center(c.Position)))
+            .First();
+    }
+
+    private static bool HasRoomFor(StoredContainer packet, string item)
+        => packet.Items.Count < MaxStacksPerDropPacket || packet.Items.Any(s => s.Item == item);
+
+    /// <summary>Where a packet actually comes to rest: the mined cell itself when it is free, otherwise the
+    /// first free cell above it (a spill from a block broken under water/inside a wall must not end up
+    /// entombed). Falls back to the origin — a packet is collected by proximity, not by line of sight.</summary>
+    private Vector3i SettleDropCell(Vector3i origin)
+    {
+        for (int dy = 0; dy <= 2; dy++)
+        {
+            var cell = new Vector3i(origin.X, origin.Y + dy, origin.Z);
+            if (!WithinBuildHeight(cell.Y))
+            {
+                break;
+            }
+
+            if (_world.GetBlock(cell).IsAir)
+            {
+                return cell;
+            }
+        }
+
+        return origin;
+    }
+
+    private static Vector3f Center(Vector3i cell) => new(cell.X + 0.5f, cell.Y + 0.5f, cell.Z + 0.5f);
+
+    /// <summary>
+    /// Pours nearby packets back into the players standing over them (4 Hz). Personal inventory first, cargo
+    /// hold when aboard; a packet keeps whatever still does not fit and only disappears once empty. A player
+    /// whose inventory is full is a pure no-op — no inventory push, no broadcast — so mining on with a full
+    /// pack costs nothing extra.
+    /// </summary>
+    private void TickDropPackets(double dt)
+    {
+        _worlds.Active.SinceDropSweep += dt;
+        if (_worlds.Active.SinceDropSweep < DropPacketSweepInterval)
+        {
+            return;
+        }
+
+        _worlds.Active.SinceDropSweep = 0;
+        if (!_containers.Any(c => c.Kind == DropPacketKind))
+        {
+            return;
+        }
+
+        bool anyRemoved = false;
+        foreach (var session in JoinedInActiveWorld())
+        {
+            SetCurrent(session); // per-player ship cursor: the cargo hold we spill into must be THEIR ship's
+            bool tookAnything = false;
+
+            foreach (var packet in _containers.Where(c => c.Kind == DropPacketKind).ToList())
+            {
+                if (WrapDistSq(session.State.Position, Center(packet.Position)) > DropPickupRadius * DropPickupRadius)
+                {
+                    continue;
+                }
+
+                var pool = new MaterialPool(_content, session.State, _ship);
+                var kept = new List<ItemStack>();
+                bool took = false;
+                foreach (var stack in packet.Items)
+                {
+                    if (stack.IsEmpty)
+                    {
+                        continue;
+                    }
+
+                    int leftover = pool.Add(stack.Item, stack.Count);
+                    if (leftover < stack.Count)
+                    {
+                        took = true;
+                    }
+
+                    if (leftover > 0)
+                    {
+                        kept.Add(new ItemStack(stack.Item, leftover));
+                    }
+                }
+
+                if (!took)
+                {
+                    continue; // full pack standing on a packet — leave it exactly as it was
+                }
+
+                tookAnything = true;
+                packet.Items = kept;
+                if (packet.Items.Count == 0)
+                {
+                    _containers.Remove(packet);
+                    _repo.DeleteContainer(packet.Id);
+                }
+                else
+                {
+                    _repo.SaveContainer(packet);
+                }
+
+                anyRemoved = true;
+            }
+
+            if (tookAnything)
+            {
+                SendInventory(session);
+            }
+        }
+
+        if (anyRemoved)
+        {
+            BroadcastDropPackets();
+        }
+    }
+
+    private static NetDropPacket ToNetDropPacket(StoredContainer c)
+    {
+        var top = c.Items.OrderByDescending(s => s.Count).FirstOrDefault();
+        return new NetDropPacket
+        {
+            Id = c.Id,
+            X = c.Position.X,
+            Y = c.Position.Y,
+            Z = c.Position.Z,
+            TopItem = top?.Item ?? string.Empty,
+            StackCount = c.Items.Count,
+            TotalCount = c.Items.Sum(s => s.Count),
+        };
+    }
+
+    private DropPacketList DropPacketMessage()
+        => new() { Packets = _containers.Where(c => c.Kind == DropPacketKind).Select(ToNetDropPacket).ToArray() };
+
+    private void BroadcastDropPackets() => BroadcastToWorld(DropPacketMessage());
+
+    private void SendDropPackets(PlayerSession session) => Send(session, DropPacketMessage());
+
+    // ---------------- Test hooks ----------------
+
+    /// <summary>Test hook: run one auto-pickup sweep on the active world without waiting out the 4 Hz
+    /// throttle (the sweep is otherwise only reachable through a timed <see cref="Tick"/>).</summary>
+    public void SweepDropPacketsForTest() => TickDropPackets(DropPacketSweepInterval);
+
+    /// <summary>Test hook: drop items on the ground exactly as a full-inventory mine would.</summary>
+    public void SpillToGroundForTest(Vector3i origin, string item, int count)
+        => SpillToGround(origin, item, count);
+}

--- a/src/BlocksBeyondTheStars.GameServer/GameServerEnemies.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerEnemies.cs
@@ -654,7 +654,9 @@ public sealed partial class GameServer
         list.Remove(target);
         _enemyWander.Remove(target.Id); // drop the dead enemy's wander state
         var pool = new MaterialPool(_content, p, _ship);
-        BankLoot(session, pool, target.Loot); // the kill already happened — warn if a full inventory loses the drop
+        // The kill already happened, so the loot cannot be refused — a full inventory drops it at the fallen
+        // enemy's feet instead of losing it (#853).
+        BankLoot(session, pool, target.Loot, spillAt: target.Position.ToBlock());
         SendInventory(session);
         OnAchievementDefeat(session);
         if (isCreature)

--- a/src/BlocksBeyondTheStars.GameServer/MaterialPool.cs
+++ b/src/BlocksBeyondTheStars.GameServer/MaterialPool.cs
@@ -67,10 +67,25 @@ public sealed class MaterialPool
     /// player, so a full backpack + full hold stops eating items unannounced.
     /// <para>
     /// This is the *after the fact* half of the story. Where the action can still be refused, prefer
-    /// <see cref="CanFit"/> and never consume anything in the first place.
+    /// <see cref="CanFit"/> and never consume anything in the first place — or hand the leftovers to the
+    /// ground via <see cref="TakeLeftovers"/> (#853), which loses nothing at all.
     /// </para>
     /// </summary>
     public int Overflow { get; private set; }
+
+    private readonly List<ItemAmount> _leftovers = new();
+
+    /// <summary>
+    /// The item amounts <see cref="Add"/> could not store, merged per key — and clears them, so a caller that
+    /// spills them onto the ground (#853) cannot spill the same overflow twice. <see cref="Overflow"/> keeps
+    /// its running total for the warning path.
+    /// </summary>
+    public List<ItemAmount> TakeLeftovers()
+    {
+        var taken = new List<ItemAmount>(_leftovers);
+        _leftovers.Clear();
+        return taken;
+    }
 
     /// <summary>
     /// True when every listed amount would fit (personal inventory first, then cargo when aboard).
@@ -113,9 +128,10 @@ public sealed class MaterialPool
 
     /// <summary>
     /// Adds items, personal inventory first then cargo. Returns the amount that did not fit anywhere
-    /// (0 = fully stored) and accumulates it into <see cref="Overflow"/>. <b>A non-zero return means those
-    /// items were destroyed</b> — check <see cref="CanFit"/> up front where the action can still be refused,
-    /// or handle the leftover (throw it away deliberately, warn via <see cref="Overflow"/>).
+    /// (0 = fully stored) and accumulates it into <see cref="Overflow"/> and <see cref="TakeLeftovers"/>.
+    /// <b>A non-zero return means those items are not stored anywhere</b> — check <see cref="CanFit"/> up
+    /// front where the action can still be refused, or take the leftovers and put them somewhere real (the
+    /// ground, #853); ignoring the return destroys them.
     /// </summary>
     public int Add(string item, int count)
     {
@@ -126,7 +142,20 @@ public sealed class MaterialPool
             leftover = _cargo.Add(item, leftover, maxStack);
         }
 
-        Overflow += leftover;
+        if (leftover > 0)
+        {
+            Overflow += leftover;
+            var known = _leftovers.Find(l => l.Item == item);
+            if (known is null)
+            {
+                _leftovers.Add(new ItemAmount(item, leftover));
+            }
+            else
+            {
+                known.Count += leftover;
+            }
+        }
+
         return leftover;
     }
 }

--- a/src/BlocksBeyondTheStars.GameServer/WorldManager.cs
+++ b/src/BlocksBeyondTheStars.GameServer/WorldManager.cs
@@ -191,6 +191,7 @@ internal sealed class LoadedWorld
     public double SinceBanditSync { get; set; }  // bandit movement stream throttle (per-world, like SinceEnemySync)
     public double SinceFluid { get; set; }
     public double SinceFire { get; set; }
+    public double SinceDropSweep { get; set; } // ground drop-packet auto-pickup throttle (#853)
     // These three run once per occupied world each tick, so their accumulate-and-reset throttles MUST be
     // per-world — a single shared field lets whichever world is iterated first reset it before the others
     // reach their interval, starving every world but one of presence/enemy syncs and the void rescue.

--- a/src/BlocksBeyondTheStars.Networking/Messages.cs
+++ b/src/BlocksBeyondTheStars.Networking/Messages.cs
@@ -1630,10 +1630,34 @@ public sealed class NetContainer
     public int ItemCount { get; set; }
 }
 
-/// <summary>Lootable containers on the current planet (salvage capsules / corpses), sent on join + on change.</summary>
+/// <summary>Lootable containers on the current planet (salvage capsules / corpses), sent on join + on change.
+/// Ground drop packets are deliberately NOT in here — they ride <see cref="DropPacketList"/> so they cannot
+/// hijack the crate/capsule loot prompt (#853).</summary>
 public sealed class ContainerList
 {
     public NetContainer[] Containers { get; set; } = System.Array.Empty<NetContainer>();
+}
+
+/// <summary>One ground drop packet: the block bundle a full inventory left lying in the world (#853). The
+/// client renders a small tumbling mini-block for it; picking it up is automatic (server-side proximity),
+/// so there is no matching intent. <see cref="TopItem"/> is the biggest stack in the bundle and decides the
+/// icon; <see cref="StackCount"/>/<see cref="TotalCount"/> label it.</summary>
+public sealed class NetDropPacket
+{
+    public string Id { get; set; } = string.Empty;
+    public int X { get; set; }
+    public int Y { get; set; }
+    public int Z { get; set; }
+    public string TopItem { get; set; } = string.Empty;
+    public int StackCount { get; set; }
+    public int TotalCount { get; set; }
+}
+
+/// <summary>All ground drop packets on the player's current body (server → client), sent on join and
+/// whenever one is spilled, topped up or collected.</summary>
+public sealed class DropPacketList
+{
+    public NetDropPacket[] Packets { get; set; } = System.Array.Empty<NetDropPacket>();
 }
 
 /// <summary>Where the player's ship hull stands in the world (for the HUD minimap / compass).</summary>

--- a/src/BlocksBeyondTheStars.Networking/NetCodec.cs
+++ b/src/BlocksBeyondTheStars.Networking/NetCodec.cs
@@ -375,6 +375,10 @@ public static class NetCodec
         Register(194, typeof(CustomShapeCraftIntent));   // Client -> Server (craft a form from a material)
         Register(195, typeof(CustomShapeData));          // Server -> Client (one form; empty = wiped)
         Register(196, typeof(CustomShapeList));          // Server -> Client (all forms, on join)
+
+        // Ground drop packets (#853): what a full inventory leaves lying on the ground. Pickup is automatic
+        // (server-side proximity), so there is no client intent — only the world list.
+        Register(197, typeof(DropPacketList));           // Server -> Client
     }
 
     private static void Register(byte tag, Type type)

--- a/tests/BlocksBeyondTheStars.Tests/DropPacketTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/DropPacketTests.cs
@@ -1,0 +1,303 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using BlocksBeyondTheStars.Networking.Transport;
+using BlocksBeyondTheStars.Persistence;
+using BlocksBeyondTheStars.Shared.Configuration;
+using BlocksBeyondTheStars.Shared.Content;
+using BlocksBeyondTheStars.Shared.Geometry;
+using BlocksBeyondTheStars.Shared.State;
+using Xunit;
+using SvGameServer = BlocksBeyondTheStars.GameServer.GameServer;
+
+namespace BlocksBeyondTheStars.Tests;
+
+/// <summary>
+/// Ground drop packets (#853): mining with a full backpack must keep working. The block breaks, the drop
+/// lands on the ground as a packet, packets STACK instead of littering one bundle per block, and walking
+/// near one with free slots collects it again by itself.
+/// </summary>
+public sealed class DropPacketTests : IDisposable
+{
+    private readonly string _root;
+    private readonly GameContent _content;
+
+    public DropPacketTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "bbts_drops_" + Guid.NewGuid().ToString("N"));
+        _content = ContentLoader.LoadFromDirectory(TestPaths.DataDir());
+    }
+
+    private SvGameServer Started(out SqliteWorldRepository repo, string world = "drops")
+    {
+        repo = new SqliteWorldRepository(new SaveGamePaths(_root, world));
+        var st = new LoopbackServerTransport(new LoopbackLink());
+        var config = new ServerConfig
+        {
+            WorldName = world,
+            Seed = 31,
+            StartPlanet = "rocky",
+            AutoSaveIntervalMinutes = 9999,
+            PlaceStarterShip = false,
+        };
+        var server = new SvGameServer(config, _content, st, repo);
+        server.Start();
+        return server;
+    }
+
+    /// <summary>Packs every slot with a full stack, so nothing new fits and no stack can be topped up.</summary>
+    private void FillEverySlot(Inventory inv, string filler = "stone")
+    {
+        int max = _content.MaxStackOf(filler);
+        for (int i = 0; i < inv.SlotCount; i++)
+        {
+            inv.SetSlot(i, new ItemStack(filler, max));
+        }
+    }
+
+    /// <summary>A player standing next to <paramref name="pos"/> with a drill in hand and — unless
+    /// <paramref name="room"/> — no room anywhere. Off the ship, so the cargo hold cannot absorb the drop
+    /// (a test player with no starter ship counts as aboard by default).</summary>
+    private BlocksBeyondTheStars.GameServer.PlayerSession Miner(SvGameServer server, Vector3i pos, bool room = false)
+    {
+        var p = server.AddLocalPlayer("Justus");
+        p.State.AboardShip = false;
+        if (!room)
+        {
+            FillEverySlot(p.State.Inventory);
+        }
+
+        p.State.Position = new Vector3f(pos.X + 1.5f, pos.Y + 0.5f, pos.Z + 0.5f);
+        p.State.Inventory.SetSlot(0, new ItemStack("basic_drill", 1));
+        return p;
+    }
+
+    private void PutStone(SvGameServer server, Vector3i pos)
+        => server.World.SetBlock(pos, _content.GetBlock("stone")!.NumericId);
+
+    // ---------------- Spilling ----------------
+
+    [Fact]
+    public void MiningOn_WithAFullPack_KeepsBreakingBlocks()
+    {
+        var server = Started(out var repo);
+        using (repo)
+        {
+            var start = new Vector3i(20, 60, 20);
+            var p = Miner(server, start);
+
+            // Four blocks in a row, all in reach — the drill used to stop dead on the first one.
+            for (int i = 0; i < 4; i++)
+            {
+                var pos = new Vector3i(start.X + i, start.Y, start.Z);
+                PutStone(server, pos);
+                p.State.Position = new Vector3f(pos.X + 1.2f, pos.Y + 0.5f, pos.Z + 0.5f);
+                server.MineBlock("Justus", pos.X, pos.Y, pos.Z);
+                Assert.True(server.World.GetBlock(pos).IsAir);
+            }
+
+            // All four stones are on the ground, and NOT as four separate bundles.
+            Assert.Equal(4, server.DropPackets.Sum(c => c.Items.Where(s => s.Item == "stone").Sum(s => s.Count)));
+            Assert.Single(server.DropPackets);
+        }
+    }
+
+    [Fact]
+    public void SpillsFarApart_StayTwoPackets()
+    {
+        var server = Started(out var repo);
+        using (repo)
+        {
+            server.AddLocalPlayer("Justus").State.AboardShip = false;
+            server.SpillToGroundForTest(new Vector3i(0, 60, 0), "iron_ore", 3);
+            server.SpillToGroundForTest(new Vector3i(40, 60, 40), "iron_ore", 2);
+
+            Assert.Equal(2, server.DropPackets.Count);
+        }
+    }
+
+    [Fact]
+    public void DyedVariant_KeepsItsOwnStackInsideThePacket()
+    {
+        var server = Started(out var repo);
+        using (repo)
+        {
+            server.AddLocalPlayer("Justus").State.AboardShip = false;
+            var cell = new Vector3i(5, 60, 5);
+            string dyed = ItemKey.Compose("stone", 0x3366CC, 0, 0);
+
+            server.SpillToGroundForTest(cell, "stone", 4);
+            server.SpillToGroundForTest(cell, dyed, 2);
+
+            var packet = Assert.Single(server.DropPackets);
+            Assert.Equal(4, packet.Items.First(s => s.Item == "stone").Count);
+            Assert.Equal(2, packet.Items.First(s => s.Item == dyed).Count); // never merged into the plain stone
+        }
+    }
+
+    [Fact]
+    public void WorldCap_MergesInsteadOfGrowingForever()
+    {
+        var server = Started(out var repo);
+        using (repo)
+        {
+            server.AddLocalPlayer("Justus").State.AboardShip = false;
+
+            // Far enough apart that every spill would otherwise start its own packet.
+            for (int i = 0; i < 90; i++)
+            {
+                server.SpillToGroundForTest(new Vector3i(i * 20, 60, 0), "stone", 1);
+            }
+
+            Assert.True(server.DropPackets.Count <= 64, $"packet count {server.DropPackets.Count} exceeds the world cap");
+            Assert.Equal(90, server.DropPackets.Sum(c => c.Items.Sum(s => s.Count))); // and nothing was thrown away
+        }
+    }
+
+    // ---------------- Automatic pickup ----------------
+
+    [Fact]
+    public void WalkingOverAPacket_WithRoom_CollectsItByItself()
+    {
+        var server = Started(out var repo);
+        using (repo)
+        {
+            var cell = new Vector3i(8, 60, 8);
+            var p = Miner(server, cell, room: true);
+            server.SpillToGroundForTest(cell, "iron_ore", 7);
+            p.State.Position = new Vector3f(cell.X + 0.5f, cell.Y + 0.5f, cell.Z + 0.5f);
+
+            server.SweepDropPacketsForTest();
+
+            Assert.Equal(7, p.State.Inventory.CountOf("iron_ore"));
+            Assert.Empty(server.DropPackets); // emptied packets despawn
+        }
+    }
+
+    [Fact]
+    public void APacketOutOfReach_IsLeftAlone()
+    {
+        var server = Started(out var repo);
+        using (repo)
+        {
+            var cell = new Vector3i(8, 60, 8);
+            var p = Miner(server, cell, room: true);
+            server.SpillToGroundForTest(cell, "iron_ore", 5);
+            p.State.Position = new Vector3f(cell.X + 12f, cell.Y + 0.5f, cell.Z);
+
+            server.SweepDropPacketsForTest();
+
+            Assert.Equal(0, p.State.Inventory.CountOf("iron_ore"));
+            Assert.Single(server.DropPackets);
+        }
+    }
+
+    [Fact]
+    public void AFullPackStandingOnAPacket_ChangesNothing()
+    {
+        var server = Started(out var repo);
+        using (repo)
+        {
+            var cell = new Vector3i(8, 60, 8);
+            var p = Miner(server, cell);
+            server.SpillToGroundForTest(cell, "iron_ore", 5);
+            p.State.Position = new Vector3f(cell.X + 0.5f, cell.Y + 0.5f, cell.Z + 0.5f);
+
+            server.SweepDropPacketsForTest();
+
+            var packet = Assert.Single(server.DropPackets);
+            Assert.Equal(5, packet.Items.First(s => s.Item == "iron_ore").Count);
+        }
+    }
+
+    [Fact]
+    public void APacketKeepsWhatStillDoesNotFit()
+    {
+        var server = Started(out var repo);
+        using (repo)
+        {
+            var cell = new Vector3i(8, 60, 8);
+            var p = Miner(server, cell);
+
+            // Exactly one slot free, and the packet holds more than one stack's worth of two different items.
+            p.State.Inventory.SetSlot(3, null);
+            int max = _content.MaxStackOf("iron_ore");
+            server.SpillToGroundForTest(cell, "iron_ore", max);
+            server.SpillToGroundForTest(cell, "titanium_ore", 6);
+            p.State.Position = new Vector3f(cell.X + 0.5f, cell.Y + 0.5f, cell.Z + 0.5f);
+
+            server.SweepDropPacketsForTest();
+
+            Assert.Equal(max, p.State.Inventory.CountOf("iron_ore")); // the free slot took the first stack …
+            var packet = Assert.Single(server.DropPackets);
+            Assert.Equal(6, packet.Items.First(s => s.Item == "titanium_ore").Count); // … the rest stays lying
+        }
+    }
+
+    [Fact]
+    public void MiningThenMakingRoom_GetsTheDropBack()
+    {
+        var server = Started(out var repo);
+        using (repo)
+        {
+            var pos = new Vector3i(14, 60, 14);
+            var p = Miner(server, pos);
+            PutStone(server, pos);
+
+            server.MineBlock("Justus", pos.X, pos.Y, pos.Z);
+            Assert.Single(server.DropPackets);
+
+            // Make room (throw a stack away) and step onto the packet — no key press, no prompt.
+            p.State.Inventory.SetSlot(5, null);
+            p.State.Position = new Vector3f(pos.X + 0.5f, pos.Y + 0.5f, pos.Z + 0.5f);
+            server.SweepDropPacketsForTest();
+
+            Assert.Empty(server.DropPackets);
+        }
+    }
+
+    // ---------------- Persistence ----------------
+
+    [Fact]
+    public void Packets_SurviveAServerRestart()
+    {
+        {
+            var s1 = Started(out var repo1, "drops_persist");
+            using (repo1)
+            {
+                s1.AddLocalPlayer("Justus").State.AboardShip = false;
+                s1.SpillToGroundForTest(new Vector3i(9, 60, 9), "iron_ore", 12);
+                Assert.Single(s1.DropPackets);
+                repo1.Flush();
+            }
+        }
+
+        Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+
+        var s2 = Started(out var repo2, "drops_persist");
+        using (repo2)
+        {
+            var packet = Assert.Single(s2.DropPackets);
+            Assert.Equal(12, packet.Items.First(s => s.Item == "iron_ore").Count);
+
+            // And it is still a drop packet, not something the loot prompt would offer.
+            Assert.DoesNotContain(s2.Containers, c => c.Id == packet.Id);
+        }
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+            if (Directory.Exists(_root))
+            {
+                Directory.Delete(_root, recursive: true);
+            }
+        }
+        catch (IOException)
+        {
+            // A locked save file must never fail the test run.
+        }
+    }
+}

--- a/tests/BlocksBeyondTheStars.Tests/InventoryFullSafetyTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/InventoryFullSafetyTests.cs
@@ -161,8 +161,11 @@ public sealed class InventoryFullSafetyTests : IDisposable
         }
     }
 
+    /// <summary>Since #853 a full inventory no longer stops the drill: the block breaks and its drop lands on
+    /// the ground as a packet. What must never happen — and what this test still guards — is the drop being
+    /// destroyed. (It used to be guarded by refusing the break; the block stayed standing.)</summary>
     [Fact]
-    public void Mining_WithNoRoomForTheDrop_LeavesTheBlockStanding()
+    public void Mining_WithNoRoomForTheDrop_BreaksTheBlockAndDropsItOnTheGround()
     {
         var server = Started(out var repo);
         using (repo)
@@ -179,9 +182,9 @@ public sealed class InventoryFullSafetyTests : IDisposable
 
             server.MineBlock("Justus", pos.X, pos.Y, pos.Z);
 
-            // The drop had nowhere to go, so the block must still be there — mining used to clear the cell
-            // and silently destroy the stone.
-            Assert.False(server.World.GetBlock(pos).IsAir);
+            Assert.True(server.World.GetBlock(pos).IsAir); // digging on is the whole point of #853 …
+            var packet = Assert.Single(server.DropPackets);
+            Assert.Equal(1, packet.Items.Count(s => s.Item == "stone" && s.Count > 0)); // … and the stone is not lost
         }
     }
 


### PR DESCRIPTION
Closes #853.

## What

Mining stopped dead once the backpack (and the cargo hold, when aboard) was full — `BreakBlockAt` checked `MaterialPool.CanFit` and left the block standing with `@inventory_full`. That refusal was the right call in #600/#607 (a full inventory used to *destroy* drops silently), because the world had nowhere to put the overflow. This PR adds that place: the block always breaks, and whatever does not fit lands on the ground as a small **drop packet** that is collected again automatically.

## How

- **Packet = `StoredContainer` with kind `"drop"`.** The container store is already generic over its kind in all three repositories (`id, planet, kind, x, y, z, json`), so packets persist across reload with **no schema change and no migration**. They are filtered out of `ContainerList` (they'd steal the crate/capsule loot prompt and collect themselves anyway) and travel on their own `DropPacketList`, NetCodec tag **197** (194–196 went to #852 while this branch was in flight).
- **Stacking, not littering.** `SpillToGround` merges into the nearest packet within 3.5 m by **exact item key**, so dyed/glowing/shaped variants keep their own stack. Caps: 12 distinct keys per packet, 64 packets per body — at the cap a spill pours into the nearest packet at any distance, so the count is bounded and **nothing is ever destroyed**. An area drill's whole burst spills once from the shared pool: one bundle, not one per cell. `MaterialPool.TakeLeftovers()` hands the overflow over exactly once.
- **Auto-pickup.** `TickDropPackets` sweeps at 4 Hz per world: packets within 2.5 m of a joined player pour back in (personal slots first, cargo when aboard), keep what still does not fit, and despawn once empty. A full pack standing on a packet is a deliberate no-op. Collected items surface through the existing HUD pickup feed (#745) via the inventory diff.
- **Client.** New `DropPacketView`: a small tumbling mini-block wearing its biggest stack's atlas tile (world containers had no 3-D representation to reuse). New throttled toast `@dropped_on_ground`, localized EN/DE/FR/ES.
- **Also covered:** creature/bandit kills spill their loot at the fallen enemy's feet (`BankLoot` takes an optional spill cell) instead of only *reporting* it lost.
- **Deliberately kept:** EVA / ship-hull mining in space still refuses (no body, no ground — the block stays, losslessly), and there is **no despawn timer** (cap + merging is the save-size guard). First player in range collects; no ownership tag.

## Tests

- `DropPacketTests` (9): digging four blocks on a full pack leaves **one** packet with all four stones; distant spills stay separate; dyed variants keep their own stack; the world cap merges without loss; pickup collects / partially collects / leaves out-of-reach packets alone; a full pack changes nothing; packets survive a restart.
- `InventoryFullSafetyTests.Mining_WithNoRoomForTheDrop_LeavesTheBlockStanding` pinned the old refusal and is rewritten to the new mechanism — same guarantee (the drop is never lost), new behaviour (the block breaks and the stone is on the ground).
- Local verification: full server suite **1615/1615** (incl. Slow), client tests **194/194**, clean Release rebuild 0 warnings, local Unity client build green after the rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
