### PR TITLE
fix(fauna): creatures and insects no longer pass through walls

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7409,6 +7409,40 @@ is **pre-approved** (keys in `tools/ai-assets/.env`, run via `uv`).
 
 ---
 
+## ✅ Done (2026-08-09): fauna stops walking through walls; insects respect blocks (#855)
+
+Playtest report: insects fly straight through walls, and creatures sometimes stand half inside one.
+Two root causes, both fixed:
+
+- **Server — creatures were a POINT, and the terrain gate only compared ground heights.** A 1–2 block
+  player wall read as a walkable step (`TerrainStepBlocked` tolerance ±2), only `Land`/`Water` habitats
+  were gated at all, only titans (`Size ≥ 3`) had any body-volume check, and nothing swept the step —
+  so animals tunnelled thin walls and rendered half inside masonry. New `CreatureBodyBlocked`
+  (feet→`ceil(Size×1.8)` body column, clamped 2..8) + `CreaturePathBlocked` (¼-block swept segment,
+  the same recipe `PathBlockedByWorld` used to fix NPCs) now gate **every habitat** in `MoveCreatures`,
+  the steer-around probes, spawn (`TrySpawnCreatureNear` + herd members) and **companions**
+  (`MoveCompanion` previously checked only ship + fence — pets walked through their owner's base).
+  Since walls now genuinely stop a pet, a companion left > 24 blocks behind is re-placed beside its
+  owner (`CompanionSpotNear`) so "follows you anywhere" stays true.
+- **Collision predicate ≠ `Solid`.** `Solid` defaults to `true`, so every cross-billboard `flora_*`
+  prop (plus torch/lantern/ladder) counts as solid despite having no collider — gating on it would
+  wall fauna out of meadows. New `IsCollidingCell*` (server counterpart of the client's
+  `IsCollidingKey`, fluids passable, `tree_leaves` passable for fliers) — and `BlockedByWorld` for
+  **NPCs** now uses it too, fixing the pre-existing "a grass tuft blocks an NPC" quirk. Movement reads
+  use `GetBlockIfLoaded`, so the 15 Hz tick never generates chunks.
+- **Client — micro-fauna had no cell test at all.** `MoveFly`/`MoveDrift` integrated x/z unchecked
+  (butterflies crossed bases like they weren't there), `MoveHop` only checked landing, `MoveCrawl`
+  compared ground heights (and `GroundTopY` returns the ROOF indoors), and spawns never checked the
+  cell. All motion models now veer off/bounce at a blocking cell (`IsBlocking`, same key exceptions),
+  bobbing won't enter ceilings, blocked spawn cells are skipped — and crawlers/hoppers sit at
+  `gy + 1.12` (the walkable surface) instead of `gy + 0.12`, which had parked beetles a block INSIDE
+  the ground.
+
+Tests: a hunting creature is held by a 2-block wall; a sealed room stays creature-free; a companion
+neither crosses a wall slab nor is lost behind it (leash catches it up). Playtest pending.
+
+---
+
 ## ✅ Done (2026-08-08): the ship is still there after leaving and reloading a world (#848)
 
 "I start a world, leave the game, load it again — and my ship is gone." Two save-game gaps, both

--- a/client/Assets/BlocksBeyondTheStars/Scripts/MicroFaunaView.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/MicroFaunaView.cs
@@ -296,7 +296,12 @@ namespace BlocksBeyondTheStars.Client
                 if (!airborne)
                 {
                     int g2 = GroundTopY(Mathf.FloorToInt(jx), Mathf.FloorToInt(jz));
-                    if (g2 != int.MinValue) y = g2 + 0.12f;
+                    if (g2 != int.MinValue) y = g2 + CrawlSurfaceY;
+                }
+
+                if (IsBlockingAt(jx, y, jz))
+                {
+                    continue; // never seed a critter inside a block (#855) — the swarm just comes out smaller
                 }
 
                 Spawn(kindIdx, new Vector3(jx, y, jz), group, airborne ? baseY : gy + 1f);
@@ -365,7 +370,7 @@ namespace BlocksBeyondTheStars.Client
 
             int gy = GroundTopY(ix, iz);
             if (gy == int.MinValue) return false;
-            Spawn(kindIdx, new Vector3(wx, gy + 0.12f, wz), -1, gy + 1f);
+            Spawn(kindIdx, new Vector3(wx, gy + CrawlSurfaceY, wz), -1, gy + 1f);
             return true;
         }
 
@@ -464,15 +469,24 @@ namespace BlocksBeyondTheStars.Client
             Steer(c, dt, weave: 1.4f, cohesion: 0.6f);
 
             Vector3 vel = Heading(c) * c.Speed;
-            c.WorldPos.x += vel.x * dt;
-            c.WorldPos.z += vel.z * dt;
+            float nx = c.WorldPos.x + vel.x * dt, nz = c.WorldPos.z + vel.z * dt;
+            if (IsBlockingAt(nx, c.WorldPos.y, nz))
+            {
+                c.Heading += Mathf.PI * (0.6f + Random.value * 0.5f); // a wall — veer off (#855)
+                c.LastVelX = 0f;
+                return;
+            }
+
+            c.WorldPos.x = nx;
+            c.WorldPos.z = nz;
 
             // Gentle altitude wave around a ground-relative cruising height; low gravity exaggerates the
             // bob so flight on light worlds reads floatier.
             c.BobPhase += dt * 2.2f;
             int gy = GroundTopY(Mathf.FloorToInt(c.WorldPos.x), Mathf.FloorToInt(c.WorldPos.z));
             if (gy != int.MinValue) c.BaseY = Mathf.Lerp(c.BaseY, gy + 2.0f, 0.04f);
-            c.WorldPos.y = c.BaseY + Mathf.Sin(c.BobPhase) * 0.45f * LowGravityScale();
+            float ny = c.BaseY + Mathf.Sin(c.BobPhase) * 0.45f * LowGravityScale();
+            if (!IsBlockingAt(c.WorldPos.x, ny, c.WorldPos.z)) c.WorldPos.y = ny; // don't bob into a ceiling
             c.LastVelX = vel.x;
         }
 
@@ -483,9 +497,21 @@ namespace BlocksBeyondTheStars.Client
             {
                 float g = 14f * Mathf.Max(0.3f, Game.Environment?.GravityFactor ?? 1f);
                 Vector3 vel = Heading(c) * (c.Speed * 2f);
-                c.WorldPos.x += vel.x * dt;
-                c.WorldPos.z += vel.z * dt;
-                c.WorldPos.y += c.VertVel * dt;
+                float hx = c.WorldPos.x + vel.x * dt, hz = c.WorldPos.z + vel.z * dt;
+                float hy = c.WorldPos.y + c.VertVel * dt;
+                if (IsBlockingAt(hx, hy, hz))
+                {
+                    // Hopped into a wall (#855): drop straight down here and turn around for the next hop.
+                    c.Heading += Mathf.PI;
+                    hx = c.WorldPos.x;
+                    hz = c.WorldPos.z;
+                    c.VertVel = Mathf.Min(c.VertVel, 0f);
+                    hy = c.WorldPos.y;
+                }
+
+                c.WorldPos.x = hx;
+                c.WorldPos.z = hz;
+                c.WorldPos.y = hy;
                 c.VertVel -= g * dt;
                 c.LastVelX = vel.x;
 
@@ -496,9 +522,9 @@ namespace BlocksBeyondTheStars.Client
                     gy = Mathf.FloorToInt(c.WorldPos.y);
                 }
 
-                if (c.VertVel < 0f && c.WorldPos.y <= gy + 0.12f)
+                if (c.VertVel < 0f && c.WorldPos.y <= gy + CrawlSurfaceY)
                 {
-                    c.WorldPos.y = gy + 0.12f;
+                    c.WorldPos.y = gy + CrawlSurfaceY;
                     c.Airborne = false;
                     c.PauseTimer = Random.Range(0.4f, 1.8f);
                 }
@@ -526,13 +552,22 @@ namespace BlocksBeyondTheStars.Client
             Steer(c, dt, weave: 0.5f, cohesion: 0.3f);
 
             Vector3 vel = Heading(c) * c.Speed;
-            c.WorldPos.x += vel.x * dt;
-            c.WorldPos.z += vel.z * dt;
+            float nx = c.WorldPos.x + vel.x * dt, nz = c.WorldPos.z + vel.z * dt;
+            if (IsBlockingAt(nx, c.WorldPos.y, nz))
+            {
+                c.Heading += Mathf.PI * (0.6f + Random.value * 0.5f); // drifted into a wall — bounce off (#855)
+                c.LastVelX = 0f;
+                return;
+            }
+
+            c.WorldPos.x = nx;
+            c.WorldPos.z = nz;
 
             // A slow balloon bob around a lazily ground-following cruise height.
             int gy = GroundTopY(Mathf.FloorToInt(c.WorldPos.x), Mathf.FloorToInt(c.WorldPos.z));
             if (gy != int.MinValue) c.BaseY = Mathf.Lerp(c.BaseY, gy + 2.2f, 0.02f);
-            c.WorldPos.y = c.BaseY + Mathf.Sin(c.BobPhase) * 0.9f * LowGravityScale();
+            float ny = c.BaseY + Mathf.Sin(c.BobPhase) * 0.9f * LowGravityScale();
+            if (!IsBlockingAt(c.WorldPos.x, ny, c.WorldPos.z)) c.WorldPos.y = ny; // don't bob into a ceiling
             c.LastVelX = vel.x;
         }
 
@@ -550,7 +585,10 @@ namespace BlocksBeyondTheStars.Client
             Vector3 vel = Heading(c) * c.Speed;
             float nx = c.WorldPos.x + vel.x * dt, nz = c.WorldPos.z + vel.z * dt;
             int gy = GroundTopY(Mathf.FloorToInt(nx), Mathf.FloorToInt(nz));
-            if (gy == int.MinValue || Mathf.Abs((gy + 0.12f) - c.WorldPos.y) > 1.6f)
+            // The height delta alone let a crawler walk into anything a block tall (#855) — and inside a room
+            // GroundTopY reports the ROOF, not the floor. So the cell it would occupy has to be free as well.
+            if (gy == int.MinValue || Mathf.Abs((gy + CrawlSurfaceY) - c.WorldPos.y) > 1.6f
+                || IsBlockingAt(nx, c.WorldPos.y, nz) || IsBlockingAt(nx, c.WorldPos.y + 0.5f, nz))
             {
                 c.Heading += Mathf.PI * 0.6f; // a ledge / wall — turn away
                 c.LastVelX = 0f;
@@ -558,7 +596,7 @@ namespace BlocksBeyondTheStars.Client
             }
 
             c.WorldPos.x = nx; c.WorldPos.z = nz;
-            c.WorldPos.y = Mathf.Lerp(c.WorldPos.y, gy + 0.12f, 0.3f);
+            c.WorldPos.y = Mathf.Lerp(c.WorldPos.y, gy + CrawlSurfaceY, 0.3f);
             c.LastVelX = vel.x;
 
             c.RepathTimer -= dt;
@@ -706,6 +744,12 @@ namespace BlocksBeyondTheStars.Client
             }
         }
 
+        /// <summary>Where a crawling/hopping critter's belly sits relative to the ground cell <see cref="GroundTopY"/>
+        /// reports (#855). That cell is the last SOLID one, spanning world Y <c>gy..gy+1</c> — so the walkable
+        /// surface is <c>gy + 1</c> and the old bare <c>gy + 0.12</c> parked beetles, ants and hoppers almost a
+        /// full block INSIDE the ground (the flyers' <c>gy + 2</c> cruise height always used the right frame).</summary>
+        private const float CrawlSurfaceY = 1.12f;
+
         /// <summary>Top solid surface Y near the player's vertical band at a column, or int.MinValue if none.</summary>
         private int GroundTopY(int wx, int wz)
         {
@@ -738,6 +782,30 @@ namespace BlocksBeyondTheStars.Client
 
         private bool IsWater(int wx, int wy, int wz)
             => Game.Content.BlockById(Game.World.GetBlock(wx, wy, wz))?.Key == "water";
+
+        /// <summary>Whether a cell stops a critter (#855). Critters are cosmetic billboards with no colliders, so
+        /// before this every motion model except <see cref="MoveSwim"/> integrated straight through walls — a
+        /// butterfly crossed a base like it wasn't there. Keyed on the same idea as the player's
+        /// <c>IsCollidingKey</c>: `Solid` alone won't do (it defaults to true, so grass would be a wall), and a
+        /// critter is small enough to slip through foliage and past a torch, so canopies stay passable too.</summary>
+        private bool IsBlocking(int wx, int wy, int wz)
+        {
+            var def = Game.Content?.BlockById(Game.World.GetBlock(wx, wy, wz));
+            if (def == null || !def.Solid)
+            {
+                return false; // air, water, lava, or a block the content DB marks as non-solid
+            }
+
+            string key = def.Key;
+            return key != "water" && key != "lava" && key != "tree_leaves"
+                && key != "torch" && key != "lantern" && key != "ladder"
+                && !key.StartsWith("flora_", System.StringComparison.Ordinal);
+        }
+
+        /// <summary>Whether the cell a critter is about to occupy is free — the world-space variant of
+        /// <see cref="IsBlocking"/>.</summary>
+        private bool IsBlockingAt(float x, float y, float z)
+            => IsBlocking(Mathf.FloorToInt(x), Mathf.FloorToInt(y), Mathf.FloorToInt(z));
 
         private bool IsNight()
         {

--- a/src/BlocksBeyondTheStars.GameServer/GameServerCreatures.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerCreatures.cs
@@ -451,6 +451,11 @@ public sealed partial class GameServer
                     continue; // never spawn inside (or clipping into) a landed ship
                 }
 
+                if (CreatureBodyBlocked(sp, pos))
+                {
+                    continue; // its body would materialise inside a wall / ruin masonry (#855)
+                }
+
                 // Titans need level ground (#638): a 3×3 clearance whose surface stays within ±1 of the
                 // centre column, so a six-block giant doesn't materialise half-buried in a cliff face —
                 // creatures have no colliders, so the spawn spot is the only terrain check they ever get.
@@ -561,9 +566,9 @@ public sealed partial class GameServer
             }
 
             var pos = new Vector3f(mx + 0.5f, y, mz + 0.5f);
-            if (!HabitatSuitable(sp, pos) || EntityBlockedByShip(pos))
+            if (!HabitatSuitable(sp, pos) || EntityBlockedByShip(pos) || CreatureBodyBlocked(sp, pos))
             {
-                continue;
+                continue; // the herd stays smaller rather than planting a member inside a wall (#855)
             }
 
             SpawnCreature(sp, pos);
@@ -826,7 +831,8 @@ public sealed partial class GameServer
             // skirting an obstacle. Only when every probe is blocked too does it fall back to the re-roll,
             // which preserves the "nothing can ever get stuck" property.
             if (EntityBlockedByShip(next) || BlockedByEnergyFence(creature.Position, next)
-                || StepBlockedByTerrain(sp, creature.Position, next))
+                || StepBlockedByTerrain(sp, creature.Position, next)
+                || CreaturePathBlocked(sp, creature.Position, next))
             {
                 if (TrySteerAround(creature, sp, res.Position, res.VertWave, profile, moveDt,
                         out var detour, out float detourHeading))
@@ -901,7 +907,8 @@ public sealed partial class GameServer
                     c.Position.Z + (float)System.Math.Sin(h) * len);
                 var adjusted = AdjustHabitatHeight(sp, cand, vertWave, prof, dt);
                 if (!EntityBlockedByShip(adjusted) && !BlockedByEnergyFence(c.Position, adjusted)
-                    && !StepBlockedByTerrain(sp, c.Position, adjusted))
+                    && !StepBlockedByTerrain(sp, c.Position, adjusted)
+                    && !CreaturePathBlocked(sp, c.Position, adjusted))
                 {
                     detour = adjusted;
                     heading = h;
@@ -951,6 +958,59 @@ public sealed partial class GameServer
         int nextDepth = _generator.TryGetWaterSurface(_world.Planet, nx, nz, out int nextTop, out int nextBed)
             ? nextTop - nextBed : 0;
         return CreatureBehaviour.TerrainStepBlocked(sp.Habitat, sp.BodyPlan, curFeet, nextFeet, curDepth, nextDepth);
+    }
+
+    private const float CreatureSweepStep = 0.25f; // swept-step sampling distance (same as the NPC path check)
+    private const int CreatureBodyMinHeight = 2;   // even a mouse-sized animal occupies feet + head
+    private const int CreatureBodyMaxHeight = 8;   // ...and a titan is gated by its shoulders, not its full crown
+
+    /// <summary>How many cells tall a creature's body is for collision purposes (its render height is
+    /// <c>Size × 1.8</c>), clamped so tiny fauna still gets a head cell and a titan can still duck under an
+    /// overhang instead of being walled in by its own crown.</summary>
+    private static int CreatureBodyHeight(CreatureSpecies sp) => System.Math.Clamp(
+        (int)System.Math.Ceiling(sp.Size * 1.8f), CreatureBodyMinHeight, CreatureBodyMaxHeight);
+
+    /// <summary>Whether a creature's BODY would sit inside colliding blocks at a spot (#855). Creatures have no
+    /// colliders and the server tracks a single point, so before this gate a wall was only ever seen indirectly —
+    /// as a ground-height delta (<see cref="StepBlockedByTerrain"/>), which reads a 1–2 block player wall as a
+    /// walkable step and lets the rendered body clip into it. Checks the creature's own column from the feet cell
+    /// up through its body height; flying species pass through tree canopies (they hover inside them).</summary>
+    private bool CreatureBodyBlocked(CreatureSpecies sp, Vector3f pos)
+    {
+        int x = (int)System.Math.Floor(pos.X);
+        int y = (int)System.Math.Floor(pos.Y);
+        int z = (int)System.Math.Floor(pos.Z);
+        bool flier = sp.Habitat == CreatureHabitat.Air;
+        int height = CreatureBodyHeight(sp);
+        for (int dy = 0; dy < height; dy++)
+        {
+            if (IsCollidingCellIfLoaded(x, y + dy, z, foliagePasses: flier))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>The swept version of <see cref="CreatureBodyBlocked"/> (#855): samples the whole step every
+    /// <see cref="CreatureSweepStep"/> of a block, so a fast animal can't tunnel through a one-block-thin wall
+    /// between two ticks. Mirrors <c>PathBlockedByWorld</c>, which fixed exactly this for NPCs.</summary>
+    private bool CreaturePathBlocked(CreatureSpecies sp, Vector3f from, Vector3f to)
+    {
+        float dx = to.X - from.X, dy = to.Y - from.Y, dz = to.Z - from.Z;
+        float dist = (float)System.Math.Sqrt(dx * dx + dy * dy + dz * dz);
+        int steps = System.Math.Max(1, (int)System.Math.Ceiling(dist / CreatureSweepStep));
+        for (int s = 1; s <= steps; s++)
+        {
+            float f = s / (float)steps;
+            if (CreatureBodyBlocked(sp, new Vector3f(from.X + dx * f, from.Y + dy * f, from.Z + dz * f)))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private const float LargeBodySize = 3f; // species at/above this Size get the body-volume checks (#750)

--- a/src/BlocksBeyondTheStars.GameServer/GameServerNpcs.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerNpcs.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using BlocksBeyondTheStars.Networking.Messages;
 using BlocksBeyondTheStars.Shared.Definitions;
 using BlocksBeyondTheStars.Shared.Geometry;
+using BlocksBeyondTheStars.Shared.Primitives;
 
 namespace BlocksBeyondTheStars.GameServer;
 
@@ -342,23 +343,24 @@ public sealed partial class GameServer
     /// without fighting the enemy/creature ground-snapping that would move a hand-placed combatant.</summary>
     public bool HasLineOfSightForTest(Vector3f from, Vector3f to) => HasLineOfSight(from, to);
 
-    /// <summary>True if an NPC's body (feet + head) would sit inside a solid block at this position — a wall,
+    /// <summary>True if an NPC's body (feet + head) would sit inside a colliding block at this position — a wall,
     /// so it can't stroll there. A doorway opening stays air, so NPCs pass through doorways but not walls.</summary>
     private bool BlockedByWorld(Vector3f pos)
     {
         int x = (int)System.Math.Floor(pos.X);
         int y = (int)System.Math.Floor(pos.Y);
         int z = (int)System.Math.Floor(pos.Z);
-        return IsSolidCell(x, y, z)       // feet
-            || IsSolidCell(x, y + 1, z);  // head
+        return IsCollidingCell(x, y, z)       // feet
+            || IsCollidingCell(x, y + 1, z);  // head
     }
 
     /// <summary>Whether a cell is a movement-blocking solid block. Keyed on the block's <c>Solid</c> flag, not
     /// just "non-air", so the two are kept distinct: <b>glass</b> is solid-but-transparent (blocks NPCs, you see
     /// through it), while a non-solid transparent block like <b>water</b> is passable. Air is never solid.</summary>
-    private bool IsSolidCell(int x, int y, int z)
+    private bool IsSolidCell(int x, int y, int z) => IsSolidBlock(_world.GetBlock(new Vector3i(x, y, z)));
+
+    private bool IsSolidBlock(BlockId id)
     {
-        var id = _world.GetBlock(new Vector3i(x, y, z));
         if (id.IsAir)
         {
             return false;
@@ -367,6 +369,46 @@ public sealed partial class GameServer
         var def = _content.BlockById(id);
         return def == null || def.Solid; // unknown id → treat as solid (safe default)
     }
+
+    /// <summary>Whether a cell actually <b>collides</b> with a walking body. <see cref="IsSolidCell"/> keys on
+    /// the <c>Solid</c> flag alone, which defaults to <c>true</c> — so every cross-billboard prop (small flora,
+    /// the torch/lantern, the walk-through ladder) counts as solid there even though the mesher gives it no
+    /// collider and the player strolls straight through it. Movement must use this predicate instead, or a
+    /// meadow would be an impassable wall for anything that isn't a player. Sight (<see cref="HasLineOfSight"/>)
+    /// keeps the plain solid test.</summary>
+    private bool IsCollidingCell(int x, int y, int z)
+        => IsCollidingBlock(_world.GetBlock(new Vector3i(x, y, z)), fluidsPass: false, foliagePasses: false);
+
+    /// <summary>The no-load sibling of <see cref="IsCollidingCell"/> used by the creature gates: an unloaded chunk
+    /// reads as air (permissive, matching <c>StandableAt</c>), so a per-tick movement check never generates chunks
+    /// as a side effect. Fluids never block an animal — swimmers live in them — and flying species additionally
+    /// pass through tree canopies (their hover altitude sits right inside the crown on forest worlds).</summary>
+    private bool IsCollidingCellIfLoaded(int x, int y, int z, bool foliagePasses)
+        => IsCollidingBlock(_world.GetBlockIfLoaded(new Vector3i(x, y, z)), fluidsPass: true, foliagePasses);
+
+    private bool IsCollidingBlock(BlockId id, bool fluidsPass, bool foliagePasses)
+    {
+        if (!IsSolidBlock(id))
+        {
+            return false;
+        }
+
+        if (fluidsPass && IsFluid(id.Value))
+        {
+            return false; // water/lava are `Solid` in the content DB but are wadeable/swimmable, not walls
+        }
+
+        var def = _content.BlockById(id);
+        return def != null && !IsWalkThroughProp(def.Key, foliagePasses);
+    }
+
+    /// <summary>Blocks that are solid on paper but have <b>no collider</b> in the mesher, so bodies pass through
+    /// them (mirrors the client's <c>PlayerController.IsCollidingKey</c>). <paramref name="foliagePasses"/> adds
+    /// tree canopies for FLYING creatures — a winged animal weaves through a crown rather than bouncing off it.</summary>
+    private static bool IsWalkThroughProp(string key, bool foliagePasses)
+        => key.StartsWith("flora_", System.StringComparison.Ordinal)
+            || key is "torch" or "lantern" or "ladder"
+            || (foliagePasses && key == "tree_leaves");
 
     private void BroadcastNpcs() => BroadcastToWorld(new NpcList { Npcs = _npcs.Select(ToNetNpc).ToArray() });
 

--- a/src/BlocksBeyondTheStars.GameServer/GameServerTaming.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerTaming.cs
@@ -480,9 +480,7 @@ public sealed partial class GameServer
         }
 
         var sp = _speciesById[tc.SpeciesId];
-        float ang = (Hash(tc.Id, "spawn") % 360) * (float)(System.Math.PI / 180.0);
-        var pos = new Vector3f(near.X + (float)System.Math.Cos(ang) * 3f, near.Y, near.Z + (float)System.Math.Sin(ang) * 3f);
-        pos = AdjustHabitatHeight(sp, pos);
+        var pos = CompanionSpotNear(sp, tc.Id, near);
 
         _creatures.Add(new CombatEntity
         {
@@ -501,6 +499,28 @@ public sealed partial class GameServer
         });
     }
 
+    private const float CompanionLeashRange = 24f; // beyond this a companion is re-placed beside its owner (#855)
+
+    /// <summary>A free spot beside a player for a companion to (re-)appear on: bearings fanned out from a
+    /// per-pet stable angle, first one whose body isn't inside a wall wins. Falls back to the owner's own
+    /// position (they are standing in open space by definition) when the pet is boxed in on every side.</summary>
+    private Vector3f CompanionSpotNear(CreatureSpecies sp, string companionId, Vector3f near)
+    {
+        float baseAngle = (Hash(companionId, "spawn") % 360) * (float)(System.Math.PI / 180.0);
+        for (int i = 0; i < 8; i++)
+        {
+            float ang = baseAngle + i * 0.7853982f; // 45° apart
+            var spot = AdjustHabitatHeight(sp, new Vector3f(
+                near.X + (float)System.Math.Cos(ang) * 3f, near.Y, near.Z + (float)System.Math.Sin(ang) * 3f));
+            if (!CreatureBodyBlocked(sp, spot) && !EntityBlockedByShip(spot))
+            {
+                return spot;
+            }
+        }
+
+        return AdjustHabitatHeight(sp, near);
+    }
+
     /// <summary>Advances one companion: it follows its owner (or holds position if the owner isn't here).</summary>
     private void MoveCompanion(CombatEntity c, double moveDt)
     {
@@ -515,14 +535,25 @@ public sealed partial class GameServer
             return; // owner not on this world — hold (reconciliation will despawn it)
         }
 
+        // Leash (#855): now that walls actually stop a companion it can fall behind for good — an owner who
+        // walks around a building leaves the pet probing the masonry. Past this range it simply catches up by
+        // being re-placed beside its owner, which is what players expect of a pet that "follows you anywhere".
+        if (WrapDistSq(c.Position, owner.State.Position) > CompanionLeashRange * CompanionLeashRange)
+        {
+            c.Position = CompanionSpotNear(sp, c.Id, owner.State.Position);
+            return;
+        }
+
         var profile = ProfileFor(c.SpeciesId);
         var res = LocomotionController.FollowStep(
             c.Loco, profile, c.Position, owner.State.Position, CompanionFollowDistance, moveDt, Hash(c.Id, "wander"));
         c.Loco = res.State;
         var next = AdjustHabitatHeight(sp, res.Position, res.VertWave, profile, moveDt);
         // Companions respect energy fences like wild fauna do — a penned companion stays penned even
-        // when its owner steps out through the gate membrane (that is the point of the pen).
-        if (EntityBlockedByShip(next) || BlockedByEnergyFence(c.Position, next))
+        // when its owner steps out through the gate membrane (that is the point of the pen). Walls stop them
+        // like they stop wild fauna (#855) — a pet used to walk straight through the player's own base.
+        if (EntityBlockedByShip(next) || BlockedByEnergyFence(c.Position, next)
+            || CreaturePathBlocked(sp, c.Position, next))
         {
             c.Loco.ModeTimer = 0f;
         }

--- a/tests/BlocksBeyondTheStars.Tests/CreatureTamingTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/CreatureTamingTests.cs
@@ -91,6 +91,20 @@ public sealed class CreatureTamingTests : IDisposable
 
     private readonly record struct CombatEntityRef(string Id, Vector3f Position);
 
+    /// <summary>Y of the topmost non-air block in a column (the local ground), or 0 if the column is empty.</summary>
+    private static int SurfaceTopY(SvGameServer server, int x, int z)
+    {
+        for (int y = 200; y > -200; y--)
+        {
+            if (!server.World.GetBlock(new Vector3i(x, y, z)).IsAir)
+            {
+                return y;
+            }
+        }
+
+        return 0;
+    }
+
     [Fact]
     public void Taming_APassiveCreature_CreatesANamedCompanionInPlace()
     {
@@ -219,6 +233,62 @@ public sealed class CreatureTamingTests : IDisposable
             tc.HomeBodyId = home;
             server.ReconcileCompanionsForTest();
             Assert.Single(server.CompanionEntitiesForTest("Ranger"));
+        }
+    }
+
+    [Fact]
+    public void Companion_DoesNotWalkThroughAWall_AndIsLeashedBackWhenLeftBehind()
+    {
+        // #855: MoveCompanion only ever checked the ship hull and energy fences, so a pet strolled straight
+        // through its owner's base walls. With the wall gate in place it can genuinely fall behind — the
+        // leash is what keeps "it follows you anywhere" true.
+        var server = Started(out var repo);
+        using (repo)
+        {
+            var p = Ranger(server);
+            server.Tick(6.0);
+            var target = FirstWild(server, CreatureTemperament.Passive);
+            Assert.True(TameNearest(server, p, target));
+            var pet = Assert.Single(server.CompanionEntitiesForTest("Ranger"));
+            server.SpeciesRoster.First(s => s.Id == pet.SpeciesId).Habitat = CreatureHabitat.Land; // a walker, not a flier
+
+            // Wall the owner off: a stone slab at x = wallX, pet on one side, owner on the other. The slab
+            // spans one continuous vertical band — from below the pet's feet to above the tallest column —
+            // because a per-column top would sit at a floating jungle CANOPY block and leave a ground-level gap.
+            var stone = _content.GetBlock("stone")!.NumericId;
+            int wallX = (int)System.Math.Floor(pet.Position.X) + 3;
+            int petZ = (int)System.Math.Floor(pet.Position.Z);
+            int lo = (int)System.Math.Floor(pet.Position.Y) - 4;
+            int hi = lo;
+            for (int dz = -40; dz <= 40; dz++)
+            {
+                hi = System.Math.Max(hi, SurfaceTopY(server, wallX, petZ + dz) + 4);
+            }
+
+            for (int dz = -40; dz <= 40; dz++) // long enough that it cannot simply walk around an end
+            {
+                for (int y = lo; y <= hi; y++)
+                {
+                    server.World.SetBlock(new Vector3i(wallX, y, petZ + dz), stone);
+                }
+            }
+
+            p.State.Position = new Vector3f(wallX + 4.5f, pet.Position.Y, pet.Position.Z);
+            for (int i = 0; i < 40; i++)
+            {
+                server.Tick(0.1);
+                var live = server.CompanionEntitiesForTest("Ranger").Single();
+                Assert.True(live.Position.X < wallX,
+                    $"the companion walked through the wall at x={wallX} (tick {i}, at {live.Position.X:F2}/{live.Position.Y:F2}/{live.Position.Z:F2}, owner {p.State.Position.X:F2})");
+            }
+
+            // Owner walks far away → the pet is re-placed beside them instead of being stuck at the wall forever.
+            p.State.Position = new Vector3f(pet.Position.X + 200f, pet.Position.Y, pet.Position.Z);
+            server.Tick(0.2);
+            var caughtUp = server.CompanionEntitiesForTest("Ranger").Single();
+            float dx = caughtUp.Position.X - p.State.Position.X, dz2 = caughtUp.Position.Z - p.State.Position.Z;
+            Assert.True(dx * dx + dz2 * dz2 <= 9f * 9f,
+                $"a companion left far behind must catch up to its owner (still {System.Math.Sqrt(dx * dx + dz2 * dz2):F1} away)");
         }
     }
 

--- a/tests/BlocksBeyondTheStars.Tests/CreatureTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/CreatureTests.cs
@@ -846,6 +846,100 @@ public sealed class CreatureTests : IDisposable
         }
     }
 
+    /// <summary>Raises a solid stone wall along the z axis at column <paramref name="wallX"/>.</summary>
+    private void BuildWall(SvGameServer server, int wallX, int cz, int r, int padY, int height)
+    {
+        var stone = _content.GetBlock("stone")!.NumericId;
+        for (int dz = -r; dz <= r; dz++)
+        {
+            for (int dy = 1; dy <= height; dy++)
+            {
+                server.World.SetBlock(new Vector3i(wallX, padY + dy, cz + dz), stone);
+            }
+        }
+    }
+
+    [Fact]
+    public void AWall_StopsAHuntingCreature_InsteadOfLettingItWalkThrough()
+    {
+        // #855: the terrain gate only compared GROUND HEIGHTS with a ±2 tolerance, so a two-block player
+        // wall read as a walkable step — a hunter strolled through the masonry and bit the player inside
+        // their own base. The body-cell + swept-path gate must hold it on its own side.
+        var server = Started("jungle", out var repo);
+        using (repo)
+        {
+            var p = server.AddLocalPlayer("Walled");
+            p.State.AboardShip = false;
+            var sp = ForcePlainLandWalker(server);
+            sp.Temperament = CreatureTemperament.Aggressive; // hunts the player → steers straight at the wall
+
+            const int cx = 100, cz = 100;
+            int padY = MaxTopY(server, cx, cz, 12) + 8;
+            BuildPad(server, cx, cz, 11, padY);
+            BuildWall(server, cx, cz, 11, padY, height: 2);
+
+            p.State.Position = new Vector3f(cx + 3.5f, padY + 1, cz + 0.5f);
+            string id = server.SpawnCreatureAtForTest(new Vector3f(cx - 3.5f, padY + 1, cz + 0.5f));
+
+            for (int i = 0; i < 120; i++)
+            {
+                server.TickForTest(0.1);
+                var live = server.Creatures.First(x => x.Id == id);
+                Assert.True(live.Position.X < cx,
+                    $"the creature crossed the wall at x={cx} (reached {live.Position.X:F2}/{live.Position.Z:F2})");
+            }
+        }
+    }
+
+    [Fact]
+    public void ARoamingCreature_StaysOutOfASealedRoom_ItCannotEnter()
+    {
+        // The same gate from the other side: a room with a closed wall ring must stay creature-free, and
+        // the animal outside must not end up standing inside the masonry either.
+        var server = Started("jungle", out var repo);
+        using (repo)
+        {
+            var p = server.AddLocalPlayer("Builder");
+            p.State.AboardShip = false;
+            ForcePlainLandWalker(server);
+
+            const int cx = -100, cz = -100;
+            int padY = MaxTopY(server, cx, cz, 12) + 8;
+            BuildPad(server, cx, cz, 11, padY);
+
+            // A 5×5 room ring (3 tall) around the pad centre; the creature starts outside it.
+            var stone = _content.GetBlock("stone")!.NumericId;
+            for (int dx = -2; dx <= 2; dx++)
+            {
+                for (int dz = -2; dz <= 2; dz++)
+                {
+                    if (System.Math.Abs(dx) != 2 && System.Math.Abs(dz) != 2)
+                    {
+                        continue; // interior stays open
+                    }
+
+                    for (int dy = 1; dy <= 3; dy++)
+                    {
+                        server.World.SetBlock(new Vector3i(cx + dx, padY + dy, cz + dz), stone);
+                    }
+                }
+            }
+
+            p.State.Position = new Vector3f(cx + 0.5f, padY + 1, cz + 0.5f); // inside the room
+            string id = server.SpawnCreatureAtForTest(new Vector3f(cx + 6.5f, padY + 1, cz + 0.5f));
+
+            for (int i = 0; i < 150; i++)
+            {
+                server.TickForTest(0.1);
+                var live = server.Creatures.First(x => x.Id == id);
+                bool insideRing = System.Math.Abs(live.Position.X - cx) <= 2.5f
+                    && System.Math.Abs(live.Position.Z - cz) <= 2.5f;
+                Assert.False(insideRing,
+                    $"the creature got into the sealed room ({live.Position.X:F2}/{live.Position.Z:F2})");
+            }
+        }
+    }
+
     [Fact]
     public void HurtingOneHerdMember_StartlesItsKin_WhoFleeThePlayer()
     {


### PR DESCRIPTION
closes #855

Playtest report: insects fly straight through walls, and creatures sometimes stand half inside one. Two root causes, fixed on both sides of the wire.

## Server — creatures were a point; the terrain gate only compared ground heights

- **`CreatureBodyBlocked`** — checks the creature's own column from the feet cell through its body height (`ceil(Size × 1.8)`, clamped 2..8), so even a mouse-sized animal has a feet + head cell and a titan is gated by its shoulders rather than walled in by its own crown.
- **`CreaturePathBlocked`** — the swept version (¼-block samples), mirroring `PathBlockedByWorld`, which fixed exactly this class of bug for NPCs. No more tunnelling thin walls between ticks.
- Both now gate **every habitat** in `MoveCreatures` (previously only `Land`/`Water` were height-gated; `Air`/`Cave`/`Lava`/`Amphibian` ignored walls entirely), the `TrySteerAround` probes, and **spawn placement** — the leader spot and each herd member (`HabitatSuitable` returned `true` unconditionally for Land/Air, so animals could materialise inside ruins and bases). The existing steer-around + heading re-roll keeps the "nothing can ever get stuck" property.
- **Companions** (`MoveCompanion`) previously checked only the ship hull and energy fences — a tamed pet walked straight through its owner's base walls. It now runs the same gate; and since a wall can genuinely strand a pet, a companion left more than 24 blocks behind is re-placed beside its owner (`CompanionSpotNear`, 8 fanned bearings, body-checked), keeping "follows you anywhere" true.

### The predicate is NOT `BlockDefinition.Solid`

`Solid` defaults to `true`, so every cross-billboard `flora_*` prop (plus torch/lantern/ladder) counts as solid despite being meshed **without a collider**. Gating on `Solid` alone would make a meadow impassable for fauna. New `IsCollidingCell*` is the server counterpart of the client's `PlayerController.IsCollidingKey`: solid, minus the colliderless props; fluids passable (swimmers live in them); `tree_leaves` passable for flying species. Movement reads use `GetBlockIfLoaded`, so the 15 Hz creature tick never generates chunks as a side effect.

Bonus: NPC `BlockedByWorld` now uses the same predicate — fixing the pre-existing quirk where a grass tuft could block an NPC.

## Client — micro-fauna had no cell test at all

`MoveFly`/`MoveDrift` integrated x/z unchecked (butterflies crossed a base like it wasn't there), `MoveHop` only checked the landing, `MoveCrawl` compared ground heights (and `GroundTopY` returns the ROOF indoors), and spawns never validated the cell. Now:

- all four motion models veer off / bounce at a blocking cell (`IsBlocking`, same prop exceptions),
- the altitude bob won't push a critter into a ceiling,
- blocked spawn cells are skipped (the swarm just comes out smaller),
- crawlers/hoppers sit at `gy + 1.12` — the walkable surface — instead of `gy + 0.12`, which had parked beetles almost a full block **inside** the ground (the rest of the file already used `gy + 1` as the surface frame).

## Tests

- `AWall_StopsAHuntingCreature_InsteadOfLettingItWalkThrough` — an aggressive creature steering at the player is held by a 2-block wall for 120 ticks.
- `ARoamingCreature_StaysOutOfASealedRoom_ItCannotEnter` — a sealed 5×5 room ring stays creature-free.
- `Companion_DoesNotWalkThroughAWall_AndIsLeashedBackWhenLeftBehind` — a pet neither crosses a wall slab nor is lost behind it.

Full non-Slow suite: **1554/1554 green**. Local Unity Windows build verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
