### PR TITLE
fix(swim): stop the entombed rescue from teleporting divers to the surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,13 @@ the richer, screenshot-laden versions live there. `(#123)` references the pull r
 
 ### Fixed
 
+- **You can actually dive now (#858).** Swimming down in deep water instantly bounced you back onto
+  the surface, once per second, with "You were stuck in the rock — dug out." The rescue that frees
+  players sealed inside blocks mistook every submerged swimmer (and every ladder climber, and anyone
+  in a kelp forest) for a player entombed in rock, because water counted as a solid block in the game
+  data. Water, ladders, torches and lanterns are now correctly non-solid, the rescue only triggers on
+  blocks that can really trap a body, and it still frees players genuinely buried in stone. NPCs keep
+  treating water as a wall — nothing wanders into ponds or spots you through a lake.
 - **You can build under water (#851).** Every placement while swimming was refused with "Target is
   not empty" — the cell you aim at under water holds water, and the server only accepted air. A block
   now displaces water or lava, so underwater walls, pillars out of a lake and a dry room on the

--- a/TODO.md
+++ b/TODO.md
@@ -104,6 +104,31 @@ Per-item detail lives in the dated work log below. **Since 2026-07 versions are 
 
 ---
 
+### ★ Diving made possible: the entombed rescue no longer fishes swimmers out (#858, 2026-08-09, branch fix/swim-void-rescue)
+Wading into 2+ blocks of water, you sank in and **instantly popped back onto the surface** — once per second,
+with *"You were stuck in the rock — dug out."* The swim code was never at fault: `water` carries no
+`"solid": false` in `data/blocks.json` and `BlockDefinition.Solid` defaults to **true**, so the server's
+entombed guard (`IsEntombed`: feet + head cells solid) saw every submerged player as sealed inside rock, and
+the 1 Hz `TickVoidRescue`/`DigOutUpwards` "dug them out" to the first cell above the water — exactly the
+surface. The guard's own doc comment promised the opposite ("a swimmer (water is non-solid) … is never
+mistaken for entombed"); the data just never matched it.
+
+**Fix, four layers.** (1) *Data:* `"solid": false` for `water`, `ladder`, `torch`, `lantern` — everything the
+client meshes without a collider (a climber stands INSIDE the ladder cell, #803; the props are walk-through).
+(2) *Spawn safety gets its own predicate:* `IsBodyBlockingCell` (solid AND not flora, fluids never count) for
+`IsEntombed` + `DigOutUpwards` — kelp/vine strands stack into columns and would have re-opened the loop for
+anyone swimming through a kelp forest, but flora keeps `Solid=true` for the NPC/flora systems. (3) *NPC
+behaviour preserved:* `IsNpcBlockingCell` (solid OR fluid) keeps `BlockedByWorld` + `HasLineOfSight` exactly
+as before — settlement NPCs still don't stroll into ponds, nothing aggros through a lake. The flora void-check
+counts fluids as ground too (a water lily host still passes). (4) *Client:* `LiftOutOfBlockAt` — the
+pillar-jump guard — only fires for blocks that actually collide (`IsCollidingKey`, now also excluding
+`fire`/`energy_gate` to match the mesher's collidable set): the fluid simulation writes water cells into the
+swimmer's column when refilling a mined hole, and that lift teleported divers to the top of the column too.
+
+Tests: `SwimVoidRescueTests` (10) — passable blocks carry no Solid flag; a submerged player is not entombed
+and the rescue leaves them alone (tick + join); ladder climber and kelp swimmer are not entombed; a player
+genuinely sealed in stone is STILL freed (#834 pinned); a wall of water still breaks NPC line-of-sight.
+
 ### ★ Keep digging with a full pack: mined blocks fall as stacking ground packets (#853, 2026-08-09, branch feat/ground-drop-packets)
 Mining **stopped** once the backpack (and the cargo hold, when aboard) was full: `BreakBlockAt` priced the
 whole yield, asked `MaterialPool.CanFit` and left the block standing with an `@inventory_full` rejection. That

--- a/client/Assets/BlocksBeyondTheStars/Scripts/GameBootstrap.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/GameBootstrap.cs
@@ -2279,8 +2279,11 @@ namespace BlocksBeyondTheStars.Client
             // A cell that just became solid where we are standing must lift us out, not swallow us: the server
             // allows placing into your own feet cell (pillar jumping), and mid-fall that used to drop the player
             // straight through the world. Every block change funnels through here, so another player filling the
-            // cell is covered too.
-            if (m.Block != BlockId.AirValue && Player != null)
+            // cell is covered too. ONLY blocks that actually collide count: the fluid simulation writes water
+            // cells into the swimmer's column (mining/placing near a body wakes it), and lifting on those
+            // teleported the diver out of the water onto the surface.
+            if (m.Block != BlockId.AirValue && Player != null
+                && PlayerController.IsCollidingKey(Content?.BlockById(new BlockId(m.Block))?.Key))
             {
                 Player.LiftOutOfBlockAt(m.X, m.Y, m.Z);
             }

--- a/client/Assets/BlocksBeyondTheStars/Scripts/PlayerController.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/PlayerController.cs
@@ -2449,11 +2449,13 @@ namespace BlocksBeyondTheStars.Client
         /// player standing in a grass tuft (or next to a wall torch) was embedded in geometry, and would make a
         /// torch overhead cancel the auto-step.
         /// </summary>
-        private static bool IsCollidingKey(string key)
+        internal static bool IsCollidingKey(string key)
             => IsSolidKey(key)
                && key != "torch"
                && key != "lantern" // slim prop like the torch (#809)
                && key != "ladder"  // walk-through since #803 — a climber stands INSIDE the ladder cell
+               && key != "fire"        // burns, doesn't block — meshed without a collider
+               && key != "energy_gate" // walk-through membrane — meshed without a collider
                && !key.StartsWith("flora_", System.StringComparison.Ordinal);
 
         /// <summary>Whether there is solid footing just past the player's edge in a horizontal direction — used by

--- a/data/blocks.json
+++ b/data/blocks.json
@@ -15,7 +15,7 @@
   { "key": "light_white",  "nameKey": "block.light_white.name", "category": "light",  "hardness": 0.5, "requiredTool": "none",  "minToolTier": 0, "drops": [] },
   { "key": "light_red",    "nameKey": "block.light_red.name", "category": "light",    "hardness": 0.5, "requiredTool": "none",  "minToolTier": 0, "drops": [] },
   { "key": "light_green",  "nameKey": "block.light_green.name", "category": "light",  "hardness": 0.5, "requiredTool": "none",  "minToolTier": 0, "drops": [] },
-  { "key": "water",        "nameKey": "block.water.name", "category": "terrain",        "hardness": 4, "requiredTool": "drill", "minToolTier": 3, "mineable": true, "drops": [ { "item": "water", "count": 1 } ] },
+  { "key": "water",        "nameKey": "block.water.name", "category": "terrain",        "hardness": 4, "requiredTool": "drill", "minToolTier": 3, "mineable": true, "solid": false, "drops": [ { "item": "water", "count": 1 } ] },
   { "key": "lava",         "nameKey": "block.lava.name", "category": "terrain",         "hardness": 4, "requiredTool": "drill", "minToolTier": 3, "mineable": true, "drops": [ { "item": "lava", "count": 1 } ] },
   { "key": "sand",         "nameKey": "block.sand.name", "category": "terrain",         "hardness": 0.5, "requiredTool": "none",  "minToolTier": 0, "drops": [ { "item": "sand", "count": 1 } ] },
   { "key": "mud",          "nameKey": "block.mud.name", "category": "terrain",          "hardness": 0.6, "requiredTool": "none",  "minToolTier": 0, "drops": [ { "item": "mud", "count": 1 } ] },
@@ -52,7 +52,7 @@
   { "key": "flora_emberbloom","nameKey": "block.flora_emberbloom.name", "category": "flora","hardness": 0.5, "requiredTool": "none", "minToolTier": 0, "flammable": true, "drops": [ { "item": "crystal", "count": 1 } ] },
   { "key": "flora_kelp",   "nameKey": "block.flora_kelp.name", "category": "flora",   "hardness": 0.3, "requiredTool": "none",  "minToolTier": 0, "drops": [ { "item": "plant_fiber", "count": 2 } ] },
   { "key": "flora_lily",   "nameKey": "block.flora_lily.name", "category": "flora",   "hardness": 0.2, "requiredTool": "none",  "minToolTier": 0, "drops": [ { "item": "plant_fiber", "count": 1 }, { "item": "berries", "count": 1 } ] },
-  { "key": "ladder",       "nameKey": "block.ladder.name", "category": "building",       "hardness": 0.4, "requiredTool": "none",  "minToolTier": 0, "drops": [ { "item": "ladder", "count": 1 } ] },
+  { "key": "ladder",       "nameKey": "block.ladder.name", "category": "building",       "hardness": 0.4, "requiredTool": "none",  "minToolTier": 0, "solid": false, "drops": [ { "item": "ladder", "count": 1 } ] },
   { "key": "stairs",       "nameKey": "block.stairs.name", "category": "building",       "hardness": 0.6, "requiredTool": "none",  "minToolTier": 0, "drops": [ { "item": "stairs", "count": 1 } ] },
 
   { "key": "gold_ore",      "nameKey": "block.gold_ore.name", "category": "ore",      "hardness": 4.8, "requiredTool": "drill", "minToolTier": 1, "drops": [ { "item": "gold_ore", "count": 1 } ] },
@@ -84,7 +84,7 @@
   { "key": "door_slide",   "nameKey": "block.door_slide.name", "category": "door",   "hardness": 1.5, "requiredTool": "none",  "minToolTier": 0, "drops": [ { "item": "door_slide", "count": 1 } ] },
   { "key": "door_wood",    "nameKey": "block.door_wood.name", "category": "door",    "hardness": 1.0, "requiredTool": "none",  "minToolTier": 0, "drops": [ { "item": "door_wood", "count": 1 } ] },
   { "key": "door_energy",  "nameKey": "block.door_energy.name", "category": "door",  "hardness": 1.5, "requiredTool": "none",  "minToolTier": 0, "drops": [ { "item": "door_energy", "count": 1 } ] },
-  { "key": "torch",        "nameKey": "block.torch.name", "category": "light",       "hardness": 0.2, "requiredTool": "none",  "minToolTier": 0, "emission": 0.85, "color": 16758855, "drops": [ { "item": "torch", "count": 1 } ] },
+  { "key": "torch",        "nameKey": "block.torch.name", "category": "light",       "hardness": 0.2, "requiredTool": "none",  "minToolTier": 0, "solid": false, "emission": 0.85, "color": 16758855, "drops": [ { "item": "torch", "count": 1 } ] },
   { "key": "flora_palm",      "nameKey": "block.flora_palm.name", "category": "flora",      "hardness": 0.4, "requiredTool": "none", "minToolTier": 0, "flammable": true, "drops": [ { "item": "plant_fiber", "count": 2 } ] },
   { "key": "flora_moss",      "nameKey": "block.flora_moss.name", "category": "flora",      "hardness": 0.2, "requiredTool": "none", "minToolTier": 0, "flammable": true, "drops": [ { "item": "plant_fiber", "count": 1 } ] },
   { "key": "flora_orchid",    "nameKey": "block.flora_orchid.name", "category": "flora",    "hardness": 0.2, "requiredTool": "none", "minToolTier": 0, "flammable": true, "drops": [ { "item": "plant_fiber", "count": 1 }, { "item": "berries", "count": 1 } ] },
@@ -168,7 +168,7 @@
   { "key": "bed",        "nameKey": "block.bed.name",        "category": "machine",  "hardness": 1.2, "requiredTool": "none", "minToolTier": 0, "flammable": true, "color": 10967111, "drops": [ { "item": "bed", "count": 1 } ] },
   { "key": "campfire",   "nameKey": "block.campfire.name",   "category": "machine",  "hardness": 0.8, "requiredTool": "none", "minToolTier": 0, "emission": 0.8, "color": 16734488, "drops": [ { "item": "campfire", "count": 1 } ] },
   { "key": "wood_crate", "nameKey": "block.wood_crate.name", "category": "building", "hardness": 1.2, "requiredTool": "none", "minToolTier": 0, "flammable": true, "color": 9127187, "drops": [ { "item": "wood_crate", "count": 1 } ] },
-  { "key": "lantern",    "nameKey": "block.lantern.name",    "category": "light",    "hardness": 0.4, "requiredTool": "none", "minToolTier": 0, "emission": 0.8, "color": 16758855, "drops": [ { "item": "lantern", "count": 1 } ] },
+  { "key": "lantern",    "nameKey": "block.lantern.name",    "category": "light",    "hardness": 0.4, "requiredTool": "none", "minToolTier": 0, "solid": false, "emission": 0.8, "color": 16758855, "drops": [ { "item": "lantern", "count": 1 } ] },
   { "key": "rug",        "nameKey": "block.rug.name",        "category": "building", "hardness": 0.2, "requiredTool": "none", "minToolTier": 0, "flammable": true, "tintable": true, "color": 11553354, "drops": [ { "item": "rug", "count": 1 } ] },
   { "key": "flower_pot", "nameKey": "block.flower_pot.name", "category": "building", "hardness": 0.4, "requiredTool": "none", "minToolTier": 0, "color": 10841676, "drops": [ { "item": "flower_pot", "count": 1 } ] }
 ]

--- a/src/BlocksBeyondTheStars.GameServer/GameServerFlora.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerFlora.cs
@@ -157,7 +157,10 @@ public sealed partial class GameServer
         bool Solid(Vector3i p)
         {
             ushort id = get(p);
-            return id != 0 && (_content.BlockById(new BlockId(id))?.Solid ?? false);
+            // Fluids count as ground here: a fall into water/lava lands, it doesn't leave the world — and
+            // water lily / kelp hosts must keep passing this check now that water's Solid flag is false
+            // (dropped so the entombed rescue stops teleporting swimmers to the surface).
+            return id != 0 && (IsFluid(id) || (_content.BlockById(new BlockId(id))?.Solid ?? false));
         }
 
         // True when a cell has nothing to land on: no solid block within probe range below it.

--- a/src/BlocksBeyondTheStars.GameServer/GameServerNpcs.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerNpcs.cs
@@ -330,7 +330,7 @@ public sealed partial class GameServer
             int x = (int)System.Math.Floor(ax + dx * f);
             int y = (int)System.Math.Floor(ay + dy * f);
             int z = (int)System.Math.Floor(az + dz * f);
-            if (IsSolidCell(x, y, z))
+            if (IsSightBlockingCell(x, y, z)) // fluids occlude like before water lost its Solid flag
             {
                 return false;
             }
@@ -344,7 +344,9 @@ public sealed partial class GameServer
     public bool HasLineOfSightForTest(Vector3f from, Vector3f to) => HasLineOfSight(from, to);
 
     /// <summary>True if an NPC's body (feet + head) would sit inside a colliding block at this position — a wall,
-    /// so it can't stroll there. A doorway opening stays air, so NPCs pass through doorways but not walls.</summary>
+    /// so it can't stroll there. A doorway opening stays air, so NPCs pass through doorways but not walls.
+    /// Fluids block too (<c>fluidsPass: false</c>): settlement NPCs have no swim logic, so a pond must stay a
+    /// wall to them even though a player swims straight in.</summary>
     private bool BlockedByWorld(Vector3f pos)
     {
         int x = (int)System.Math.Floor(pos.X);
@@ -353,6 +355,13 @@ public sealed partial class GameServer
         return IsCollidingCell(x, y, z)       // feet
             || IsCollidingCell(x, y + 1, z);  // head
     }
+
+    /// <summary>A cell that blocks an NPC's SIGHT: solid (the plain flag — hiding in tall grass works, a
+    /// meadow occludes), or a fluid. Water/lava lost their <c>Solid</c> flag (a submerged player must not
+    /// count as entombed — see GameServerSpawnSafety), but a body of water must keep breaking the sightline
+    /// exactly as before: no aggro through a lake.</summary>
+    private bool IsSightBlockingCell(int x, int y, int z)
+        => IsSolidCell(x, y, z) || IsFluid(_world.GetBlock(new Vector3i(x, y, z)).Value);
 
     /// <summary>Whether a cell is a movement-blocking solid block. Keyed on the block's <c>Solid</c> flag, not
     /// just "non-air", so the two are kept distinct: <b>glass</b> is solid-but-transparent (blocks NPCs, you see
@@ -388,14 +397,17 @@ public sealed partial class GameServer
 
     private bool IsCollidingBlock(BlockId id, bool fluidsPass, bool foliagePasses)
     {
+        // Fluids are decided EXPLICITLY, not via the Solid flag: water is Solid=false in the content DB
+        // (a submerged player must not read as entombed — see GameServerSpawnSafety), yet a pond must stay
+        // a wall to a walking NPC (fluidsPass: false) while swimmers wade right through (fluidsPass: true).
+        if (IsFluid(id.Value))
+        {
+            return !fluidsPass;
+        }
+
         if (!IsSolidBlock(id))
         {
             return false;
-        }
-
-        if (fluidsPass && IsFluid(id.Value))
-        {
-            return false; // water/lava are `Solid` in the content DB but are wadeable/swimmable, not walls
         }
 
         var def = _content.BlockById(id);

--- a/src/BlocksBeyondTheStars.GameServer/GameServerSpawnSafety.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerSpawnSafety.cs
@@ -71,8 +71,8 @@ public sealed partial class GameServer
     /// spawned at the world-origin column 85 blocks down, motionless for the whole session, 7550 stone
     /// blocks around him and no air anywhere. Full health, so nothing ever killed him out of it either.
     /// </para>
-    /// Keyed on the <c>Solid</c> flag rather than "non-air" so a swimmer (water is non-solid) or someone in
-    /// a torch/flora cell is never mistaken for entombed.
+    /// Keyed on <see cref="IsBodyBlockingCell"/> rather than "non-air" so a swimmer (water is non-solid), a
+    /// ladder climber, or someone in a torch/flora cell is never mistaken for entombed.
     /// </summary>
     private bool IsEntombed(Vector3f pos)
     {
@@ -84,7 +84,32 @@ public sealed partial class GameServer
         int x = (int)System.Math.Floor(pos.X);
         int y = (int)System.Math.Floor(pos.Y);
         int z = (int)System.Math.Floor(pos.Z);
-        return IsSolidCell(x, y, z) && IsSolidCell(x, y + 1, z);
+        return IsBodyBlockingCell(x, y, z) && IsBodyBlockingCell(x, y + 1, z);
+    }
+
+    /// <summary>
+    /// A cell the player's body genuinely cannot occupy — the ONLY kind that counts for the entombed rescue.
+    /// Deliberately stricter than <see cref="IsSolidCell"/>: fluids are excluded (a submerged swimmer is not
+    /// stuck — the 1 Hz rescue used to "dig out" every diver onto the surface the moment the water was two
+    /// deep), and so is the flora category (kelp/vine strands stack into columns, have no client collider,
+    /// and would re-open the same loop for anyone swimming through a kelp forest). Belt-and-braces on the
+    /// fluid check: even a fluid whose data ever regains <c>solid: true</c> must not re-trap swimmers.
+    /// </summary>
+    private bool IsBodyBlockingCell(int x, int y, int z)
+    {
+        var id = _world.GetBlock(new Vector3i(x, y, z));
+        if (id.IsAir || IsFluid(id.Value))
+        {
+            return false;
+        }
+
+        var def = _content.BlockById(id);
+        if (def == null)
+        {
+            return true; // unknown id → treat as blocking (safe default, matches IsSolidCell)
+        }
+
+        return def.Solid && def.Category != "flora";
     }
 
     /// <summary>
@@ -111,8 +136,9 @@ public sealed partial class GameServer
     }
 
     /// <summary>Lifts an entombed position straight up to the first cell with standing room (feet + head
-    /// clear) resting on something solid. Returns null when the column has no such gap within
-    /// <see cref="EntombedProbeHeight"/> — the caller then falls back to the ship/landing pad.</summary>
+    /// clear) resting on something the body actually stands on. Returns null when the column has no such gap
+    /// within <see cref="EntombedProbeHeight"/> — the caller then falls back to the ship/landing pad.
+    /// Same predicate as <see cref="IsEntombed"/>, so water or a kelp cell is never offered as a floor.</summary>
     private Vector3f? DigOutUpwards(Vector3f pos)
     {
         int x = (int)System.Math.Floor(pos.X);
@@ -120,7 +146,7 @@ public sealed partial class GameServer
         int y0 = (int)System.Math.Floor(pos.Y);
         for (int y = y0 + 1; y <= y0 + EntombedProbeHeight; y++)
         {
-            if (!IsSolidCell(x, y, z) && !IsSolidCell(x, y + 1, z) && IsSolidCell(x, y - 1, z))
+            if (!IsBodyBlockingCell(x, y, z) && !IsBodyBlockingCell(x, y + 1, z) && IsBodyBlockingCell(x, y - 1, z))
             {
                 return new Vector3f(x + 0.5f, y, z + 0.5f);
             }

--- a/tests/BlocksBeyondTheStars.Tests/SwimVoidRescueTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/SwimVoidRescueTests.cs
@@ -1,0 +1,254 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using System;
+using BlocksBeyondTheStars.GameServer;
+using BlocksBeyondTheStars.Networking.Transport;
+using BlocksBeyondTheStars.Persistence;
+using BlocksBeyondTheStars.Shared.Configuration;
+using BlocksBeyondTheStars.Shared.Content;
+using BlocksBeyondTheStars.Shared.Geometry;
+using BlocksBeyondTheStars.Shared.Primitives;
+using Xunit;
+using SvGameServer = BlocksBeyondTheStars.GameServer.GameServer;
+
+namespace BlocksBeyondTheStars.Tests;
+
+/// <summary>
+/// Regressions for the entombed-rescue vs. swimmer bug (playtest 2026-08-09): "wenn ich in Wasser
+/// hineingehe, das tief genug ist, sinke ich ein, aber ich steige sofort wieder auf". Water carried
+/// <c>Solid=true</c> in the data, so a player two blocks deep counted as sealed-in-rock and the 1 Hz
+/// void/entombed rescue "dug them out" onto the surface every second. Same pattern for ladders (a
+/// climber stands INSIDE the ladder cell) and stacked flora (kelp/vine strands).
+/// </summary>
+public sealed class SwimVoidRescueTests : IDisposable
+{
+    private readonly string _root;
+    private readonly GameContent _content;
+
+    public SwimVoidRescueTests()
+    {
+        _root = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "bbts_swim_" + Guid.NewGuid().ToString("N"));
+        _content = ContentLoader.LoadFromDirectory(TestPaths.DataDir());
+    }
+
+    public void Dispose()
+    {
+        try { System.IO.Directory.Delete(_root, recursive: true); } catch { /* best effort */ }
+    }
+
+    private SvGameServer Started(string world, out SqliteWorldRepository repo)
+    {
+        repo = new SqliteWorldRepository(new SaveGamePaths(_root, world));
+        var st = new LoopbackServerTransport(new LoopbackLink());
+        var config = new ServerConfig
+        {
+            WorldName = world,
+            Seed = 9,
+            StartPlanet = "rocky",
+            AutoSaveIntervalMinutes = 9999,
+            PlaceStarterShip = false,
+            PlaceSettlements = false,
+            PlaceWrecks = false,
+            ViewDistanceChunks = 1,
+        };
+        var server = new SvGameServer(config, _content, st, repo);
+        server.Start();
+        return server;
+    }
+
+    /// <summary>Passable-on-the-client blocks must not carry the Solid flag: the client meshes them without
+    /// a collider (you swim into water, stand inside a ladder, walk through a torch/lantern), so the server
+    /// treating them as solid is what turned divers and climbers into "entombed" rescue cases.</summary>
+    [Theory]
+    [InlineData("water")]
+    [InlineData("ladder")]
+    [InlineData("torch")]
+    [InlineData("lantern")]
+    public void PassableBlocks_AreNotSolidInTheData(string key)
+    {
+        Assert.False(_content.GetBlock(key)!.Solid, $"'{key}' has no client collider and must not be Solid");
+    }
+
+    /// <summary>The core bug: a swimmer two blocks under is NOT sealed in rock, and the 1 Hz rescue must
+    /// leave them exactly where they are instead of teleporting them onto the surface every second.</summary>
+    [Fact]
+    public void SubmergedPlayer_IsNotEntombed_AndVoidRescueLeavesThemAlone()
+    {
+        var server = Started("diver", out var repo);
+        using (repo)
+        {
+            var pilot = server.AddLocalPlayer("Diver");
+            pilot.State.AboardShip = false;
+
+            // A small pool carved at the spawn column: stone floor, three blocks of water above it.
+            var at = pilot.State.Position;
+            int px = (int)Math.Floor(at.X), py = (int)Math.Floor(at.Y), pz = (int)Math.Floor(at.Z);
+            var stone = _content.GetBlock("stone")!.NumericId;
+            var water = _content.GetBlock("water")!.NumericId;
+            for (int dx = -1; dx <= 1; dx++)
+                for (int dz = -1; dz <= 1; dz++)
+                {
+                    server.World.SetBlock(new Vector3i(px + dx, py - 1, pz + dz), stone);
+                    for (int dy = 0; dy <= 2; dy++)
+                    {
+                        server.World.SetBlock(new Vector3i(px + dx, py + dy, pz + dz), water);
+                    }
+                }
+
+            var submerged = new Vector3f(px + 0.5f, py + 0.2f, pz + 0.5f); // feet AND head in water
+            pilot.State.Position = submerged;
+
+            Assert.False(server.IsEntombedForTest(submerged), "a swimmer inside water is not sealed in rock");
+            Assert.False(server.IsInVoidForTest(submerged), "the pool floor is right below — not the void");
+
+            server.RunVoidRescueForTest();
+
+            Assert.Equal(submerged.X, pilot.State.Position.X);
+            Assert.Equal(submerged.Y, pilot.State.Position.Y);
+            Assert.Equal(submerged.Z, pilot.State.Position.Z);
+        }
+    }
+
+    /// <summary>Same on join: a save persisted while diving must load back under water, not on the bank.</summary>
+    [Fact]
+    public void SubmergedPlayer_KeepsTheirPositionOnJoin()
+    {
+        var server = Started("diverJoin", out var repo);
+        using (repo)
+        {
+            var pilot = server.AddLocalPlayer("DiverJoin");
+            pilot.State.AboardShip = false;
+
+            var at = pilot.State.Position;
+            int px = (int)Math.Floor(at.X), py = (int)Math.Floor(at.Y), pz = (int)Math.Floor(at.Z);
+            var stone = _content.GetBlock("stone")!.NumericId;
+            var water = _content.GetBlock("water")!.NumericId;
+            server.World.SetBlock(new Vector3i(px, py - 1, pz), stone);
+            for (int dy = 0; dy <= 2; dy++)
+            {
+                server.World.SetBlock(new Vector3i(px, py + dy, pz), water);
+            }
+
+            var submerged = new Vector3f(px + 0.5f, py + 0.2f, pz + 0.5f);
+            pilot.State.Position = submerged;
+
+            server.EnsureSafeSpawnForTest(pilot);
+
+            Assert.Equal(submerged.Y, pilot.State.Position.Y);
+        }
+    }
+
+    /// <summary>A climber stands INSIDE the ladder cells (#803) — two stacked ladders must not read as
+    /// "sealed inside blocks" (the rescue would yank them off the ladder once per second).</summary>
+    [Fact]
+    public void LadderClimber_IsNotEntombed()
+    {
+        var server = Started("climber", out var repo);
+        using (repo)
+        {
+            var pilot = server.AddLocalPlayer("Climber");
+            pilot.State.AboardShip = false;
+
+            var at = pilot.State.Position;
+            int px = (int)Math.Floor(at.X), py = (int)Math.Floor(at.Y), pz = (int)Math.Floor(at.Z);
+            var stone = _content.GetBlock("stone")!.NumericId;
+            var ladder = _content.GetBlock("ladder")!.NumericId;
+            server.World.SetBlock(new Vector3i(px, py - 1, pz), stone);
+            server.World.SetBlock(new Vector3i(px, py, pz), ladder);
+            server.World.SetBlock(new Vector3i(px, py + 1, pz), ladder);
+
+            var climbing = new Vector3f(px + 0.5f, py + 0.2f, pz + 0.5f);
+            pilot.State.Position = climbing;
+
+            Assert.False(server.IsEntombedForTest(climbing), "a climber inside ladder cells is not entombed");
+
+            server.RunVoidRescueForTest();
+            Assert.Equal(climbing.Y, pilot.State.Position.Y);
+        }
+    }
+
+    /// <summary>Kelp/vine strands stack into columns and have no client collider — swimming through a kelp
+    /// forest (feet and head both in flora cells) must not trigger the rescue either. Flora stays Solid in
+    /// the data (the NPC/flora systems key on it), so this pins the rescue's own body-blocking predicate.</summary>
+    [Fact]
+    public void KelpForestSwimmer_IsNotEntombed()
+    {
+        var server = Started("kelp", out var repo);
+        using (repo)
+        {
+            var pilot = server.AddLocalPlayer("KelpSwimmer");
+            pilot.State.AboardShip = false;
+
+            var at = pilot.State.Position;
+            int px = (int)Math.Floor(at.X), py = (int)Math.Floor(at.Y), pz = (int)Math.Floor(at.Z);
+            var stone = _content.GetBlock("stone")!.NumericId;
+            var kelp = _content.GetBlock("flora_kelp")!.NumericId;
+            server.World.SetBlock(new Vector3i(px, py - 1, pz), stone);
+            server.World.SetBlock(new Vector3i(px, py, pz), kelp);
+            server.World.SetBlock(new Vector3i(px, py + 1, pz), kelp);
+
+            var inKelp = new Vector3f(px + 0.5f, py + 0.2f, pz + 0.5f);
+            pilot.State.Position = inKelp;
+
+            Assert.False(server.IsEntombedForTest(inKelp), "a swimmer inside a kelp strand is not entombed");
+        }
+    }
+
+    /// <summary>A player genuinely sealed in stone must STILL be rescued — the predicate got stricter, not
+    /// the rescue weaker. Pins the original #834 behaviour against this change.</summary>
+    [Fact]
+    public void GenuinelyEntombedPlayer_IsStillFreed()
+    {
+        var server = Started("stillBuried", out var repo);
+        using (repo)
+        {
+            var pilot = server.AddLocalPlayer("StillBuried");
+            pilot.State.AboardShip = false;
+
+            var buried = new Vector3f(0.5f, pilot.State.Position.Y - 40f, 0.5f);
+            var stone = _content.GetBlock("stone")!.NumericId;
+            int bx = (int)Math.Floor(buried.X), by = (int)Math.Floor(buried.Y), bz = (int)Math.Floor(buried.Z);
+            for (int dx = -1; dx <= 1; dx++)
+                for (int dy = -2; dy <= 3; dy++)
+                    for (int dz = -1; dz <= 1; dz++)
+                    {
+                        server.World.SetBlock(new Vector3i(bx + dx, by + dy, bz + dz), stone);
+                    }
+
+            pilot.State.Position = buried;
+            Assert.True(server.IsEntombedForTest(buried), "stone in feet + head cells must still count as entombed");
+
+            server.EnsureSafeSpawnForTest(pilot);
+            Assert.False(server.IsEntombedForTest(pilot.State.Position));
+        }
+    }
+
+    /// <summary>Water lost its Solid flag, but NPC line-of-sight must keep treating a body of water as an
+    /// occluder — no aggro through a lake (the pre-fix behaviour, preserved on purpose).</summary>
+    [Fact]
+    public void LineOfSight_IsStillBlockedByWater()
+    {
+        var server = Started("waterlos", out var repo);
+        using (repo)
+        {
+            var pilot = server.AddLocalPlayer("Looker");
+            pilot.State.AboardShip = false;
+
+            var at = pilot.State.Position;
+            var open = new Vector3f(at.X, at.Y + 40f, at.Z); // clear air, so only our wall can occlude
+            var target = new Vector3f(open.X + 4f, open.Y, open.Z);
+            Assert.True(server.HasLineOfSightForTest(open, target), "baseline: nothing between them yet");
+
+            var water = _content.GetBlock("water")!.NumericId;
+            int wallX = (int)Math.Floor(open.X) + 2;
+            for (int dy = 0; dy <= 4; dy++)
+                for (int dz = -1; dz <= 1; dz++)
+                {
+                    server.World.SetBlock(new Vector3i(wallX, (int)Math.Floor(open.Y) + dy, (int)Math.Floor(open.Z) + dz), water);
+                }
+
+            Assert.False(server.HasLineOfSightForTest(open, target), "a wall of water must still break the sightline");
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Wade into 2+ blocks of water and you sink in — then instantly pop back onto the surface, once per second, with *"You were stuck in the rock — dug out."* Diving was effectively impossible (reported in the 2026-08-09 playtest).

The swim code was never at fault: `water` never declares `"solid": false` in `data/blocks.json`, and `BlockDefinition.Solid` defaults to **true**. The server's sealed-in-rock guard (`IsEntombed`: feet + head cells solid) therefore saw every submerged player as entombed, and the 1 Hz `TickVoidRescue` → `DigOutUpwards` teleported them to the first cell above the water — exactly the surface. The guard's own doc comment promised the opposite ("a swimmer (water is non-solid) … is never mistaken for entombed"); the data never matched it.

## Fix (four layers)

1. **Data** — `"solid": false` for `water`, `ladder`, `torch`, `lantern`: everything the client meshes without a collider (a climber stands *inside* the ladder cell since #803; the props are walk-through).
2. **Spawn safety gets its own predicate** — `IsBodyBlockingCell` (solid AND not flora; fluids never count) for `IsEntombed` + `DigOutUpwards`. Kelp/vine strands stack into columns and would have re-opened the loop for anyone swimming through a kelp forest; flora keeps `Solid=true` for the NPC/flora systems.
3. **NPC behaviour preserved** — `IsNpcBlockingCell` (solid OR fluid) keeps `BlockedByWorld` + `HasLineOfSight` exactly as before: settlement NPCs still don't stroll into ponds, nothing aggros through a lake. The flora void-check counts fluids as ground, so water-lily/kelp hosts still pass.
4. **Client** — `LiftOutOfBlockAt` (the pillar-jump guard) only fires for blocks that actually collide: the fluid simulation writes water cells into the swimmer's column when refilling a mined hole, which also teleported divers upward. `IsCollidingKey` now additionally excludes `fire`/`energy_gate`, matching the mesher's collidable set exactly.

## Tests

`SwimVoidRescueTests` (10 new, all green):
- passable blocks (`water`/`ladder`/`torch`/`lantern`) carry no Solid flag in the data
- a submerged player is not entombed and keeps their position through the rescue tick AND on join
- ladder climber and kelp-forest swimmer are not entombed
- a player genuinely sealed in stone is **still** freed (pins #834 against this change)
- a wall of water still breaks NPC line-of-sight (preserved on purpose)

Full suite: **1748/1748 green**. Local Unity build: **verified** (client/Assets changed).

closes #858

🤖 Generated with [Claude Code](https://claude.com/claude-code)