### PR TITLE
fix(save): stop the per-join ship-residue wipe that erased builds beside the pad

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7,7 +7,7 @@ plans live under [docs/](docs/) (committed); the long-range direction is the str
 keep it current when controls/features change. Last consolidated 2026-06-04.
 
 **Build:** `scripts/build-client.ps1` (Windows) or `scripts/build-client.sh` (Linux) — publishes shared libs + bundled server + Unity player.
-**Test:** `./scripts/run-tests.sh` — currently **1545 server + 194 client passing** (2026-08-08). Locale parity (en/de) is enforced by a test.
+**Test:** `./scripts/run-tests.sh` — currently **1547 server + 194 client passing** (2026-08-09). Locale parity (en/de) is enforced by a test.
 CI runs two tiers: PRs skip the tests marked `[Trait("Category", "Slow")]`; pushes to `main` and the release workflow run the full suite. CI builds/runs
 tests in Release, and a per-test duration guardrail (`scripts/check-test-durations.py`, PRs only) fails the gate when a non-Slow test exceeds 120 s.
 The server suite is sharded across a 4-runner matrix (`scripts/partition-tests.py` + checked-in weights; `Tests passed` is the required fan-in check) — PR gate ~4½ min.
@@ -7445,6 +7445,27 @@ is **pre-approved** (keys in `tools/ai-assets/.env`, run via `uv`).
    footprint so nothing seeps up. Leave landing at the seabed (so it *can* land underwater) unless the user
    prefers dry-land preference (see questions). Tests: collider excludes fluids; fluid won't enter a stamped
    ship interior; ship interior is water-free after landing in a sea.
+
+---
+
+## ✅ Done (2026-08-09): builds beside the landing pad survive rejoins — "singleplayer doesn't save" (#870)
+
+Playtest repro on a fresh world: place blocks beside the starter ship, quit, reload — gone. The save
+pipeline itself was fine (stdin-stop drain, write-through `block_edit` rows); the data was **deleted on
+the next join**: `CleanLegacyStampResidue`, the pre-ship-as-object migration that erases the old stamped
+hull from a save, ran on **every** `PlaceLandedShip()` (join, respawn, landing, ship switch, interior
+enter) and deleted ALL block edits in a box around the parked ship — footprint +4 on each side, 8 below
+to hull +3 above. That box is exactly where a new player builds first; on the bundled solo host the
+player is `--admins`, so even the pad-reservation build block didn't apply. Save-file forensics matched
+perfectly: every ghost-heal cell inside the box had its DB row deleted, every one outside survived.
+
+Fix, following the `StampedFeatures` one-shot pattern: new worlds are stamped `CreatedWithShipObjects`
+at creation (the cleanup never runs — they can't carry legacy hulls); old saves clean **once per
+location+pad**, recorded in `WorldMetadata.ShipResidueCleaned`, then never again. Also fixed the
+cleanup's chunk re-stream loop, which strode world coordinates and skipped chunks on the max faces —
+the source of the lingering client-side ghost blocks. Tests: build in the margin ring survives a real
+server restart on the same save; a simulated legacy save still cleans its stamped hull exactly once and
+keeps later builds. Playtest pending.
 
 ---
 

--- a/src/BlocksBeyondTheStars.GameServer/GameServer.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServer.cs
@@ -326,6 +326,9 @@ public sealed partial class GameServer
             CreativeStarterKit = _config.CreativeStarterKit,
             // World options: the rules chosen at creation become the world's own (live admin edits update them).
             RulesOverride = _config.Rules.Clone(),
+            // Born after ship-as-object: no stamped hulls can exist in this save, so the legacy
+            // stamp-residue cleanup (#870) must never touch it.
+            CreatedWithShipObjects = true,
         };
     }
 

--- a/src/BlocksBeyondTheStars.GameServer/GameServerShipStructure.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerShipStructure.cs
@@ -83,7 +83,7 @@ public sealed partial class GameServer
             ? new Vector3f(rec.Origin.X + mb.X + 0.5f, rec.Origin.Y + mb.Y + 1f, rec.Origin.Z + mb.Z + 0.5f)
             : new Vector3f(rec.Origin.X + s.Width / 2 + 0.5f, rec.Origin.Y + 1f, rec.Origin.Z + s.Length / 2 + 0.5f);
 
-        CleanLegacyStampResidue(rec); // pre-object saves carry the old stamped hull as world block edits
+        CleanLegacyStampResidueOnce(rec, pad); // pre-object saves carry the old stamped hull as world block edits
 
         rec.Placed = true;
         _log.Info($"Ship parked at ({rec.Origin.X}, {rec.Origin.Y}, {rec.Origin.Z}) — {s.Cells.Count} cells, {rec.Stations.Count} stations.");
@@ -170,12 +170,28 @@ public sealed partial class GameServer
         return msg;
     }
 
-    /// <summary>One-shot migration per placement: pre-object saves persisted the STAMPED hull as world
+    /// <summary>One-shot migration per pad (#870): pre-object saves persisted the STAMPED hull as world
     /// block edits — delete any edits inside the parked ship's volume (incl. the old silhouette margin and
     /// foundation) and regenerate the affected chunks, so the old block hull doesn't stand inside the new
-    /// object. Pad volumes are reserved (no building there), so no legitimate player edits are lost.</summary>
-    private void CleanLegacyStampResidue(LandedShip rec)
+    /// object. The cleanup box also covers legally buildable ground (the margin ring beyond the pad
+    /// reservation, and 8 blocks below it), and it used to run on EVERY placement — join, respawn, landing,
+    /// ship switch — deleting the player's own builds beside their pad on each rejoin. Hence the persisted
+    /// once-per-pad gate: a save that was already cleaned here never loses edits to this box again.</summary>
+    private void CleanLegacyStampResidueOnce(LandedShip rec, LandingPad pad)
     {
+        if (_meta.CreatedWithShipObjects)
+        {
+            return; // born after ship-as-object — this save never persisted a stamped hull anywhere
+        }
+
+        string key = $"{_world.LocationId}|shipresidue:{pad.CenterX}:{pad.CenterZ}";
+        if (_meta.ShipResidueCleaned.Contains(key))
+        {
+            return;
+        }
+
+        _meta.ShipResidueCleaned.Add(key); // persisted by the next SaveAll (checkpoint/autosave/shutdown)
+
         var s = rec.Structure;
         var min = new Vector3i(rec.Origin.X - 4, rec.Origin.Y - 8, rec.Origin.Z - 4);
         var max = new Vector3i(rec.Origin.X + s.Width + 4, rec.Origin.Y + s.Height + 3, rec.Origin.Z + s.Length + 4);
@@ -183,15 +199,18 @@ public sealed partial class GameServer
         _world.ForgetChunksIn(min, max);
 
         // Re-stream the affected chunks to everyone on this world so stale hull blocks vanish client-side.
+        // Iterate in CHUNK coordinates: the old world-coordinate stride skipped chunks on the max faces
+        // (only the single max corner was patched in), leaving clients with stale ghost blocks there.
+        var minChunk = WorldConstants.WorldToChunk(min);
+        var maxChunk = WorldConstants.WorldToChunk(max);
         var seen = new HashSet<ChunkCoord>();
-        for (int x = min.X; x <= max.X; x += WorldConstants.ChunkSize)
-            for (int y = min.Y; y <= max.Y; y += WorldConstants.ChunkSize)
-                for (int z = min.Z; z <= max.Z; z += WorldConstants.ChunkSize)
+        for (int cx = minChunk.X; cx <= maxChunk.X; cx++)
+            for (int cy = minChunk.Y; cy <= maxChunk.Y; cy++)
+                for (int cz = minChunk.Z; cz <= maxChunk.Z; cz++)
                 {
-                    seen.Add(WorldConstants.CanonicalChunk(WorldConstants.WorldToChunk(new Vector3i(x, y, z)), _world.Circumference));
+                    seen.Add(WorldConstants.CanonicalChunk(new ChunkCoord(cx, cy, cz), _world.Circumference));
                 }
 
-        seen.Add(WorldConstants.CanonicalChunk(WorldConstants.WorldToChunk(max), _world.Circumference));
         foreach (var session in JoinedInActiveWorld())
         {
             foreach (var coord in seen)
@@ -397,6 +416,13 @@ public sealed partial class GameServer
     private static Vector3i AnchorOf(LandedShip rec) => rec.Placed
         ? new Vector3i(rec.Origin.X + rec.Structure.Width / 2, rec.Origin.Y - 1, rec.Origin.Z + rec.Structure.Length / 2)
         : default;
+
+    /// <summary>Test/diagnostic: a player's parked-ship origin and structure size (W,H,L) in the active world.</summary>
+    public (Vector3i Origin, Vector3i Size) LandedShipBoundsForTest(string playerId)
+    {
+        var rec = _worlds.Active.LandedFor(playerId);
+        return (rec.Origin, new Vector3i(rec.Structure.Width, rec.Structure.Height, rec.Structure.Length));
+    }
 
     /// <summary>Test/diagnostic: whether a block cell lies inside a ship interior (cell-centre probe).</summary>
     public bool ShipInteriorContainsCellForTest(int x, int y, int z)

--- a/src/BlocksBeyondTheStars.Shared/State/WorldMetadata.cs
+++ b/src/BlocksBeyondTheStars.Shared/State/WorldMetadata.cs
@@ -81,6 +81,24 @@ public sealed class WorldMetadata
     /// </summary>
     public System.Collections.Generic.Dictionary<string, string> BodyPlanetTypes { get; set; } = new();
 
+    /// <summary>
+    /// True for worlds created after ships became placed objects (#870): such a save never persisted a
+    /// stamped hull, so the legacy stamp-residue cleanup must never run on it (it would delete the player's
+    /// own builds beside a pad on their first landing there). False (missing) on older saves — they migrate
+    /// via <see cref="ShipResidueCleaned"/>.
+    /// </summary>
+    public bool CreatedWithShipObjects { get; set; }
+
+    /// <summary>
+    /// One-time ship-stamp residue cleanups already performed on pre-object saves (#870):
+    /// "{locationId}|shipresidue:{padX}:{padZ}" once the legacy stamped-hull migration ran for that pad.
+    /// The cleanup used to run on EVERY ship placement (join, respawn, landing, ship switch), deleting all
+    /// persisted block edits in a box around the parked ship — wiping the player's own builds beside their
+    /// pad on each rejoin ("singleplayer doesn't save"). A missing entry means "clean once more", so
+    /// pre-object saves migrate by cleaning one final time (the <see cref="StampedFeatures"/> pattern).
+    /// </summary>
+    public System.Collections.Generic.List<string> ShipResidueCleaned { get; set; } = new();
+
     // --- Singleplayer "Creative" world options (chosen at creation; persisted so they reapply on every load).
     // A head-start sandbox: everything available + a starter set, while survival mechanics stay on. All false =
     // the normal "Explorer" world. Blueprints + ships are re-applied per join (idempotent); the kit is one-time. ---

--- a/tests/BlocksBeyondTheStars.Tests/ShipReloadPersistenceTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/ShipReloadPersistenceTests.cs
@@ -7,6 +7,7 @@ using BlocksBeyondTheStars.Networking.Transport;
 using BlocksBeyondTheStars.Persistence;
 using BlocksBeyondTheStars.Shared.Configuration;
 using BlocksBeyondTheStars.Shared.Content;
+using BlocksBeyondTheStars.Shared.Geometry;
 using BlocksBeyondTheStars.Shared.State;
 using Xunit;
 using SvGameServer = BlocksBeyondTheStars.GameServer.GameServer;
@@ -177,6 +178,88 @@ public sealed class ShipReloadPersistenceTests : IDisposable
             Assert.Equal(2, a.AssignedPadIndex);          // first in keeps the pad
             Assert.NotEqual(a.AssignedPadIndex, b.AssignedPadIndex); // the other is moved to a free one
             Assert.NotEqual(reloaded.ShipAnchorOf("Ann"), reloaded.ShipAnchorOf("Ben"));
+        }
+    }
+
+    [Fact]
+    public void BuildBesideTheShip_SurvivesAReload()
+    {
+        // #870 — the legacy stamp-residue cleanup ran on EVERY ship placement and deleted all block edits
+        // in a box around the parked ship (footprint + 4, 8 below to hull + 3 above). Anything built beside
+        // the starter ship was wiped on the next join — "singleplayer doesn't save my game".
+        var stone = _content.GetBlock("stone")!.NumericId;
+        Vector3i cell;
+
+        var first = Start("residue", out var repo1, placeShip: true);
+        using (repo1)
+        {
+            first.AddLocalPlayer("Pilot"); // join parks the ship (and runs the one-shot cleanup on the fresh save)
+            var (origin, size) = first.LandedShipBoundsForTest("Pilot");
+
+            // In the margin ring: beyond the hull but inside the old cleanup box — legally buildable ground.
+            cell = new Vector3i(origin.X + size.X + 3, origin.Y + 2, origin.Z + 1);
+            first.World.SetBlock(cell, stone, owner: "Pilot");
+            first.Stop();
+        }
+
+        var reloaded = Start("residue", out var repo2, placeShip: true);
+        using (repo2)
+        {
+            reloaded.AddLocalPlayer("Pilot"); // re-parks the ship — this used to wipe the box again
+
+            Assert.Equal(stone.Value, reloaded.World.GetBlock(cell).Value);
+        }
+    }
+
+    [Fact]
+    public void LegacyStampResidue_IsCleanedOnce_ThenBuildsAreSafe()
+    {
+        // Where the ship will park is deterministic from the seed — probe it on a throwaway save.
+        Vector3i origin, size;
+        string location;
+        var probe = Start("residue_probe", out var probeRepo, placeShip: true);
+        using (probeRepo)
+        {
+            probe.AddLocalPlayer("Pilot");
+            (origin, size) = probe.LandedShipBoundsForTest("Pilot");
+            location = probe.World.LocationId;
+        }
+
+        // Turn a freshly created save into a pre-ship-as-object one: drop the born-clean flag and persist
+        // the stamped hull as a world block edit inside the ship volume, like the old stamp did.
+        var setup = Start("residue_legacy", out var setupRepo, placeShip: true);
+        setup.Stop();
+        var ironWall = _content.GetBlock("iron_wall")!.NumericId;
+        var inside = new Vector3i(origin.X + 2, origin.Y + 1, origin.Z + 2);
+        using (setupRepo)
+        {
+            var meta = setupRepo.LoadMetadata()!;
+            meta.CreatedWithShipObjects = false;
+            setupRepo.SaveMetadata(meta);
+            setupRepo.SetBlock(location, inside, ironWall.Value);
+        }
+
+        var stone = _content.GetBlock("stone")!.NumericId;
+        Vector3i cell;
+        var first = Start("residue_legacy", out var repo1, placeShip: true);
+        using (repo1)
+        {
+            first.AddLocalPlayer("Pilot");
+
+            // The migration still runs (once): the old stamped hull block is gone from inside the ship volume.
+            Assert.True(first.World.GetBlock(inside).IsAir, "the legacy stamped hull must be cleaned on first placement");
+
+            cell = new Vector3i(origin.X + size.X + 3, origin.Y + 2, origin.Z + 1);
+            first.World.SetBlock(cell, stone, owner: "Pilot");
+            first.Stop();
+        }
+
+        var reloaded = Start("residue_legacy", out var repo2, placeShip: true);
+        using (repo2)
+        {
+            reloaded.AddLocalPlayer("Pilot");
+
+            Assert.Equal(stone.Value, reloaded.World.GetBlock(cell).Value); // the gate is closed — no second wipe
         }
     }
 


### PR DESCRIPTION
Closes #870

## What happened

*"Singleplayer doesn't save my game"* — build beside the starter ship, quit, reload: the build is gone. The save pipeline itself was fine (stdin-stop drain, `SaveAll`, write-through `block_edit` rows). The data was written correctly and then **deleted on the next join**.

## Root cause

`CleanLegacyStampResidue` — the pre-ship-as-object migration that erases the old *stamped hull* block edits from a save — ran on **every** `PlaceLandedShip()`: join, world enter/landing, respawn, heal-tank respawn, observer return, ship switch, ship-interior enter. Each run deleted **all** persisted block edits in a box around the parked ship (footprint +4 on each side, 8 below the pad to hull +3 above) and regenerated the chunks.

That box is exactly where a new player builds first. The margin ring extends past the pad reservation (radius 8), the box reaches 8 blocks underground (mined tunnels refill), and on the bundled solo host the player is passed as `--admins`, so the pad-reservation build rejection doesn't apply to them at all.

Save-file forensics from the repro world confirmed the mechanism exactly: every ghost-heal cell **inside** the box had its `block_edit` row deleted; every cell **outside** survived.

## Fix

Following the existing `WorldMetadata.StampedFeatures` one-shot pattern:

- **New worlds never clean.** `CreatedWithShipObjects` is stamped into the metadata at creation — a save born after ship-as-object cannot carry legacy hulls, so the cleanup is skipped entirely (including first landings on other pads/bodies).
- **Old saves clean once per location+pad.** The cleanup records `"{locationId}|shipresidue:{padX}:{padZ}"` in `WorldMetadata.ShipResidueCleaned` and never runs again for that pad. A missing entry means "clean once more", so pre-object saves migrate by cleaning one final time.
- **Chunk re-stream loop fixed.** The old loop strode world coordinates by `ChunkSize` from `min` and only patched in the single `max` corner, so chunks on the max faces were never re-streamed — the source of the lingering client-side ghost blocks the server log shows (`Ghost block healed …`). It now iterates chunk coordinates inclusively.

## Tests

- `BuildBesideTheShip_SurvivesAReload` — a block placed in the margin ring beside the parked ship survives a real server restart on the same save (fails on the old code: the rejoin wiped it).
- `LegacyStampResidue_IsCleanedOnce_ThenBuildsAreSafe` — a simulated pre-object save (born-clean flag dropped, stamped hull row seeded inside the ship volume) still cleans its residue exactly once on the next placement, and blocks built afterwards survive further reloads.

Full non-Slow suite green locally; no client changes (server + shared only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
