### PR TITLE
feat(tools): wix-i18n website translation audit + import tooling

### DIFF
--- a/.github/workflows/detect-doc-only.yml
+++ b/.github/workflows/detect-doc-only.yml
@@ -1,8 +1,9 @@
 # Reusable doc/asset-only change detector, shared by ci.yml, lint.yml and codeql.yml.
 #
-# Output `nondocs` is "true" when the PR diff contains ANY file that is not documentation or an
-# image (marketing screenshot, texture, icon, …). Callers gate their heavy jobs on it, so a PR that
-# only touches Markdown/docs/licences or image files skips build, tests, format, lint and CodeQL.
+# Output `nondocs` is "true" when the PR diff contains ANY file that is not documentation, an
+# image (marketing screenshot, texture, icon, …) or standalone external-service tooling. Callers
+# gate their heavy jobs on it, so a PR that only touches Markdown/docs/licences, image files or
+# the website tooling under tools/ skips build, tests, format, lint and CodeQL.
 # Because each of those is a job-name required check, a *skipped* required job still counts as a pass,
 # so doc/screenshot-only PRs stay green and are never blocked. (CodeQL is handled separately: its
 # required check is posted by the code-scanning service, not the job, so it is gated here AND removed
@@ -52,6 +53,11 @@ jobs:
               # Images (screenshots, textures, icons) — none affect the .NET tests, ruff,
               # actionlint or CodeQL analysis, so an image-only change is safe to skip everywhere.
               *.png|*.jpg|*.jpeg|*.gif|*.webp|*.bmp|*.svg|*.ico) ;;
+              # Standalone external-service tooling (website devblog, Wix i18n, glitch.fun store
+              # media) — pure Python scripts talking to external APIs, not part of the game build
+              # and not imported by any test. Push-to-main runs (ruff, CodeQL) still cover them
+              # because detection only applies to pull_request events.
+              tools/devblog/*|tools/wix-i18n/*|tools/glitch-media/*) ;;
               *) nondocs=true; break ;;
             esac
           done <<< "$files"

--- a/.gitignore
+++ b/.gitignore
@@ -117,6 +117,9 @@ client/Assets/BlocksBeyondTheStars/Scripts/GlitchIntegrationSecrets.Generated.cs
 tools/devblog/*.json
 tools/devblog/devblog-artikel*.md
 
+# Wix i18n audit/import — website content dumps and translations (never committed)
+tools/wix-i18n/out/
+
 # Build/capture run logs (client)
 client/build-run.log
 client/capture-run.log

--- a/TODO.md
+++ b/TODO.md
@@ -104,6 +104,17 @@ Per-item detail lives in the dated work log below. **Since 2026-07 versions are 
 
 ---
 
+### ★ Website i18n tooling: Wix translation audit + import (2026-08-10, branch feat/wix-i18n-audit)
+`tools/wix-i18n/` — manage the website's translations via the Wix Multilingual REST APIs, bypassing
+Wix's machine translation. `audit_translations.py` (read-only) dumps schemas + per-locale contents and
+reports missing / partially translated / copied-not-translated / stale items per secondary locale;
+`import_translations.py` writes reviewed translations back (dry-run by default, `--apply` to write,
+large HTML via `textFile` refs); `extract_texts.py` prints source texts for translating. Content dumps
+and translations live in the gitignored `out/`. Findings 2026-08-10: the hidden `it` locale was missing
+the Mitmachen/Schul-AG/Datenschutz pages (translations prepared, pending review); most of the raw gap
+count is untranslated template leftovers (fake team/jobs/portfolio) that should be cleaned up, not
+translated. Page SEO meta + slugs are per-language but editor-only (not exposed via API).
+
 ### ★ Dutch (Nederlands) locale (#881, 2026-08-09, branch feat/nl-locale)
 Machine first pass per TRANSLATION_GUIDE Step 6: `data/locales/nl.json` (full main table) +
 `data/stories/vega_protocol/locales/nl.json`, generated with `tools/translate_locale.py nl`

--- a/tools/wix-i18n/README.md
+++ b/tools/wix-i18n/README.md
@@ -1,0 +1,39 @@
+# wix-i18n — website translation audit + import
+
+Tools for managing the website's translations (Wix Multilingual) via the
+Wix REST API, without Wix's machine translation. Translations are produced
+locally (Claude), reviewed, then imported.
+
+## Setup
+
+Needs `WIX_API_KEY` + `WIX_SITE_ID` in `.env` here (or reuses
+`tools/devblog/.env`). The API key needs the Wix Multilingual read/write
+scopes (already present on the devblog key).
+
+## Workflow
+
+1. `uv run audit_translations.py` — read-only. Dumps schemas + per-locale
+   contents and writes `out/report.md` (gap report: missing / partial /
+   stale items per target locale) and `out/todo-<locale>.json`.
+2. Translate: copy `todo-<locale>.json` to `translations-<locale>.json` and
+   replace each field's `text` with the translation (keep HTML markup
+   intact; keep game terms like "Blocks Beyond the Stars" or "VEGA"
+   untranslated; translate image alt texts SEO-consciously).
+3. Review with Marcel (side-by-side file).
+4. `uv run import_translations.py out/translations-<locale>.json` — dry run,
+   shows every write. Add `--apply` to actually write. Fields are written
+   `published: true`; a HIDDEN locale stays invisible to visitors until its
+   visibility is flipped (dashboard or Update Locale API).
+
+`out/` and all website content dumps are gitignored — only the scripts live
+in the repo.
+
+## Notes
+
+- Page SEO settings (meta title/description, URL slugs) are handled by
+  Wix's SEO system, not the Translation Content API — see the analysis doc
+  for the current findings.
+- Blog posts are translated separately via `tools/devblog`
+  (translationId-linked DE/EN drafts).
+- hreflang + language subdirectories (`/en/`, `/it/`) are managed by Wix
+  automatically for multilingual sites.

--- a/tools/wix-i18n/audit_translations.py
+++ b/tools/wix-i18n/audit_translations.py
@@ -1,0 +1,252 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["requests"]
+# ///
+"""Audit Wix Multilingual translation coverage of the website.
+
+Read-only. Dumps all translation schemas and per-locale contents from the
+Wix Translation Content API, then writes into out/ (gitignored):
+
+  schemas.json           raw schema catalog
+  contents-<locale>.json raw content dump per locale
+  report.md              human-readable gap report per target locale
+  todo-<locale>.json     items/fields that need a translation, with the
+                         primary-language source text (input for
+                         import_translations.py after translating)
+
+A field needs translation when the primary-locale content has a non-empty
+text value (schema field types SHORT_TEXT / LONG_TEXT / HTML, not
+displayOnly) and the target locale is missing the content item or that
+field. Items whose primary content was updated after the translation are
+reported as stale.
+
+Usage (from tools/wix-i18n/):
+  uv run audit_translations.py                 # targets: all secondary locales
+  uv run audit_translations.py --targets it    # single target locale
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+import requests
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+OUT_DIR = SCRIPT_DIR / "out"
+API = "https://www.wixapis.com"
+TEXT_TYPES = {"SHORT_TEXT", "LONG_TEXT", "HTML"}
+TAG_RE = re.compile(r"<[^>]+>")
+
+
+def load_env() -> dict[str, str]:
+    """Read WIX_API_KEY / WIX_SITE_ID from .env here or tools/devblog/.env."""
+    for candidate in (SCRIPT_DIR / ".env", SCRIPT_DIR.parent / "devblog" / ".env"):
+        if candidate.exists():
+            env = {}
+            for line in candidate.read_text(encoding="utf-8").splitlines():
+                if "=" in line and not line.lstrip().startswith("#"):
+                    k, v = line.split("=", 1)
+                    env[k.strip()] = v.strip()
+            if "WIX_API_KEY" in env and "WIX_SITE_ID" in env:
+                return env
+    sys.exit("No .env with WIX_API_KEY/WIX_SITE_ID found (tools/wix-i18n/ or tools/devblog/)")
+
+
+def make_session(env: dict[str, str]) -> requests.Session:
+    s = requests.Session()
+    s.headers.update({
+        "Authorization": env["WIX_API_KEY"],
+        "wix-site-id": env["WIX_SITE_ID"],
+        "Content-Type": "application/json",
+    })
+    return s
+
+
+def fetch_locales(s: requests.Session) -> list[dict]:
+    r = s.post(f"{API}/locales/v2/locale/query", json={"query": {}})
+    r.raise_for_status()
+    return r.json().get("locales", [])
+
+
+def fetch_schemas(s: requests.Session) -> dict[str, dict]:
+    schemas: dict[str, dict] = {}
+    cursor = None
+    while True:
+        params: dict = {"paging.limit": 100}
+        if cursor:
+            params["paging.cursor"] = cursor
+        r = s.get(f"{API}/translation-schema/v1/schemas/site", params=params)
+        r.raise_for_status()
+        d = r.json()
+        for sc in d.get("schemas", []):
+            schemas[sc["id"]] = sc
+        pm = d.get("pagingMetadata", {})
+        cursor = pm.get("cursors", {}).get("next")
+        if not pm.get("hasNext"):
+            return schemas
+
+
+def fetch_contents(s: requests.Session, locale: str) -> list[dict]:
+    items: list[dict] = []
+    cursor = None
+    while True:
+        paging: dict = {"limit": 100}
+        body: dict = {"search": {"cursorPaging": paging}}
+        if cursor:
+            paging["cursor"] = cursor
+        else:
+            body["search"]["filter"] = {"locale": locale}
+        r = s.post(f"{API}/translation-content/v1/contents/search", json=body)
+        r.raise_for_status()
+        d = r.json()
+        items += d.get("contents", [])
+        pm = d.get("pagingMetadata", {})
+        cursor = pm.get("cursors", {}).get("next")
+        if not pm.get("hasNext"):
+            return items
+
+
+def text_preview(value: str, limit: int = 90) -> str:
+    text = TAG_RE.sub(" ", value)
+    text = re.sub(r"\s+", " ", text).strip()
+    return text[:limit] + ("…" if len(text) > limit else "")
+
+
+def translatable_fields(content: dict, schema: dict | None) -> dict[str, dict]:
+    """Field key -> {text, type} for non-empty primary text fields."""
+    result: dict[str, dict] = {}
+    schema_fields = (schema or {}).get("fields", {})
+    for key, fval in content.get("fields", {}).items():
+        text = fval.get("textValue")
+        if not text or not text.strip():
+            continue
+        sfield = schema_fields.get(key, {})
+        ftype = sfield.get("type", "SHORT_TEXT")
+        if ftype not in TEXT_TYPES or sfield.get("displayOnly"):
+            continue
+        if ftype == "HTML" and not TAG_RE.sub("", text).strip():
+            continue  # markup without any text content
+        result[key] = {"text": text, "type": ftype}
+    return result
+
+
+def schema_label(schema: dict | None) -> str:
+    if not schema:
+        return "unknown schema"
+    return schema.get("displayName") or schema["key"]["entityType"]
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--targets", help="comma-separated target locales (default: all secondary)")
+    args = ap.parse_args()
+
+    env = load_env()
+    s = make_session(env)
+    OUT_DIR.mkdir(exist_ok=True)
+
+    locales = fetch_locales(s)
+    primary = next(l["id"] for l in locales if l.get("primaryLocale"))
+    secondary = [l["id"] for l in locales if not l.get("primaryLocale")]
+    targets = args.targets.split(",") if args.targets else secondary
+    print(f"Primary locale: {primary}; targets: {', '.join(targets)}")
+
+    schemas = fetch_schemas(s)
+    (OUT_DIR / "schemas.json").write_text(
+        json.dumps(schemas, indent=1, ensure_ascii=False), encoding="utf-8")
+
+    contents: dict[str, dict[tuple[str, str], dict]] = {}
+    for locale in [primary, *targets]:
+        rows = fetch_contents(s, locale)
+        contents[locale] = {(c["schemaId"], c["entityId"]): c for c in rows}
+        (OUT_DIR / f"contents-{locale}.json").write_text(
+            json.dumps(rows, indent=1, ensure_ascii=False), encoding="utf-8")
+        print(f"{locale}: {len(rows)} content items")
+
+    report = ["# Wix translation gap report", ""]
+    for target in targets:
+        missing_items: list[dict] = []
+        missing_fields: list[dict] = []
+        identical: list[dict] = []
+        stale: list[dict] = []
+        todo: list[dict] = []
+
+        for (schema_id, entity_id), de in contents[primary].items():
+            schema = schemas.get(schema_id)
+            de_fields = translatable_fields(de, schema)
+            if not de_fields:
+                continue
+            tgt = contents[target].get((schema_id, entity_id))
+            entry = {
+                "schemaId": schema_id,
+                "entityId": entity_id,
+                "schema": schema_label(schema),
+                "entityType": (schema or {}).get("key", {}).get("entityType", ""),
+                "parentEntityId": de.get("parentEntityId"),
+                "locale": target,
+                "fields": {},
+            }
+            if tgt is None:
+                entry["fields"] = {k: v for k, v in de_fields.items()}
+                missing_items.append(entry)
+                todo.append(entry)
+                continue
+            tgt_fields = tgt.get("fields", {})
+            gaps = {k: v for k, v in de_fields.items()
+                    if not tgt_fields.get(k, {}).get("textValue", "").strip()}
+            same = {k: v for k, v in de_fields.items()
+                    if k not in gaps
+                    and tgt_fields.get(k, {}).get("textValue", "").strip() == v["text"].strip()
+                    and len(v["text"].strip()) > 3}
+            if gaps:
+                entry["fields"] = gaps
+                missing_fields.append(entry)
+                todo.append(entry)
+            if same:
+                identical.append({**entry, "fields": same})
+            if not gaps and de.get("updatedDate", "") > tgt.get("updatedDate", ""):
+                stale.append({**entry, "deUpdated": de.get("updatedDate"),
+                              "targetUpdated": tgt.get("updatedDate")})
+
+        report += [f"## {primary} → {target}", "",
+                   f"- Primary items with translatable text: "
+                   f"{sum(1 for k, c in contents[primary].items() if translatable_fields(c, schemas.get(k[0])))}",
+                   f"- Missing entirely in {target}: {len(missing_items)}",
+                   f"- Existing but with untranslated fields: {len(missing_fields)}",
+                   f"- Translation identical to {primary} (copied, not translated?): {len(identical)}",
+                   f"- Possibly stale ({primary} edited after translation): {len(stale)}", ""]
+        for title, rows in (("Missing items", missing_items),
+                            ("Untranslated fields", missing_fields),
+                            (f"Identical to {primary}", identical)):
+            if not rows:
+                continue
+            report.append(f"### {title}")
+            report.append("")
+            for e in sorted(rows, key=lambda x: (x["schema"], x["entityId"])):
+                for key, f in e["fields"].items():
+                    report.append(f"- **{e['schema']}** `{e['entityId']}` "
+                                  f"[{f['type']}] {text_preview(f['text'])}")
+            report.append("")
+        if stale:
+            report.append("### Possibly stale")
+            report.append("")
+            for e in sorted(stale, key=lambda x: (x["schema"], x["entityId"])):
+                report.append(f"- **{e['schema']}** `{e['entityId']}` "
+                              f"({primary} {e['deUpdated']} > {target} {e['targetUpdated']})")
+            report.append("")
+
+        todo_path = OUT_DIR / f"todo-{target}.json"
+        todo_path.write_text(json.dumps(todo, indent=1, ensure_ascii=False), encoding="utf-8")
+        print(f"{target}: {len(missing_items)} missing items, {len(missing_fields)} partial, "
+              f"{len(stale)} stale -> {todo_path.name}")
+
+    (OUT_DIR / "report.md").write_text("\n".join(report), encoding="utf-8")
+    print(f"Report: {OUT_DIR / 'report.md'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/wix-i18n/extract_texts.py
+++ b/tools/wix-i18n/extract_texts.py
@@ -1,0 +1,40 @@
+# /// script
+# requires-python = ">=3.11"
+# ///
+"""Print full texts for given entity ids (helper for translating).
+
+Usage: uv run extract_texts.py [--locale de] comp-l0jod52i comp-mri7q69m ...
+With no entity ids: prints all Site Pages (page titles) and Form field values.
+"""
+import json
+import sys
+from pathlib import Path
+
+sys.stdout.reconfigure(encoding="utf-8")
+
+args = sys.argv[1:]
+locale = "de"
+if args and args[0] == "--locale":
+    locale = args[1]
+    args = args[2:]
+sys.argv = [sys.argv[0], *args]
+
+OUT = Path(__file__).resolve().parent / "out"
+contents = json.loads((OUT / f"contents-{locale}.json").read_text(encoding="utf-8"))
+schemas = json.loads((OUT / "schemas.json").read_text(encoding="utf-8"))
+
+wanted = set(sys.argv[1:])
+for c in contents:
+    schema = schemas.get(c["schemaId"], {})
+    label = schema.get("displayName") or schema.get("key", {}).get("entityType", "?")
+    if wanted and c["entityId"] not in wanted:
+        continue
+    if not wanted and label not in ("Site Pages", "Form"):
+        continue
+    print(f"=== {label} | schema={c['schemaId']} | entity={c['entityId']} ===")
+    for key, f in c.get("fields", {}).items():
+        tv = f.get("textValue")
+        if tv and tv.strip():
+            print(f"--- field {key} ---")
+            print(tv)
+    print()

--- a/tools/wix-i18n/import_translations.py
+++ b/tools/wix-i18n/import_translations.py
@@ -1,0 +1,127 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["requests"]
+# ///
+"""Import translated website texts into Wix Multilingual.
+
+Reads a translations file (same shape as the audit's todo-<locale>.json but
+with each field's "text" replaced by the translation), then creates or
+updates the translation content per item. DRY-RUN by default: shows exactly
+what would be written; nothing is sent without --apply.
+
+Fields are written with published=true so they go live on the locale's site
+(the locale itself stays invisible while its visibility is HIDDEN).
+
+Usage (from tools/wix-i18n/):
+  uv run import_translations.py out/translations-it.json          # dry run
+  uv run import_translations.py out/translations-it.json --apply  # write!
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import requests
+
+sys.stdout.reconfigure(encoding="utf-8")
+
+from audit_translations import API, load_env, make_session, text_preview
+
+
+def fetch_existing_keys(s: requests.Session, locale: str) -> set[tuple[str, str]]:
+    keys: set[tuple[str, str]] = set()
+    cursor = None
+    while True:
+        paging: dict = {"limit": 100}
+        body: dict = {"search": {"cursorPaging": paging}}
+        if cursor:
+            paging["cursor"] = cursor
+        else:
+            body["search"]["filter"] = {"locale": locale}
+        r = s.post(f"{API}/translation-content/v1/contents/search", json=body)
+        r.raise_for_status()
+        d = r.json()
+        keys |= {(c["schemaId"], c["entityId"]) for c in d.get("contents", [])}
+        pm = d.get("pagingMetadata", {})
+        cursor = pm.get("cursors", {}).get("next")
+        if not pm.get("hasNext"):
+            return keys
+
+
+def field_text(f: dict, base_dir: Path) -> str:
+    """A field carries its translation inline ("text") or in a file ("textFile")."""
+    if "textFile" in f:
+        return (base_dir / f["textFile"]).read_text(encoding="utf-8").strip()
+    return f["text"]
+
+
+def content_payload(item: dict, locale: str, base_dir: Path) -> dict:
+    return {
+        "schemaId": item["schemaId"],
+        "entityId": item["entityId"],
+        "locale": locale,
+        "fields": {key: {"textValue": field_text(f, base_dir), "published": True}
+                   for key, f in item["fields"].items()},
+    }
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("file", type=Path, help="translations JSON (list of todo items)")
+    ap.add_argument("--apply", action="store_true", help="actually write to Wix")
+    args = ap.parse_args()
+
+    items = json.loads(args.file.read_text(encoding="utf-8"))
+    base_dir = args.file.resolve().parent
+    if not items:
+        sys.exit("Nothing to import.")
+    locales = {i["locale"] for i in items}
+    if len(locales) != 1:
+        sys.exit(f"Mixed locales in one file: {locales}")
+    locale = locales.pop()
+
+    env = load_env()
+    s = make_session(env)
+    existing = fetch_existing_keys(s, locale)
+
+    creates = [i for i in items if (i["schemaId"], i["entityId"]) not in existing]
+    updates = [i for i in items if (i["schemaId"], i["entityId"]) in existing]
+    n_fields = sum(len(i["fields"]) for i in items)
+    print(f"{locale}: {len(creates)} creates, {len(updates)} updates, {n_fields} fields total")
+
+    if not args.apply:
+        for i in items:
+            action = "CREATE" if i in creates else "UPDATE"
+            for key, f in i["fields"].items():
+                print(f"  {action} {i['schema']} `{i['entityId']}` {key}: "
+                      f"{text_preview(field_text(f, base_dir))}")
+        print("\nDry run — re-run with --apply to write.")
+        return
+
+    failures = 0
+    for item in creates:
+        r = s.post(f"{API}/translation-content/v1/contents",
+                   json={"content": content_payload(item, locale, base_dir)})
+        if r.status_code != 200:
+            failures += 1
+            print(f"FAILED create {item['schema']} {item['entityId']}: "
+                  f"{r.status_code} {r.text[:200]}")
+    for start in range(0, len(updates), 100):
+        batch = updates[start:start + 100]
+        r = s.post(f"{API}/translation-content/v1/bulk/contents/update-by-key",
+                   json={"contents": [{"content": content_payload(i, locale, base_dir)}
+                                      for i in batch]})
+        if r.status_code != 200:
+            failures += 1
+            print(f"FAILED bulk update ({len(batch)} items): {r.status_code} {r.text[:200]}")
+
+    print(f"Done: {len(creates)} creates, {len(updates)} updates, {failures} failures.")
+    if failures:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Tooling to manage the website's translations (Wix Multilingual) via the Wix REST API — audit gaps per locale, then import locally produced, reviewed translations instead of Wix machine translation.

- `tools/wix-i18n/audit_translations.py` — **read-only** audit: dumps all translation schemas + per-locale contents, reports missing / partially translated / copied-not-translated / stale items per secondary locale, writes `todo-<locale>.json` work files
- `tools/wix-i18n/import_translations.py` — imports reviewed translations (create or bulk-update-by-key); **dry-run by default**, `--apply` to write; large HTML payloads referenced via `textFile`
- `tools/wix-i18n/extract_texts.py` — prints source texts for translating
- website content dumps/reports/translations stay in the gitignored `out/` (no website-internal content in the repo)

No game/runtime code touched; scripts only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)