### PR TITLE
Singleplayer Esc pause: stop the world the player can actually see

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -104,6 +104,20 @@ Per-item detail lives in the dated work log below. **Since 2026-07 versions are 
 
 ---
 
+### ★ The Esc pause actually stops the world the player can see (#908, 2026-08-10, branch fix/908-singleplayer-pause)
+Follow-up to #612, which made the Esc menu hold the **server** but never told the client about it:
+`NetworkClient.PauseStateReceived` had no subscribers, so everything the client simulates itself kept
+running behind the dialog. `GameBootstrap` now exposes `WorldPaused` / `WorldDeltaTime` / `WorldTime`,
+fed from `PauseState` by a new unit-tested `WorldClock` (Client.Core) that stands still while held and
+skips the paused stretch, so timers don't all fire at once on resume. Moved onto that clock: the
+player's own gravity (pausing mid-fall no longer drops you), micro-fauna, creature bodies + idle/answer
+calls + lunges, planet enemies and bandits, settlement NPCs, the geyser/lava-fall/waterfall ambience,
+and — the "night keeps falling" part — the client's *local* day clock in `Sky` and `SkyBodiesView` plus
+the cloud deck. Deliberately still live: music, UI, the camera and shader/station-prop flicker, because
+a fully frozen image reads as a crash. Weather needed no change (already gated on `MenuOpen`). Server
+side: `JoinedCount` no longer counts spectators (#487 observers), so an admin quietly watching a world
+stops silently denying its only player their pause. No new locale keys.
+
 ### ★ Website translated into all 13 game languages (2026-08-10, branch feat/wix-i18n-locale-tools)
 The full website (all pages, menu, forms, image alt texts) now has complete translations in every
 game language: en/it plus newly created es, fr, nl, pl, pt, tr, ru, uk, ja, ko, zh — the 11 new Wix

--- a/client/Assets/BlocksBeyondTheStars/Scripts/AuroraView.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/AuroraView.cs
@@ -76,7 +76,7 @@ namespace BlocksBeyondTheStars.Client
                     continue;
                 }
 
-                float t = Time.time * 0.06f + i * 2.1f;
+                float t = (Game != null ? Game.WorldTime : Time.time) * 0.06f + i * 2.1f; // world time (#908)
 
                 // Hang high over the player, each band at its own bearing, slowly drifting + undulating.
                 var p = Game.PlayerPosition;

--- a/client/Assets/BlocksBeyondTheStars/Scripts/Clouds.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/Clouds.cs
@@ -194,8 +194,11 @@ namespace BlocksBeyondTheStars.Client
             }
 
             Vector3 camPos = Camera.transform.position;
-            float wind = Time.time * 0.012f * windScale;
-            float t = Time.time;
+            // World time, not frame time (#908): the cloud deck drifts and boils on this clock, so it parks
+            // itself while the world is held instead of sailing on over a frozen landscape.
+            float worldNow = Game != null ? Game.WorldTime : Time.time;
+            float wind = worldNow * 0.012f * windScale;
+            float t = worldNow;
 
             for (int i = 0; i < MaxClouds; i++)
             {

--- a/client/Assets/BlocksBeyondTheStars/Scripts/CreatureView.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/CreatureView.cs
@@ -24,7 +24,7 @@ namespace BlocksBeyondTheStars.Client
             public string Bank;   // creature_{size}_{disposition} voice bank (hurt/alert/attack/die)
             public string Call;   // this species' signature idle call (creature_call_*)
             public float Pitch;   // per-species voice pitch (size + a per-species offset)
-            public float NextCall; // Time.time of the next idle vocalisation
+            public float NextCall; // world time of the next idle vocalisation
             public float AnswerAt; // pending call-answer time (#876) — 0 while none is scheduled
             public float NextAttack; // throttles the attack call while hostile + close
             public bool PrevHostile; // to detect the turn-hostile transition (alert)
@@ -33,7 +33,7 @@ namespace BlocksBeyondTheStars.Client
             public Vector3 PrevSettled; // last frame's smoothed position → velocity for facing
             public Vector3 FaceDir;     // smoothed heading the body turns to face (so it doesn't moonwalk)
             public Vector3 TargetVel;     // velocity estimated from consecutive server updates (#654)
-            public float LastTargetChange; // Time.time of the last authoritative position change (#654)
+            public float LastTargetChange; // world time of the last authoritative position change (#654)
             public float PitchDeg;         // smoothed slope pitch (#652) — nose up/down along real motion
             public float RollDeg;          // smoothed banking roll (#652) — fliers lean into turns
             public Vector3 PrevFaceDir;    // last frame's facing → heading rate for the banking roll
@@ -59,6 +59,12 @@ namespace BlocksBeyondTheStars.Client
             {
                 return;
             }
+
+            // World time, not frame time (#908). While the server holds the world for the pause menu both are
+            // stationary, so animals stop walking, calling, answering and lunging with everything else — and
+            // because WorldTime skips the paused stretch, the timers below do not all fire at once on resume.
+            float now = Game.WorldTime;
+            float dt = Game.WorldDeltaTime;
 
             var seen = _seenScratch;
             seen.Clear();
@@ -87,12 +93,12 @@ namespace BlocksBeyondTheStars.Client
                         Call = CallForHabitat(c.Habitat, idh),
                         Echo = string.Equals(c.Habitat, "Cave", System.StringComparison.OrdinalIgnoreCase),
                         Pitch = Mathf.Clamp(sizePitch * speciesOffset, 0.6f, 1.85f),
-                        NextCall = Time.time + Random.Range(2f, 6f),
+                        NextCall = now + Random.Range(2f, 6f),
                         Settled = pos,
                         PrevSettled = pos,
                         FaceDir = Vector3.forward,
                         PrevFaceDir = Vector3.forward,
-                        LastTargetChange = Time.time,
+                        LastTargetChange = now,
                         PrevHostile = c.Hostile,
                         PrevHull = c.Hull,
                     };
@@ -106,21 +112,21 @@ namespace BlocksBeyondTheStars.Client
                 // (spawn shove, eviction) reset the estimate instead of predicting through them.
                 if ((pos - entry.Target).sqrMagnitude > 1e-6f)
                 {
-                    float gap = Mathf.Max(0.05f, Time.time - entry.LastTargetChange);
+                    float gap = Mathf.Max(0.05f, now - entry.LastTargetChange);
                     var estimated = (pos - entry.Target) / gap;
                     entry.TargetVel = estimated.sqrMagnitude > 64f ? Vector3.zero : estimated;
-                    entry.LastTargetChange = Time.time;
+                    entry.LastTargetChange = now;
                 }
 
                 entry.Target = pos;
-                var predicted = entry.Target + entry.TargetVel * Mathf.Min(Time.time - entry.LastTargetChange, 0.3f);
+                var predicted = entry.Target + entry.TargetVel * Mathf.Min(now - entry.LastTargetChange, 0.3f);
                 // Smoothly chase the (extrapolated) authoritative position; a visible lunge toward the
                 // player is added on top during an attack so attacks read clearly.
-                entry.Settled = Vector3.Lerp(entry.Settled, predicted, Time.deltaTime * 8f);
+                entry.Settled = Vector3.Lerp(entry.Settled, predicted, dt * 8f);
                 Vector3 lunge = Vector3.zero;
-                if (Time.time < entry.AttackUntil)
+                if (now < entry.AttackUntil)
                 {
-                    float k = 1f - (entry.AttackUntil - Time.time) / 0.22f;
+                    float k = 1f - (entry.AttackUntil - now) / 0.22f;
                     var to = Game.PlayerPosition - Game.ScenePos(entry.Settled.x, entry.Settled.y, entry.Settled.z); to.y = 0f;
                     if (to.sqrMagnitude > 0.04f)
                     {
@@ -146,7 +152,7 @@ namespace BlocksBeyondTheStars.Client
                 vel.y = 0f;
                 if (vel.sqrMagnitude > 1e-5f)
                 {
-                    entry.FaceDir = Vector3.Slerp(entry.FaceDir, vel.normalized, 1f - Mathf.Exp(-8f * Time.deltaTime));
+                    entry.FaceDir = Vector3.Slerp(entry.FaceDir, vel.normalized, 1f - Mathf.Exp(-8f * dt));
                     bool medusa = string.Equals(c.BodyPlan, "Medusa", System.StringComparison.OrdinalIgnoreCase);
                     float targetPitch = 0f, targetRoll = 0f;
                     if (!medusa)
@@ -157,14 +163,14 @@ namespace BlocksBeyondTheStars.Client
                         if (string.Equals(c.Habitat, "Air", System.StringComparison.OrdinalIgnoreCase))
                         {
                             float turnRate = Vector3.SignedAngle(entry.PrevFaceDir, entry.FaceDir, Vector3.up)
-                                / Mathf.Max(Time.deltaTime, 1e-4f);
+                                / Mathf.Max(dt, 1e-4f);
                             targetRoll = Mathf.Clamp(-turnRate * 0.25f, -20f, 20f);
                         }
                     }
 
                     entry.PrevFaceDir = entry.FaceDir;
-                    entry.PitchDeg = Mathf.Lerp(entry.PitchDeg, targetPitch, 1f - Mathf.Exp(-6f * Time.deltaTime));
-                    entry.RollDeg = Mathf.Lerp(entry.RollDeg, targetRoll, 1f - Mathf.Exp(-6f * Time.deltaTime));
+                    entry.PitchDeg = Mathf.Lerp(entry.PitchDeg, targetPitch, 1f - Mathf.Exp(-6f * dt));
+                    entry.RollDeg = Mathf.Lerp(entry.RollDeg, targetRoll, 1f - Mathf.Exp(-6f * dt));
                     if (entry.FaceDir.sqrMagnitude > 1e-4f)
                     {
                         entry.Root.transform.rotation = Quaternion.LookRotation(entry.FaceDir, Vector3.up)
@@ -180,29 +186,29 @@ namespace BlocksBeyondTheStars.Client
                 // quiet — only an occasional soft, low snore rather than its full waking call. Every utterance
                 // gets a small pitch/volume jitter and a random take of the species call (#876/#879) — the
                 // species voice stays deterministic, only the individual utterance varies.
-                if (Time.time >= entry.NextCall)
+                if (now >= entry.NextCall)
                 {
                     if (c.Asleep)
                     {
-                        entry.NextCall = Time.time + Random.Range(9f, 18f);
+                        entry.NextCall = now + Random.Range(9f, 18f);
                         ClientAudio.Instance?.At(TakeOf(entry.Call), entry.Root.transform.position,
                             entry.Pitch * 0.7f * PitchJitter(), 0.3f * VolJitter(), entry.Echo);
                     }
                     else
                     {
-                        entry.NextCall = Time.time + Random.Range(5f, 12f);
+                        entry.NextCall = now + Random.Range(5f, 12f);
                         ClientAudio.Instance?.At(TakeOf(entry.Call), entry.Root.transform.position,
                             entry.Pitch * PitchJitter(), 0.8f * VolJitter(), entry.Echo);
                         if (Random.value < 0.2f)
                         {
-                            entry.AnswerAt = Time.time + Random.Range(0.4f, 0.9f); // a second animal "answers"
+                            entry.AnswerAt = now + Random.Range(0.4f, 0.9f); // a second animal "answers"
                         }
                     }
                 }
 
                 // The scheduled answer call (#876): the same species voice from a slightly different spot at a
                 // slightly different pitch — reads as a second animal answering the first.
-                if (entry.AnswerAt > 0f && Time.time >= entry.AnswerAt)
+                if (entry.AnswerAt > 0f && now >= entry.AnswerAt)
                 {
                     entry.AnswerAt = 0f;
                     if (!c.Asleep)
@@ -230,12 +236,12 @@ namespace BlocksBeyondTheStars.Client
 
                     // No bite-lunge once the player has fled into their ship: the server stops targeting a
                     // boarded player (no proximity damage), so the render side must not keep mauling the hull.
-                    if (c.Hostile && !Game.Aboard && Time.time >= entry.NextAttack
+                    if (c.Hostile && !Game.Aboard && now >= entry.NextAttack
                         && (entry.Root.transform.position - Game.PlayerPosition).sqrMagnitude < 9f)
                     {
-                        entry.NextAttack = Time.time + Random.Range(1.5f, 3.5f);
+                        entry.NextAttack = now + Random.Range(1.5f, 3.5f);
                         audio.At(entry.Bank + "_attack", entry.Root.transform.position, entry.Pitch * PitchJitter(), 1f * VolJitter(), entry.Echo);
-                        entry.AttackUntil = Time.time + 0.22f;            // lunge
+                        entry.AttackUntil = now + 0.22f;            // lunge
                         SpawnAttackFx(Vector3.Lerp(Game.PlayerPosition, entry.Settled, 0.35f) + Vector3.up * 0.9f);
                     }
                 }
@@ -355,7 +361,7 @@ namespace BlocksBeyondTheStars.Client
             }
 
             float s = Mathf.Clamp(c.Size, 0.4f, 8f); // 8: titans (#638)
-            float breathe = Mathf.Sin(Time.time * 1.6f) * 0.03f * s;
+            float breathe = Mathf.Sin(Game.WorldTime * 1.6f) * 0.03f * s;
             e.Root.transform.position += Vector3.up * (breathe - 0.12f * s); // settle low + gentle breathing
 
             if (e.Zzz == null)
@@ -377,7 +383,7 @@ namespace BlocksBeyondTheStars.Client
             }
 
             float top = 1.5f * s + 0.5f;
-            float drift = Mathf.Repeat(Time.time * 0.4f, 1f) * 0.5f; // slow upward drift
+            float drift = Mathf.Repeat(Game.WorldTime * 0.4f, 1f) * 0.5f; // slow upward drift
             var platePos = e.Root.transform.position + Vector3.up * (top + drift);
             e.Zzz.transform.position = platePos;
 
@@ -397,7 +403,7 @@ namespace BlocksBeyondTheStars.Client
             }
 
             if (!e.Zzz.activeSelf) e.Zzz.SetActive(true);
-            alpha *= 0.6f + 0.4f * Mathf.Abs(Mathf.Sin(Time.time * 1.2f)); // gentle breathing pulse
+            alpha *= 0.6f + 0.4f * Mathf.Abs(Mathf.Sin(Game.WorldTime * 1.2f)); // gentle breathing pulse
             var col = new Color(0.8f, 0.88f, 1f, 0.85f * alpha);
             if (e.ZzzText.color != col) e.ZzzText.color = col;
         }

--- a/client/Assets/BlocksBeyondTheStars/Scripts/GameBootstrap.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/GameBootstrap.cs
@@ -172,6 +172,27 @@ namespace BlocksBeyondTheStars.Client
         /// <summary>Live total playtime = the server's saved cumulative seconds plus this session so far.</summary>
         public long TotalPlaytimeSeconds => CumulativePlaytimeSeconds + (long)SessionSeconds;
 
+        // --- The held world (#908) -----------------------------------------------------------------------
+        // #612 made the Esc menu stop the SERVER simulation, but the client was never told about it, so
+        // everything it animates itself kept running behind the dialog. Fed from the server's PauseState.
+        private readonly BlocksBeyondTheStars.Client.WorldClock _worldClock = new BlocksBeyondTheStars.Client.WorldClock();
+
+        /// <summary>True while the server is holding the world for our pause menu. False whenever the server
+        /// declined the hold (more than one player joined) — the world really is still running then.</summary>
+        public bool WorldPaused => _worldClock.Paused;
+
+        /// <summary>Seconds to advance CLIENT-SIDE world simulation by this frame — <c>Time.deltaTime</c> while
+        /// the world runs, 0 while it is held. Deliberately derived from the live frame rather than from the
+        /// clock's stored delta so it is correct regardless of script execution order.
+        /// <para>Use this instead of <c>Time.deltaTime</c> for anything that is part of the WORLD (fauna,
+        /// weather, creature bodies). Menus, music, the camera and shader time keep real time on purpose: a
+        /// completely frozen image reads as a crash rather than as a pause.</para></summary>
+        public float WorldDeltaTime => _worldClock.Paused ? 0f : Time.deltaTime;
+
+        /// <summary>Monotonic count of unpaused seconds — the <c>Time.time</c> equivalent for world simulation.
+        /// Timers scheduled against it (a creature's next idle call) do not all fire at once after a long pause.</summary>
+        public float WorldTime => _worldClock.Now;
+
         /// <summary>Recomputes the world's per-species flora colours (deterministic from seed + location,
         /// so every client agrees). Chunks meshed afterwards pick them up via the tint resolver.</summary>
         private void RebuildFloraTints()
@@ -1553,6 +1574,9 @@ namespace BlocksBeyondTheStars.Client
 
                 Knowledge = m.KnowledgePoints;
             };
+            // The server's answer to our pause intent (#908). Honours Allowed implicitly: a declined hold comes
+            // back with Paused = false, so the client keeps simulating exactly as it did before.
+            Network.PauseStateReceived += m => _worldClock.SetPaused(m.Paused);
             Network.ShipPlacementReceived += m => ShipPosition = new Vector3(m.X, m.Y, m.Z);
             Network.ShipStationsReceived += m => Stations = m.Stations;
             Network.PlanetPoisReceived += m => PlanetPois = m.Pois;
@@ -1858,6 +1882,7 @@ namespace BlocksBeyondTheStars.Client
         private void Update()
         {
             Network?.Poll();
+            _worldClock.Advance(Time.deltaTime); // after Poll, so a PauseState that just landed takes effect now
 
             _skyScanTimer -= Time.deltaTime;
             if (_skyScanTimer <= 0f)

--- a/client/Assets/BlocksBeyondTheStars/Scripts/GeyserView.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/GeyserView.cs
@@ -35,7 +35,9 @@ namespace BlocksBeyondTheStars.Client
                 Rescan();
             }
 
-            float now = Time.time;
+            // World time (#908): no vent goes off behind the pause menu. A plume already in flight is left to
+            // finish its half-second arc rather than freezing in mid-air.
+            float now = Game.WorldTime;
             // Erupt any vent whose timer is up (snapshot the keys — Erupt doesn't mutate the dict).
             foreach (var cell in _ventKeys())
             {

--- a/client/Assets/BlocksBeyondTheStars/Scripts/LavaFallView.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/LavaFallView.cs
@@ -66,8 +66,9 @@ namespace BlocksBeyondTheStars.Client
             }
 
             FeedHeat();
-            Emit(Time.deltaTime);
-            Step(Time.deltaTime);
+            // World time (#908): the falling embers hold with the rest of the world behind the pause menu.
+            Emit(Game.WorldDeltaTime);
+            Step(Game.WorldDeltaTime);
         }
 
         private void Rescan()

--- a/client/Assets/BlocksBeyondTheStars/Scripts/MicroFaunaView.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/MicroFaunaView.cs
@@ -145,7 +145,10 @@ namespace BlocksBeyondTheStars.Client
                 return;
             }
 
-            float dt = Mathf.Min(Time.deltaTime, 0.1f);
+            // World time, not frame time (#908): micro-fauna is simulated entirely client-side, so a held world
+            // kept swarming with insects until this read the world clock. At dt = 0 every Move* below is a no-op
+            // while Render still runs, which parks the critters in place instead of making them disappear.
+            float dt = Mathf.Min(Game.WorldDeltaTime, 0.1f);
             bool enclosed = !Game.ExposedToSky; // in a cave / under a roof
             bool active = ContextAllows(out bool surfaceOk, enclosed);
 
@@ -157,7 +160,11 @@ namespace BlocksBeyondTheStars.Client
 
             RefreshPlanetSeed(dt);
             RefreshWaterCells(dt);
-            MaintainPopulation(surfaceOk, enclosed);
+            if (!Game.WorldPaused)
+            {
+                MaintainPopulation(surfaceOk, enclosed); // no critter pops into existence behind the pause menu
+            }
+
             MoveAndRender(dt);
         }
 

--- a/client/Assets/BlocksBeyondTheStars/Scripts/NpcView.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/NpcView.cs
@@ -28,13 +28,19 @@ namespace BlocksBeyondTheStars.Client
             public float GestureTimer;     // counts down to the next work gesture (mine/place/talk swing)
             public float GestureLo, GestureHi; // cadence range from the NPC's theme/role
             public string Greeting;        // item 15: a contextual speech-bubble line (empty = none showing)
-            public float GreetingUntil;    // Time.time after which the bubble fades out
+            public float GreetingUntil;    // world time after which the bubble fades out
         }
 
         private const float GreetingSeconds = 7f; // how long a greeting bubble stays up
 
         private readonly Dictionary<int, Npc> _npcs = new Dictionary<int, Npc>();
         private bool _subscribed;
+
+        // World time rather than frame time (#908): settlement NPCs stop walking and gesturing while the server
+        // holds the world, and a greeting bubble that was up stays up for the rest of its seven seconds instead
+        // of expiring behind the pause menu. Falls back to frame time before the bootstrap is wired.
+        private float WorldNow => Game != null ? Game.WorldTime : Time.time;
+        private float WorldDelta => Game != null ? Game.WorldDeltaTime : Time.deltaTime;
 
         private void Update()
         {
@@ -50,13 +56,13 @@ namespace BlocksBeyondTheStars.Client
             {
                 // Track the latest target without fully catching up before the next snapshot arrives, so the
                 // NPC keeps gliding (and its walk cycle keeps running) instead of stop-start jerking.
-                n.SettledWorld = Vector3.Lerp(n.SettledWorld, n.Target, Time.deltaTime * 5f);
+                n.SettledWorld = Vector3.Lerp(n.SettledWorld, n.Target, WorldDelta * 5f);
                 n.Go.transform.position = Game != null ? Game.ScenePos(n.SettledWorld.x, n.SettledWorld.y, n.SettledWorld.z) : n.SettledWorld;
                 n.Go.transform.rotation = Quaternion.Euler(0f, n.Yaw, 0f);
 
                 // Ambient work gestures: a periodic tool/arm swing so settlement NPCs look busy (miners chip
                 // away often, settlers/builders place now and then, vendors gesture occasionally).
-                n.GestureTimer -= Time.deltaTime;
+                n.GestureTimer -= WorldDelta;
                 if (n.GestureTimer <= 0f)
                 {
                     n.Avatar?.Swing();
@@ -80,7 +86,7 @@ namespace BlocksBeyondTheStars.Client
 
             string text = string.IsNullOrWhiteSpace(m.Text) ? FallbackGreeting(m.Role) : m.Text.Trim();
             n.Greeting = text;
-            n.GreetingUntil = Time.time + GreetingSeconds;
+            n.GreetingUntil = WorldNow + GreetingSeconds;
         }
 
         /// <summary>The localized static greeting shown when no AI line is available, keyed by NPC role.</summary>
@@ -220,7 +226,7 @@ namespace BlocksBeyondTheStars.Client
                 labels.World(cam, n.Go.transform.position + Vector3.up * 2.1f, n.Label, UiKit.Cyan, false, 18f, 28f);
 
                 // A live greeting bubble sits just above the nameplate (item 15).
-                if (!string.IsNullOrEmpty(n.Greeting) && Time.time < n.GreetingUntil)
+                if (!string.IsNullOrEmpty(n.Greeting) && WorldNow < n.GreetingUntil)
                 {
                     labels.World(cam, n.Go.transform.position + Vector3.up * 2.5f, $"“{n.Greeting}”", UiKit.TextCol, false, 18f, 28f);
                 }

--- a/client/Assets/BlocksBeyondTheStars/Scripts/PlayerController.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/PlayerController.cs
@@ -1884,6 +1884,15 @@ namespace BlocksBeyondTheStars.Client
 
         private void ApplyGravityOnly()
         {
+            // A held world (#908) holds the body too. Without this, opening the pause menu mid-jump or mid-fall
+            // kept dropping the player through a world that had otherwise stopped — the single most obvious way
+            // the "pause" failed to look like one. The vertical velocity is left untouched, so resuming carries
+            // the fall on from exactly where it stopped instead of restarting it.
+            if (Game != null && Game.WorldPaused)
+            {
+                return;
+            }
+
             bool grounded = _controller.isGrounded;
             UpdateFloorWait(grounded);
             if (grounded)

--- a/client/Assets/BlocksBeyondTheStars/Scripts/Sky.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/Sky.cs
@@ -194,7 +194,9 @@ namespace BlocksBeyondTheStars.Client
                 }
             }
 
-            _time = Mathf.Repeat(_time + Time.deltaTime / _dayLength, 1f);
+            // World time, not frame time (#908): this local advance is what kept the sun crawling — and night
+            // falling — behind the pause menu, long after the server had stopped sending a new TimeOfDay.
+            _time = Mathf.Repeat(_time + (Game != null ? Game.WorldDeltaTime : Time.deltaTime) / _dayLength, 1f);
 
             float intensity = env?.Intensity ?? 0f;
             Color sun = env != null ? Rgb(env.SunColor) : new Color(1f, 0.96f, 0.88f); // match Space/Station fallback

--- a/client/Assets/BlocksBeyondTheStars/Scripts/SkyBodiesView.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/SkyBodiesView.cs
@@ -98,8 +98,11 @@ namespace BlocksBeyondTheStars.Client
             bool show = !Game.SpaceViewActive && Game.Environment != null && _bodies.Count > 0;
 
             // Continuous day clock: the server's TimeOfDay only arrives in periodic steps — the slow sun hides
-            // that, but our faster bodies would visibly JUMP between updates. Advance a local clock with real
+            // that, but our faster bodies would visibly JUMP between updates. Advance a local clock with world
             // time (the world's day length) and softly resync it to the authoritative value (wrap-aware).
+            // World time, not frame time (#908): this local clock is why "night kept falling" behind the pause
+            // menu even though the server had stopped broadcasting a new TimeOfDay.
+            float dtWorld = Game.WorldDeltaTime;
             float target = Game.LocalTimeOfDay;
             if (_tod < 0f)
             {
@@ -107,9 +110,9 @@ namespace BlocksBeyondTheStars.Client
             }
 
             float dayLen = Mathf.Max(30f, Game.Environment?.DayLengthSeconds > 1 ? (float)Game.Environment.DayLengthSeconds : 600f);
-            _tod = Mathf.Repeat(_tod + Time.deltaTime / dayLen, 1f);
+            _tod = Mathf.Repeat(_tod + dtWorld / dayLen, 1f);
             float err = Mathf.DeltaAngle(_tod * 360f, target * 360f) / 360f;
-            _tod = Mathf.Repeat(_tod + err * Mathf.Min(1f, Time.deltaTime * 0.4f), 1f);
+            _tod = Mathf.Repeat(_tod + err * Mathf.Min(1f, dtWorld * 0.4f), 1f);
 
             // The monotonic orbital clock: advance locally (fixed reference day) and softly resync to the
             // authoritative SystemTimeDays so the slow phase drift is a glide, not 5-second broadcast steps.
@@ -119,10 +122,10 @@ namespace BlocksBeyondTheStars.Client
                 _sysDays = sysTarget >= 0.0 ? sysTarget : 0.0;
             }
 
-            _sysDays += Time.deltaTime / SystemDaySeconds;
+            _sysDays += dtWorld / SystemDaySeconds;
             if (sysTarget >= 0.0)
             {
-                _sysDays += (sysTarget - _sysDays) * Mathf.Min(1f, Time.deltaTime * 0.4f);
+                _sysDays += (sysTarget - _sysDays) * Mathf.Min(1f, dtWorld * 0.4f);
             }
 
             float day = Mathf.Clamp01(Mathf.Sin(_tod * Mathf.PI));

--- a/client/Assets/BlocksBeyondTheStars/Scripts/WaterfallMistView.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/WaterfallMistView.cs
@@ -63,8 +63,9 @@ namespace BlocksBeyondTheStars.Client
                 Rescan();
             }
 
-            Emit(Time.deltaTime);
-            Step(Time.deltaTime);
+            // World time (#908): the mist holds with the rest of the world behind the pause menu.
+            Emit(Game.WorldDeltaTime);
+            Step(Game.WorldDeltaTime);
         }
 
         private void Rescan()

--- a/client/Assets/BlocksBeyondTheStars/Scripts/WorldEntities.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/WorldEntities.cs
@@ -68,6 +68,9 @@ namespace BlocksBeyondTheStars.Client
                 _subscribed = true;
             }
 
+            // Everything below runs on the world clock rather than on frame time (#908): while the server holds
+            // the world for the pause menu, bandits and beasts stop stepping, growling, lunging and firing —
+            // an enemy that kept mauling the player through the "Pause" dialog was the loudest tell of all.
             var seen = _seenScratch;
             seen.Clear();
             var cam = Camera.main; // for the floating health bars (#692)
@@ -84,7 +87,7 @@ namespace BlocksBeyondTheStars.Client
                 }
 
                 en.Target = new Vector3(e.X, e.Y, e.Z);
-                en.Settled = Vector3.Lerp(en.Settled, en.Target, Time.deltaTime * 8f);
+                en.Settled = Vector3.Lerp(en.Settled, en.Target, Game.WorldDeltaTime * 8f);
 
                 // Face the walk direction (or the player when hostile and close — it stalks you).
                 Vector3 scenePos = Game.ScenePos(en.Settled.x, en.Settled.y, en.Settled.z);
@@ -102,40 +105,40 @@ namespace BlocksBeyondTheStars.Client
                 if (face.sqrMagnitude > 0.01f)
                 {
                     en.Root.transform.rotation = Quaternion.Slerp(
-                        en.Root.transform.rotation, Quaternion.LookRotation(face.normalized), Time.deltaTime * 6f);
+                        en.Root.transform.rotation, Quaternion.LookRotation(face.normalized), Game.WorldDeltaTime * 6f);
                 }
 
                 en.Root.transform.position = scenePos;
-                Animate(en, vel.magnitude / Mathf.Max(Time.deltaTime, 1e-4f), e.Hostile);
+                Animate(en, vel.magnitude / Mathf.Max(Game.WorldDeltaTime, 1e-4f), e.Hostile);
 
                 var audio = ClientAudio.Instance;
                 if (audio != null)
                 {
                     // Periodic menacing growl, spatialised at the enemy (bandits are people — no robot growls).
-                    if (!en.IsBandit && Time.time >= en.NextGrowl)
+                    if (!en.IsBandit && Game.WorldTime >= en.NextGrowl)
                     {
-                        en.NextGrowl = Time.time + Random.Range(6f, 14f);
+                        en.NextGrowl = Game.WorldTime + Random.Range(6f, 14f);
                         audio.At("enemy_growl", en.Root.transform.position, en.Pitch * MachineJitter(), 0.9f);
                     }
 
                     // Hurt flinch + bark on a hull drop (the player's hit landed).
                     if (en.PrevHull >= 0f && e.Hull < en.PrevHull - 0.25f)
                     {
-                        en.FlinchUntil = Time.time + 0.25f;
+                        en.FlinchUntil = Game.WorldTime + 0.25f;
                         audio.At("enemy_hurt", en.Root.transform.position, en.Pitch * MachineJitter(), 0.9f);
                     }
 
                     // Hostile attack (throttled). Hovering drones snipe with a red laser from afar; ground
                     // robots only claw in melee range. Suppressed entirely once the player is aboard the ship —
                     // they've broken off pursuit, so no laser bolts or claw swipes follow them inside.
-                    if (e.Hostile && !playerAboard && Time.time >= en.NextAttack)
+                    if (e.Hostile && !playerAboard && Game.WorldTime >= en.NextAttack)
                     {
                         if (en.IsDrone)
                         {
                             if (toPlayer.sqrMagnitude < DroneFireRange * DroneFireRange)
                             {
-                                en.NextAttack = Time.time + Random.Range(0.7f, 1.3f);
-                                en.AttackUntil = Time.time + 0.18f; // brief charge/recoil tic
+                                en.NextAttack = Game.WorldTime + Random.Range(0.7f, 1.3f);
+                                en.AttackUntil = Game.WorldTime + 0.18f; // brief charge/recoil tic
                                 FireDroneLaser(en, audio);
                             }
                         }
@@ -144,15 +147,15 @@ namespace BlocksBeyondTheStars.Client
                             // Bandit gunner: tracer shots at aura range (cosmetic — the server aura damages).
                             if (toPlayer.sqrMagnitude < BanditGunFireRange * BanditGunFireRange)
                             {
-                                en.NextAttack = Time.time + Random.Range(0.8f, 1.5f);
-                                en.AttackUntil = Time.time + 0.2f;
+                                en.NextAttack = Game.WorldTime + Random.Range(0.8f, 1.5f);
+                                en.AttackUntil = Game.WorldTime + 0.2f;
                                 FireDroneLaser(en, audio);
                             }
                         }
                         else if (toPlayer.sqrMagnitude < 7f)
                         {
-                            en.NextAttack = Time.time + Random.Range(1.4f, 2.8f);
-                            en.AttackUntil = Time.time + 0.35f;
+                            en.NextAttack = Game.WorldTime + Random.Range(1.4f, 2.8f);
+                            en.AttackUntil = Game.WorldTime + 0.35f;
                             audio.At("enemy_attack", en.Root.transform.position, en.Pitch * MachineJitter());
                         }
                     }
@@ -228,19 +231,19 @@ namespace BlocksBeyondTheStars.Client
             if (en.IsDrone)
             {
                 // Hovering scan-drone: a gentle bob + a slow scanning yaw; no limbs to pose.
-                float pitch = Mathf.Sin((Time.time + en.Seed) * 2f) * 4f;
-                if (Time.time < en.AttackUntil)
+                float pitch = Mathf.Sin((Game.WorldTime + en.Seed) * 2f) * 4f;
+                if (Game.WorldTime < en.AttackUntil)
                 {
                     pitch -= 12f; // a brief nose-up recoil kick when it fires
                 }
 
-                en.Body.localRotation = Quaternion.Euler(pitch, (Time.time * 50f) % 360f, 0f);
+                en.Body.localRotation = Quaternion.Euler(pitch, (Game.WorldTime * 50f) % 360f, 0f);
                 return;
             }
 
             float moving = Mathf.Clamp01(speed / 2.5f);
-            en.WalkPhase += Time.deltaTime * (3f + speed * 1.6f);
-            float t = Time.time + en.Seed;
+            en.WalkPhase += Game.WorldDeltaTime * (3f + speed * 1.6f);
+            float t = Game.WorldTime + en.Seed;
 
             float swing = Mathf.Sin(en.WalkPhase) * Mathf.Lerp(4f, 38f, moving);
             float armL = -swing, armR = swing, legL = swing, legR = -swing;
@@ -263,15 +266,15 @@ namespace BlocksBeyondTheStars.Client
                 }
             }
 
-            if (Time.time < en.AttackUntil)
+            if (Game.WorldTime < en.AttackUntil)
             {
                 // Claw swipe: the right arm whips from raised to a downward slash.
-                float k = 1f - (en.AttackUntil - Time.time) / 0.35f;
+                float k = 1f - (en.AttackUntil - Game.WorldTime) / 0.35f;
                 armR = Mathf.Lerp(-130f, 45f, Mathf.SmoothStep(0f, 1f, k));
                 bodyPitch += 8f * Mathf.Sin(Mathf.Clamp01(k) * Mathf.PI); // lunge into the swipe
             }
 
-            if (Time.time < en.FlinchUntil)
+            if (Game.WorldTime < en.FlinchUntil)
             {
                 bodyPitch -= 14f; // recoil back when hit
             }

--- a/src/BlocksBeyondTheStars.Client.Core/WorldClock.cs
+++ b/src/BlocksBeyondTheStars.Client.Core/WorldClock.cs
@@ -1,0 +1,56 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+
+namespace BlocksBeyondTheStars.Client
+{
+    /// <summary>
+    /// The client's own clock for things it animates itself, which STANDS STILL while the server is holding the
+    /// world for the singleplayer pause menu.
+    ///
+    /// <para>
+    /// Issue #612 made the Esc menu actually stop the simulation, but only on the server: the hold is a server
+    /// intent because singleplayer runs the bundled server as a separate process. Everything the client simulates
+    /// on its own kept running regardless — insects swarming, rain falling, creatures calling and animating — so a
+    /// held world still looked and sounded alive. Those systems read this clock instead of <c>Time.deltaTime</c> /
+    /// <c>Time.time</c>, and freeze with the world.
+    /// </para>
+    ///
+    /// Pure (no UnityEngine) so it lives in Client.Core and is unit-tested headless; the Unity layer sets the pause
+    /// flag from <c>PauseState</c> and advances it once per frame.
+    /// </summary>
+    public sealed class WorldClock
+    {
+        /// <summary>True while the server is holding the world — world simulation must not advance.</summary>
+        public bool Paused { get; private set; }
+
+        /// <summary>Seconds to advance world simulation by this frame; always 0 while held.</summary>
+        public float Delta { get; private set; }
+
+        /// <summary>Monotonic count of UNPAUSED seconds. Timers scheduled against it (a creature's next idle
+        /// call, say) survive a pause of any length instead of all firing at once on resume.</summary>
+        public float Now { get; private set; }
+
+        /// <summary>Applies the server's answer. Zeroing <see cref="Delta"/> on entry matters: a reader that runs
+        /// before the next <see cref="Advance"/> would otherwise still see the last live frame's delta.</summary>
+        public void SetPaused(bool paused)
+        {
+            Paused = paused;
+            if (paused)
+            {
+                Delta = 0f;
+            }
+        }
+
+        /// <summary>Advances the clock by one frame of real time and returns the world delta for it. Non-positive
+        /// and non-finite real deltas contribute nothing, so a stalled or garbled frame can never rewind
+        /// <see cref="Now"/> or teleport a simulation that is integrating against it.</summary>
+        public float Advance(float realDeltaSeconds)
+        {
+            bool usable = realDeltaSeconds > 0f && !float.IsNaN(realDeltaSeconds) && !float.IsInfinity(realDeltaSeconds);
+            Delta = Paused || !usable ? 0f : realDeltaSeconds;
+            Now += Delta;
+            return Delta;
+        }
+    }
+}

--- a/src/BlocksBeyondTheStars.GameServer/GameServer.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServer.cs
@@ -1103,7 +1103,10 @@ public sealed partial class GameServer
     public void PauseForTest(PlayerSession session, bool paused)
         => HandlePause(session, new PauseIntent { Paused = paused });
 
-    /// <summary>Number of players who have completed the join handshake.</summary>
+    /// <summary>Number of players who have completed the join handshake. Spectators do not count (#908): an
+    /// invisible admin observing a world is not someone whose game a pause could interrupt, and counting them
+    /// silently denied a lone player their pause — or lifted one that was already running. Everywhere else in
+    /// the server draws the same line (see <c>GameServerObserver</c>).</summary>
     private int JoinedCount
     {
         get
@@ -1111,7 +1114,7 @@ public sealed partial class GameServer
             int n = 0;
             foreach (var s in _sessions.Values)
             {
-                if (s.Joined)
+                if (s.Joined && !s.Spectating)
                 {
                     n++;
                 }

--- a/tests/BlocksBeyondTheStars.Client.Tests/WorldClockTests.cs
+++ b/tests/BlocksBeyondTheStars.Client.Tests/WorldClockTests.cs
@@ -1,0 +1,86 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using BlocksBeyondTheStars.Client;
+using Xunit;
+
+namespace BlocksBeyondTheStars.Client.Tests;
+
+/// <summary>
+/// The clock the client's own world simulation runs on (#908). #612 stopped the SERVER while the Esc menu is up,
+/// but micro-fauna, creature bodies, enemies, NPCs and the local sun all kept running on frame time — so a held
+/// world still moved. Those systems read this clock instead.
+/// </summary>
+public sealed class WorldClockTests
+{
+    [Fact]
+    public void ARunningWorld_AdvancesWithRealTime()
+    {
+        var clock = new WorldClock();
+
+        Assert.Equal(0.25f, clock.Advance(0.25f));
+        clock.Advance(0.25f);
+
+        Assert.False(clock.Paused);
+        Assert.Equal(0.5f, clock.Now, 4);
+    }
+
+    [Fact]
+    public void AHeldWorld_DoesNotAdvanceAtAll()
+    {
+        var clock = new WorldClock();
+        clock.Advance(0.5f);
+        float held = clock.Now;
+
+        clock.SetPaused(true);
+        for (int i = 0; i < 40; i++)
+        {
+            Assert.Equal(0f, clock.Advance(0.5f)); // 20 seconds of wall clock
+        }
+
+        Assert.True(clock.Paused);
+        Assert.Equal(held, clock.Now, 4);
+    }
+
+    [Fact]
+    public void AfterResuming_ItPicksUpWhereItStopped()
+    {
+        var clock = new WorldClock();
+        clock.Advance(0.5f);
+        clock.SetPaused(true);
+        clock.Advance(9.0f);
+
+        clock.SetPaused(false);
+        clock.Advance(0.5f);
+
+        // The paused stretch is skipped, not banked: a timer scheduled for "now + 1" before the pause must not
+        // be a second overdue the moment the world resumes, or every creature in earshot would call at once.
+        Assert.Equal(1.0f, clock.Now, 4);
+    }
+
+    [Fact]
+    public void PausingZeroesTheDelta_BeforeTheNextFrame()
+    {
+        var clock = new WorldClock();
+        clock.Advance(0.5f);
+        Assert.Equal(0.5f, clock.Delta);
+
+        // A reader that runs between SetPaused and the next Advance must not still see the live frame's delta.
+        clock.SetPaused(true);
+        Assert.Equal(0f, clock.Delta);
+    }
+
+    [Theory]
+    [InlineData(0f)]
+    [InlineData(-1f)]
+    [InlineData(float.NaN)]
+    [InlineData(float.PositiveInfinity)]
+    public void AGarbledFrame_NeverMovesTheClock(float bad)
+    {
+        var clock = new WorldClock();
+        clock.Advance(0.5f);
+
+        Assert.Equal(0f, clock.Advance(bad));
+        Assert.Equal(0.5f, clock.Now, 4); // never rewinds, never teleports a simulation integrating against it
+    }
+}

--- a/tests/BlocksBeyondTheStars.Tests/SingleplayerPauseTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/SingleplayerPauseTests.cs
@@ -121,6 +121,26 @@ public sealed class SingleplayerPauseTests : IDisposable
     }
 
     [Fact]
+    public void AWatchingAdmin_DoesNotCostThePlayerTheirPause()
+    {
+        var server = Started(out var repo);
+        using (repo)
+        {
+            var p = server.AddLocalPlayer("Justus");
+            var admin = server.AddLocalPlayer("Marcel");
+            admin.Spectating = true; // observer mode (#487): invisible, no footprint, ignored by creatures
+
+            // Nobody's game is interrupted by holding the world for its only actual player (#908). Before this,
+            // an admin quietly watching a world denied that player their pause — and lifted one already running.
+            server.PauseForTest(p, true);
+            Assert.True(server.IsPaused);
+
+            server.TickForTest(0.1);
+            Assert.True(server.IsPaused);
+        }
+    }
+
+    [Fact]
     public void APauseIsLifted_WhenSomeoneElseJoins()
     {
         var server = Started(out var repo);


### PR DESCRIPTION
Closes #908. Follow-up to #612.

## The problem

#612 made the Esc menu hold the world as a **server** intent, and that part works — all six `SingleplayerPauseTests` still pass. But the client was never told about it: `NetworkClient.PauseStateReceived` was declared and raised and had **no subscribers**, so there was no notion of a held world anywhere in the client. Everything it simulates itself kept running behind the dialog:

- the player kept **falling** (`ApplyGravityOnly` runs on purpose while a menu is open)
- micro-fauna kept swarming, creatures kept walking, calling, answering and lunging
- bandits and planet enemies kept stepping, growling and attacking
- settlement NPCs kept walking and gesturing
- the client's **own local day clock** kept the sun moving and night falling, and the cloud deck kept sailing

The hold was real. It just didn't look or sound like one.

## The fix

A `WorldClock` in Client.Core (pure, unit-tested headless) that stands still while the world is held. `GameBootstrap` feeds it from `PauseState` and exposes `WorldPaused` / `WorldDeltaTime` / `WorldTime`; world-simulation scripts read those instead of `Time.deltaTime` / `Time.time`.

`WorldTime` **skips** the paused stretch rather than banking it, so a creature scheduled to call in one second doesn't find itself ten minutes overdue the moment the world resumes — otherwise every animal in earshot would call at once. `WorldDeltaTime` is derived from the live frame rather than from the clock's stored delta, so it is correct regardless of Unity's script execution order.

Moved onto it: `PlayerController.ApplyGravityOnly`, `MicroFaunaView`, `CreatureView`, `WorldEntities`, `NpcView`, `GeyserView`, `LavaFallView`, `WaterfallMistView`, `Sky`, `SkyBodiesView`, `Clouds`, `AuroraView`.

**Deliberately still live:** music, UI animation, the camera, and shader / station-prop flicker. A completely frozen image reads as a crash rather than as a pause.

## Two deviations from the issue

- **Weather needed no change.** Precipitation is already gated on `!Game.MenuOpen` (`WeatherFx3D.cs:92`, `WeatherFx.cs:406`), so it stops on its own. The issue overstated this.
- **`StationDecorView` left alone.** Its flickering lights, glow pulses and sparks live in five nested MonoBehaviours with no `GameBootstrap` reference, and they are decoration on a par with the shader time this PR deliberately keeps running.

## Server side

`JoinedCount` no longer counts spectators, matching the line every other call site draws (`GameServerObserver.cs:33`, #487). An invisible admin observing a world was silently denying its only player their pause — and lifting one that was already running. New test covers it.

## Verification

- `dotnet build -c Release` — 0 warnings, 0 errors
- `dotnet test -c Release --filter Category!=Slow` — **1612 server + 195 client tests green**, 0 failures
- local Unity Windows build (`scripts/build-client.ps1`) — succeeded, no `error CS` / `warning CS`

No new locale keys: the dialog is already titled "Pause" with a "Resume" button.

Playtest still pending — the in-game feel is the real acceptance test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
