### PR TITLE
feat(build): orientable ladders, real crafted stairs, Auto follows the crosshair (#909)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -135,6 +135,30 @@ a fully frozen image reads as a crash. Weather needed no change (already gated o
 side: `JoinedCount` no longer counts spectators (#487 observers), so an admin quietly watching a world
 stops silently denying its only player their pause. No new locale keys.
 
+### ★ Orientable ladders, real crafted stairs, Auto follows the crosshair (#909, 2026-08-10, branch feat/orientable-ladders-909)
+Three placement fixes that all live on the existing per-voxel shape descriptor — no wire, save or format
+change anywhere. **(1) Auto uses the face you clicked.** `DeriveShapeUpFace` picked the surface a shape
+rests on by scanning neighbours in a fixed order, so building a ramp into a corner landed on whichever
+neighbour that order reached first. The client now answers the Auto question itself (`PendingPlacement`)
+and sends the result: floor first as before, then **the wall under the crosshair**, then the old scan
+order. The server keeps its own derivation for intents with no up-face (older clients, internal
+placements). **(2) The ladder keeps the wall it was given.** A placed ladder stored *no* form at all —
+`ladder` is neither shapeable nor furniture — and the mesher re-invented the look on every rebuild
+(`LadderMountUpFace`), so ladders hugged the wrong wall, turned into poles when free-standing, and flipped
+whenever a neighbouring wall was mined. Placement now stamps the real form (`Panel` + mount face, or
+`Post` free-standing) and the mesher prefers it, falling back to the old heuristic for a descriptor of 0 —
+so pre-#909 saves, settlement ladders and ship layouts keep behaving exactly as before. The rotate key gets
+a ladder-sized cycle: **Auto → the four walls → free-standing → Auto** (its plate is a square Panel, so the
+24-state walk would offer four identical turns and two useless tips). **(3) The crafted staircase is a
+staircase.** `stairs` placed as a plain solid cube although `BlockShape.Stairs` was fully implemented; it
+is now stamped like a prop (step geometry + collider, R turns and tips it). Existing stairs blocks stay
+cubes until re-placed. Plus a drop-strip fix: `BreakBlockAt` compared the stamped form against the ONE
+default, so the ladder's pole form would have dropped as its own item key, split the stack and then placed
+as a plate anyway — the rule now asks `PropShapes.IsStampedForm`. `FurnitureShapes` → `PropShapes`
+(furniture, ladder and stairs share the path) with a `PropOrientation` per prop, so the client cycle can
+only ever offer what the server honours. 7 new tests, `hud.shape.on_wall`/`free_standing` in en+de, manual
+updated.
+
 ### ★ Website translated into all 13 game languages (2026-08-10, branch feat/wix-i18n-locale-tools)
 The full website (all pages, menu, forms, image alt texts) now has complete translations in every
 game language: en/it plus newly created es, fr, nl, pl, pt, tr, ru, uk, ja, ko, zh — the 11 new Wix

--- a/client/Assets/BlocksBeyondTheStars/Scripts/ChunkMesher.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/ChunkMesher.cs
@@ -522,9 +522,14 @@ namespace BlocksBeyondTheStars.Client
 
                 // Ladder (#803): a thin wall plate WITHOUT a collider, so the player can step into the cell
                 // and the climb detection (PlayerController.OnLadder) can actually engage — the old full
-                // collidable cube made the climb state unreachable from the side. The plate leans against
-                // the first solid horizontal neighbour (settlement ladders hug walls); a free-standing
-                // ladder renders as a slim pole instead. Collider tris go to a throwaway list on purpose.
+                // collidable cube made the climb state unreachable from the side. Collider tris go to a
+                // throwaway list on purpose.
+                //
+                // Which wall it hugs is STORED since #909: a ladder placed by a player carries its own form
+                // (plate + mount face, or the free-standing pole) in the shape descriptor, so it keeps the
+                // side it was given and no longer flips when a neighbouring wall is mined. A ladder with no
+                // descriptor — placed before #909, by worldgen, or inside a ship layout — falls back to the
+                // original heuristic: lean on the first solid horizontal neighbour, else stand as a pole.
                 if (atlas != null && collKey == "ladder")
                 {
                     var dumpTris = _ladderColliderTrisDump ??= new List<int>();
@@ -534,10 +539,14 @@ namespace BlocksBeyondTheStars.Client
                     float ladSky = Skylight(wx, wy + 1, wz);
                     Vector3 ladBl = BlockLightAt(wx, wy, wz);
                     Vector3 ladBlDir = BlockLightDirAt(wx, wy, wz);
-                    int ladUp = LadderMountUpFace(content, worldBlock, wx, wy, wz);
+                    int ladDesc = chunk.GetShapeLocal(WorldConstants.LocalIndex(x, y, z));
+                    int ladShape = ShapeCode.ShapeOf(ladDesc);
+                    int ladUp = ladShape == (int)BlockShape.Panel ? ShapeCode.UpFaceOf(ladDesc)
+                        : ladShape == (int)BlockShape.Post ? -1
+                        : LadderMountUpFace(content, worldBlock, wx, wy, wz);
                     AddShapedBlock(verts, tris, dumpTris, dumpVerts, colors, uvs, tangents, skyUv, leafUv, blockLight, blockLightDir,
-                        ladUp >= 0 ? (int)BlockShape.Panel : (int)BlockShape.Post,
-                        0, ladUp >= 0 ? ladUp : ShapeCode.UpPlusY, new Vector3(x, y, z), uv,
+                        ladUp >= 2 ? (int)BlockShape.Panel : (int)BlockShape.Post,
+                        0, ladUp >= 2 ? ladUp : ShapeCode.UpPlusY, new Vector3(x, y, z), uv,
                         matR, matG, emission, Color.black, 0f, ladSky, ladBl, ladBlDir);
                     continue;
                 }
@@ -1348,8 +1357,9 @@ namespace BlocksBeyondTheStars.Client
         }
 
         /// <summary>A neighbour the ladder plate can visually hang on: an opaque solid — not air, glass,
-        /// flora, foliage or another ladder.</summary>
-        private static bool IsLadderMountWall(GameContent content, BlockId nb)
+        /// flora, foliage or another ladder. Public because the placement preview asks the same question
+        /// (#909): a ghost that promises a wall mount the mesher would draw as a pole is worse than none.</summary>
+        public static bool IsLadderMountWall(GameContent content, BlockId nb)
             => !nb.IsAir && !IsTransparent(content, nb) && !IsFloraBlock(content, nb) && !IsFoliageBlock(content, nb)
                && content.BlockById(nb)?.Key != "ladder";
 

--- a/client/Assets/BlocksBeyondTheStars/Scripts/PlayerController.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/PlayerController.cs
@@ -437,18 +437,19 @@ namespace BlocksBeyondTheStars.Client
             // shape descriptor has always stored yaw × up-face (24 orientations); this just hands the player the
             // controls. Furniture (bed/campfire/rug/pot) cycles too, but yaw-only: the server pins its up-face
             // to +Y so sit/heal/warmth keep working — the cycle mirrors that instead of promising a tip that
-            // the place would ignore. Only cycles for a rotatable block, so it never clashes with RepairWreck
-            // on the same key.
+            // the place would ignore. The ladder gets its own five-state cycle (#909): the four walls it can
+            // hug plus free-standing, because quarter turns of its square plate are four identical states.
+            // Only cycles for a rotatable block, so it never clashes with RepairWreck on the same key.
             if (InputMap.Down(InputAction.RotateShape))
             {
                 string held = Game != null ? Game.ItemInSlot(Game.SelectedHotbarSlot) : null;
-                if (HeldPlaceShape(held, out bool furnitureHeld) > 0)
+                if (HeldPlaceShape(held, out var heldCycle) > 0)
                 {
                     bool backwards = Input.GetKey(KeyCode.LeftShift) || Input.GetKey(KeyCode.RightShift);
-                    StepPlaceOrientation(backwards, furnitureHeld);
+                    StepPlaceOrientation(backwards, heldCycle);
                     Game.ShowMessage(string.Format(
                         Game.Localizer?.Get("hud.shape.orient") ?? "Shape orientation: {0}",
-                        OrientationLabel(furnitureHeld)));
+                        OrientationLabel(heldCycle)));
                 }
             }
 
@@ -2832,7 +2833,13 @@ namespace BlocksBeyondTheStars.Client
                     }
                     else
                     {
-                        Game.Network.SendPlace(placeCell.x, placeCell.y, placeCell.z, item, upFace: _placeUpFace, yaw: _placeYaw);
+                        // Send the orientation the ghost was showing (an explicit rotate-key state, or the
+                        // client's own Auto answer — see PendingPlacement). An item with nothing to orient
+                        // sends the raw override fields and lets the server derive, exactly as before.
+                        bool orientable = PendingPlacement(item, hitCell, placeCell, out _, out int upFace, out int yaw);
+                        Game.Network.SendPlace(placeCell.x, placeCell.y, placeCell.z, item,
+                            upFace: orientable ? upFace : _placeUpFace,
+                            yaw: orientable ? yaw : _placeYaw);
                     }
 
                     TriggerSwing();
@@ -2950,12 +2957,14 @@ namespace BlocksBeyondTheStars.Client
         }
 
         /// <summary>The shape index the held item would place: the crafted form carried in the item key
-        /// (slabs, stairs, player-designed forms, …), or a furniture block's server-stamped default form
-        /// (bed/campfire/rug/pot — <paramref name="furniture"/> is true for those). 0 = places a plain cube
-        /// or no block at all, i.e. nothing the rotate key or the placement ghost should react to.</summary>
-        private int HeldPlaceShape(string held, out bool furniture)
+        /// (slabs, stairs, player-designed forms, …), or a prop block's server-stamped default form
+        /// (bed/campfire/rug/pot, the ladder's wall plate, the crafted staircase). 0 = places a plain cube
+        /// or no block at all, i.e. nothing the rotate key or the placement ghost should react to.
+        /// <paramref name="cycle"/> says how far this item's orientation may be steered — the rotate key and
+        /// the ghost must offer exactly what the server will honour.</summary>
+        private int HeldPlaceShape(string held, out PropOrientation cycle)
         {
-            furniture = false;
+            cycle = PropOrientation.None;
             if (string.IsNullOrEmpty(held))
             {
                 return 0;
@@ -2964,6 +2973,7 @@ namespace BlocksBeyondTheStars.Client
             int shape = BlocksBeyondTheStars.Shared.State.ItemKey.Shape(held);
             if (shape > 0)
             {
+                cycle = PropOrientation.Full; // a crafted form is a building block: all 24 orientations
                 return shape;
             }
 
@@ -2973,17 +2983,35 @@ namespace BlocksBeyondTheStars.Client
                 return 0;
             }
 
-            shape = BlocksBeyondTheStars.Shared.World.FurnitureShapes.DefaultPlaceShape(def.PlacesBlock);
-            furniture = shape != 0;
-            return shape;
+            cycle = PropShapes.OrientationOf(def.PlacesBlock);
+            return cycle == PropOrientation.None ? 0 : PropShapes.DefaultPlaceShape(def.PlacesBlock);
         }
 
-        /// <summary>One step of the rotate-key cycle. Shaped blocks walk Auto → the 24 up-face × quarter-turn
-        /// orientations → Auto; furniture walks Auto → the four quarter turns → Auto (its up-face is pinned
-        /// to +Y server-side, see the rotate-key comment). <paramref name="backwards"/> reverses the walk.</summary>
-        private void StepPlaceOrientation(bool backwards, bool furniture)
+        /// <summary>The ladder's rotate-key states, in cycle order: the four walls it can hug, then
+        /// free-standing (#909). Auto sits in front of them as index -1. Its plate is a square Panel, so the
+        /// quarter turns the other shapes cycle through would be four identical states here, and the two
+        /// vertical up-faces are the two a ladder has no use for.</summary>
+        private static readonly int[] LadderCycle = { 2, 3, 4, 5, ShapeCode.UpPlusY };
+
+        /// <summary>One step of the rotate-key cycle. Shaped blocks and the crafted staircase walk
+        /// Auto → the 24 up-face × quarter-turn orientations → Auto; furniture walks Auto → the four quarter
+        /// turns → Auto (its up-face is pinned to +Y server-side, see the rotate-key comment); the ladder
+        /// walks its own five mount states. <paramref name="backwards"/> reverses the walk.</summary>
+        private void StepPlaceOrientation(bool backwards, PropOrientation cycle)
         {
-            int lastUpFace = furniture ? 0 : 5;
+            if (cycle == PropOrientation.LadderMount)
+            {
+                _placeYaw = 0; // meaningless for both ladder forms — never send a turn the server drops
+                int at = _placeUpFace < 0 ? -1 : System.Array.IndexOf(LadderCycle, _placeUpFace);
+                int next = at + (backwards ? -1 : 1);
+                if (next >= LadderCycle.Length) { next = -1; }        // past the last state → back to Auto
+                else if (next < -1) { next = LadderCycle.Length - 1; } // before Auto → wrap to the last state
+                _placeUpFace = next < 0 ? -1 : LadderCycle[next];
+                return;
+            }
+
+            bool yawOnly = cycle == PropOrientation.YawOnly;
+            int lastUpFace = yawOnly ? 0 : 5;
             if (_placeUpFace < 0)
             {
                 // Leaving Auto: forwards starts at the first orientation, backwards at the last.
@@ -2992,7 +3020,7 @@ namespace BlocksBeyondTheStars.Client
                 return;
             }
 
-            if (furniture)
+            if (yawOnly)
             {
                 _placeUpFace = 0; // a stale up-face from a previously held shaped block never sticks to furniture
             }
@@ -3011,6 +3039,80 @@ namespace BlocksBeyondTheStars.Client
             }
         }
 
+        /// <summary>
+        /// The exact form + orientation the next place would carry, for the aim the player is holding right
+        /// now. Returns false when the held item places nothing orientable, in which case the place sends the
+        /// raw override fields and the server decides — same as before #909.
+        /// <para>
+        /// In Auto the client answers the orientation question ITSELF instead of leaving it to the server,
+        /// because it knows one thing the intent cannot carry: which block FACE the player clicked. That is
+        /// what makes a ladder hug the wall you aimed at rather than whichever neighbour wins a fixed scan
+        /// order. The server keeps its own derivation for intents that carry no up-face (older clients, its
+        /// own internal placements), so nothing depends on this being sent.
+        /// </para>
+        /// </summary>
+        private bool PendingPlacement(string held, Vector3Int hitCell, Vector3Int placeCell,
+            out int shape, out int upFace, out int yaw)
+        {
+            shape = HeldPlaceShape(held, out var cycle);
+            upFace = _placeUpFace;
+            yaw = _placeYaw;
+            if (shape <= 0)
+            {
+                return false;
+            }
+
+            // The face the player clicked: the step from the block they aimed at to the cell being filled.
+            int clicked = ShapeCode.FaceFromDirection(
+                placeCell.x - hitCell.x, placeCell.y - hitCell.y, placeCell.z - hitCell.z);
+
+            if (yaw < 0)
+            {
+                yaw = ((int)Mathf.Round(transform.eulerAngles.y / 90f)) & 3;
+            }
+
+            switch (cycle)
+            {
+                case PropOrientation.LadderMount:
+                {
+                    if (upFace < 0)
+                    {
+                        upFace = PropShapes.DeriveLadderMount(face => IsLadderMountWall(placeCell, face), clicked);
+                    }
+
+                    var form = PropShapes.LadderForm(upFace);
+                    shape = form.Shape;
+                    upFace = form.UpFace;
+                    yaw = 0;
+                    break;
+                }
+
+                case PropOrientation.YawOnly:
+                    upFace = ShapeCode.UpPlusY; // the server pins it; promising anything else would be a lie
+                    break;
+
+                default:
+                    if (upFace < 0)
+                    {
+                        upFace = DeriveAutoUpFace(placeCell, clicked);
+                    }
+
+                    break;
+            }
+
+            return true;
+        }
+
+        /// <summary>True when the cell on the far side of <paramref name="upFace"/> is a wall a ladder plate
+        /// can hang on. The up-face points AWAY from the plate's support, so the wall sits at the opposite
+        /// offset. Uses the mesher's own classification, so the preview and the drawn ladder cannot disagree.</summary>
+        private bool IsLadderMountWall(Vector3Int cell, int upFace)
+        {
+            var dir = ShapeCode.FaceDirection(upFace);
+            return ChunkMesher.IsLadderMountWall(
+                Game.Content, Game.World.GetBlock(cell.x - dir.X, cell.y - dir.Y, cell.z - dir.Z));
+        }
+
         /// <summary>Refreshes the placement ghost (#863): while a rotatable block is held and the aim ray
         /// has a place cell, the exact form + pending orientation hovers there translucently. Runs only on
         /// the on-foot path — every other state (menus, space view, driving, seated) is caught by the
@@ -3021,47 +3123,66 @@ namespace BlocksBeyondTheStars.Client
         {
             _ghostFrame = Time.frameCount;
             string held = Game != null ? Game.ItemInSlot(Game.SelectedHotbarSlot) : null;
-            int shape = HeldPlaceShape(held, out bool furniture);
+            bool rotatable = HeldPlaceShape(held, out _) > 0;
             if (Game != null)
             {
-                Game.HoldingRotatableBlock = shape > 0; // drives the HUD's "R — rotate" control hint
+                // Drives the HUD's "R — rotate" control hint. Answered from the held item alone, so the hint
+                // does not flicker while the crosshair sweeps past the sky.
+                Game.HoldingRotatableBlock = rotatable;
             }
 
-            if (shape <= 0 || !AimTarget(out _, out var placeCell, out var aimedShip) || aimedShip != null)
+            if (!rotatable || !AimTarget(out var hitCell, out var placeCell, out var aimedShip) || aimedShip != null
+                || !PendingPlacement(held, hitCell, placeCell, out int shape, out int upFace, out int yaw))
             {
                 _placementGhost?.Hide();
                 return;
             }
 
-            // Mirror the server's orientation choice exactly (HandlePlace): an explicit rotate-key override
-            // wins; Auto derives yaw from the facing and the up-face from the surface built against.
-            int yaw = _placeYaw >= 0 ? _placeYaw : ((int)Mathf.Round(transform.eulerAngles.y / 90f)) & 3;
-            int upFace = furniture
-                ? ShapeCode.UpPlusY
-                : (_placeUpFace >= 0 ? _placeUpFace : DeriveGhostUpFace(placeCell));
+            // Shows exactly what the place will send (PendingPlacement feeds both), so the hologram cannot
+            // promise a form or an orientation the placed block then contradicts.
             _placementGhost ??= new PlacementGhost();
             _placementGhost.Show(placeCell, shape, yaw, upFace);
         }
 
-        /// <summary>Client mirror of the server's DeriveShapeUpFace: the shape's base rests on the first
-        /// solid neighbour — floor first (→ +Y up), then the four walls, then the ceiling. Fluids are no
-        /// surface to build against, same as the server. Only feeds the ghost preview; the server still
-        /// derives its own answer on the actual place.</summary>
-        private int DeriveGhostUpFace(Vector3Int cell)
+        /// <summary>The up-face for an Auto placement: the shape's base rests on the surface it was built
+        /// against — the floor first (→ +Y up, the common case of laying a slab on the ground), then the WALL
+        /// THE PLAYER CLICKED, then the remaining walls in the server's fixed scan order, then the ceiling.
+        /// Fluids are no surface to build against, same as the server.
+        /// <para>
+        /// The clicked-face preference (#909) is the one thing the client can answer better than
+        /// <c>GameServer.DeriveShapeUpFace</c>, whose intent carries no aim: it is what lets you build a ramp
+        /// against the wall you are looking at instead of whichever neighbour the scan order happens to reach
+        /// first. The floor still wins over it — extending a floor by clicking the side of the last slab must
+        /// keep laying it flat, not stand it up against that slab.
+        /// </para></summary>
+        private int DeriveAutoUpFace(Vector3Int cell, int clickedFace)
         {
-            bool Solid(int dx, int dy, int dz)
+            bool Supported(int face)
             {
-                var id = Game.World.GetBlock(cell.x + dx, cell.y + dy, cell.z + dz);
+                var dir = ShapeCode.FaceDirection(face);
+                var id = Game.World.GetBlock(cell.x - dir.X, cell.y - dir.Y, cell.z - dir.Z);
                 return !id.IsAir && !IsFluidBlock(id);
             }
 
-            if (Solid(0, -1, 0)) return 0; // floor → +Y up
-            if (Solid(-1, 0, 0)) return 2; // wall → +X up
-            if (Solid(1, 0, 0)) return 3;  // wall → -X up
-            if (Solid(0, 0, -1)) return 4; // wall → +Z up
-            if (Solid(0, 0, 1)) return 5;  // wall → -Z up
-            if (Solid(0, 1, 0)) return 1;  // ceiling → -Y up
-            return 0;
+            if (Supported(ShapeCode.UpPlusY))
+            {
+                return ShapeCode.UpPlusY; // floor below → upright
+            }
+
+            if (clickedFace >= 2 && clickedFace <= 5 && Supported(clickedFace))
+            {
+                return clickedFace; // the wall under the crosshair
+            }
+
+            foreach (int face in ShapeCode.WallFaces)
+            {
+                if (Supported(face))
+                {
+                    return face;
+                }
+            }
+
+            return Supported(1) ? 1 : ShapeCode.UpPlusY; // ceiling, else nothing to rest on
         }
 
         private void LateUpdate()
@@ -3088,7 +3209,7 @@ namespace BlocksBeyondTheStars.Client
         /// (upright / upside down / on its side) plus the quarter-turn in degrees — instead of the old
         /// axis-speak ("+X · 90°") nobody without a maths degree could predict (#863). The placement ghost
         /// shows the exact result; this label just needs to say roughly what changed.</summary>
-        private string OrientationLabel(bool furniture)
+        private string OrientationLabel(PropOrientation cycle)
         {
             var loc = Game?.Localizer;
             if (_placeUpFace < 0)
@@ -3096,7 +3217,16 @@ namespace BlocksBeyondTheStars.Client
                 return loc?.Get("hud.shape.auto") ?? "Auto";
             }
 
-            int upFace = furniture ? 0 : _placeUpFace;
+            if (cycle == PropOrientation.LadderMount)
+            {
+                // Which of the four walls it is naming would need compass words nobody can map to a key press —
+                // the ghost hanging on that exact wall says it better than any label could.
+                return _placeUpFace >= 2
+                    ? loc?.Get("hud.shape.on_wall") ?? "On the wall"
+                    : loc?.Get("hud.shape.free_standing") ?? "Free-standing";
+            }
+
+            int upFace = cycle == PropOrientation.YawOnly ? 0 : _placeUpFace;
             string word = upFace switch
             {
                 0 => loc?.Get("hud.shape.upright") ?? "Upright",

--- a/data/locales/de.json
+++ b/data/locales/de.json
@@ -1640,6 +1640,8 @@
   "hud.shape.upright": "Aufrecht",
   "hud.shape.upside_down": "Kopfüber",
   "hud.shape.sideways": "Auf der Seite",
+  "hud.shape.on_wall": "An der Wand",
+  "hud.shape.free_standing": "Freistehend",
   "ui.hud.ship": "Schiff",
   "ui.hud.hull": "Hülle",
   "ui.hud.shield": "Schild",

--- a/data/locales/en.json
+++ b/data/locales/en.json
@@ -1640,6 +1640,8 @@
   "hud.shape.upright": "Upright",
   "hud.shape.upside_down": "Upside down",
   "hud.shape.sideways": "On its side",
+  "hud.shape.on_wall": "On the wall",
+  "hud.shape.free_standing": "Free-standing",
   "ui.hud.ship": "Ship",
   "ui.hud.hull": "Hull",
   "ui.hud.shield": "Shield",

--- a/docs/user/USER_MANUAL.md
+++ b/docs/user/USER_MANUAL.md
@@ -76,7 +76,7 @@ Last updated: 2026-08-08.
 | **Mouse wheel** | Cycle hotbar slot |
 | **1 – 9** | Select hotbar slot |
 | **F** | Attack with the held tool/weapon — hits what's **under your crosshair** (the reticle turns red over a target; with **auto-aim** on, the nearest enemy in front of you is acquired automatically) |
-| **R** | Repair the targeted wreck breach with the selected hotbar block (see §5 → Wrecks); with a **shaped block or furniture** selected: rotate its placement orientation (**Shift+R** cycles backwards — see §5 → Craftable block shapes) |
+| **R** | Repair the targeted wreck breach with the selected hotbar block (see §5 → Wrecks); with a **shaped block, furniture, ladder or stairs** selected: rotate its placement orientation (**Shift+R** cycles backwards — see §5 → Craftable block shapes) |
 | **L** | Toggle the suit headlamp (requires a `suit_lamp`) |
 | **G** | Loot the nearest container |
 | **E** | Use a nearby ship/station tile (cockpit, workshop, cargo, medbay, …); **trade with a vendor** (opens the Market); **board your hover speeder**; **beam** from a teleporter pad you're standing on |
@@ -701,6 +701,16 @@ separate unlock; admins can still disable it through server world rules.
   the vertical axis — it always stays upright so beds and campfires keep working. Symmetric forms (sphere,
   dome, cylinder, …) ignore orientation. Mining returns the shaped item; orientation is re-derived each
   time you place it again.
+- **Auto follows your crosshair:** when a cell has no floor under it, the shape leans on **the wall face you
+  actually clicked** instead of whichever neighbouring wall the game finds first. Building on a floor still
+  keeps the shape upright, so extending a floor sideways lays the next block flat as before.
+- **Ladders** are rotatable too, with their own short cycle: **Auto → each of the four walls → free-standing
+  → Auto**. A placed ladder now *keeps* the side you gave it — mining the wall next to it no longer flips the
+  whole column around or turns it into poles. Ladders placed before this update, and those in settlements,
+  keep choosing their wall automatically.
+- **Stairs** you craft are a real staircase now instead of a full cube: they get step geometry you can walk
+  up, and **R** turns them to face any direction (or tips them upside down for an inverted step). Stairs
+  placed before this update stay cubes until you mine and place them again.
 
 ### Designing your own forms
 - Craft the **Shaping Tool** (`shape_tool`, workshop recipe + the cheap `shape_tool` blueprint) and

--- a/src/BlocksBeyondTheStars.GameServer/GameServer.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServer.cs
@@ -3351,30 +3351,26 @@ public sealed partial class GameServer
             ? place.Yaw
             : ((int)System.MathF.Round(session.State.Yaw / 90f)) & 3;
 
-        switch (cycle)
+        if (cycle == PropOrientation.LadderMount)
         {
-            case PropOrientation.LadderMount:
-            {
-                // The ladder's whole orientation IS its mount face, so the intent's up-face carries it: 2..5
-                // hug that wall, anything else means free-standing (the client's fifth cycle state sends +Y).
-                // Yaw is dropped on purpose — both forms are square about their own axis.
-                int mount = ShapeCode.IsValidUpFace(place.UpFace) ? place.UpFace : DeriveLadderMount(pos);
-                var (ladderShape, ladderUp) = PropShapes.LadderForm(mount);
-                return ShapeCode.Pack(ladderShape, 0, ladderUp);
-            }
-
-            case PropOrientation.Full:
-            {
-                // The crafted staircase is a directional form like any shaped block: it may tip onto walls and
-                // ceilings, and auto-orients against the surface it was built on when nothing was chosen.
-                int upFace = ShapeCode.IsValidUpFace(place.UpFace) ? place.UpFace : DeriveShapeUpFace(pos);
-                return ShapeCode.Pack(PropShapes.DefaultPlaceShape(blockKey), facing, upFace);
-            }
-
-            default:
-                // Furniture turns but never tips: a bed/campfire on a wall would break its sit/heal/warmth checks.
-                return ShapeCode.Pack(PropShapes.DefaultPlaceShape(blockKey), facing, ShapeCode.UpPlusY);
+            // The ladder's whole orientation IS its mount face, so the intent's up-face carries it: 2..5 hug
+            // that wall, anything else means free-standing (the client's fifth cycle state sends +Y). Yaw is
+            // dropped on purpose — both ladder forms are square about their own axis.
+            int mount = ShapeCode.IsValidUpFace(place.UpFace) ? place.UpFace : DeriveLadderMount(pos);
+            var (ladderShape, ladderUp) = PropShapes.LadderForm(mount);
+            return ShapeCode.Pack(ladderShape, 0, ladderUp);
         }
+
+        if (cycle == PropOrientation.Full)
+        {
+            // The crafted staircase is a directional form like any shaped block: it may tip onto walls and
+            // ceilings, and auto-orients against the surface it was built on when nothing was chosen.
+            int upFace = ShapeCode.IsValidUpFace(place.UpFace) ? place.UpFace : DeriveShapeUpFace(pos);
+            return ShapeCode.Pack(PropShapes.DefaultPlaceShape(blockKey), facing, upFace);
+        }
+
+        // Furniture turns but never tips: a bed/campfire on a wall would break its sit/heal/warmth checks.
+        return ShapeCode.Pack(PropShapes.DefaultPlaceShape(blockKey), facing, ShapeCode.UpPlusY);
     }
 
     /// <summary>Which wall a ladder hugs when the client sent no choice — an old client, a test, or one of the

--- a/src/BlocksBeyondTheStars.GameServer/GameServer.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServer.cs
@@ -3173,10 +3173,14 @@ public sealed partial class GameServer
         var current = _world.GetBlock(pos);
         var (dropTint, dropGlow) = _world.GetModifier(pos); // read the dye/glow BEFORE clearing, to recover it into the drop
         int dropShape = ShapeCode.ShapeOf(_world.GetShape(pos)); // recover the FORM (orientation is re-derived on re-place)
-        if (dropShape != 0 && dropShape == FurnitureShapes.DefaultPlaceShape(def.Key))
+        if (PropShapes.IsStampedForm(def.Key, dropShape))
         {
-            // A furniture block's server-stamped default form is not player data — dropping it plain keeps
-            // the mined item stacking with crafted ones (a "bed#s01" would never merge with a "bed").
+            // A prop's server-stamped form is not player data — dropping it plain keeps the mined item
+            // stacking with crafted ones (a "bed#s01" would never merge with a "bed"). Asking the shared
+            // helper rather than comparing against the ONE default matters for the ladder (#909), which is
+            // stamped as a wall plate OR a free-standing pole: the pole form would otherwise drop as its own
+            // item key, split the stack, and then place as a plate anyway (the ladder item is not shapeable,
+            // so a shape suffix on it is ignored at place time).
             dropShape = 0;
         }
 
@@ -3329,6 +3333,78 @@ public sealed partial class GameServer
         if (Solid(0, 0, 1)) return 5;  // wall → -Z up
         if (Solid(0, 1, 0)) return 1;  // ceiling → -Y up
         return 0;
+    }
+
+    /// <summary>The packed shape descriptor a prop block is stamped with on placement (#909), or 0 when the
+    /// key is no prop. Each <see cref="PropOrientation"/> honours exactly as much of the intent's orientation
+    /// as its client-side rotate cycle offers — a pinned-back tip or an ignored quarter turn would make the
+    /// placement ghost a liar.</summary>
+    private int StampPropShape(PlayerSession session, PlaceBlockIntent place, string blockKey, Vector3i pos)
+    {
+        var cycle = PropShapes.OrientationOf(blockKey);
+        if (cycle == PropOrientation.None)
+        {
+            return 0;
+        }
+
+        int facing = place.Yaw >= 0 && place.Yaw <= 3
+            ? place.Yaw
+            : ((int)System.MathF.Round(session.State.Yaw / 90f)) & 3;
+
+        switch (cycle)
+        {
+            case PropOrientation.LadderMount:
+            {
+                // The ladder's whole orientation IS its mount face, so the intent's up-face carries it: 2..5
+                // hug that wall, anything else means free-standing (the client's fifth cycle state sends +Y).
+                // Yaw is dropped on purpose — both forms are square about their own axis.
+                int mount = ShapeCode.IsValidUpFace(place.UpFace) ? place.UpFace : DeriveLadderMount(pos);
+                var (ladderShape, ladderUp) = PropShapes.LadderForm(mount);
+                return ShapeCode.Pack(ladderShape, 0, ladderUp);
+            }
+
+            case PropOrientation.Full:
+            {
+                // The crafted staircase is a directional form like any shaped block: it may tip onto walls and
+                // ceilings, and auto-orients against the surface it was built on when nothing was chosen.
+                int upFace = ShapeCode.IsValidUpFace(place.UpFace) ? place.UpFace : DeriveShapeUpFace(pos);
+                return ShapeCode.Pack(PropShapes.DefaultPlaceShape(blockKey), facing, upFace);
+            }
+
+            default:
+                // Furniture turns but never tips: a bed/campfire on a wall would break its sit/heal/warmth checks.
+                return ShapeCode.Pack(PropShapes.DefaultPlaceShape(blockKey), facing, ShapeCode.UpPlusY);
+        }
+    }
+
+    /// <summary>Which wall a ladder hugs when the client sent no choice — an old client, a test, or one of the
+    /// server's own internal placements. Mirrors the mesher heuristic #803 shipped with (first solid horizontal
+    /// neighbour, in <see cref="ShapeCode.WallFaces"/> order), so those placements keep landing where they
+    /// always did. The client normally decides this itself and sends the answer, because it can also honour
+    /// the wall the player actually aimed at.</summary>
+    private int DeriveLadderMount(Vector3i pos) => PropShapes.DeriveLadderMount(
+        face =>
+        {
+            // The up-face points AWAY from the plate's support, so the wall sits at the opposite offset.
+            var dir = ShapeCode.FaceDirection(face);
+            var p = WorldConstants.CanonicalBlock(
+                new Vector3i(pos.X - dir.X, pos.Y - dir.Y, pos.Z - dir.Z), _world.Circumference);
+            return IsLadderMountWall(_world.GetBlock(p));
+        },
+        clickedFace: -1);
+
+    /// <summary>A neighbour a ladder plate can hang on. The mesher additionally rules out see-through walls
+    /// (glass, force fields), which the server has no flag for — the divergence only shows for a client old
+    /// enough not to send its own mount face, and costs at most a plate where a pole was drawn before.</summary>
+    private bool IsLadderMountWall(BlockId id)
+    {
+        if (id.IsAir || IsFluid(id.Value) || IsFlora(id.Value))
+        {
+            return false;
+        }
+
+        var def = _content.BlockById(id);
+        return def is not null && def.Solid && def.Key != "ladder";
     }
 
     private void HandlePlace(PlayerSession session, PlaceBlockIntent place)
@@ -3548,19 +3624,16 @@ public sealed partial class GameServer
             }
         }
 
-        // Furniture blocks (#804/#807/#809) read as their real silhouette out of the box: stamp their
-        // default form on placement — the same per-voxel shape channel the Shape action writes, so the
-        // mesher, save and wire all treat it like any player-shaped cell. The quarter-turn honours the
-        // rotate key like any shaped block (#863); without one it follows the player's facing. The up-face
-        // stays +Y on purpose: a bed/campfire tipped onto a wall would break their sit/heal/warmth checks,
-        // so furniture rotates but never tips. BreakBlockAt strips this default again so the drop stacks
-        // with freshly crafted items.
-        if (placeShape == 0 && FurnitureShapes.DefaultPlaceShape(blockDef.Key) is int defShape && defShape != 0)
+        // Prop blocks (furniture #804/#807/#809, ladder + crafted staircase #909) read as their real
+        // silhouette out of the box: stamp their default form on placement — the same per-voxel shape channel
+        // the Shape action writes, so the mesher, save and wire all treat it like any player-shaped cell. The
+        // quarter-turn honours the rotate key like any shaped block (#863); without one it follows the
+        // player's facing. How far the orientation may travel is per prop (PropOrientation), because the
+        // cycle the client offers must promise exactly what is honoured here. BreakBlockAt strips the stamped
+        // form again so the drop stacks with freshly crafted items.
+        if (placeShape == 0)
         {
-            int facing = place.Yaw >= 0 && place.Yaw <= 3
-                ? place.Yaw
-                : ((int)System.MathF.Round(session.State.Yaw / 90f)) & 3;
-            placeShape = ShapeCode.Pack(defShape, facing, ShapeCode.UpPlusY);
+            placeShape = StampPropShape(session, place, blockDef.Key, pos);
         }
 
         _world.SetBlock(pos, blockDef.NumericId, placeTint, placeGlow, placeShape, session.State.PlayerId);

--- a/src/BlocksBeyondTheStars.Shared/World/BlockShape.cs
+++ b/src/BlocksBeyondTheStars.Shared/World/BlockShape.cs
@@ -37,23 +37,109 @@ public enum BlockShape : byte
     Pot = 18,     // small centred planter box with a rim (bowls, pots)
 }
 
+/// <summary>How much of the orientation a prop's rotate-key cycle may reach (#909). The cycle the player
+/// walks must promise exactly what the placement will honour — offering a tip the server pins back to +Y,
+/// or four quarter turns of a square plate nobody can tell apart, is worse than offering nothing.</summary>
+public enum PropOrientation : byte
+{
+    /// <summary>Not a stamped prop — the item places a plain cube (or no block at all).</summary>
+    None = 0,
+
+    /// <summary>Quarter turns only; the up-face stays +Y (bed/campfire/rug/pot — a tipped bed would break
+    /// its sit/heal/warmth checks).</summary>
+    YawOnly = 1,
+
+    /// <summary>The full 24 orientations, exactly like a shaped building block (the crafted staircase).</summary>
+    Full = 2,
+
+    /// <summary>The ladder's own five states: the four walls it can hug, plus free-standing. Yaw is
+    /// meaningless (its plate is a square <see cref="BlockShape.Panel"/>) and the two vertical up-faces are
+    /// the two a ladder has no use for.</summary>
+    LadderMount = 3,
+}
+
 /// <summary>
-/// The default FORM a furniture block is stamped with on placement (#804/#807/#809), so it reads as its
+/// The default FORM a prop block is stamped with on placement (#804/#807/#809, #909), so it reads as its
 /// silhouette without the player using the Shape action. Shared between the server (stamp on place, strip
 /// from the mined drop) and the client (the rotate key + placement ghost must treat these items as
 /// rotatable even though their item key carries no shape suffix).
 /// </summary>
-public static class FurnitureShapes
+public static class PropShapes
 {
-    /// <summary>The default shape index for a furniture block key, or 0 (plain cube) for everything else.</summary>
+    /// <summary>The default shape index for a prop block key, or 0 (plain cube) for everything else.
+    /// The ladder's default is its wall plate; see <see cref="LadderFreeStanding"/> for the other form it
+    /// can be stamped with.</summary>
     public static int DefaultPlaceShape(string blockKey) => blockKey switch
     {
         "bed" => (int)BlockShape.Slab,
         "campfire" => (int)BlockShape.Slab,
         "rug" => (int)BlockShape.Sheet,
         "flower_pot" => (int)BlockShape.Pot,
+        "ladder" => (int)BlockShape.Panel,     // thin plate hugging a wall (#803 meshed this, #909 stores it)
+        "stairs" => (int)BlockShape.Stairs,    // the crafted staircase used to place as a full cube (#909)
         _ => 0,
     };
+
+    /// <summary>The form a ladder takes when it hugs no wall: a slim pole through the cell. The mesher has
+    /// always drawn a free-standing ladder this way; since #909 the choice can also be stored.</summary>
+    public const int LadderFreeStanding = (int)BlockShape.Post;
+
+    /// <summary>How far this prop's placement orientation may be steered.</summary>
+    public static PropOrientation OrientationOf(string blockKey) => blockKey switch
+    {
+        "ladder" => PropOrientation.LadderMount,
+        "stairs" => PropOrientation.Full,
+        _ => DefaultPlaceShape(blockKey) != 0 ? PropOrientation.YawOnly : PropOrientation.None,
+    };
+
+    /// <summary>True when <paramref name="shape"/> is a form the SERVER stamps on this block key rather than
+    /// player data. Such a form is stripped from the mined drop so it stacks with freshly crafted items —
+    /// which matters most for the ladder, whose two forms (wall plate / free-standing pole) would otherwise
+    /// split the stack into two item keys that both place as a plate anyway.</summary>
+    public static bool IsStampedForm(string blockKey, int shape)
+        => shape != 0
+           && (shape == DefaultPlaceShape(blockKey)
+               || (shape == LadderFreeStanding && blockKey == "ladder"));
+
+    /// <summary>The form + up-face a ladder is stamped with for a chosen mount face: an up-face pointing away
+    /// from one of the four walls keeps the plate, anything else (no wall to hug) becomes the pole. Server and
+    /// client run this same function so the placement ghost cannot promise the wrong silhouette.</summary>
+    public static (int Shape, int UpFace) LadderForm(int upFace)
+        => upFace >= 2 && upFace <= 5
+            ? (DefaultPlaceShape("ladder"), upFace)
+            : (LadderFreeStanding, ShapeCode.UpPlusY);
+
+    /// <summary>
+    /// Picks the wall a ladder hugs when the player let placement decide: the wall they aimed at wins
+    /// (<paramref name="clickedFace"/>, -1 = none), otherwise the first one in <see cref="ShapeCode.WallFaces"/>
+    /// order — the heuristic the mesher has used since #803, kept so a ladder placed by an old client, by
+    /// worldgen or inside a ship layout lands exactly where it always did. Returns <see cref="ShapeCode.UpPlusY"/>
+    /// when there is no wall at all, which <see cref="LadderForm"/> turns into the free-standing pole.
+    /// <paramref name="hasWall"/> answers "is the cell on the far side of this up-face a wall the plate can
+    /// hang on" for one of the four horizontal up-faces.
+    /// </summary>
+    public static int DeriveLadderMount(System.Func<int, bool> hasWall, int clickedFace)
+    {
+        if (hasWall is null)
+        {
+            return ShapeCode.UpPlusY;
+        }
+
+        if (clickedFace >= 2 && clickedFace <= 5 && hasWall(clickedFace))
+        {
+            return clickedFace;
+        }
+
+        foreach (int face in ShapeCode.WallFaces)
+        {
+            if (hasWall(face))
+            {
+                return face;
+            }
+        }
+
+        return ShapeCode.UpPlusY;
+    }
 }
 
 /// <summary>
@@ -133,6 +219,38 @@ public static class ShapeCode
 
     /// <summary>True when <paramref name="upFace"/> is a valid up-face index (0..5).</summary>
     public static bool IsValidUpFace(int upFace) => upFace is >= 0 and <= 5;
+
+    /// <summary>The unit direction an up-face points in — which is also the direction AWAY from the surface
+    /// the shape's base rests on, so the supporting neighbour always sits at the opposite offset.</summary>
+    public static (int X, int Y, int Z) FaceDirection(int upFace) => upFace switch
+    {
+        1 => (0, -1, 0),
+        2 => (1, 0, 0),
+        3 => (-1, 0, 0),
+        4 => (0, 0, 1),
+        5 => (0, 0, -1),
+        _ => (0, 1, 0),
+    };
+
+    /// <summary>The up-face pointing along a unit direction, or -1 for anything that is not one of the six.
+    /// Placement uses it to turn "the block face the player clicked" (the step from the aimed cell to the
+    /// cell being filled) into the up-face that rests the shape on exactly that face.</summary>
+    public static int FaceFromDirection(int dx, int dy, int dz) => (dx, dy, dz) switch
+    {
+        (0, 1, 0) => 0,
+        (0, -1, 0) => 1,
+        (1, 0, 0) => 2,
+        (-1, 0, 0) => 3,
+        (0, 0, 1) => 4,
+        (0, 0, -1) => 5,
+        _ => -1,
+    };
+
+    /// <summary>The four up-faces that lean a shape against a WALL, in the order placement falls back on
+    /// when the player expressed no preference (unchanged from the ladder heuristic #803 shipped with).</summary>
+    public static System.Collections.Generic.IReadOnlyList<int> WallFaces => WallFaceOrder;
+
+    private static readonly int[] WallFaceOrder = { 2, 3, 4, 5 };
 
     // --- Paint design reference (bits 11..26) ---
     // Like the up-face field, the design id was added on top of the existing descriptor: bits 11+ were

--- a/tests/BlocksBeyondTheStars.Tests/LadderStairsOrientationTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/LadderStairsOrientationTests.cs
@@ -1,0 +1,275 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using BlocksBeyondTheStars.Networking.Transport;
+using BlocksBeyondTheStars.Persistence;
+using BlocksBeyondTheStars.Shared.Configuration;
+using BlocksBeyondTheStars.Shared.Content;
+using BlocksBeyondTheStars.Shared.Geometry;
+using BlocksBeyondTheStars.Shared.Primitives;
+using BlocksBeyondTheStars.Shared.State;
+using BlocksBeyondTheStars.Shared.World;
+using Xunit;
+using SvGameServer = BlocksBeyondTheStars.GameServer.GameServer;
+
+namespace BlocksBeyondTheStars.Tests;
+
+/// <summary>
+/// Orientable ladders and the crafted staircase (#909). Both used to place with NO stored form: the ladder's
+/// look was re-derived by the mesher on every rebuild (so it flipped walls whenever a neighbour was mined),
+/// and the crafted <c>stairs</c> block was a plain cube despite <see cref="BlockShape.Stairs"/> existing.
+/// They now go through the prop-stamp path, which pins what the player chose — while a ladder with no
+/// descriptor (older saves, settlements) keeps falling back to the original heuristic.
+/// </summary>
+public sealed class LadderStairsOrientationTests : IDisposable
+{
+    private readonly string _root;
+    private readonly GameContent _content;
+
+    public LadderStairsOrientationTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "bbts_ladder_" + Guid.NewGuid().ToString("N"));
+        _content = ContentLoader.LoadFromDirectory(TestPaths.DataDir());
+    }
+
+    private SvGameServer Started(out SqliteWorldRepository repo)
+    {
+        repo = new SqliteWorldRepository(new SaveGamePaths(_root, "ladder"));
+        var st = new LoopbackServerTransport(new LoopbackLink());
+        var config = new ServerConfig { WorldName = "ladder", Seed = 11, AutoSaveIntervalMinutes = 9999, PlaceStarterShip = false };
+        var server = new SvGameServer(config, _content, st, repo);
+        server.Start();
+        return server;
+    }
+
+    /// <summary>Empties the cell and everything touching it, so a placement test sees the neighbourhood it
+    /// asked for rather than whatever terrain the seed grew there.</summary>
+    private static void ClearAround(SvGameServer server, Vector3i cell)
+    {
+        for (int dx = -1; dx <= 1; dx++)
+        {
+            for (int dy = -1; dy <= 1; dy++)
+            {
+                for (int dz = -1; dz <= 1; dz++)
+                {
+                    server.World.SetBlock(new Vector3i(cell.X + dx, cell.Y + dy, cell.Z + dz), BlockId.Air);
+                }
+            }
+        }
+    }
+
+    [Fact]
+    public void Ladder_StampsTheWallItWasGiven()
+    {
+        var server = Started(out var repo);
+        using (repo)
+        {
+            var p = server.AddLocalPlayer("Climber");
+            p.State.AboardShip = false;
+            p.State.Position = new Vector3f(0.5f, 64, 0.5f);
+            p.State.Inventory.Add("ladder", 8, 64);
+
+            // Auto with exactly one wall around: the plate leans on it. The up-face points AWAY from the
+            // support, so a wall at -X stores up-face +X (2).
+            var cell = new Vector3i(2, 64, 0);
+            ClearAround(server, cell);
+            server.World.SetBlock(new Vector3i(1, 64, 0), _content.GetBlock("stone")!.NumericId);
+            server.PlaceBlock(p.State.PlayerId, cell.X, cell.Y, cell.Z, "ladder");
+
+            int stamped = server.World.GetShape(cell);
+            Assert.Equal((int)BlockShape.Panel, ShapeCode.ShapeOf(stamped));
+            Assert.Equal(2, ShapeCode.UpFaceOf(stamped));
+
+            // An explicit mount face (the client's rotate cycle) wins over the neighbour scan.
+            var chosen = new Vector3i(2, 64, 3);
+            ClearAround(server, chosen);
+            server.World.SetBlock(new Vector3i(1, 64, 3), _content.GetBlock("stone")!.NumericId);
+            server.PlaceBlock(p.State.PlayerId, chosen.X, chosen.Y, chosen.Z, "ladder", upFace: 5);
+
+            int forced = server.World.GetShape(chosen);
+            Assert.Equal((int)BlockShape.Panel, ShapeCode.ShapeOf(forced));
+            Assert.Equal(5, ShapeCode.UpFaceOf(forced));
+        }
+    }
+
+    [Fact]
+    public void Ladder_WithNoWall_OrAskedTo_StandsFree()
+    {
+        var server = Started(out var repo);
+        using (repo)
+        {
+            var p = server.AddLocalPlayer("Poler");
+            p.State.AboardShip = false;
+            p.State.Position = new Vector3f(0.5f, 64, 0.5f);
+            p.State.Inventory.Add("ladder", 8, 64);
+
+            // Nothing to hug → the pole form, and it is STORED (a bare 0 descriptor would let the mesher
+            // start re-deriving the look again).
+            var free = new Vector3i(2, 64, 0);
+            ClearAround(server, free);
+            server.PlaceBlock(p.State.PlayerId, free.X, free.Y, free.Z, "ladder");
+
+            int pole = server.World.GetShape(free);
+            Assert.Equal(PropShapes.LadderFreeStanding, ShapeCode.ShapeOf(pole));
+            Assert.NotEqual(0, pole);
+
+            // Free-standing is also the fifth state of the rotate cycle: it sends +Y, which means "no wall"
+            // even where there is one to hug.
+            var beside = new Vector3i(2, 64, 3);
+            ClearAround(server, beside);
+            server.World.SetBlock(new Vector3i(1, 64, 3), _content.GetBlock("stone")!.NumericId);
+            server.PlaceBlock(p.State.PlayerId, beside.X, beside.Y, beside.Z, "ladder", upFace: ShapeCode.UpPlusY);
+
+            Assert.Equal(PropShapes.LadderFreeStanding, ShapeCode.ShapeOf(server.World.GetShape(beside)));
+        }
+    }
+
+    [Fact]
+    public void Ladder_DropsPlain_SoBothFormsStackAgain()
+    {
+        var server = Started(out var repo);
+        using (repo)
+        {
+            var p = server.AddLocalPlayer("Miner");
+            p.State.AboardShip = false;
+            p.State.Position = new Vector3f(0.5f, 64, 0.5f);
+            p.State.Inventory.Add("ladder", 2, 64);
+
+            var onWall = new Vector3i(2, 64, 0);
+            ClearAround(server, onWall);
+            server.World.SetBlock(new Vector3i(1, 64, 0), _content.GetBlock("stone")!.NumericId);
+            server.PlaceBlock(p.State.PlayerId, onWall.X, onWall.Y, onWall.Z, "ladder");
+
+            var free = new Vector3i(2, 64, 3);
+            ClearAround(server, free);
+            server.PlaceBlock(p.State.PlayerId, free.X, free.Y, free.Z, "ladder");
+            Assert.Equal(0, p.State.Inventory.CountOf("ladder"));
+
+            // Both come back as the SAME plain item: a "ladder#s10" pole would split the stack and then
+            // place as a plate anyway (the ladder item carries no shape).
+            server.MineBlock(p.State.PlayerId, onWall.X, onWall.Y, onWall.Z);
+            server.MineBlock(p.State.PlayerId, free.X, free.Y, free.Z);
+            Assert.Equal(2, p.State.Inventory.CountOf("ladder"));
+            Assert.DoesNotContain(p.State.Inventory.Slots, s => s?.Item?.StartsWith("ladder#", StringComparison.Ordinal) == true);
+        }
+    }
+
+    [Fact]
+    public void CraftedStairs_PlaceAsARealStaircase_AndDropPlain()
+    {
+        var server = Started(out var repo);
+        using (repo)
+        {
+            var p = server.AddLocalPlayer("Builder");
+            p.State.AboardShip = false;
+            p.State.Position = new Vector3f(0.5f, 64, 0.5f);
+            p.State.Yaw = 180f;
+            p.State.Inventory.Add("stairs", 4, 64);
+
+            // Auto: step geometry (it used to place as a plain cube), turned the way the player faces.
+            var cell = new Vector3i(2, 64, 0);
+            ClearAround(server, cell);
+            server.World.SetBlock(new Vector3i(2, 63, 0), _content.GetBlock("stone")!.NumericId);
+            server.PlaceBlock(p.State.PlayerId, cell.X, cell.Y, cell.Z, "stairs");
+
+            int stamped = server.World.GetShape(cell);
+            Assert.Equal((int)BlockShape.Stairs, ShapeCode.ShapeOf(stamped));
+            Assert.Equal(2, ShapeCode.OrientationOf(stamped));
+            Assert.Equal(ShapeCode.UpPlusY, ShapeCode.UpFaceOf(stamped));
+
+            // Unlike furniture, the staircase may tip: upside-down steps are a normal building move.
+            var tipped = new Vector3i(2, 64, 3);
+            ClearAround(server, tipped);
+            server.PlaceBlock(p.State.PlayerId, tipped.X, tipped.Y, tipped.Z, "stairs", upFace: 1, yaw: 3);
+
+            int inverted = server.World.GetShape(tipped);
+            Assert.Equal((int)BlockShape.Stairs, ShapeCode.ShapeOf(inverted));
+            Assert.Equal(3, ShapeCode.OrientationOf(inverted));
+            Assert.Equal(1, ShapeCode.UpFaceOf(inverted));
+
+            server.MineBlock(p.State.PlayerId, tipped.X, tipped.Y, tipped.Z);
+            Assert.Equal(3, p.State.Inventory.CountOf("stairs"));
+        }
+    }
+
+    [Fact]
+    public void PropShapes_DescribeEachPropsReach()
+    {
+        // What the server honours per prop — the client's rotate cycle mirrors exactly this table.
+        Assert.Equal(PropOrientation.LadderMount, PropShapes.OrientationOf("ladder"));
+        Assert.Equal(PropOrientation.Full, PropShapes.OrientationOf("stairs"));
+        Assert.Equal(PropOrientation.YawOnly, PropShapes.OrientationOf("bed"));
+        Assert.Equal(PropOrientation.YawOnly, PropShapes.OrientationOf("flower_pot"));
+        Assert.Equal(PropOrientation.None, PropShapes.OrientationOf("stone"));
+        Assert.Equal(0, PropShapes.DefaultPlaceShape("stone"));
+
+        // The mount face decides the form: the four walls keep the plate, everything else is the pole.
+        foreach (int wall in ShapeCode.WallFaces)
+        {
+            Assert.Equal(((int)BlockShape.Panel, wall), PropShapes.LadderForm(wall));
+        }
+
+        Assert.Equal((PropShapes.LadderFreeStanding, ShapeCode.UpPlusY), PropShapes.LadderForm(ShapeCode.UpPlusY));
+        Assert.Equal((PropShapes.LadderFreeStanding, ShapeCode.UpPlusY), PropShapes.LadderForm(1));
+        Assert.Equal((PropShapes.LadderFreeStanding, ShapeCode.UpPlusY), PropShapes.LadderForm(-1));
+
+        // Both ladder forms are server-stamped, so both are stripped from the drop; a player's own form on a
+        // shapeable material is not.
+        Assert.True(PropShapes.IsStampedForm("ladder", (int)BlockShape.Panel));
+        Assert.True(PropShapes.IsStampedForm("ladder", PropShapes.LadderFreeStanding));
+        Assert.True(PropShapes.IsStampedForm("stairs", (int)BlockShape.Stairs));
+        Assert.True(PropShapes.IsStampedForm("bed", (int)BlockShape.Slab));
+        Assert.False(PropShapes.IsStampedForm("ladder", (int)BlockShape.Sphere));
+        Assert.False(PropShapes.IsStampedForm("stone", (int)BlockShape.Post));
+        Assert.False(PropShapes.IsStampedForm("ladder", 0));
+    }
+
+    [Fact]
+    public void LadderMount_PrefersTheWallThePlayerClicked()
+    {
+        // Two walls around the cell: the scan order would take +X (2), but the aim says otherwise.
+        bool HasWall(int face) => face == 2 || face == 5;
+
+        Assert.Equal(5, PropShapes.DeriveLadderMount(HasWall, clickedFace: 5));
+        Assert.Equal(2, PropShapes.DeriveLadderMount(HasWall, clickedFace: -1));
+
+        // A clicked face with no wall behind it (aiming at the floor, or at a glass pane) falls back to the
+        // scan order rather than hanging the plate on nothing.
+        Assert.Equal(2, PropShapes.DeriveLadderMount(HasWall, clickedFace: 4));
+        Assert.Equal(2, PropShapes.DeriveLadderMount(HasWall, clickedFace: 0));
+
+        // No wall at all → free-standing, whatever was clicked.
+        Assert.Equal(ShapeCode.UpPlusY, PropShapes.DeriveLadderMount(_ => false, clickedFace: 3));
+        Assert.Equal(ShapeCode.UpPlusY, PropShapes.DeriveLadderMount(null!, clickedFace: 3));
+    }
+
+    [Fact]
+    public void ShapeCodeFaces_RoundTripBetweenIndexAndDirection()
+    {
+        for (int face = 0; face <= 5; face++)
+        {
+            var dir = ShapeCode.FaceDirection(face);
+            Assert.Equal(face, ShapeCode.FaceFromDirection(dir.X, dir.Y, dir.Z));
+            Assert.Equal(1, System.Math.Abs(dir.X) + System.Math.Abs(dir.Y) + System.Math.Abs(dir.Z));
+        }
+
+        Assert.Equal(-1, ShapeCode.FaceFromDirection(0, 0, 0));
+        Assert.Equal(-1, ShapeCode.FaceFromDirection(1, 1, 0)); // a diagonal is no block face
+        Assert.Equal(new[] { 2, 3, 4, 5 }, ShapeCode.WallFaces);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_root))
+            {
+                Directory.Delete(_root, recursive: true);
+            }
+        }
+        catch (IOException)
+        {
+            // A leftover temp world is no reason to fail a green test run.
+        }
+    }
+}


### PR DESCRIPTION
Three placement fixes that all ride the per-voxel shape descriptor already in place — **no wire, save or format change anywhere**.

## 1. Auto uses the face you clicked

`DeriveShapeUpFace` picked the surface a shape rests on by scanning neighbours in a fixed order (floor, −X, +X, −Z, +Z, ceiling), so building a ramp into a corner landed on whichever neighbour that order reached first. The client now answers the Auto question itself (`PendingPlacement`) and sends the result: **floor first as before, then the wall under the crosshair, then the old scan order**. `AimTarget` already returns the aimed cell and the cell being filled, so the clicked face is just their difference.

The server keeps its own derivation for intents that carry no up-face (older clients, its own internal placements), so nothing depends on the client sending one. A useful side effect: the ghost and the placed block are now computed by the same function, so the preview cannot disagree with the result.

Extending a floor by clicking the side of the last slab still lays the next one flat — the floor keeps winning over the clicked wall.

## 2. A ladder keeps the wall it was given

A placed ladder stored **no form at all**: `ladder` is neither shapeable nor furniture, so `HandlePlace` wrote descriptor `0` and the client re-invented the look on every mesh rebuild (`LadderMountUpFace`: first solid horizontal neighbour, else a pole). That meant ladders hugged a different wall than the one you aimed at, free-standing columns silently became poles, and mining a wall next to a ladder flipped the whole column.

Placement now stamps the real form — `Panel` + mount face, or `Post` for free-standing — and the mesher prefers it, falling back to the old heuristic when the descriptor is `0`. **Ladders in existing saves, in settlements and in ship layouts therefore behave exactly as they do today**; only newly placed ones are pinned.

The rotate key gets a ladder-sized cycle: **Auto → the four walls → free-standing → Auto**. The generic 24-state walk would have offered four identical quarter turns (its plate is a square `Panel`) and two up-faces a ladder has no use for.

Small bonus: because a stamped ladder is no longer a "cube" to the neighbour face-culling, the wall behind it stops being culled away.

## 3. The crafted staircase is a staircase

`stairs` placed as a plain solid cube even though `BlockShape.Stairs` has been fully implemented for shaped materials for a long time. It is now stamped like a prop: step geometry, a matching stepped collider, and **R** turns it or tips it upside down. Nothing in worldgen or the layout data places `stairs`, so this only affects player builds; blocks placed before this stay cubes until re-placed.

## Drop-strip fix

`BreakBlockAt` stripped a server-stamped form only when it equalled *the one* default for that block key. With the ladder's two forms, the pole variant would have dropped as its own item key, split the inventory stack, and then placed as a plate anyway (the ladder item is not shapeable, so a shape suffix on it is ignored at place time). The rule now asks `PropShapes.IsStampedForm`.

## Shape of the change

`FurnitureShapes` → `PropShapes` (furniture, ladder and stairs share the same stamp path) with a `PropOrientation` per prop — `YawOnly` / `Full` / `LadderMount` — so the client's rotate cycle can only ever offer what the server honours. `ShapeCode` gains `FaceDirection` / `FaceFromDirection` / `WallFaces`, and the ladder's Auto rule lives in one shared function that server, ghost and mesher all call.

## Verification

- `dotnet test` fast tier: **1618 server + 187 client tests pass**, including 7 new ones in `LadderStairsOrientationTests` (mount stamping, free-standing, drop stacking, stairs geometry + tipping, the prop table, clicked-wall preference, face round-trips).
- Release build: 0 warnings.
- Local Unity Windows build: 0 errors, no generated files to commit.
- Playtest still pending (kid-test on the ladder cycle).

Closes #909

🤖 Generated with [Claude Code](https://claude.com/claude-code)
