### PR TITLE
fix(client): the space HUD cargo readout no longer overprints the hull bar

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -104,6 +104,25 @@ Per-item detail lives in the dated work log below. **Since 2026-07 versions are 
 
 ---
 
+### ★ Space HUD: the cargo readout stopped overprinting the hull bar (#915, 2026-08-10, branch fix/space-hud-cargo-overlap)
+The flight view's top-left `Cargo: N` label was drawn straight across the on-foot HUD's **Hull** bar (and
+`O₂: n%` did the same on an EVA). The two live on **different canvases** — `SpaceView`'s overlay at
+`sortingOrder 12` over `HudUi` at `10` — but both are built at the same 1536×864 reference with the same
+`Expand` mode and UI-scale divisor, so they share one coordinate space and the overlay's text wins the
+depth test. The label sat at a hard-coded `y = -160`, which is exactly where the vitals panel's content ends
+**on foot**; `RefreshVitals` appends the hull + shield rows and grows the panel from 116 to 196 px whenever
+`ShipCombat != null` — precisely the space-flight state — so the first appended row landed in the reserved
+slot. Guaranteed in flight, impossible on foot, which is why it survived so long.
+**Fix, two parts.** `HudUi` now publishes its live panel edge as `VitalsBottomY` and `SpaceView` parks the
+readout below it every frame, so the label follows whatever rows the panel is showing instead of assuming a
+fixed edge — the bug class is gone, not just this instance. And the hull/shield bars now **hide while
+piloting**, where they merely repeat the bottom-left instrument line, matching what the compass and the
+time-of-day panel already do. Because those bars also carried the low-vitals blink and beep, the instrument
+line took over the alarm: `HULL`/`SHD` blink red below 10 % (clearing at 15 %, the panel's own hysteresis)
+and drive the same 2.5 s `vitals_warning` cue — now skipping a system the ship doesn't have, so a
+shield-less hull no longer alarms forever. Clears the "known pre-existing wart" noted under the screenshot
+work below.
+
 ### ★ Every species gets its own voice: phrase, cadence, timbre — and the combat cues too (#901–#907, 2026-08-10, branch feat/creature-voice-genome)
 Generated species differed enormously by sight and barely at all by ear, because **the voice was not a
 generated trait**: the client picked `pool[hash(speciesId) % poolLength]` plus a pitch multiplier — and
@@ -320,7 +339,8 @@ locale fix):
 - **Space shot aims at the home planet**: new `SpaceView.CaptureAimAtNearestBody()` snaps flight
   yaw+pitch toward the nearest landable body, so `space_flight.png` shows ship + ringed planet instead
   of empty starfield (fixed `FlightHeading` stays as the no-bodies fallback).
-- Known pre-existing wart (unchanged): the space HUD "Cargo: N" label overlaps the Hull bar.
+- Known pre-existing wart (noted here, since **fixed** — see the #915 entry above): the space HUD
+  "Cargo: N" label overlapped the Hull bar.
 docs/screenshots/README.md documents the sandbox mode, the lava seed and the single-language-reshoot
 gotcha (reused save resumes on foot; a wandered creature can block the frame — delete the save).
 

--- a/TODO.md
+++ b/TODO.md
@@ -113,14 +113,18 @@ depth test. The label sat at a hard-coded `y = -160`, which is exactly where the
 **on foot**; `RefreshVitals` appends the hull + shield rows and grows the panel from 116 to 196 px whenever
 `ShipCombat != null` — precisely the space-flight state — so the first appended row landed in the reserved
 slot. Guaranteed in flight, impossible on foot, which is why it survived so long.
-**Fix, two parts.** `HudUi` now publishes its live panel edge as `VitalsBottomY` and `SpaceView` parks the
-readout below it every frame, so the label follows whatever rows the panel is showing instead of assuming a
-fixed edge — the bug class is gone, not just this instance. And the hull/shield bars now **hide while
-piloting**, where they merely repeat the bottom-left instrument line, matching what the compass and the
-time-of-day panel already do. Because those bars also carried the low-vitals blink and beep, the instrument
-line took over the alarm: `HULL`/`SHD` blink red below 10 % (clearing at 15 %, the panel's own hysteresis)
-and drive the same 2.5 s `vitals_warning` cue — now skipping a system the ship doesn't have, so a
-shield-less hull no longer alarms forever. Clears the "known pre-existing wart" noted under the screenshot
+**Fix, two parts.** `HudUi` now publishes its live panel edge as `VitalsBottomY` and `SpaceView` parks its
+readout below it every frame, so the block follows whatever rows the panel is showing instead of assuming a
+fixed edge — the bug class is gone, not just this instance. And **hull + shield moved into the flight HUD**
+as real gauges: the vitals panel drops its ship rows while piloting (the same step-aside the compass and the
+time-of-day panel already make), and the flight view draws its own hull/shield bars under the cargo line, in
+the same column as the suit's bars so the two read as one stack. A pilot gets the fill back — `HULL 240`
+alone never said 240 *of what* — and the numbers stay, printed on the bars. The old duplicate `HULL/SHD`
+text is gone from the instrument line, which is back to `SPD/THR/HDG`. The bars inherit the panel's warning
+behaviour (blink toward red below 10 %, clearing at 15 %, plus the 2.5 s `vitals_warning` cue) and add a
+guard the panel lacked: a system the ship doesn't *have* (`Max == 0`) never alarms, so a shield-less ship
+stops screaming. On an EVA nothing changes — the panel keeps its rows there, because the flight instruments
+are hidden and it is the only hull readout. Clears the "known pre-existing wart" noted under the screenshot
 work below.
 
 ### ★ Every species gets its own voice: phrase, cadence, timbre — and the combat cues too (#901–#907, 2026-08-10, branch feat/creature-voice-genome)

--- a/client/Assets/BlocksBeyondTheStars/Scripts/HudUi.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/HudUi.cs
@@ -30,6 +30,19 @@ namespace BlocksBeyondTheStars.Client
         // objective chip 594…642 — see VegaPanel), so this panel starts at 650 (#482).
         private const float ScanPanelY = 650f, ScanPanelW = 390f, ScanPanelH = 182f;
 
+        // Vitals panel (top-left, under the location panel), in HUD reference units. Its HEIGHT VARIES:
+        // the ship rows (hull/shield) are appended only in the states that have them, so anything parked
+        // below it must read VitalsBottomY rather than assume a fixed edge (#915).
+        private const float VitalsPanelY = 64f;
+
+        /// <summary>Bottom edge of the vitals panel in HUD reference coordinates (y down from the top),
+        /// republished on every refresh. The space-flight overlay is a SEPARATE canvas drawn above this
+        /// one, but at the same reference resolution — it parks its cargo/oxygen readout below this edge
+        /// so the two can't overprint each other whichever rows the panel is currently showing (#915).
+        /// The initial value is the tallest the panel ever gets, so a reader that runs before the first
+        /// refresh still clears it.</summary>
+        public static float VitalsBottomY { get; private set; } = VitalsPanelY + 196f;
+
         /// <summary>How long a scan readout lingers once the scanner is put away. Was 12 s — long enough to
         /// read the old one-liner, not the fuller readout (#482). While the scanner is still the held item
         /// the panel stays pinned regardless (see <see cref="RefreshScan"/>).</summary>
@@ -456,7 +469,7 @@ namespace BlocksBeyondTheStars.Client
             _locPlace = UiKit.AddText(_locationPanel.transform, 10, 22, 260, 18, string.Empty, 14, UiKit.TextCol, TextAnchor.MiddleLeft);
 
             // Vitals panel (6 rows; ship rows toggled).
-            _vitalsPanel = Panel(root, 10, 64, 226, 196).gameObject;
+            _vitalsPanel = Panel(root, 10, VitalsPanelY, 226, 196).gameObject;
             _vitals = new VitalRow[6];
             string[] order = { "health", "oxygen", "energy", "hunger", "hull", "shield" };
             for (int i = 0; i < 6; i++)
@@ -674,7 +687,13 @@ namespace BlocksBeyondTheStars.Client
             SetVital(2, loc.Get("ui.hud.energy"), Game.SuitEnergy, Game.SuitEnergy / 100f,
                 Game.SuitClimateActive ? EnergyStressed : Energy, true);
             SetVital(3, loc.Get("ui.hud.hunger"), Game.Hunger, Game.Hunger / 100f, Hunger, true);
-            bool ship = Game.ShipCombat != null;
+            // Ship rows (hull/shield) exist whenever the player owns a ship in combat range — but while
+            // PILOTING they repeat the flight instrument line (SPD/THR/HDG + HULL/SHD, bottom-left), so
+            // hide them there, exactly as the compass and the time-of-day panel already do (#915). On an
+            // EVA the instrument line is hidden (it needs !_eva), so these bars are the only hull readout
+            // and must stay.
+            bool piloting = Game.SpaceViewActive && !Game.InEva;
+            bool ship = Game.ShipCombat != null && !piloting;
             if (ship)
             {
                 var c = Game.ShipCombat;
@@ -687,7 +706,9 @@ namespace BlocksBeyondTheStars.Client
                 SetVital(5, null, 0, 0, ShieldC, false);
             }
 
-            _vitalsPanel.GetComponent<RectTransform>().sizeDelta = new Vector2(226, ship ? 196 : 116);
+            float vitalsHeight = ship ? 196f : 116f;
+            _vitalsPanel.GetComponent<RectTransform>().sizeDelta = new Vector2(226, vitalsHeight);
+            VitalsBottomY = VitalsPanelY + vitalsHeight;
 
             RefreshHotbar(loc);
             RefreshTimeOfDay(loc);

--- a/client/Assets/BlocksBeyondTheStars/Scripts/SpaceView.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/SpaceView.cs
@@ -3865,7 +3865,8 @@ namespace BlocksBeyondTheStars.Client
         private Text _hint;
         private Text _board;
         private Text _cargo;
-        private RectTransform _cargoRect;  // repositioned each frame — the HUD panel above it changes height
+        private RectTransform _shipStatus;  // repositioned each frame — the HUD panel above it changes height
+        private StatusBar _hullBar, _shieldBar;
         private Text _instruments;         // flight readout: speed / throttle / heading (+ hull/shield)
         private Vector3 _instLastCamPos;
         private float _instSpeed;          // smoothed speed for a steady readout
@@ -4033,17 +4034,21 @@ namespace BlocksBeyondTheStars.Client
             _board.raycastTarget = false;
             _board.gameObject.SetActive(false);
 
-            // Cargo readout (top-left), pulses when salvage is tractored in. Its y is NOT fixed: it trails
-            // the on-foot HUD's vitals panel, which lives on a lower canvas at the same reference
-            // resolution and changes height with the rows it shows (see PositionCargoReadout, #915).
+            // Ship status block (top-left): the cargo readout, then the hull and shield bars. Its y is NOT
+            // fixed — it trails the on-foot HUD's vitals panel, which lives on a lower canvas at the same
+            // reference resolution and changes height with the rows it shows (PositionShipStatus, #915).
+            var statusGo = new GameObject("ShipStatus", typeof(RectTransform));
+            statusGo.transform.SetParent(_ui.transform, false);
+            _shipStatus = statusGo.GetComponent<RectTransform>();
+            _shipStatus.anchorMin = _shipStatus.anchorMax = new Vector2(0f, 1f);
+            _shipStatus.pivot = new Vector2(0f, 1f);
+            _shipStatus.sizeDelta = new Vector2(StatusWidth, 82f);
+            PositionShipStatus();
+
+            // Cargo readout, pulses when salvage is tractored in.
             var cargoGo = new GameObject("Cargo", typeof(RectTransform));
-            cargoGo.transform.SetParent(_ui.transform, false);
-            var crt = cargoGo.GetComponent<RectTransform>();
-            crt.anchorMin = crt.anchorMax = new Vector2(0f, 1f);
-            crt.pivot = new Vector2(0f, 1f);
-            crt.sizeDelta = new Vector2(320f, 26f);
-            _cargoRect = crt;
-            PositionCargoReadout();
+            cargoGo.transform.SetParent(_shipStatus, false);
+            UiKit.Place(cargoGo, 0f, 0f, StatusWidth, 26f);
             _cargo = cargoGo.AddComponent<Text>();
             _cargo.font = UiKit.Font;
             _cargo.fontSize = 18;
@@ -4052,7 +4057,14 @@ namespace BlocksBeyondTheStars.Client
             _cargo.horizontalOverflow = HorizontalWrapMode.Overflow;
             _cargo.raycastTarget = false;
 
-            // Flight instruments (bottom-left): smoothed speed, throttle, heading + hull/shield.
+            // Hull + shield as BARS, directly under the suit's own bars and in the same column — a pilot
+            // reads "how much is left" off a fill, not off a number. The flight view owns them while
+            // piloting, because the vitals panel's hull/shield rows step aside then (#915). Hidden on an
+            // EVA, where that panel shows them again.
+            _hullBar = MakeStatusBar(_shipStatus, 30f, "HULL", HullBarCol);
+            _shieldBar = MakeStatusBar(_shipStatus, 56f, "SHD", ShieldBarCol);
+
+            // Flight instruments (bottom-left): smoothed speed, throttle, heading.
             // Avionics-style abbreviations (SPD/THR/HDG) — identical in DE and EN cockpits.
             var instGo = new GameObject("Instruments", typeof(RectTransform));
             instGo.transform.SetParent(_ui.transform, false);
@@ -4193,8 +4205,8 @@ namespace BlocksBeyondTheStars.Client
             _hit.color = new Color(1f, 0.2f, 0.2f, _hitFlash * 0.35f);
 
             // The vitals panel under us sheds its ship rows the moment we take the helm, so re-park the
-            // readout every frame rather than only on entry (#915).
-            PositionCargoReadout();
+            // status block every frame rather than only on entry (#915).
+            PositionShipStatus();
 
             if (_phase != Phase.Cruise)
             {
@@ -4332,6 +4344,7 @@ namespace BlocksBeyondTheStars.Client
             }
 
             UpdateInstruments();
+            UpdateShipBars();
 
             // Lens flare only during free flight (hidden behind the launch/landing/boarding fades + EVA).
             if (_phase == Phase.Cruise && !_eva)
@@ -4504,7 +4517,7 @@ namespace BlocksBeyondTheStars.Client
 
         /// <summary>Flight instruments: smoothed speed (camera delta — the camera rides the ship),
         /// throttle, heading, plus hull/shield while combat data is present. Shown in cruise only.</summary>
-        /// <summary>Parks the cargo/oxygen readout just below the on-foot HUD's vitals panel.
+        /// <summary>Parks the ship-status block just below the on-foot HUD's vitals panel.
         ///
         /// That panel belongs to <see cref="HudUi"/> — a DIFFERENT canvas, drawn under this overlay
         /// (sortingOrder 10 vs 12) but built at the same reference resolution, so the two share one
@@ -4512,18 +4525,98 @@ namespace BlocksBeyondTheStars.Client
         /// used to sit at a hard-coded y that cleared the panel as it looks ON FOOT; in flight the panel
         /// grows by its hull/shield rows and the label landed straight on the hull bar (#915). Reading the
         /// panel's live bottom edge instead means it follows whatever the panel is currently showing.</summary>
-        private void PositionCargoReadout()
+        private void PositionShipStatus()
         {
-            if (_cargoRect == null)
+            if (_shipStatus == null)
             {
                 return;
             }
 
             float y = -(HudUi.VitalsBottomY + ReadoutGap);
-            if (!Mathf.Approximately(_cargoRect.anchoredPosition.y, y))
+            if (!Mathf.Approximately(_shipStatus.anchoredPosition.y, y))
             {
-                _cargoRect.anchoredPosition = new Vector2(20f, y);
+                _shipStatus.anchoredPosition = new Vector2(20f, y);
             }
+        }
+
+        // A hull/shield gauge in the flight HUD: caption, track, fill and the raw value on top of it —
+        // the vitals panel's row style, so the ship's bars read as a continuation of the suit's.
+        private struct StatusBar
+        {
+            public GameObject Go;
+            public Image Fill;
+            public Text Value;
+        }
+
+        private const float StatusWidth = 320f;   // ship-status block width (the cargo line overflows freely)
+        private const float StatusBarWidth = 178f; // matches the vitals rows above, so the columns line up
+
+        private static readonly Color HullBarCol = new Color(0.6f, 0.66f, 0.74f);
+        private static readonly Color ShieldBarCol = new Color(0.4f, 0.7f, 1f);
+        private static readonly Color BarWarn = new Color(1f, 0.25f, 0.2f);
+
+        private static StatusBar MakeStatusBar(Transform parent, float y, string caption, Color color)
+        {
+            var go = new GameObject("Bar_" + caption, typeof(RectTransform));
+            go.transform.SetParent(parent, false);
+            UiKit.Place(go, 0f, y, StatusWidth, 20f);
+            UiKit.AddText(go.transform, 0f, 2f, 44f, 16f, caption, 13, UiKit.Cyan, TextAnchor.MiddleLeft, FontStyle.Bold);
+            UiKit.AddImage(go.transform, 46f, 2f, StatusBarWidth, 16f, UiKit.SolidSprite, new Color(0.03f, 0.07f, 0.13f, 0.9f));
+            var fill = UiKit.AddImage(go.transform, 46f, 2f, StatusBarWidth, 16f, UiKit.SolidSprite, color);
+            fill.type = Image.Type.Filled;
+            fill.fillMethod = Image.FillMethod.Horizontal;
+            var value = UiKit.AddText(go.transform, 52f, 2f, StatusBarWidth - 12f, 16f, string.Empty, 12,
+                UiKit.TextCol, TextAnchor.MiddleLeft, FontStyle.Bold);
+            return new StatusBar { Go = go, Fill = fill, Value = value };
+        }
+
+        /// <summary>Drives one gauge. A system in the warning band blinks toward red on the same curve the
+        /// vitals rows use, so the cue is the one the player already learned on foot.</summary>
+        private static void SetStatusBar(StatusBar bar, float frac, float value, Color baseColor, bool warn)
+        {
+            if (bar.Fill == null)
+            {
+                return;
+            }
+
+            bar.Fill.fillAmount = Mathf.Clamp01(frac);
+            bar.Value.text = Mathf.CeilToInt(value).ToString();
+            float k = UiKit.ReducedMotion ? 1f : Mathf.PingPong(Time.time * 2.4f, 1f);
+            bar.Fill.color = warn ? Color.Lerp(baseColor, BarWarn, 0.35f + 0.65f * k) : baseColor;
+        }
+
+        /// <summary>Updates the hull/shield gauges and their alarm. Shown only while actually piloting: on
+        /// an EVA (and during the launch/landing sequences) the on-foot vitals panel carries hull + shield
+        /// itself, and two copies of the same bar is what this whole change is undoing (#915).</summary>
+        private void UpdateShipBars()
+        {
+            var combat = Game?.ShipCombat;
+            bool show = _phase == Phase.Cruise && !_eva && combat != null;
+            if (_hullBar.Go != null && _hullBar.Go.activeSelf != show)
+            {
+                _hullBar.Go.SetActive(show);
+                _shieldBar.Go.SetActive(show);
+            }
+
+            if (!show)
+            {
+                _hullWarn = _shieldWarn = false;
+                _hullBeepTimer = 0f;
+                return;
+            }
+
+            // Same thresholds as the vitals panel (#753): trips below 10 %, clears above 15 %, so a value
+            // sitting on the edge can't flicker the alarm on and off. Unlike the panel these skip a system
+            // the ship doesn't HAVE (Max 0) — a shieldless hull would otherwise alarm forever.
+            bool alive = Game != null && Game.Health > 0f;
+            float hullFrac = combat.HullMax > 0f ? combat.Hull / combat.HullMax : 0f;
+            float shieldFrac = combat.ShieldMax > 0f ? combat.Shield / combat.ShieldMax : 0f;
+            _hullWarn = alive && combat.HullMax > 0f && hullFrac < (_hullWarn ? 0.15f : 0.10f);
+            _shieldWarn = alive && combat.ShieldMax > 0f && shieldFrac < (_shieldWarn ? 0.15f : 0.10f);
+
+            SetStatusBar(_hullBar, hullFrac, combat.Hull, HullBarCol, _hullWarn);
+            SetStatusBar(_shieldBar, shieldFrac, combat.Shield, ShieldBarCol, _shieldWarn);
+            UpdateHullAlarm(Mathf.Max(Time.deltaTime, 1e-4f));
         }
 
         private void UpdateInstruments()
@@ -4551,53 +4644,15 @@ namespace BlocksBeyondTheStars.Client
 
             int thr = Mathf.RoundToInt(Mathf.Clamp01(InputMap.MoveY()) * 100f);
             int hdg = Mathf.RoundToInt(Mathf.Repeat(_yaw, 360f));
-            string text = $"SPD {_instSpeed:0.0}   THR {thr}%   HDG {hdg:000}°";
-            var combat = Game?.ShipCombat;
-            if (combat != null)
-            {
-                bool alive = Game != null && Game.Health > 0f;
-                _hullWarn = alive && combat.HullMax > 0f && combat.Hull / combat.HullMax < (_hullWarn ? 0.15f : 0.10f);
-                _shieldWarn = alive && combat.ShieldMax > 0f && combat.Shield / combat.ShieldMax < (_shieldWarn ? 0.15f : 0.10f);
-                text += $"   {WarnTint($"HULL {Mathf.CeilToInt(combat.Hull)}", _hullWarn)}"
-                      + $"   {WarnTint($"SHD {Mathf.CeilToInt(combat.Shield)}", _shieldWarn)}";
-                UpdateHullAlarm(dt);
-            }
-            else
-            {
-                _hullWarn = _shieldWarn = false;
-                _hullBeepTimer = 0f;
-            }
-
-            _instruments.text = text;
+            // Hull/shield are NOT repeated here — they're gauges in the ship-status block now (#915).
+            _instruments.text = $"SPD {_instSpeed:0.0}   THR {thr}%   HDG {hdg:000}°";
         }
 
-        // Low hull/shield alarm, carried by the instrument line. The vitals panel's hull + shield bars are
-        // hidden while piloting because this line already prints the same numbers (#915) — and their blink
-        // and beep went with them, so the readout that replaced them has to raise the alarm itself. Same
-        // thresholds as the panel (#753): trips below 10 %, clears above 15 %, so a value sitting on the
-        // edge can't flicker the alarm on and off. Unlike the panel these skip a MISSING system (Max 0) —
-        // a ship with no shield module would otherwise alarm forever.
         private bool _hullWarn, _shieldWarn;
         private float _hullBeepTimer;
 
-        private static readonly Color InstrumentWarn = new Color(1f, 0.25f, 0.2f);
-
-        /// <summary>Wraps an instrument token in a blinking red tint while its system is critical. Rich text
-        /// (the HUD's established idiom for a coloured value); steady red under reduced motion.</summary>
-        private static string WarnTint(string token, bool warn)
-        {
-            if (!warn)
-            {
-                return token;
-            }
-
-            float k = UiKit.ReducedMotion ? 1f : Mathf.PingPong(Time.time * 2.4f, 1f);
-            var c = Color.Lerp(UiKit.TextCol, InstrumentWarn, 0.35f + 0.65f * k);
-            return $"<color=#{ColorUtility.ToHtmlStringRGB(c)}>{token}</color>";
-        }
-
-        /// <summary>Drives the shared low-systems beep at the vitals panel's cadence, so losing the hull bar
-        /// while piloting doesn't cost the audible warning too.</summary>
+        /// <summary>Drives the low-systems beep at the vitals panel's cadence, so the ship gauges warn by
+        /// ear exactly like the suit bars they replace while piloting.</summary>
         private void UpdateHullAlarm(float dt)
         {
             if (!_hullWarn && !_shieldWarn)

--- a/client/Assets/BlocksBeyondTheStars/Scripts/SpaceView.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/SpaceView.cs
@@ -3865,6 +3865,7 @@ namespace BlocksBeyondTheStars.Client
         private Text _hint;
         private Text _board;
         private Text _cargo;
+        private RectTransform _cargoRect;  // repositioned each frame — the HUD panel above it changes height
         private Text _instruments;         // flight readout: speed / throttle / heading (+ hull/shield)
         private Vector3 _instLastCamPos;
         private float _instSpeed;          // smoothed speed for a steady readout
@@ -3962,6 +3963,7 @@ namespace BlocksBeyondTheStars.Client
                                                      // clusters at the same transform, #683)
         private const float KeepOutMargin = 10f;     // how far outside a body's surface the ship is held
         private const float LandBand = 40f;          // land prompt shows within (body radius + margin + band)
+        private const float ReadoutGap = 10f;        // breathing room between the vitals panel and the cargo readout
 
         private void EnsureUi()
         {
@@ -4031,14 +4033,17 @@ namespace BlocksBeyondTheStars.Client
             _board.raycastTarget = false;
             _board.gameObject.SetActive(false);
 
-            // Cargo readout (top-left), pulses when salvage is tractored in.
+            // Cargo readout (top-left), pulses when salvage is tractored in. Its y is NOT fixed: it trails
+            // the on-foot HUD's vitals panel, which lives on a lower canvas at the same reference
+            // resolution and changes height with the rows it shows (see PositionCargoReadout, #915).
             var cargoGo = new GameObject("Cargo", typeof(RectTransform));
             cargoGo.transform.SetParent(_ui.transform, false);
             var crt = cargoGo.GetComponent<RectTransform>();
             crt.anchorMin = crt.anchorMax = new Vector2(0f, 1f);
             crt.pivot = new Vector2(0f, 1f);
             crt.sizeDelta = new Vector2(320f, 26f);
-            crt.anchoredPosition = new Vector2(20f, -160f);
+            _cargoRect = crt;
+            PositionCargoReadout();
             _cargo = cargoGo.AddComponent<Text>();
             _cargo.font = UiKit.Font;
             _cargo.fontSize = 18;
@@ -4186,6 +4191,10 @@ namespace BlocksBeyondTheStars.Client
             _hitFlash = Mathf.Max(0f, _hitFlash - Time.deltaTime * 2f);
             _cargoFlash = Mathf.Max(0f, _cargoFlash - Time.deltaTime * 1.5f);
             _hit.color = new Color(1f, 0.2f, 0.2f, _hitFlash * 0.35f);
+
+            // The vitals panel under us sheds its ship rows the moment we take the helm, so re-park the
+            // readout every frame rather than only on entry (#915).
+            PositionCargoReadout();
 
             if (_phase != Phase.Cruise)
             {
@@ -4495,6 +4504,28 @@ namespace BlocksBeyondTheStars.Client
 
         /// <summary>Flight instruments: smoothed speed (camera delta — the camera rides the ship),
         /// throttle, heading, plus hull/shield while combat data is present. Shown in cruise only.</summary>
+        /// <summary>Parks the cargo/oxygen readout just below the on-foot HUD's vitals panel.
+        ///
+        /// That panel belongs to <see cref="HudUi"/> — a DIFFERENT canvas, drawn under this overlay
+        /// (sortingOrder 10 vs 12) but built at the same reference resolution, so the two share one
+        /// coordinate space and this overlay's text wins the depth test wherever they meet. The readout
+        /// used to sit at a hard-coded y that cleared the panel as it looks ON FOOT; in flight the panel
+        /// grows by its hull/shield rows and the label landed straight on the hull bar (#915). Reading the
+        /// panel's live bottom edge instead means it follows whatever the panel is currently showing.</summary>
+        private void PositionCargoReadout()
+        {
+            if (_cargoRect == null)
+            {
+                return;
+            }
+
+            float y = -(HudUi.VitalsBottomY + ReadoutGap);
+            if (!Mathf.Approximately(_cargoRect.anchoredPosition.y, y))
+            {
+                _cargoRect.anchoredPosition = new Vector2(20f, y);
+            }
+        }
+
         private void UpdateInstruments()
         {
             if (_instruments == null)
@@ -4524,10 +4555,63 @@ namespace BlocksBeyondTheStars.Client
             var combat = Game?.ShipCombat;
             if (combat != null)
             {
-                text += $"   HULL {Mathf.CeilToInt(combat.Hull)}   SHD {Mathf.CeilToInt(combat.Shield)}";
+                bool alive = Game != null && Game.Health > 0f;
+                _hullWarn = alive && combat.HullMax > 0f && combat.Hull / combat.HullMax < (_hullWarn ? 0.15f : 0.10f);
+                _shieldWarn = alive && combat.ShieldMax > 0f && combat.Shield / combat.ShieldMax < (_shieldWarn ? 0.15f : 0.10f);
+                text += $"   {WarnTint($"HULL {Mathf.CeilToInt(combat.Hull)}", _hullWarn)}"
+                      + $"   {WarnTint($"SHD {Mathf.CeilToInt(combat.Shield)}", _shieldWarn)}";
+                UpdateHullAlarm(dt);
+            }
+            else
+            {
+                _hullWarn = _shieldWarn = false;
+                _hullBeepTimer = 0f;
             }
 
             _instruments.text = text;
+        }
+
+        // Low hull/shield alarm, carried by the instrument line. The vitals panel's hull + shield bars are
+        // hidden while piloting because this line already prints the same numbers (#915) — and their blink
+        // and beep went with them, so the readout that replaced them has to raise the alarm itself. Same
+        // thresholds as the panel (#753): trips below 10 %, clears above 15 %, so a value sitting on the
+        // edge can't flicker the alarm on and off. Unlike the panel these skip a MISSING system (Max 0) —
+        // a ship with no shield module would otherwise alarm forever.
+        private bool _hullWarn, _shieldWarn;
+        private float _hullBeepTimer;
+
+        private static readonly Color InstrumentWarn = new Color(1f, 0.25f, 0.2f);
+
+        /// <summary>Wraps an instrument token in a blinking red tint while its system is critical. Rich text
+        /// (the HUD's established idiom for a coloured value); steady red under reduced motion.</summary>
+        private static string WarnTint(string token, bool warn)
+        {
+            if (!warn)
+            {
+                return token;
+            }
+
+            float k = UiKit.ReducedMotion ? 1f : Mathf.PingPong(Time.time * 2.4f, 1f);
+            var c = Color.Lerp(UiKit.TextCol, InstrumentWarn, 0.35f + 0.65f * k);
+            return $"<color=#{ColorUtility.ToHtmlStringRGB(c)}>{token}</color>";
+        }
+
+        /// <summary>Drives the shared low-systems beep at the vitals panel's cadence, so losing the hull bar
+        /// while piloting doesn't cost the audible warning too.</summary>
+        private void UpdateHullAlarm(float dt)
+        {
+            if (!_hullWarn && !_shieldWarn)
+            {
+                _hullBeepTimer = 0f; // first beep fires immediately when a system next runs low
+                return;
+            }
+
+            _hullBeepTimer -= dt;
+            if (_hullBeepTimer <= 0f)
+            {
+                _hullBeepTimer = 2.5f;
+                ClientAudio.Instance?.Cue("vitals_warning", 0.5f);
+            }
         }
 
         private void OnDestroy()


### PR DESCRIPTION
The flight view's top-left `Cargo: N` label was drawn straight across the on-foot HUD's **Hull** bar,
and `O₂: n%` did the same during an EVA.

## Why

The two live on **different canvases** — `SpaceView`'s overlay at `sortingOrder 12` over `HudUi` at
`10` — but both are built at the same 1536×864 reference with the same `Expand` mode and UI-scale
divisor, so they share one coordinate space and the overlay's text wins the depth test:

| Element | Rect (y down from the top) |
|---|---|
| Cargo readout — `anchoredPosition (20, -160)`, 320×26 | y **160 … 186** |
| Hull row — vitals index 4 (panel at y 64, rows at local `8 + i*24`, h 16) | y **168 … 184** |

`y = -160` is exactly where the vitals panel's content ends **on foot** — the label was positioned to
clear the panel in that state. But `RefreshVitals` appends the hull + shield rows and grows the panel
from 116 to 196 px whenever `ShipCombat != null`, which is precisely the space-flight state, so the
first appended row landed in the reserved slot. Guaranteed in flight, impossible on foot — which is
why it survived so long.

## What changed

**The readout follows the panel instead of guessing.** `HudUi` publishes its live bottom edge as
`VitalsBottomY`; `SpaceView.PositionShipStatus()` parks its block below that every frame. Whatever rows
the panel shows in future, the block clears them — the bug class is gone, not just this instance.

**Hull and shield moved into the flight HUD as real gauges.** The vitals panel drops its ship rows
while piloting — the same step-aside the compass and the time-of-day panel already make — and the
flight view draws its own hull/shield bars under the cargo line, in the same column and row style as
the suit's bars, so the two read as one stack. The pilot keeps the *fill* (`HULL 240` alone never said
240 *of what*) and the numbers, which are printed on the bars. The duplicate `HULL/SHD` text is gone
from the instrument line, which is back to `SPD/THR/HDG`.

Bottom-left was not an option for the bars: the on-foot scan panel owns that band (y 650…832) and can
be up in flight, so putting them there would have recreated this very overlap.

**The gauges inherit the alarm.** The vitals rows carried the low-vitals blink and beep, so dropping
them in flight would have silently removed the low-hull warning exactly where hull matters most —
`SpaceView` has no low-hull alarm of its own, only a hit flash. The bars blink toward red below 10 %
(clearing at 15 % — the panel's own hysteresis) and drive the same 2.5 s `vitals_warning` cue, plus a
guard the panel lacked: a system the ship doesn't *have* (`Max == 0`) never alarms, so a shield-less
ship stops screaming.

**EVA is unchanged** — the vitals panel keeps hull and shield there, since the flight instruments are
hidden on a spacewalk and it is the only hull readout.

## Verification

- `dotnet build -c Release` — **0 warnings, 0 errors**
- `dotnet test -c Release --filter Category!=Slow` — **1657 server + 195 client passing**
- Local Unity Windows build (twice, once per iteration) — compiles, nothing generated left uncommitted;
  PR CI never builds Unity

Playtest still worth a look: the status block vs. the vitals panel in flight, the `O₂` line on an EVA,
and a low-hull run to see the bars blink and hear the cue.

closes #915
