### PR TITLE
Long button labels stay inside their frames (Best Fit never constrained the width)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,13 @@ the richer, screenshot-laden versions live there. `(#123)` references the pull r
 
   ⚠ Multiplayer: client and server must both be on this version (protocol 3).
 
+### 🔤 Long button labels stay inside their buttons (#918)
+
+- A localized label that is wider than its button — German "Farbe aufnehmen" in the paint editor,
+  and others across the menus — used to run past the button's frame. Labels now shrink to fit, which
+  is what they were always meant to do; menu tabs, the sidebar headings and the touch controls get
+  the same treatment. Text that already fits looks exactly as before.
+
 ## [2026.8.10] — 2026-08-10
 
 The polyglot release. In one week the game went from four languages to **fourteen** — Dutch,

--- a/TODO.md
+++ b/TODO.md
@@ -186,6 +186,16 @@ snow a *player* placed. New `weather_scanner` gadget + forecast messages read th
 Client: extrapolated intensity/wind (no more 5 s staircase), lightning that lights the **terrain**,
 thunder delayed by distance, a HUD weather chip, 7 new audio beds, 15 languages.
 
+### ★ Button labels stay inside their frames: Best Fit never constrained the width (#918, 2026-08-10, branch fix/button-label-fit-918)
+German "Farbe aufnehmen" hung out of its button in the paint editor — and it turned out **no** button
+label had ever been able to shrink horizontally. `UiKit.AddText` builds every label with
+`horizontalOverflow = Overflow`, and Unity's `TextGenerator` then treats the width as unbounded, so
+`resizeTextForBestFit` only ever scaled text to fit the HEIGHT. All three "shrink long labels" fixes
+(button B57, tab bar B28, touch controls) were quietly no-ops sideways. New shared
+`UiKit.FitLabel(label, min, max)` sets Wrap + Truncate alongside Best Fit, so the width is actually
+considered, and the three call sites go through it. The paint editor's tool row also got wider
+(200 px) so its long labels barely need to shrink; it stops at x=580 where the region tiles begin.
+
 ### ★ Paint editors: fill tool, findable eyedropper, 32-colour palette, one Appearance screen (#899, 2026-08-10, branch feat/paint-editor-tools)
 Every pixel editor (avatar face, the four body-paint parts, the block paint tool — all one `FaceEditor`)
 gained a **fill tool** (region-clamped flood fill; Shift = replace that colour everywhere in the region)

--- a/client/Assets/BlocksBeyondTheStars/Scripts/CraftingTechShipUI.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/CraftingTechShipUI.cs
@@ -483,13 +483,7 @@ namespace BlocksBeyondTheStars.Client
 
                 // Auto-fit the label so a long localized tab (e.g. German "Einstellungen") shrinks to fit the
                 // fixed-width button instead of spilling over its graphic (B28); short labels keep full size.
-                var lbl = b.GetComponentInChildren<Text>();
-                if (lbl != null)
-                {
-                    lbl.resizeTextForBestFit = true;
-                    lbl.resizeTextMaxSize = 22;
-                    lbl.resizeTextMinSize = 12;
-                }
+                UiKit.FitLabel(b.GetComponentInChildren<Text>(), 12, 22);
 
                 // Badge a tab that has new content waiting behind it: the Tech tab when research is affordable
                 // now, the Story tab when an unread beat/fragment/memory arrived. Cleared by opening the tab.
@@ -552,9 +546,7 @@ namespace BlocksBeyondTheStars.Client
                     }
 
                     var h = UiKit.AddText(_sidebar, 10, y, 270, 30, label, 17, UiKit.Cyan, TextAnchor.LowerLeft, FontStyle.Bold);
-                    h.resizeTextForBestFit = true;
-                    h.resizeTextMaxSize = 17;
-                    h.resizeTextMinSize = 11;
+                    UiKit.FitLabel(h, 11, 17);
                     y += 36f;
                     continue;
                 }

--- a/client/Assets/BlocksBeyondTheStars/Scripts/FaceEditor.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/FaceEditor.cs
@@ -521,10 +521,15 @@ namespace BlocksBeyondTheStars.Client
             UiKit.AddText(eraser.transform, 0f, 0f, swatch, swatch, "E", 15, UiKit.TextCol, TextAnchor.MiddleCenter, FontStyle.Bold);
 
             // Tool row: fill, eyedropper, undo — grouped so they read as a toolbox rather than as loose buttons.
+            // 200 wide because these carry the longest labels in the panel ("Farbe aufnehmen" in German, and
+            // longer still in Polish/Turkish): a label only auto-shrinks so far before it stops being readable
+            // at arm's length, so give it the room instead (#918).
             float toolsY = paletteLabelY + 32f + 3f * pitch + 12f;
-            _fillButton = UiKit.AddButton(panel, 24f, toolsY, 170f, 44f, L("ui.face.fill"), () => SetFilling(!_filling)).image;
-            _pickButton = UiKit.AddButton(panel, 204f, toolsY, 170f, 44f, L("ui.face.pick"), () => SetPicking(!_picking)).image;
-            UiKit.AddButton(panel, 384f, toolsY, 170f, 44f, L("ui.face.undo"), Undo);
+            // The row stops at x=580: that is where the region-tile column starts, and the helmet's fifth tile
+            // reaches down to this row's top edge.
+            _fillButton = UiKit.AddButton(panel, 24f, toolsY, 200f, 44f, L("ui.face.fill"), () => SetFilling(!_filling)).image;
+            _pickButton = UiKit.AddButton(panel, 232f, toolsY, 200f, 44f, L("ui.face.pick"), () => SetPicking(!_picking)).image;
+            UiKit.AddButton(panel, 440f, toolsY, 140f, 44f, L("ui.face.undo"), Undo);
 
             BuildColorWheel(panel, wide ? 900f : 470f, wide ? 300f : paletteLabelY + 8f);
             if (wide)

--- a/client/Assets/BlocksBeyondTheStars/Scripts/TouchControlsUi.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/TouchControlsUi.cs
@@ -355,9 +355,8 @@ namespace BlocksBeyondTheStars.Client
 
             var text = UiKit.AddText(rt, 0f, 0f, size, size, label, Mathf.RoundToInt(size * 0.24f),
                 new Color(0.9f, 0.97f, 1f, 0.95f), TextAnchor.MiddleCenter, FontStyle.Bold);
-            text.resizeTextForBestFit = true; // localized labels vary in length (e.g. DE "Tanken")
-            text.resizeTextMinSize = 10;
-            text.resizeTextMaxSize = Mathf.RoundToInt(size * 0.26f);
+            // Localized labels vary in length (e.g. DE "Tanken") — shrink to fit rather than spill.
+            UiKit.FitLabel(text, 10, Mathf.RoundToInt(size * 0.26f));
 
             return go.GetComponent<TouchButton>();
         }

--- a/client/Assets/BlocksBeyondTheStars/Scripts/UiKit.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/UiKit.cs
@@ -653,10 +653,35 @@ namespace BlocksBeyondTheStars.Client
             var labelText = AddText(go.transform, textX, 0f, w - textX - 10f, h, label, 22, TextCol, TextAnchor.MiddleLeft, FontStyle.Bold);
             // Shrink the label to fit its button so a longer word (e.g. German "Einstellungen"/"Schließen") never
             // spills out of the frame (B57); it stays at 22 when it fits and only scales down when it must.
-            labelText.resizeTextForBestFit = true;
-            labelText.resizeTextMinSize = 11;
-            labelText.resizeTextMaxSize = 22;
+            FitLabel(labelText, 11, 22);
             return btn;
+        }
+
+        /// <summary>
+        /// Makes a label shrink to fit its rect instead of running past it.
+        /// <para>
+        /// ⚠ <b>`resizeTextForBestFit` alone does not do this.</b> <see cref="AddText"/> builds every label with
+        /// <c>horizontalOverflow = Overflow</c>, and Unity's <c>TextGenerator</c> then treats the available
+        /// width as unbounded — so the Best Fit search only ever shrinks text to fit the HEIGHT, and a long
+        /// localized label keeps its full size and spills sideways out of the frame. Three separate "shrink
+        /// long labels" fixes (button B57, tab bar B28, touch controls) were all quietly no-ops horizontally
+        /// for that reason (#918: German "Farbe aufnehmen" hanging out of the paint editor's button).
+        /// </para>
+        /// Giving the text a width to wrap into is what makes Best Fit consider the width at all; truncating
+        /// vertically keeps it from growing a second line instead of scaling down.
+        /// </summary>
+        public static void FitLabel(Text label, int minSize, int maxSize)
+        {
+            if (label == null)
+            {
+                return;
+            }
+
+            label.horizontalOverflow = HorizontalWrapMode.Wrap;
+            label.verticalOverflow = VerticalWrapMode.Truncate;
+            label.resizeTextForBestFit = true;
+            label.resizeTextMinSize = minSize;
+            label.resizeTextMaxSize = maxSize;
         }
 
         /// <summary>Pins a small amber "new content" badge dot to the top-right corner of a freshly built button,


### PR DESCRIPTION
closes #918

Reported from the in-game paint editor: the German label **"Farbe aufnehmen"** hangs out of its
button frame.

## The actual cause

It is not that one button. **No button label had ever been able to shrink horizontally.**

`UiKit.AddButton` sets `resizeTextForBestFit` with a min/max range precisely so a long localized label
scales down instead of spilling (B57), and two other places do the same thing by hand (the menu tab
bar, B28; the touch controls). But `UiKit.AddText` — which builds every label — sets
`horizontalOverflow = HorizontalWrapMode.Overflow`, and Unity's `TextGenerator` then treats the
available width as unbounded. The Best Fit search therefore only ever shrank text to fit the
**height**, and a label wider than its button kept its full size and ran past the frame.

So all three "shrink long labels" fixes were quietly no-ops sideways, and the symptom is not
German-specific: it hits **any** button whose translated text is wider than its frame, in all 14
languages.

## The fix

- **`UiKit.FitLabel(label, min, max)`** — one shared helper that sets `Wrap` + `Truncate` alongside
  Best Fit, so the width is part of what "fits" means. `AddButton`, the tab bar and the touch
  controls all go through it now, so they cannot drift apart again.
- **Paint editor tool row 170 → 200 px.** It carries the longest labels in the panel, and a label
  only auto-shrinks so far before it stops being readable at a glance — better to give it the room.
  The row stops at x=580, where the region-tile column starts and the helmet's fifth tile reaches
  this row's top edge.

Labels that already fit are untouched: Best Fit only scales down, and its maximum stays each site's
current font size. Where a label is *very* long for its button it may now wrap to a second line
inside the frame rather than shrink to an unreadable size — deliberately, since the label rect keeps
the full button height, which also rules out a too-tight band truncating a line into invisibility.

## Verification

- Unity script compilation clean; local Windows player build runs through.
- 202 client tests pass.
- Visual check is worth doing on the paint editor's tool row and the menu tab bar in German
  (the two places where labels are longest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
