### PR TITLE
ci: narrow test lane for locales-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,14 @@
 # doc/image skip list lives in the shared reusable workflow .github/workflows/detect-doc-only.yml (also
 # used by lint.yml and codeql.yml). The `format` job stays a directly-required check (its name is stable
 # and GitHub counts its skip as a pass, as before).
+#
+# LOCALES-ONLY NARROW GATE (#921): when the PR diff touches nothing but data/locales/*.json (a
+# translation PR), the 4-shard matrix and `format` are skipped and the single `locale-tests` job runs
+# the classes that can actually observe a locale edit (scripts/locale-test-filter.py: a marker scan
+# for direct locale-table readers plus hand-listed indirect consumers, found by mutating every locale
+# value and collecting the failing classes). `tests-passed` requires locale-tests' success in that
+# case. Safety: an under-selected filter cannot reach a release — the push to main after merge runs
+# the COMPLETE suite, and release.yml re-runs it on the tagged commit; the worst case is a red main.
 
 name: CI
 
@@ -71,7 +79,8 @@ jobs:
     needs: changes
     # Run for any push to main, or for a PR that touched at least one non-doc file. A docs-only PR
     # skips this job; the `tests-passed` fan-in treats that as passing, so docs PRs are never blocked.
-    if: github.event_name != 'pull_request' || needs.changes.outputs.nondocs == 'true'
+    # A locales-only PR skips the matrix too and runs `locale-tests` instead (see header).
+    if: github.event_name != 'pull_request' || (needs.changes.outputs.nondocs == 'true' && needs.changes.outputs.localesonly != 'true')
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false # one failing shard must not cancel the others' results
@@ -160,26 +169,78 @@ jobs:
           path: TestResults/*.trx
           if-no-files-found: ignore
 
+  # Narrow test gate for locales-only PRs (see LOCALES-ONLY NARROW GATE in the header): builds the
+  # server test project once and runs only the locale-consuming classes. `verify` runs first so a
+  # stale HAND_EXTRAS entry or a broken marker scan fails loudly instead of silently under-testing.
+  # Same Release + -warnaserror regime as the matrix; the fast-tier duration guardrail is pointless
+  # here (the guards run in seconds) and needs the full trx picture, so it stays matrix-only.
+  locale-tests:
+    name: Locale guard tests
+    needs: changes
+    if: github.event_name == 'pull_request' && needs.changes.outputs.localesonly == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
+          cache: true
+          cache-dependency-path: |
+            **/*.csproj
+            Directory.Build.props
+
+      - name: Restore + build (treat warnings as errors)
+        run: |
+          dotnet restore tests/BlocksBeyondTheStars.Tests/BlocksBeyondTheStars.Tests.csproj
+          dotnet build tests/BlocksBeyondTheStars.Tests/BlocksBeyondTheStars.Tests.csproj --no-restore -c Release -warnaserror
+
+      - name: Run locale guard tests
+        run: |
+          python3 scripts/locale-test-filter.py verify
+          FILTER="$(python3 scripts/locale-test-filter.py)"
+          dotnet test tests/BlocksBeyondTheStars.Tests/BlocksBeyondTheStars.Tests.csproj --no-build -c Release --filter "Category!=Slow&$FILTER" --logger "trx;LogFileName=locale.trx" --results-directory TestResults
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: test-results-locale
+          path: TestResults/*.trx
+          if-no-files-found: ignore
+
   # Fan-in for branch protection: the ONE required check standing in for the whole test matrix.
   # Required checks must not point at matrix jobs directly (names carry the shard index, and a
   # docs-only PR would leave them "Expected — Waiting for status" forever). Passing states:
   #   * build-test == success  → all four shards green
-  #   * build-test == skipped  → docs-only PR (the `changes` job said nondocs=false) — counts as pass,
-  #     but ONLY when `changes` itself succeeded, so a cancelled/failed upstream can't sneak through.
+  #   * build-test == skipped  → docs-only PR (the `changes` job said nondocs=false) or locales-only
+  #     PR (locale-tests ran instead) — counts as pass, but ONLY when `changes` itself succeeded, so
+  #     a cancelled/failed upstream can't sneak through.
+  #   * locale-tests is held to the same success-or-skipped bar, so a red locale guard blocks the PR.
+  # Belt-and-braces: on a locales-only PR the matrix MUST be skipped and locale-tests MUST have run —
+  # any other combination (e.g. both skipped) fails the fan-in rather than passing vacuously.
   tests-passed:
     name: Tests passed
-    needs: [changes, build-test]
+    needs: [changes, build-test, locale-tests]
     if: always()
     runs-on: ubuntu-latest
     steps:
       - name: Check matrix result
         run: |
-          echo "changes: ${{ needs.changes.result }} / build-test: ${{ needs.build-test.result }}"
+          echo "changes: ${{ needs.changes.result }} / build-test: ${{ needs.build-test.result }} / locale-tests: ${{ needs.locale-tests.result }}"
           if [ "${{ needs.changes.result }}" != "success" ]; then exit 1; fi
           case "${{ needs.build-test.result }}" in
-            success|skipped) exit 0 ;;
+            success|skipped) ;;
             *) exit 1 ;;
           esac
+          case "${{ needs.locale-tests.result }}" in
+            success|skipped) ;;
+            *) exit 1 ;;
+          esac
+          if [ "${{ needs.changes.outputs.localesonly }}" = "true" ]; then
+            if [ "${{ needs.locale-tests.result }}" != "success" ] || [ "${{ needs.build-test.result }}" != "skipped" ]; then exit 1; fi
+          fi
 
   # Verifies C# code style/formatting (whitespace, using-order, object-initializer line breaks, …) per
   # .editorconfig. Runs against BlocksBeyondTheStars.CI.slnf, a solution filter listing every project EXCEPT
@@ -189,7 +250,9 @@ jobs:
   format:
     name: Format (dotnet format)
     needs: changes
-    if: github.event_name != 'pull_request' || needs.changes.outputs.nondocs == 'true'
+    # Locales-only PRs skip this too: dotnet format checks the C# projects in CI.slnf, which cannot
+    # be affected by a data/locales/*.json diff (and a skipped required job counts as a pass).
+    if: github.event_name != 'pull_request' || (needs.changes.outputs.nondocs == 'true' && needs.changes.outputs.localesonly != 'true')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@
 # used by lint.yml and codeql.yml). The `format` job stays a directly-required check (its name is stable
 # and GitHub counts its skip as a pass, as before).
 #
-# LOCALES-ONLY NARROW GATE (#921): when the PR diff touches nothing but data/locales/*.json (a
+# LOCALES-ONLY NARROW GATE (#922): when the PR diff touches nothing but data/locales/*.json (a
 # translation PR), the 4-shard matrix and `format` are skipped and the single `locale-tests` job runs
 # the classes that can actually observe a locale edit (scripts/locale-test-filter.py: a marker scan
 # for direct locale-table readers plus hand-listed indirect consumers, found by mutating every locale

--- a/.github/workflows/detect-doc-only.yml
+++ b/.github/workflows/detect-doc-only.yml
@@ -15,6 +15,12 @@
 # IMPORTANT: this is the SINGLE SOURCE OF TRUTH for the doc/image skip list. To change what counts as
 # doc-only, edit the `case` below here — do not re-add per-workflow copies. `data/**` is
 # deliberately NOT skipped: it feeds the headless tests (e.g. the en/de locale-parity test).
+#
+# Second output `localesonly` (#921): "true" when the diff's non-doc files are ALL under
+# data/locales/. ci.yml then replaces the 4-shard matrix with the narrow `locale-tests` job
+# (scripts/locale-test-filter.py), because only the classes that read the locale tables can
+# observe such a change. `nondocs` stays true in that case — lint.yml and codeql.yml are
+# unaffected and keep running.
 name: Detect doc-only changes
 
 on:
@@ -23,6 +29,9 @@ on:
       nondocs:
         description: "true if the PR diff contains any non-doc, non-image file"
         value: ${{ jobs.detect.outputs.nondocs }}
+      localesonly:
+        description: "true if every non-doc file in the PR diff is under data/locales/"
+        value: ${{ jobs.detect.outputs.localesonly }}
 
 permissions:
   contents: read
@@ -33,6 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       nondocs: ${{ steps.detect.outputs.nondocs }}
+      localesonly: ${{ steps.detect.outputs.localesonly }}
     steps:
       # Lists the PR's changed files via the API (no checkout needed) and sets nondocs=true if ANY file
       # is neither documentation nor an image. (Explicit case match rather than dorny/paths-filter, whose
@@ -44,7 +54,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           files="$(gh api --paginate "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" --jq '.[].filename')"
-          nondocs=false
+          haslocales=false
+          hascode=false
           while IFS= read -r f; do
             [ -z "$f" ] && continue
             case "$f" in
@@ -58,8 +69,20 @@ jobs:
               # and not imported by any test. Push-to-main runs (ruff, CodeQL) still cover them
               # because detection only applies to pull_request events.
               tools/devblog/*|tools/wix-i18n/*|tools/glitch-media/*) ;;
-              *) nondocs=true; break ;;
+              # Locale tables: non-doc (they feed the headless tests), but when the WHOLE diff
+              # stays inside data/locales/ the caller may narrow the test matrix (see header).
+              data/locales/*) haslocales=true ;;
+              *) hascode=true; break ;;
             esac
           done <<< "$files"
+          nondocs=false
+          localesonly=false
+          if [ "$hascode" = true ]; then
+            nondocs=true
+          elif [ "$haslocales" = true ]; then
+            nondocs=true
+            localesonly=true
+          fi
           echo "nondocs=$nondocs" >> "$GITHUB_OUTPUT"
-          echo "Changed files:"; printf '%s\n' "$files"; echo "nondocs=$nondocs"
+          echo "localesonly=$localesonly" >> "$GITHUB_OUTPUT"
+          echo "Changed files:"; printf '%s\n' "$files"; echo "nondocs=$nondocs localesonly=$localesonly"

--- a/.github/workflows/detect-doc-only.yml
+++ b/.github/workflows/detect-doc-only.yml
@@ -16,7 +16,7 @@
 # doc-only, edit the `case` below here — do not re-add per-workflow copies. `data/**` is
 # deliberately NOT skipped: it feeds the headless tests (e.g. the en/de locale-parity test).
 #
-# Second output `localesonly` (#921): "true" when the diff's non-doc files are ALL under
+# Second output `localesonly` (#922): "true" when the diff's non-doc files are ALL under
 # data/locales/. ci.yml then replaces the 4-shard matrix with the narrow `locale-tests` job
 # (scripts/locale-test-filter.py), because only the classes that read the locale tables can
 # observe such a change. `nondocs` stays true in that case — lint.yml and codeql.yml are

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,10 @@ the richer, screenshot-laden versions live there. `(#123)` references the pull r
 
 - Ahmed Mohamed Abdelhady Kamel joins the credits for the first unit tests covering `Vector3i`,
   the block-coordinate type the whole world sits on (#917).
+- Translation PRs get a faster, focused CI lane: a pull request that touches nothing but
+  `data/locales/*.json` now runs exactly the test classes that read the locale tables (found by
+  mutating every translated string and collecting what fails) instead of the full four-runner
+  matrix. Pushes to `main` and releases still run the complete suite (#921).
 
 ## [2026.8.10] — 2026-08-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,7 +82,7 @@ the richer, screenshot-laden versions live there. `(#123)` references the pull r
 - Translation PRs get a faster, focused CI lane: a pull request that touches nothing but
   `data/locales/*.json` now runs exactly the test classes that read the locale tables (found by
   mutating every translated string and collecting what fails) instead of the full four-runner
-  matrix. Pushes to `main` and releases still run the complete suite (#921).
+  matrix. Pushes to `main` and releases still run the complete suite (#922).
 
 ## [2026.8.10] — 2026-08-10
 

--- a/TODO.md
+++ b/TODO.md
@@ -11,6 +11,7 @@ keep it current when controls/features change. Last consolidated 2026-06-04.
 CI runs two tiers: PRs skip the tests marked `[Trait("Category", "Slow")]`; pushes to `main` and the release workflow run the full suite. CI builds/runs
 tests in Release, and a per-test duration guardrail (`scripts/check-test-durations.py`, PRs only) fails the gate when a non-Slow test exceeds 120 s.
 The server suite is sharded across a 4-runner matrix (`scripts/partition-tests.py` + checked-in weights; `Tests passed` is the required fan-in check) — PR gate ~4½ min.
+A PR touching nothing but `data/locales/*.json` runs a single narrow `locale-tests` job instead of the matrix (`scripts/locale-test-filter.py`, ~140 tests).
 **Conventions:** English docs/comments; in-game text localized via locale keys — EN+DE mandatory-complete,
 FR/ES/PT/PL/TR/NL/RU/UK/ZH/JA/KO machine-first-pass, IT community + machine top-up (see docs/developer/TRANSLATION_GUIDE.md); commit to `main` with the
 Claude `Co-Authored-By` trailer; OpenAI texture + ElevenLabs sound generation is blanket-approved
@@ -103,6 +104,20 @@ Per-item detail lives in the dated work log below. **Since 2026-07 versions are 
   single-source-of-truth working end-to-end (validated: published the initial Windows zip).
 
 ---
+
+### ★ Translation PRs get a narrow CI lane: locales-only diffs skip the 4-shard matrix (#921, 2026-08-11, branch ci/locale-only-test-gate)
+A PR whose non-doc diff stays inside `data/locales/*.json` now runs one `locale-tests` job (~140 tests,
+< 1 min of test time) instead of the 4-runner matrix + `dotnet format`. The affected-test set lives in
+`scripts/locale-test-filter.py`: a self-maintaining marker scan for direct locale-table readers
+(TestLocales.Load / CreateLocalizer) plus hand-listed indirect consumers; `verify` runs in CI and fails
+loudly on stale entries. The set was validated EMPIRICALLY: replace every locale value with junk
+(placeholders kept), run the full fast tier — only marker-visible classes fail, and Client.Tests passes
+195/195 against destroyed locales, so skipping it is proven safe. Two method gotchas recorded for
+regeneration: appending junk is too weak (Contains() assertions survive; replacement is required), and
+NpcHintTests' locale-consuming methods are Slow-tier (never in the PR gate to begin with) — it stays in
+HAND_EXTRAS anyway in case those methods ever lose the trait. `detect-doc-only.yml` gained a
+`localesonly` output; the `tests-passed` fan-in refuses the vacuous both-skipped state on such PRs.
+Coverage guarantee unchanged: pushes to main and release.yml still run the COMPLETE suite.
 
 ### ★ Space HUD: the cargo readout stopped overprinting the hull bar (#915, 2026-08-10, branch fix/space-hud-cargo-overlap)
 The flight view's top-left `Cargo: N` label was drawn straight across the on-foot HUD's **Hull** bar (and

--- a/TODO.md
+++ b/TODO.md
@@ -105,7 +105,7 @@ Per-item detail lives in the dated work log below. **Since 2026-07 versions are 
 
 ---
 
-### ★ Translation PRs get a narrow CI lane: locales-only diffs skip the 4-shard matrix (#921, 2026-08-11, branch ci/locale-only-test-gate)
+### ★ Translation PRs get a narrow CI lane: locales-only diffs skip the 4-shard matrix (#922, 2026-08-11, branch ci/locale-only-test-gate)
 A PR whose non-doc diff stays inside `data/locales/*.json` now runs one `locale-tests` job (~140 tests,
 < 1 min of test time) instead of the 4-runner matrix + `dotnet format`. The affected-test set lives in
 `scripts/locale-test-filter.py`: a self-maintaining marker scan for direct locale-table readers

--- a/scripts/locale-test-filter.py
+++ b/scripts/locale-test-filter.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+# Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+"""Emits the vstest --filter for the locale guard job (ci.yml `locale-tests`).
+
+When a PR touches NOTHING but data/locales/*.json, ci.yml skips the 4-shard test matrix and
+runs only the test classes that can actually observe a locale edit. This script owns that set.
+
+The set is the union of two sources:
+  * A marker scan: every test class in a file that reads the locale tables directly
+    (TestLocales.Load / CreateLocalizer / a "locales/" path). Self-maintaining.
+  * HAND_EXTRAS: classes that consume locale VALUES indirectly — the text travels through the
+    game server (e.g. NpcHintTests asserts a hint built from an en.json template) — which no
+    source scan can find. Found empirically; regenerate after big test-suite changes with the
+    mutation experiment: REPLACE every value in all data/locales/*.json with junk (keep the
+    {n} placeholders; merely appending is too weak — Contains() assertions survive it), run
+    the full fast tier, and every failing class belongs here (or in the marker set). A class
+    listed here that stops existing fails `verify`, so the list cannot rot silently.
+
+Empirical status (2026-08-11): under that mutation the fast tier fails only in ChatHelpTextTests
+and ContentTests (both marker-visible), and Client.Tests passes 195/195 — so skipping it on
+locales-only PRs is proven safe. NpcHintTests' locale-consuming methods are all Slow-tier (they
+never ran on PRs to begin with); it stays listed so the class remains covered even if those
+methods ever lose the Slow trait, which no source scan would notice.
+
+Filter tokens are dot-anchored (`FullyQualifiedName~.<Class>.`) exactly like
+scripts/partition-tests.py, so a token can never substring-match a longer class name.
+
+Safety framing: an over-broad set costs seconds; an under-broad set is caught downstream — a
+push to main runs the COMPLETE suite (ci.yml two-tier gate), and release.yml re-runs it on the
+tagged commit. A miss here can redden main after merge but cannot reach a release.
+
+Usage:
+  locale-test-filter.py            # print the --filter expression
+  locale-test-filter.py verify     # sanity-check the set (ci.yml runs this before testing)
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+TEST_DIR = Path(__file__).resolve().parent.parent / "tests" / "BlocksBeyondTheStars.Tests"
+
+# Same declaration regex as partition-tests.py: one file may declare several classes, and
+# non-test classes ride along harmlessly (their tokens match nothing).
+CLASS_RE = re.compile(
+    r"^\s*(?:public|internal)?\s*(?:sealed\s+|static\s+|abstract\s+|partial\s+)*class\s+([A-Za-z_]\w*)",
+    re.MULTILINE,
+)
+
+# Direct locale-table readers, findable in test source.
+MARKER_RE = re.compile(r"TestLocales\.Load|CreateLocalizer|locales/")
+
+# Indirect consumers (locale values reach the assertion through the game server), found via the
+# mutation experiment described above. Keep sorted.
+HAND_EXTRAS = [
+    "NpcHintTests",
+]
+
+
+def affected_classes() -> tuple[set[str], set[str]]:
+    """Returns (marker-scanned classes, all known classes in the test project)."""
+    scanned: set[str] = set()
+    all_classes: set[str] = set()
+    for path in sorted(TEST_DIR.glob("*.cs")):
+        text = path.read_text(encoding="utf-8-sig")
+        classes = CLASS_RE.findall(text)
+        all_classes.update(classes)
+        if MARKER_RE.search(text):
+            scanned.update(classes)
+    return scanned, all_classes
+
+
+def main() -> int:
+    mode = sys.argv[1] if len(sys.argv) > 1 else "filter"
+    scanned, all_classes = affected_classes()
+
+    missing = [c for c in HAND_EXTRAS if c not in all_classes]
+    if missing:
+        print(f"HAND_EXTRAS entries no longer exist as classes: {missing}", file=sys.stderr)
+        return 1
+    if len(scanned) < 3:
+        # The guards (CommunityLocaleTests, ContentTests, …) are marker-visible; finding fewer
+        # means the scan itself broke — never emit a near-empty filter silently.
+        print(f"marker scan found only {len(scanned)} classes — scan is broken", file=sys.stderr)
+        return 1
+
+    bucket = sorted(scanned | set(HAND_EXTRAS))
+    if mode == "verify":
+        print(f"locale filter covers {len(bucket)} classes: {', '.join(bucket)}")
+        return 0
+    print("(" + "|".join(f"FullyQualifiedName~.{cls}." for cls in bucket) + ")")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Answers "why does a credits line in a locale file run the whole test matrix?" — from now on it doesn't. A PR whose non-doc diff stays inside `data/locales/*.json` (i.e. a translation PR) runs a single **`locale-tests`** job with exactly the test classes that can observe a locale edit, instead of the 4-shard matrix + `dotnet format`. Measured: **140 tests in 55 s** vs 1685 across four runners.

## How the affected-test set is derived (and why it's trustworthy)

`scripts/locale-test-filter.py` owns the set — two sources:

- **Marker scan** (self-maintaining): every class in a test file that reads the locale tables directly (`TestLocales.Load` / `CreateLocalizer` / `locales/`). Currently 12 files.
- **`HAND_EXTRAS`**: indirect consumers no source scan can find — locale text that reaches the assertion through the game server. Found **empirically**: replace every value in all 14 locale files with junk (keeping `{n}` placeholders), run the full fast tier, collect the failing classes.

Findings from that experiment, recorded in the script header for the next regeneration:

- Merely **appending** junk is too weak — `Contains()`-style assertions survive it (experiment 1 caught 1 class; the destructive experiment 2 is the method of record).
- Under full value replacement, the fast tier fails **only in marker-visible classes** (ChatHelpTextTests, ContentTests).
- **Client.Tests passes 195/195 against destroyed locales** — skipping that suite is proven safe, not assumed.
- `NpcHintTests` consumes en.json values but all its consuming methods are Slow-tier (they never ran in the PR gate to begin with). It stays in `HAND_EXTRAS` so the class remains covered if those methods ever lose the trait — a change no scan would notice.

`verify` mode runs in CI before the tests and fails loudly on stale entries or a broken scan — the filter can't rot into silent under-testing.

## Safety

- `nondocs` semantics unchanged → lint.yml / codeql.yml behave exactly as before.
- The `tests-passed` fan-in requires, on a locales-only PR, that the matrix was **skipped** and locale-tests **succeeded** — the vacuous both-skipped state fails instead of passing.
- Coverage guarantee unchanged: pushes to `main` and release.yml still run the **complete** suite (incl. Slow). The worst case of an under-selected filter is a red `main` after merge — never a shipped release.
- Classification tested against 7 diff shapes, including the trap `client/Assets/StreamingAssets/data/locales/…` (correctly counts as code, not locales).

## Verification

- Narrow lane against clean locales: 140/140 green in 55 s
- Full fast tier against mutated locales: exactly the expected classes fail
- Both workflow files parse; this PR itself touches workflows+scripts, so it runs the **full** matrix