### PR TITLE
test: cover FrequencyExtensions invariants

### DIFF
--- a/tests/BlocksBeyondTheStars.Tests/FrequencyExtensionsTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/FrequencyExtensionsTests.cs
@@ -18,6 +18,18 @@ public sealed class FrequencyExtensionsTests
         Frequency.Frequent
     };
 
+    private static void AssertMonotone(
+        Func<Frequency, double> selector,
+        string? message = null)
+    {
+        for (var i = 1; i < Levels.Length; i++)
+        {
+            Assert.True(
+                selector(Levels[i]) >= selector(Levels[i - 1]),
+                message ?? $"{Levels[i]} should not produce a lower value than {Levels[i - 1]}.");
+        }
+    }
+
     [Fact]
     public void Weight_IsMonotoneAndOffMeansZero()
     {
@@ -30,6 +42,7 @@ public sealed class FrequencyExtensionsTests
                 $"{Levels[i]} should not have a lower weight than {Levels[i - 1]}.");
         }
     }
+
     [Fact]
     public void Probability_IsWithinValidRange()
     {
@@ -38,17 +51,13 @@ public sealed class FrequencyExtensionsTests
             Assert.InRange(level.Probability(), 0.0, 1.0);
         }
     }
+
     [Fact]
     public void Probability_IsMonotoneAndOffMeansZero()
     {
         Assert.Equal(0.0, Frequency.Off.Probability());
 
-        for (var i = 1; i < Levels.Length; i++)
-        {
-            Assert.True(
-                Levels[i].Probability() >= Levels[i - 1].Probability(),
-                $"{Levels[i]} should not have a lower probability than {Levels[i - 1]}.");
-        }
+        AssertMonotone(f => f.Probability());
     }
 
     [Fact]
@@ -57,12 +66,7 @@ public sealed class FrequencyExtensionsTests
         Assert.Equal(1.0, Frequency.Normal.FloraFactor());
         Assert.Equal(0.0, Frequency.Off.FloraFactor());
 
-        for (var i = 1; i < Levels.Length; i++)
-        {
-            Assert.True(
-                Levels[i].FloraFactor() >= Levels[i - 1].FloraFactor(),
-                $"{Levels[i]} should not have a lower flora factor than {Levels[i - 1]}.");
-        }
+        AssertMonotone(f => f.FloraFactor());
     }
 
     [Fact]
@@ -70,12 +74,7 @@ public sealed class FrequencyExtensionsTests
     {
         Assert.Equal(1.0, Frequency.Rare.OreFactor());
 
-        for (var i = 1; i < Levels.Length; i++)
-        {
-            Assert.True(
-                Levels[i].OreFactor() >= Levels[i - 1].OreFactor(),
-                $"{Levels[i]} should not have a lower ore factor than {Levels[i - 1]}.");
-        }
+        AssertMonotone(f => f.OreFactor());
     }
 
     [Fact]
@@ -84,12 +83,7 @@ public sealed class FrequencyExtensionsTests
         Assert.Equal(1.0, Frequency.Normal.StructureFactor());
         Assert.Equal(0.0, Frequency.Off.StructureFactor());
 
-        for (var i = 1; i < Levels.Length; i++)
-        {
-            Assert.True(
-                Levels[i].StructureFactor() >= Levels[i - 1].StructureFactor(),
-                $"{Levels[i]} should not have a lower structure factor than {Levels[i - 1]}.");
-        }
+        AssertMonotone(f => f.StructureFactor());
     }
 
     [Fact]
@@ -98,11 +92,6 @@ public sealed class FrequencyExtensionsTests
         Assert.Equal(1.0, Frequency.Normal.DangerFactor());
         Assert.Equal(0.0, Frequency.Off.DangerFactor());
 
-        for (var i = 1; i < Levels.Length; i++)
-        {
-            Assert.True(
-                Levels[i].DangerFactor() >= Levels[i - 1].DangerFactor(),
-                $"{Levels[i]} should not have a lower danger factor than {Levels[i - 1]}.");
-        }
+        AssertMonotone(f => f.DangerFactor());
     }
 }

--- a/tests/BlocksBeyondTheStars.Tests/FrequencyExtensionsTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/FrequencyExtensionsTests.cs
@@ -1,0 +1,108 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+
+using BlocksBeyondTheStars.Shared.World;
+using Xunit;
+
+namespace BlocksBeyondTheStars.Tests;
+
+public sealed class FrequencyExtensionsTests
+{
+    private static readonly Frequency[] Levels =
+    {
+        Frequency.Off,
+        Frequency.VeryRare,
+        Frequency.Rare,
+        Frequency.Normal,
+        Frequency.Frequent
+    };
+
+    [Fact]
+    public void Weight_IsMonotoneAndOffMeansZero()
+    {
+        Assert.Equal(0, Frequency.Off.Weight());
+
+        for (var i = 1; i < Levels.Length; i++)
+        {
+            Assert.True(
+                Levels[i].Weight() >= Levels[i - 1].Weight(),
+                $"{Levels[i]} should not have a lower weight than {Levels[i - 1]}.");
+        }
+    }
+    [Fact]
+    public void Probability_IsWithinValidRange()
+    {
+        foreach (var level in Levels)
+        {
+            Assert.InRange(level.Probability(), 0.0, 1.0);
+        }
+    }
+    [Fact]
+    public void Probability_IsMonotoneAndOffMeansZero()
+    {
+        Assert.Equal(0.0, Frequency.Off.Probability());
+
+        for (var i = 1; i < Levels.Length; i++)
+        {
+            Assert.True(
+                Levels[i].Probability() >= Levels[i - 1].Probability(),
+                $"{Levels[i]} should not have a lower probability than {Levels[i - 1]}.");
+        }
+    }
+
+    [Fact]
+    public void FloraFactor_IsMonotoneAndNormalIsUnchanged()
+    {
+        Assert.Equal(1.0, Frequency.Normal.FloraFactor());
+        Assert.Equal(0.0, Frequency.Off.FloraFactor());
+
+        for (var i = 1; i < Levels.Length; i++)
+        {
+            Assert.True(
+                Levels[i].FloraFactor() >= Levels[i - 1].FloraFactor(),
+                $"{Levels[i]} should not have a lower flora factor than {Levels[i - 1]}.");
+        }
+    }
+
+    [Fact]
+    public void OreFactor_IsMonotoneAndRareIsUnchanged()
+    {
+        Assert.Equal(1.0, Frequency.Rare.OreFactor());
+
+        for (var i = 1; i < Levels.Length; i++)
+        {
+            Assert.True(
+                Levels[i].OreFactor() >= Levels[i - 1].OreFactor(),
+                $"{Levels[i]} should not have a lower ore factor than {Levels[i - 1]}.");
+        }
+    }
+
+    [Fact]
+    public void StructureFactor_IsMonotoneAndNormalIsUnchanged()
+    {
+        Assert.Equal(1.0, Frequency.Normal.StructureFactor());
+        Assert.Equal(0.0, Frequency.Off.StructureFactor());
+
+        for (var i = 1; i < Levels.Length; i++)
+        {
+            Assert.True(
+                Levels[i].StructureFactor() >= Levels[i - 1].StructureFactor(),
+                $"{Levels[i]} should not have a lower structure factor than {Levels[i - 1]}.");
+        }
+    }
+
+    [Fact]
+    public void DangerFactor_IsMonotoneAndNormalIsUnchanged()
+    {
+        Assert.Equal(1.0, Frequency.Normal.DangerFactor());
+        Assert.Equal(0.0, Frequency.Off.DangerFactor());
+
+        for (var i = 1; i < Levels.Length; i++)
+        {
+            Assert.True(
+                Levels[i].DangerFactor() >= Levels[i - 1].DangerFactor(),
+                $"{Levels[i]} should not have a lower danger factor than {Levels[i - 1]}.");
+        }
+    }
+}


### PR DESCRIPTION
Adds dedicated unit tests for FrequencyExtensions.

The tests focus on the documented behavioral contracts rather than the current tuning constants:

Weight is monotone and Off maps to zero.
Probability is monotone, Off maps to zero, and results remain within [0, 1].
FloraFactor, StructureFactor, and DangerFactor are monotone, disable their features at Off, and preserve the baseline at Normal = 1.0.
OreFactor is monotone and preserves the default Rare = 1.0 baseline, while intentionally allowing Off to remain non-zero.

All focused FrequencyExtensionsTests pass: 7/7.

For the issue reference, use:

Related to #571 