### PR TITLE
test: cover server preset contracts

### DIFF
--- a/tests/BlocksBeyondTheStars.Tests/ServerPresetsTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/ServerPresetsTests.cs
@@ -1,0 +1,42 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+
+using BlocksBeyondTheStars.Shared.Configuration;
+using Xunit;
+
+namespace BlocksBeyondTheStars.Tests;
+
+public sealed class ServerPresetsTests
+{
+    [Fact]
+    public void Names_EveryPresetResolves()
+    {
+        foreach (var name in ServerPresets.Names)
+        {
+            Assert.NotNull(ServerPresets.Get(name));
+        }
+    }
+
+    [Theory]
+    [InlineData("family")]
+    [InlineData("FAMILY")]
+    [InlineData("  family  ")]
+    [InlineData("  FaMiLy  ")]
+    public void Get_IsCaseInsensitiveAndTrimsWhitespace(string name)
+    {
+        Assert.NotNull(ServerPresets.Get(name));
+    }
+
+    [Fact]
+    public void Get_ReturnsNullForUnknownName()
+    {
+        Assert.Null(ServerPresets.Get("does-not-exist"));
+    }
+
+    [Fact]
+    public void Get_ReturnsNullForNullName()
+    {
+        Assert.Null(ServerPresets.Get(null!));
+    }
+}


### PR DESCRIPTION
Relates to #571

Adds focused unit tests for the documented contracts of ServerPresets:

- Every advertised preset resolves successfully.
- Preset lookup is case-insensitive and trims whitespace.
- Unknown preset names return null.
- Null preset names return null.