### PR TITLE
Test/localizer

### DIFF
--- a/tests/BlocksBeyondTheStars.Tests/LocalizerTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/LocalizerTests.cs
@@ -1,0 +1,58 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+
+using System.Collections.Generic;
+using BlocksBeyondTheStars.Shared.Localization;
+using Xunit;
+
+namespace BlocksBeyondTheStars.Tests;
+
+public sealed class LocalizerTests
+{
+    private static Localizer CreateLocalizer(
+        Dictionary<string, string>? active = null,
+        Dictionary<string, string>? fallback = null)
+    {
+        return new Localizer(
+            GameLocale.English,
+            active ?? new Dictionary<string, string>(),
+            fallback ?? new Dictionary<string, string>());
+    }
+
+    [Fact]
+    public void Get_ReturnsBracketedKeyWhenUnknown()
+    {
+        var localizer = CreateLocalizer();
+
+        Assert.Equal("[missing.key]", localizer.Get("missing.key"));
+    }
+
+    [Fact]
+    public void Get_ReturnsEmptyStringForEmptyKey()
+    {
+        var localizer = CreateLocalizer();
+
+        Assert.Equal(string.Empty, localizer.Get(string.Empty));
+    }
+
+    [Fact]
+    public void Has_ReturnsTrueWhenKeyExistsOnlyInFallback()
+    {
+        var localizer = CreateLocalizer(
+            fallback: new Dictionary<string, string>
+            {
+                ["fallback.key"] = "English text",
+            });
+
+        Assert.True(localizer.Has("fallback.key"));
+    }
+
+    [Fact]
+    public void Has_ReturnsFalseWhenKeyDoesNotExistInEitherTable()
+    {
+        var localizer = CreateLocalizer();
+
+        Assert.False(localizer.Has("missing.key"));
+    }
+}

--- a/tests/BlocksBeyondTheStars.Tests/ServerPresetsTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/ServerPresetsTests.cs
@@ -1,0 +1,42 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+
+using BlocksBeyondTheStars.Shared.Configuration;
+using Xunit;
+
+namespace BlocksBeyondTheStars.Tests;
+
+public sealed class ServerPresetsTests
+{
+    [Fact]
+    public void Names_EveryPresetResolves()
+    {
+        foreach (var name in ServerPresets.Names)
+        {
+            Assert.NotNull(ServerPresets.Get(name));
+        }
+    }
+
+    [Theory]
+    [InlineData("family")]
+    [InlineData("FAMILY")]
+    [InlineData("  family  ")]
+    [InlineData("  FaMiLy  ")]
+    public void Get_IsCaseInsensitiveAndTrimsWhitespace(string name)
+    {
+        Assert.NotNull(ServerPresets.Get(name));
+    }
+
+    [Fact]
+    public void Get_ReturnsNullForUnknownName()
+    {
+        Assert.Null(ServerPresets.Get("does-not-exist"));
+    }
+
+    [Fact]
+    public void Get_ReturnsNullForNullName()
+    {
+        Assert.Null(ServerPresets.Get(null!));
+    }
+}


### PR DESCRIPTION
Relates to #571

Adds focused unit tests for the Localizer's documented contracts:

- Unknown keys return the key wrapped in brackets.
- Empty keys return an empty string.
- Keys found only in the English fallback are recognized by Has().
- Missing keys are correctly reported as absent by Has().

The tests use small in-memory dictionaries to exercise the pure localization logic without duplicating the existing content-loading tests.