### PR TITLE
Gamepad + touch input path for the hotbar slot-action pie (#940)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7726,6 +7726,23 @@ is **pre-approved** (keys in `tools/ai-assets/.env`, run via `uv`).
 
 ---
 
+## ✅ Done (2026-08-12): the slot-action pie works on gamepad and touch (#940)
+
+Follow-up to #935 (below): pad and touch could not OPEN the pie at all — no default pad button, no touch
+control. Now: **gamepad** gets `HotbarAction → R3` as the stock binding (right-stick click; free on the
+XInput layout, "click the stick" mirrors the middle-click; d-pad-down was considered but the project only
+defines a `DPadX` axis), `UiNav.Enable` on the pie's canvas makes the four wedges and every detail-panel
+button stick-navigable with A = click (the wedges sit exactly up/left/right/down, so `Navigation.Automatic`
+maps them 1:1), and **pad B closes** the pie (alongside the toggle key and Esc). The HUD badge/hint from
+#935 show `RS` automatically while a pad is in hand. **Touch** gets a shared "…" button beside the hotbar
+► arrow (symbol label like ◄►≡ — no locale key) that opens the pie on the selected slot via the new
+`HotbarActionUi.CanOpen`/`Toggle` API (same hidden-hotbar gates, EVA allowed); the button only shows while
+the pie could open, and the pie itself was already tap-friendly (flat overlay canvas). USER_MANUAL §2
+pad/touch tables + §5 updated. ⚠ Playtest pending on real devices — CI exercises neither pad nor touch;
+watch for R3 accidental presses while looking around (fallback candidate: d-pad-down + new DPadY axis).
+
+---
+
 ## ✅ Done (2026-08-11): the slot-action menu is a radial pie now — and the HUD finally says it exists (#935)
 
 The middle-click hotbar slot actions (#924, below) shipped with zero on-screen tell — not in the hint

--- a/client/Assets/BlocksBeyondTheStars/Scripts/HotbarActionUi.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/HotbarActionUi.cs
@@ -71,6 +71,40 @@ namespace BlocksBeyondTheStars.Client
         /// <summary>True while the action ring / a detail panel is open (gameplay hotkeys stand down).</summary>
         public bool IsOpen => _canvas != null;
 
+        /// <summary>True while the pie could open right now: no other menu owns the input, and a slot is
+        /// actually on screen. Exactly the states in which the HUD hides the hotbar (piloting/driving/
+        /// spectating) refuse — no slots on screen means no slot to act on; EVA deliberately stays allowed,
+        /// the hotbar shows there. Also gates the touch button's visibility (#940).</summary>
+        public bool CanOpen
+        {
+            get
+            {
+                if (Game == null || Game.MenuOpen)
+                {
+                    return false;
+                }
+
+                bool hotbarHidden = ((Game.SpaceViewActive || Game.InSpace) && !Game.InEva)
+                                    || !string.IsNullOrEmpty(Game.InSpeeder)
+                                    || Game.Spectating;
+                return !hotbarHidden;
+            }
+        }
+
+        /// <summary>Opens the pie on the selected slot, or closes it — the touch button's entry point
+        /// (#940). The key/pad path in <see cref="Update"/> funnels through the same gates.</summary>
+        public void Toggle()
+        {
+            if (IsOpen)
+            {
+                Close();
+            }
+            else if (CanOpen)
+            {
+                Open(Game.SelectedHotbarSlot);
+            }
+        }
+
         private void Update()
         {
             if (Game == null)
@@ -80,9 +114,11 @@ namespace BlocksBeyondTheStars.Client
 
             if (IsOpen)
             {
-                // The opening key toggles, Esc always closes. (A focused text field never lives here.)
-                // Marking the frame keeps the app shell / pause menu from ALSO acting on the same Esc (#413).
-                if (InputMap.Down(InputAction.HotbarAction) || Input.GetKeyDown(KeyCode.Escape))
+                // The opening key toggles, Esc always closes, and pad B backs out (#940) — the pie is
+                // stick-navigable, so the pad needs an exit besides re-clicking R3. Marking the frame keeps
+                // the app shell / pause menu from ALSO acting on the same press (#413).
+                if (InputMap.Down(InputAction.HotbarAction) || Input.GetKeyDown(KeyCode.Escape)
+                    || Input.GetKeyDown(KeyCode.JoystickButton1))
                 {
                     Game.MarkMenuInputHandled();
                     Close();
@@ -91,22 +127,10 @@ namespace BlocksBeyondTheStars.Client
                 return;
             }
 
-            if (!InputMap.Down(InputAction.HotbarAction) || Game.MenuOpen)
+            if (InputMap.Down(InputAction.HotbarAction))
             {
-                return;
+                Toggle();
             }
-
-            // Exactly the states in which the HUD hides the hotbar (piloting/driving/spectating): no slots
-            // on screen means no slot to act on. EVA deliberately stays allowed — the hotbar shows there.
-            bool hotbarHidden = ((Game.SpaceViewActive || Game.InSpace) && !Game.InEva)
-                                || !string.IsNullOrEmpty(Game.InSpeeder)
-                                || Game.Spectating;
-            if (hotbarHidden)
-            {
-                return;
-            }
-
-            Open(Game.SelectedHotbarSlot);
         }
 
         // --- panel lifecycle ---
@@ -118,6 +142,7 @@ namespace BlocksBeyondTheStars.Client
             _glowMode = false;
             _canvas = UiKit.CreateCanvas("HotbarActionUi");
             _canvas.sortingOrder = 40; // above the HUD (10) and the flight overlay (12), below nothing that matters
+            UiNav.Enable(_canvas.gameObject); // pad: auto-focus so the stick walks wedges/buttons, A clicks (#940)
             Game.SetMenuOwner(this, true); // freezes player control + frees the cursor via the arbiter (#413)
             BuildRing();
         }

--- a/client/Assets/BlocksBeyondTheStars/Scripts/Input/GamepadInputSource.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/Input/GamepadInputSource.cs
@@ -34,6 +34,7 @@ namespace BlocksBeyondTheStars.Client
         private const KeyCode BtnY = KeyCode.JoystickButton3;   // toggle third-person
         private const KeyCode BtnLb = KeyCode.JoystickButton4;  // place block
         private const KeyCode BtnRb = KeyCode.JoystickButton5;  // mine / attack
+        private const KeyCode BtnR3 = KeyCode.JoystickButton9;  // right-stick click
 
         // Tunables (see issue #195). Look is a rate (deg/sec at sensitivity 1) turned into a per-frame delta
         // so it lands in the same space as a mouse delta — the caller still multiplies by MouseSensitivity,
@@ -143,6 +144,10 @@ namespace BlocksBeyondTheStars.Client
         {
             InputAction.Interact => BtnX,
             InputAction.ToggleThirdPerson => BtnY,
+            // R3 (#940): free on the stock layout, and "click the stick" mirrors the action's default
+            // middle-CLICK. D-pad-down would read nicer next to the d-pad hotbar cycle, but the project
+            // only defines a DPadX axis — d-pad Y isn't readable without touching ProjectSettings.
+            InputAction.HotbarAction => BtnR3,
             _ => KeyCode.None,
         };
 

--- a/client/Assets/BlocksBeyondTheStars/Scripts/TouchControlsUi.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/TouchControlsUi.cs
@@ -14,7 +14,7 @@ namespace BlocksBeyondTheStars.Client
     /// full-screen right-side look pad, and per-context action buttons. Three button clusters cover the
     /// game's control contexts — <b>on foot</b> (jump / mine / place / use / down / chat), <b>flight + EVA</b>
     /// (fire / land / ship / autopilot / view / up / down / use) and <b>speeder</b> (boost / hop / exit /
-    /// refuel) — with the stick, look pad, hotbar ◄► and menu button shared. State is reported to
+    /// refuel) — with the stick, look pad, hotbar ◄►, slot-actions "…" (#940) and menu button shared. State is reported to
     /// <see cref="TouchInputSource"/>, which feeds it into <see cref="InputMap"/>'s combined read alongside
     /// keyboard/mouse and gamepad.
     ///
@@ -42,6 +42,7 @@ namespace BlocksBeyondTheStars.Client
         private TouchButton _fire, _flightUp, _flightDown;              // flight + EVA
         private TouchButton _boost, _hop;                               // speeder
         private TouchButton _prev, _next, _menu;                        // shared
+        private TouchButton _slotActions;                               // opens the hotbar slot-action pie (#940)
         private readonly List<(InputAction Action, TouchButton Button)> _actions = new();
         private readonly List<(InputAction Action, TouchButton Button)> _heldActions = new();
         private bool _built;
@@ -194,6 +195,20 @@ namespace BlocksBeyondTheStars.Client
             {
                 Chat.OpenInput();
             }
+
+            // The "…" button opens the slot-action pie on the selected hotbar slot (#940). Shown only while
+            // the pie could actually open (same hidden-hotbar gates; EVA allowed). Opening registers a menu
+            // owner, which hides this whole layer — so taps reach the pie, and closing it brings us back.
+            var pie = HotbarActionUi.Instance;
+            if (_slotActions != null)
+            {
+                bool canAct = pie != null && pie.CanOpen;
+                SetActive(_slotActions.gameObject, canAct);
+                if (canAct && _slotActions.DownThisFrame)
+                {
+                    pie.Toggle();
+                }
+            }
         }
 
         private static void SetActive(GameObject go, bool active)
@@ -234,6 +249,11 @@ namespace BlocksBeyondTheStars.Client
             _prev = MakeButton(canvas.transform, new Vector2(0.5f, 0f), new Vector2(-360f, 130f), 90f, "◄");
             _next = MakeButton(canvas.transform, new Vector2(0.5f, 0f), new Vector2(360f, 130f), 90f, "►");
             _menu = MakeButton(canvas.transform, new Vector2(1f, 1f), new Vector2(-90f, -90f), 96f, "≡");
+
+            // Slot-action pie opener (#940), tucked beside the ► arrow: touch has no key to press, so this
+            // button IS the feature's input path here. Symbol label like ◄►≡, so no locale key is needed;
+            // Update shows it only while the pie could actually open.
+            _slotActions = MakeButton(canvas.transform, new Vector2(0.5f, 0f), new Vector2(480f, 130f), 90f, "…");
 
             // ---- On-foot cluster (bottom-right) --------------------------------------------------------
             _onFootCluster = MakeCluster(canvas.transform, "OnFoot");

--- a/docs/user/USER_MANUAL.md
+++ b/docs/user/USER_MANUAL.md
@@ -114,6 +114,7 @@ buttons — retuning is tracked in issue #195):
 | **(A)** | Jump (hold in air = jetpack; in water = swim up) |
 | **(X)** | Use / board / interact |
 | **(Y)** | Toggle first / third-person camera |
+| **R3** (click the right stick) | **Hotbar slot actions** on the selected slot (see §5) — stick navigates the menu, **(A)** picks, **(B)** closes |
 | **Start** | Open / close the gameplay menu |
 
 In menus, the left stick / d-pad navigates, **(A)** confirms and **(B)** goes back. The right stick also
@@ -133,6 +134,7 @@ buttons swap with what you're doing:
 | **Left stick** (bottom-left) | Move / thrust / steer |
 | **Drag** anywhere on the right | Look / steer the ship |
 | **◄ ►** | Cycle hotbar slot (ship-systems bar in flight) |
+| **…** (beside ►) | **Hotbar slot actions** on the selected slot (see §5); shown only when the menu can open |
 | **≡** (top-right) | Open / close the gameplay menu |
 | *On foot:* **JUMP · MINE (hold) · PLACE · USE · DOWN · CHAT** | Jump · mine · place · use/board · descend · open chat |
 | *Flying / EVA:* **FIRE (hold) · LAND · SHIP · AUTO · VIEW · USE · UP · DOWN** | Fire · landing pads · walk the ship · autopilot · camera · dock/board · float up/down |
@@ -298,7 +300,8 @@ separate unlock; admins can still disable it through server world rules.
   simply gone — the game warns you when that happens, so throw something away or empty the hold first.
 
 ### Hotbar slot actions (swap · colour · form)
-- Press **middle mouse** (rebindable: Settings → Controls → *Hotbar slot actions*) while playing on foot (or
+- Press **middle mouse** (rebindable: Settings → Controls → *Hotbar slot actions*; gamepad: **R3**; touch:
+  the **…** button beside the hotbar arrows) while playing on foot (or
   during an EVA) to act directly on the **selected hotbar slot** — no trip through the Tab menu. A **radial
   menu** opens around the screen centre: **Swap** on top, **Colour** on the left, **Form** on the right and
   **Close** at the bottom; quarters that don't apply to the held item stay visible but dimmed:


### PR DESCRIPTION
Closes #940

The hotbar slot-action pie (#924, #935/#937) could only be opened with a key or mouse — gamepad had no default binding and no menu focus, touch had no control at all. This PR adds both input paths.

## Gamepad

- **`HotbarAction → R3`** (right-stick click) as the stock binding — free on the XInput layout, "click the stick" mirrors the middle-*click*, no new InputManager axis needed (d-pad-down was considered but the project only defines `DPadX`; noted in code). Rebindable as always.
- **`UiNav.Enable`** on the pie's canvas: the existing auto-focus component (#195) + `Navigation.Automatic` make the menu stick-navigable — the four wedges sit exactly up/left/right/down, so the stick maps to them 1:1; A clicks, detail panels navigate the same way.
- **Pad B closes** the pie (alongside the toggle key and Esc), with the same input-handled marking (#413).
- The #935 HUD badge/hint automatically show **`RS`** while a pad is the active device (`InputMap.Glyph` prefers pad glyphs once a button is mapped — no extra code).

## Touch

- A shared **"…" button** beside the hotbar ► arrow (symbol label like ◄►/≡ — no locale key needed) opens the pie on the selected slot via the new **`HotbarActionUi.CanOpen` / `Toggle`** API — the same hidden-hotbar gates the key path uses (piloting/driving/spectating refuse; EVA allowed), so the button only shows when the pie could actually open.
- Opening registers a menu owner (#413), which hides the whole touch layer — taps reach the pie (already tap-friendly: flat overlay canvas, alpha hit-tested wedges); closing brings the controls back.

## Docs

USER_MANUAL: pad table (R3 row), touch table ("…" row), §5 opener line. TODO.md entry.

## Verification

- `dotnet test -c Release --filter Category!=Slow`: **1758 + 195 green**.
- Local Unity client build: compiles clean.
- ⚠ On-device playtest pending (CI exercises neither pad nor touch). Watch: R3 accidental presses while looking around — fallback candidate is d-pad-down with a new `DPadY` axis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
