### PR TITLE
fix(worldhost): route CodeQL-flagged world id through LogSafe in join-gate logs

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7738,6 +7738,20 @@ is **pre-approved** (keys in `tools/ai-assets/.env`, run via `uv`).
 
 ---
 
+## ✅ Done (2026-08-12): CodeQL follow-up on the #943 moderation logging — `LogSafe(id)` in the join gate
+
+CodeQL raised three alerts against the fresh #943 code. The two `cs/log-forging` hits (Program.cs
+join endpoint) flagged the `{id}` route parameter in the block/watch `LogWarning` lines — a false
+positive in practice (`id` is regex-validated `^[a-f0-9]{12}$` before those lines), but CodeQL
+cannot see through the bool-returning `IsValidWorldId` guard, so both occurrences now go through
+the file's existing `LogSafe()` sanitizer like every other request-derived value. The `cs/web/xss`
+(High) alert on `AdminNotifier`'s `StringContent` was dismissed as a false positive with a comment:
+that content is the body of an OUTBOUND `text/plain` POST to the operator-configured ntfy URL —
+never served to a browser — and header injection/length are already handled by `HeaderValue()`.
+Analysis: `analysis/codeql-alerts-1008-1010.md` (local).
+
+---
+
 ## ✅ Done (2026-08-12): name screening with operator flags, moderation pings, visible paint reports (#938)
 
 Kid-facing moderation, three pieces. **(1) Shared name screening** — new `Shared.Moderation.NameScreen`

--- a/src/BlocksBeyondTheStars.WorldHost/Program.cs
+++ b/src/BlocksBeyondTheStars.WorldHost/Program.cs
@@ -1338,7 +1338,7 @@ app.MapPost("/api/worlds/{id}/join", async (HttpContext ctx, string id, JoinRequ
     if (nameScreen.Verdict == BlocksBeyondTheStars.Shared.Moderation.NameVerdict.Block)
     {
         metrics.NameBlocked();
-        log.LogWarning("Join name blocked on world {Id} for account {Account} (matched '{Term}').", id, LogSafe(account.Name), nameScreen.MatchedTerm);
+        log.LogWarning("Join name blocked on world {Id} for account {Account} (matched '{Term}').", LogSafe(id), LogSafe(account.Name), nameScreen.MatchedTerm);
         notifier.Post("Blocked player name", $"Account '{account.Name}' tried to join world {id} under a name matching blocked term '{nameScreen.MatchedTerm}'.", "no_entry");
     }
 
@@ -1360,7 +1360,7 @@ app.MapPost("/api/worlds/{id}/join", async (HttpContext ctx, string id, JoinRequ
     if (nameScreen.Verdict == BlocksBeyondTheStars.Shared.Moderation.NameVerdict.Watch)
     {
         metrics.NameFlagged();
-        log.LogWarning("Player name '{Name}' flagged on world {Id} (matched watch term '{Term}'); join allowed.", LogSafe(req.PlayerName), id, nameScreen.MatchedTerm);
+        log.LogWarning("Player name '{Name}' flagged on world {Id} (matched watch term '{Term}'); join allowed.", LogSafe(req.PlayerName), LogSafe(id), nameScreen.MatchedTerm);
         notifier.Post("Player name flagged", $"Player '{req.PlayerName}' (account '{account.Name}') joined world {id} under a name matching watch-list term '{nameScreen.MatchedTerm}'. Review manually.", "triangular_flag_on_post");
     }
 


### PR DESCRIPTION
## Summary

CodeQL alerts **#1008/#1009** (`cs/log-forging`, Medium) flagged the `{id}` route parameter in the join endpoint's block/watch moderation `LogWarning` lines (introduced with #943).

In practice this is a false positive — `id` is regex-validated (`^[a-f0-9]{12}$` via `HostRegistry.IsValidWorldId`) before those lines execute — but CodeQL cannot see through the bool-returning guard method. Wrapping the two occurrences in the file's existing `LogSafe()` sanitizer is a free defense-in-depth fix that keeps the convention consistent (every other request-derived value in these lines is already wrapped) and lets both alerts auto-close on the next scan of `main`.

The third alert from the same scan, **#1010** (`cs/web/xss`, High, `AdminNotifier.cs`), was dismissed as a false positive with a comment: the flagged `StringContent` is the body of an *outbound* `text/plain` POST to the operator-configured ntfy URL, never served to a browser; header injection is already handled by `HeaderValue()`.

## Changes

- `src/BlocksBeyondTheStars.WorldHost/Program.cs`: `id` → `LogSafe(id)` in the two join-gate moderation log lines (no behavioral change — a valid world id never contains CR/LF).
- `TODO.md`: work-log entry.

## Testing

- `dotnet build src/BlocksBeyondTheStars.WorldHost -c Release` — 0 warnings, 0 errors.
- No test changes: log-argument-only change, covered by the existing endpoint tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)