### PR TITLE
test: cover BlockId contracts

### DIFF
--- a/tests/BlocksBeyondTheStars.Tests/BlockIdTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/BlockIdTests.cs
@@ -1,0 +1,42 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+
+using BlocksBeyondTheStars.Shared.Primitives;
+using Xunit;
+
+namespace BlocksBeyondTheStars.Tests;
+
+public sealed class BlockIdTests
+{
+    [Fact]
+    public void EqualIds_AreEqualAndHaveEqualHashCodes()
+    {
+        var first = new BlockId(42);
+        var second = new BlockId(42);
+
+        Assert.Equal(first, second);
+        Assert.True(first == second);
+        Assert.Equal(first.GetHashCode(), second.GetHashCode());
+    }
+
+    [Fact]
+    public void DifferentIds_AreNotEqual()
+    {
+        var first = new BlockId(42);
+        var second = new BlockId(43);
+
+        Assert.NotEqual(first, second);
+        Assert.True(first != second);
+    }
+
+    [Fact]
+    public void Air_HasZeroValueAndIsAir()
+    {
+        Assert.Equal(BlockId.AirValue, BlockId.Air.Value);
+        Assert.True(BlockId.Air.IsAir);
+        Assert.True(new BlockId(BlockId.AirValue).IsAir);
+        Assert.False(new BlockId(1).IsAir);
+    }
+
+}


### PR DESCRIPTION
## Related Issue

Related to #571

## Summary

Adds focused unit tests for `BlockId`'s core value-type contracts.

The tests verify that:

- Equal IDs compare equal and produce equal hash codes.
- Different IDs compare as different values.
- `BlockId.Air`, `AirValue`, and `IsAir` remain consistent.

The tests pass successfully.

This also completes the remaining explicitly mentioned test targets from #571 on our side, including the primitive types and the other suggested areas covered by the previous PRs.

At this point, I'd appreciate your direction on where to go next: should we continue looking for other meaningful untested logic, pick another issue, or is there a specific area you'd like us to test?