### PR TITLE
feat(ui): show both default ports in the join dialog

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7738,6 +7738,18 @@ is **pre-approved** (keys in `tools/ai-assets/.env`, run via `uv`).
 
 ---
 
+## ✅ Done (2026-08-12): join dialog shows both default ports — official servers vs. "Host Game" worlds
+
+LAN playtest trap: "Host Game" worlds listen on the bundled server's port **31550**
+(`LocalServerLauncher.DefaultPort`), but the join dialog's port field is prefilled with the official
+server default **31415** — so joining a friend's hosted world with the untouched default port silently
+times out ("Keine Verbindung zum Server möglich"). The connect dialog now shows a dim two-line hint next
+to the port field naming both defaults (`ui.menu.connect_port_hint`, localized in all 14 languages, with
+`{official}`/`{hosted}` placeholders filled from the constants — new `AppShell.DefaultServerPort`).
+Applies to every desktop client (Windows/macOS/Linux — one shared Unity UI).
+
+---
+
 ## ✅ Done (2026-08-12): build your own ship on a planet — keel, hull, commissioning, geometry stats (#948, #949, #950)
 
 Players can now BUILD a brand-new ship block by block, anywhere on a planet surface, and fly it.

--- a/TODO.md
+++ b/TODO.md
@@ -7738,6 +7738,49 @@ is **pre-approved** (keys in `tools/ai-assets/.env`, run via `uv`).
 
 ---
 
+## 🔬 Analysis (2026-08-12): LAN-playtest multiplayer bugs — NOT implemented yet, awaiting go
+
+Two-player "Host Game" playtest (world `JustusTest`, v2026.8.11) surfaced five bugs. Root causes
+identified from code + the host-side savegame/server log; fixes are planned but NOT started.
+
+1. **Ghost ship in space (fly-through copy).** `SpaceView.OnStructureDesign` only filters
+   `Kind == "ship"`/empty — `"ship_remote"` (other players' + NPC traders' hulls) falls through and is
+   ALSO built as a static asteroid-path voxel struct: at `(0,0,0)` for player ships (server never sets a
+   position on them), unscaled (2× flight size), collider-less, and never cleaned up. The proper handler
+   in `GameBootstrap` caches the same message for the remote avatar → the hull exists twice. Fix:
+   whitelist static kinds (asteroid/station) in `OnStructureDesign` + client test. Related: `SwitchShip`
+   broadcasts the rebuilt design to everyone as kind `"ship"`, replacing other players' OWN hull.
+2. **Remote ship flickers.** Mostly the ghost from (1) interpenetrating the real remote hull. Also:
+   interpolator delay (0.15 s) < pose broadcast interval (0.2 s) → buffer underrun (hold+jump); a single
+   missing pose snapshot destroys avatar+interpolator (rebuild popping); `SpaceInstance.ShipPosition` is
+   one shared field per instance — two pilots overwrite each other (collision/weapon range/ram damage).
+3. **E-landing hangs in "Lese Landeplätze…"** The home body is registered client-side with an EMPTY id
+   ("empty = current body" convention); `HandleRequestLandingPads` does `FindBody("")` → null → silent
+   return, no reply — client waits forever (no timeout/retry; flight frozen; Esc only escape). The `L`
+   chooser sends the real id and works. Fix: resolve empty id server-side like `HandleLeaveSpace`, always
+   echo a `LandingPadList`, add a client timeout.
+4. **Joiner "lost his ship" after landing.** Savegame proves the fleet row is intact — the ship is not
+   lost, it stayed parked at its old pad ~2.4 km from where he ended up. `RelocateToAssignedPad` never
+   sends `SendShipPlacement` (travel path does) → compass/map ship markers point at the OLD pad. Pad
+   bookkeeping is unsound too: players in space count as "pad free" without releasing their
+   `AssignedPadIndex`, and `PlayerPad` never re-validates an in-range index. Joiner's saved
+   `LandingPadIndex` is 0 (int default = host's home pad) and his respawn anchor is the WORLD ORIGIN
+   (0.5, 66, 0.5) — inside the host's parked ship (#865 fixed the spawn, not the respawn anchor).
+5. **Joiner's avatar standing in the host's ship.** Presence replicates absolute world coords only, AoI
+   culling silently stops sending (no despawn message), the client never times out stale remotes, and
+   `State.Position` is never updated during space flight — the avatar freezes at the last delivered
+   position (likely his origin-anchored spot in the host's ship).
+
+Side findings: 100+ `Ghost block healed` warnings ONLY for the joiner (late-join block/stamp desync —
+needs its own analysis); anti-entomb teleported the joiner to an UNDERGROUND target (y≈45); one
+"Ship parked — 234 cells" stamp (vs. 151-cell starter) offset by one block at the host pad, unexplained.
+
+Suggested fix order (separate PRs): (1) ship_remote filter → (3) landing echo+timeout → (4)+(5) unify
+landing paths + presence despawn. Detailed notes incl. open playtest questions live in the session
+analysis; ask Marcel before implementing.
+
+---
+
 ## ✅ Done (2026-08-12): join dialog shows both default ports — official servers vs. "Host Game" worlds
 
 LAN playtest trap: "Host Game" worlds listen on the bundled server's port **31550**

--- a/client/Assets/BlocksBeyondTheStars/Scripts/AppShell.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/AppShell.cs
@@ -38,10 +38,15 @@ namespace BlocksBeyondTheStars.Client
         /// Read by the persistent <see cref="ClientMusic"/> director to pick context music.</summary>
         public GameBootstrap CurrentBoot { get; private set; }
 
+        /// <summary>Default port of official/dedicated servers (the join dialog's prefill). Locally
+        /// hosted "Host Game" worlds listen on <see cref="LocalServerLauncher.DefaultPort"/> instead —
+        /// the join dialog shows both so LAN joiners know which one to enter.</summary>
+        public const int DefaultServerPort = 31415;
+
         // Join target edited on the main menu. PlayerName is loaded from / persisted to
         // ClientSettings (Awake / the connect dialog); Password is session-only.
         public string Host = "127.0.0.1";
-        public string Port = "31415";
+        public string Port = "31415"; // = DefaultServerPort; kept as a string (it is edited in the connect dialog)
         public string PlayerName = ""; // empty until chosen — the menu gates play actions on it (#221)
         public string Password = "";
 

--- a/client/Assets/BlocksBeyondTheStars/Scripts/UiMainMenu.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/UiMainMenu.cs
@@ -269,6 +269,14 @@ namespace BlocksBeyondTheStars.Client
             UiKit.AddInput(dlg, 30f, 186f, 540f, 38f, host[0], v => host[0] = v);
             UiKit.AddText(dlg, 30f, 240f, 540f, 22f, shell.L("ui.menu.connect_port"), 15, UiKit.TextCol, TextAnchor.MiddleLeft);
             UiKit.AddInput(dlg, 30f, 266f, 260f, 38f, port[0], v => port[0] = v);
+            // Both well-known defaults next to the port field: official servers prefill 31415, but a
+            // friend's "Host Game" world listens on 31550 — without the hint every LAN join with the
+            // untouched default port times out.
+            UiKit.AddText(dlg, 306f, 258f, 264f, 54f,
+                shell.L("ui.menu.connect_port_hint")
+                    .Replace("{official}", AppShell.DefaultServerPort.ToString())
+                    .Replace("{hosted}", LocalServerLauncher.DefaultPort.ToString()),
+                13, UiKit.CyanDim, TextAnchor.MiddleLeft);
             UiKit.AddText(dlg, 30f, 320f, 540f, 22f, shell.L("ui.menu.connect_password"), 15, UiKit.TextCol, TextAnchor.MiddleLeft);
             var passInput = UiKit.AddInput(dlg, 30f, 346f, 540f, 38f, pass[0], v => pass[0] = v);
             passInput.contentType = InputField.ContentType.Password; // mask it like the portal login field

--- a/data/locales/de.json
+++ b/data/locales/de.json
@@ -1429,6 +1429,7 @@
   "ui.menu.connect_name": "Spielername",
   "ui.menu.connect_host": "Serveradresse (IP oder Hostname)",
   "ui.menu.connect_port": "Port",
+  "ui.menu.connect_port_hint": "Offizielle Server: {official}\nSpiel hosten: {hosted}",
   "ui.menu.connect_password": "Server-Passwort (leer lassen, wenn keines)",
   "ui.menu.connect": "Verbinden",
   "ui.menu.play": "Spielen",

--- a/data/locales/en.json
+++ b/data/locales/en.json
@@ -1429,6 +1429,7 @@
   "ui.menu.connect_name": "Player name",
   "ui.menu.connect_host": "Server address (IP or hostname)",
   "ui.menu.connect_port": "Port",
+  "ui.menu.connect_port_hint": "Official servers: {official}\nHost Game: {hosted}",
   "ui.menu.connect_password": "Server password (leave empty if none)",
   "ui.menu.connect": "Connect",
   "ui.menu.play": "Play",

--- a/data/locales/es.json
+++ b/data/locales/es.json
@@ -1429,6 +1429,7 @@
   "ui.menu.connect_name": "Nombre de jugador",
   "ui.menu.connect_host": "Dirección del servidor (IP o nombre de host)",
   "ui.menu.connect_port": "Puerto",
+  "ui.menu.connect_port_hint": "Servidores oficiales: {official}\nCrear partida: {hosted}",
   "ui.menu.connect_password": "Contraseña del servidor (déjalo vacío si no hay)",
   "ui.menu.connect": "Conectar",
   "ui.menu.play": "Jugar",

--- a/data/locales/fr.json
+++ b/data/locales/fr.json
@@ -1429,6 +1429,7 @@
   "ui.menu.connect_name": "Nom du joueur",
   "ui.menu.connect_host": "Adresse du serveur (IP ou nom d'hôte)",
   "ui.menu.connect_port": "Port",
+  "ui.menu.connect_port_hint": "Serveurs officiels : {official}\nHéberger une partie : {hosted}",
   "ui.menu.connect_password": "Mot de passe du serveur (laisser vide si aucun)",
   "ui.menu.connect": "Se connecter",
   "ui.menu.play": "Jouer",

--- a/data/locales/it.json
+++ b/data/locales/it.json
@@ -1429,6 +1429,7 @@
   "ui.menu.connect_name": "Nome giocatore",
   "ui.menu.connect_host": "Indirizzo server (IP o hostname)",
   "ui.menu.connect_port": "Porta",
+  "ui.menu.connect_port_hint": "Server ufficiali: {official}\nOspita partita: {hosted}",
   "ui.menu.connect_password": "Password server (lascia vuoto se nessuna)",
   "ui.menu.connect": "Connetti",
   "ui.menu.play": "Gioca",

--- a/data/locales/ja.json
+++ b/data/locales/ja.json
@@ -1429,6 +1429,7 @@
   "ui.menu.connect_name": "プレイヤー名",
   "ui.menu.connect_host": "サーバーアドレス（IPまたはホスト名）",
   "ui.menu.connect_port": "ポート",
+  "ui.menu.connect_port_hint": "公式サーバー: {official}\nゲームをホスト: {hosted}",
   "ui.menu.connect_password": "サーバーパスワード（なければ空欄）",
   "ui.menu.connect": "接続",
   "ui.menu.play": "プレイ",

--- a/data/locales/ko.json
+++ b/data/locales/ko.json
@@ -1429,6 +1429,7 @@
   "ui.menu.connect_name": "플레이어 이름",
   "ui.menu.connect_host": "서버 주소 (IP 또는 호스트명)",
   "ui.menu.connect_port": "포트",
+  "ui.menu.connect_port_hint": "공식 서버: {official}\n게임 호스트: {hosted}",
   "ui.menu.connect_password": "서버 비밀번호 (없으면 비워두세요)",
   "ui.menu.connect": "연결",
   "ui.menu.play": "플레이",

--- a/data/locales/nl.json
+++ b/data/locales/nl.json
@@ -1429,6 +1429,7 @@
   "ui.menu.connect_name": "Spelersnaam",
   "ui.menu.connect_host": "Serveradres (IP of hostnaam)",
   "ui.menu.connect_port": "Poort",
+  "ui.menu.connect_port_hint": "Officiële servers: {official}\nSpel hosten: {hosted}",
   "ui.menu.connect_password": "Serverwachtwoord (leeg laten als er geen is)",
   "ui.menu.connect": "Verbinden",
   "ui.menu.play": "Spelen",

--- a/data/locales/pl.json
+++ b/data/locales/pl.json
@@ -1429,6 +1429,7 @@
   "ui.menu.connect_name": "Nazwa gracza",
   "ui.menu.connect_host": "Adres serwera (IP lub nazwa hosta)",
   "ui.menu.connect_port": "Port",
+  "ui.menu.connect_port_hint": "Serwery oficjalne: {official}\nUruchom serwer: {hosted}",
   "ui.menu.connect_password": "Hasło serwera (zostaw puste, jeśli brak)",
   "ui.menu.connect": "Połącz",
   "ui.menu.play": "Graj",

--- a/data/locales/pt.json
+++ b/data/locales/pt.json
@@ -1429,6 +1429,7 @@
   "ui.menu.connect_name": "Nome do jogador",
   "ui.menu.connect_host": "Endereço do servidor (IP ou hostname)",
   "ui.menu.connect_port": "Porta",
+  "ui.menu.connect_port_hint": "Servidores oficiais: {official}\nHospedar jogo: {hosted}",
   "ui.menu.connect_password": "Senha do servidor (deixe vazio se não houver)",
   "ui.menu.connect": "Conectar",
   "ui.menu.play": "Jogar",

--- a/data/locales/ru.json
+++ b/data/locales/ru.json
@@ -1429,6 +1429,7 @@
   "ui.menu.connect_name": "Имя игрока",
   "ui.menu.connect_host": "Адрес сервера (IP или хост)",
   "ui.menu.connect_port": "Порт",
+  "ui.menu.connect_port_hint": "Официальные серверы: {official}\nРазместить мир: {hosted}",
   "ui.menu.connect_password": "Пароль сервера (оставь пустым, если нет)",
   "ui.menu.connect": "Подключиться",
   "ui.menu.play": "Играть",

--- a/data/locales/tr.json
+++ b/data/locales/tr.json
@@ -1429,6 +1429,7 @@
   "ui.menu.connect_name": "Oyuncu adı",
   "ui.menu.connect_host": "Sunucu adresi (IP veya host adı)",
   "ui.menu.connect_port": "Port",
+  "ui.menu.connect_port_hint": "Resmî sunucular: {official}\nOyun Sun: {hosted}",
   "ui.menu.connect_password": "Sunucu parolası (yoksa boş bırak)",
   "ui.menu.connect": "Bağlan",
   "ui.menu.play": "Oyna",

--- a/data/locales/uk.json
+++ b/data/locales/uk.json
@@ -1429,6 +1429,7 @@
   "ui.menu.connect_name": "Імʼя гравця",
   "ui.menu.connect_host": "Адреса сервера (IP або хостнейм)",
   "ui.menu.connect_port": "Порт",
+  "ui.menu.connect_port_hint": "Офіційні сервери: {official}\nЗапустити гру: {hosted}",
   "ui.menu.connect_password": "Пароль сервера (залиши порожнім, якщо нема)",
   "ui.menu.connect": "Підключитись",
   "ui.menu.play": "Грати",

--- a/data/locales/zh.json
+++ b/data/locales/zh.json
@@ -1429,6 +1429,7 @@
   "ui.menu.connect_name": "玩家名字",
   "ui.menu.connect_host": "服务器地址（IP 或主机名）",
   "ui.menu.connect_port": "端口",
+  "ui.menu.connect_port_hint": "官方服务器：{official}\n创建游戏：{hosted}",
   "ui.menu.connect_password": "服务器密码（无则留空）",
   "ui.menu.connect": "连接",
   "ui.menu.play": "开始游戏",


### PR DESCRIPTION
## What
The "Connect to server" dialog now shows a dim two-line hint next to the port field naming **both** well-known defaults: official servers (31415) and "Host Game" worlds (31550).

## Why
LAN playtest trap: "Host Game" worlds listen on the bundled server's port **31550** (`LocalServerLauncher.DefaultPort`), but the join dialog prefills the official default **31415** — joining a friend's hosted world with the untouched port silently times out ("No connection to the server possible").

## How
- New `AppShell.DefaultServerPort` constant; hint values are filled from the constants (no duplicated literals).
- New locale key `ui.menu.connect_port_hint` in **all 14 languages**, phrased with each locale's own "Host Game" menu wording, `{official}`/`{hosted}` placeholders.
- One shared Unity UI → covers the Windows, macOS and Linux clients.
- Also records the 2026-08-12 LAN-playtest bug analysis in TODO.md (fixes tracked in #954–#959).

## Verification
- Locale test suite: 48/48 green.
- Full local Unity Windows build: green, no stray generated files in the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
