### PR TITLE
fix(ui): grow the hotbar Swap/Colour panels so Back/Close clear their content

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7811,6 +7811,19 @@ false-positive guards, join gate end-to-end). Chat filtering stays a separate ta
 
 ---
 
+## ✅ Done (2026-08-12): the Swap panel no longer hides its last slot row under Back/Close (#953)
+
+The slot-action **Swap** panel opened a 660-px dialog, but its own content ran to y 774: the 4th
+backpack row overshot the panel bottom and the Back/Close buttons (placed at `h − 78`) sat directly
+ON slots 18/23, covering them and stealing their clicks; the stow button floated entirely below the
+panel on the scrim (dialog panels have no clipping mask). Same class of bug in the **Colour** panel
+(700 px): the own-design tiles clipped 8 px under Back, and the remove-design button (shown when the
+held stack carries a paint design) landed fully on top of it. Fix is purely geometric — Swap grows to
+1000×880, Colour to 900×780, both recentred; the Form panel (740 px) already fit. Cell sizes stay
+untouched on purpose: shrinking them would undercut the touch/pad targets #940/#942 just introduced.
+
+---
+
 ## ✅ Done (2026-08-12): the slot-action pie works on gamepad and touch (#940)
 
 Follow-up to #935 (below): pad and touch could not OPEN the pie at all — no default pad button, no touch

--- a/client/Assets/BlocksBeyondTheStars/Scripts/HotbarActionUi.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/HotbarActionUi.cs
@@ -311,7 +311,9 @@ namespace BlocksBeyondTheStars.Client
         /// opened on (one <c>MoveItemIntent</c>, validated server-side). The invoking slot is highlighted.</summary>
         private void BuildSwap()
         {
-            var (_, panel) = UiKit.AddModalOverlay(_canvas.transform, 460f, 210f, 1000f, 660f);
+            // 880 tall: the 6×4 slot grid ends at y 696 and the stow button at 774 — a shorter panel put
+            // the Back/Close row ON the last slot row (#953).
+            var (_, panel) = UiKit.AddModalOverlay(_canvas.transform, 460f, 100f, 1000f, 880f);
             Header(panel, L("ui.hotbar_action.swap_title"));
 
             const int cols = 6;
@@ -370,7 +372,7 @@ namespace BlocksBeyondTheStars.Client
                     () => { Game.Network?.SendMoveItem(_slot, -1); Close(); });
             }
 
-            BackClose(panel, 1000f, 660f);
+            BackClose(panel, 1000f, 880f);
         }
 
         // --- level 2: colour (dye / glow / own designs) ---
@@ -380,7 +382,9 @@ namespace BlocksBeyondTheStars.Client
         /// pins the output back to the invoking slot.</summary>
         private void BuildColour()
         {
-            var (_, panel) = UiKit.AddModalOverlay(_canvas.transform, 510f, 190f, 900f, 700f);
+            // 780 tall: the design tiles end at y 630 and the remove-design button at 688 — a shorter
+            // panel put the Back/Close row on top of both (#953).
+            var (_, panel) = UiKit.AddModalOverlay(_canvas.transform, 510f, 150f, 900f, 780f);
             Header(panel, string.Format(L("ui.hotbar_action.colour_title"), ItemName(_item), Game.CountInSlot(_slot)));
 
             // Dye/Glow mode toggle. Glow shows what it costs so the wheel never books crystals silently.
@@ -460,7 +464,7 @@ namespace BlocksBeyondTheStars.Client
                     () => { Game.Network?.SendPaintCraft(_item, string.Empty, stack, _slot); Close(); });
             }
 
-            BackClose(panel, 900f, 700f);
+            BackClose(panel, 900f, 780f);
         }
 
         // --- level 2: form (built-in + own) ---


### PR DESCRIPTION
closes #953

## What

The hotbar slot-action **Swap** panel drew its Back/Close buttons on top of the last backpack slot row — the buttons floated in front of slots 18/23 and stole their clicks — and its stow button hung entirely below the panel. The **Colour** panel had the same class of bug: the own-design tiles clipped under Back, and the remove-design button (visible when the stack carries a paint design) sat fully on top of it.

## Why

`BuildSwap()` opened a 660-px dialog whose own content runs to y 774 (6×4 grid to 696, stow to 774), and `BackClose()` anchors the button row at `h − 78` — inside the grid. Dialog panels have no clipping mask, so the overflow rendered on the scrim instead of being cut off.

## How

Purely geometric, client-only:

- Swap panel: 1000×660 → **1000×880**, recentred (grid ends 696, stow 726–774, Back/Close 802–850).
- Colour panel: 900×700 → **900×780** (design tiles end 630, remove-design 642–688, Back/Close 702–750).
- Form panel (740 px) already fit — untouched.

Cell/tile sizes deliberately stay as they are: shrinking them to fit the old height would undercut the touch/pad target sizes #940/#942 just introduced.

## Verification

- Local Unity player build in the worktree: green, fresh `BlocksBeyondTheStars.Client.dll` (PR CI doesn't build Unity).
- No server/shared/locale changes; TODO.md entry added.
- Playtest note: open the pie → Swap (all 4 rows + stow visible, corner slots clickable) and → Colour with a paint design applied (remove-design button clear of Back).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
