### PR TITLE
perf(client): pack the chunk vertex format and drop the redundant mesh RAM copy (#966)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ the richer, screenshot-laden versions live there. `(#123)` references the pull r
 
 ## [Unreleased]
 
+### 🧠 The world takes a quarter of the memory to look at (#966)
+
+- **Chunk meshes are far lighter.** Every visible chunk was stored twice — once on the graphics card
+  and once again in main memory — and each corner of every block carried a pile of full-precision
+  numbers it never needed. Both are fixed: the spare copy is gone and the data is packed, so the
+  terrain around you costs roughly a quarter of what it did. A long session at the largest view
+  distance was reaching 1.8 GB; the terrain part of that is now a fraction.
+- Nothing about how the world looks changes — same geometry, same lighting, same colours.
+
 ## [2026.8.12] — 2026-08-13
 
 The shipwright release. Until now the ship you flew was one the game handed you; from this version

--- a/TODO.md
+++ b/TODO.md
@@ -7738,6 +7738,40 @@ is **pre-approved** (keys in `tools/ai-assets/.env`, run via `uv`).
 
 ---
 
+## ✅ Done (2026-08-13): chunk-mesh memory — packed vertex format + non-readable upload (#966)
+
+Closes the part of #966 that the previous round deliberately left open: the chunk meshes themselves.
+Two independent factors, each roughly a halving:
+
+**The system-RAM copy is gone.** Unity keeps a full CPU-side copy of every mesh next to the GPU one
+unless it is told otherwise, and `UploadMeshData(markNoLongerReadable: true)` appeared nowhere in
+`client/`. The render mesh is now uploaded non-readable. That rules out the old Clear()+refill reuse
+(a non-readable mesh cannot be rewritten), so each rebuild returns a **fresh** mesh and
+`ApplyChunkMesh` destroys the one it replaces — without that, A2's rebuild rate would leak a mesh per
+remesh. Nothing reads a chunk mesh back: collision has its own mesh, and the ship/speeder meshers only
+ever assign the render mesh to a `MeshFilter`. The **collision** mesh stays readable on purpose —
+`Physics.BakeMesh`/`MeshCollider` cook from it, and its vertex count is a fraction of the render mesh's.
+
+**The vertex format is packed: 112 → 56 B/vertex.** The plain `Mesh` setters store every channel as
+floats — position, normal, tangent, colour and five UV sets. `ChunkMeshData.Pack` now interleaves the
+build lists into a `PackedVertex` uploaded through `SetVertexBufferParams`/`SetVertexBufferData`:
+normal, tangent and block-light direction as `SNorm8` (all unit vectors), the material colour as
+`UNorm8` (gloss/metal/shade×AO/emission are 0..1), sky/leaf/block-light as `Float16`. Position and the
+**atlas UV stay `Float32`** — a UV off by a quantum bleeds the neighbouring tile in. Packing runs on
+the build worker thread, not next to the main-thread upload. **Shaders are untouched:** the GPU expands
+these formats to float on read, so `BlockAtlas`/`BlockAtlasTransparent` see exactly what they saw before.
+
+New tests: `ChunkMeshPackingEditModeTests` (5, EditMode) — half/SNorm/UNorm round-trips, positions and
+atlas UVs bit-exact, buffer reuse across builds, and the upload keeping the three-submesh index split
+while reporting `isReadable == false`. Not covered by PR CI (it is .NET-only); verified with a local
+EditMode run (24/24) and a Windows player build.
+
+Still open from the issue and deliberately not done here: greedy-meshing the **render** mesh (the
+collider path already does it) — a change to the geometry itself, not to how it is stored. Playtest
+verify pending: watch peak RAM at view distance 8.
+
+---
+
 ## ✅ Done (2026-08-12): hosting stability — alt-tab freeze, reconnect after a crash, ghost-block storm, client memory (#963–#966)
 
 Second round of fixes from the same LAN playtest. Root cause of two of them was the same setting:
@@ -7777,7 +7811,8 @@ chunk cache): chunk meshes at view distance 8, kept in a system-RAM copy on top 
 `WorldMinimap`'s static preview cache and `ShapeIconFactory` now **destroy** their textures instead of just
 dropping references (Unity never collects those), and the chunk unload pass runs on a 5 s heartbeat as well
 as on movement — a standing or stuck player never released a chunk before. The vertex-format packing and
-`UploadMeshData(true)` remain open (bigger, riskier change; see the issue).
+`UploadMeshData(true)` were left open here as the bigger, riskier change — done on 2026-08-13, see the
+section above.
 
 New tests: `ReceiveBudgetTests` (5) and `ReconnectAndGhostTests` (5). Playtest verify pending.
 

--- a/client/Assets/BlocksBeyondTheStars/Scripts/ChunkMesher.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/ChunkMesher.cs
@@ -2,11 +2,13 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 using BlocksBeyondTheStars.Shared.Content;
 using BlocksBeyondTheStars.Shared.Geometry;
 using BlocksBeyondTheStars.Shared.Primitives;
 using BlocksBeyondTheStars.Shared.World;
 using UnityEngine;
+using Rendering = UnityEngine.Rendering;
 
 namespace BlocksBeyondTheStars.Client
 {
@@ -832,6 +834,11 @@ namespace BlocksBeyondTheStars.Client
             AccumulateFlatNormals(verts, trisP, normals);
             data.Bounds = ComputeBounds(verts, n);
             data.ColliderBounds = ComputeBounds(colliderVerts, n);
+
+            // Interleave the per-attribute lists into the compact GPU vertex layout (#966). Done HERE, on the
+            // build (worker) thread, because it is pure struct maths — doing it in ToMeshes would put a
+            // per-vertex loop back on the main thread right next to the upload.
+            data.Pack();
 
             // Return plain data — the Unity Mesh upload happens in ChunkMeshData.ToMeshes() on the main thread.
             return data;
@@ -1932,6 +1939,14 @@ namespace BlocksBeyondTheStars.Client
         public Bounds ColliderBounds;
         public readonly List<Vector4> Scatter = new List<Vector4>();  // ground-detail scatter points (xyz = local pos, w = type); NOT uploaded to the mesh
 
+        /// <summary>The interleaved GPU vertex buffer produced by <see cref="Pack"/> — <see cref="PackedCount"/>
+        /// valid entries (the array itself is grown geometrically and reused with the pooled instance).</summary>
+        public PackedVertex[] Packed = System.Array.Empty<PackedVertex>();
+
+        /// <summary>How many entries of <see cref="Packed"/> are valid (equals <c>Verts.Count</c> after
+        /// <see cref="Pack"/>).</summary>
+        public int PackedCount;
+
         // Small bounded pool: builds run on worker threads while Release happens on the main thread, so access
         // is lock-guarded (a handful of ops per frame — contention is negligible). The cap bounds how much list
         // capacity idles here; an over-cap Release simply drops the instance to the GC (= the old behaviour).
@@ -1971,6 +1986,7 @@ namespace BlocksBeyondTheStars.Client
                 Verts.Clear(); OpaqueTris.Clear(); TransparentTris.Clear(); PaintTris.Clear(); ColliderTris.Clear(); ColliderVerts.Clear();
                 Colors.Clear(); Uvs.Clear(); SkyUv.Clear(); LeafUv.Clear();
                 BlockLight.Clear(); BlockLightDir.Clear(); Tangents.Clear(); Normals.Clear(); Scatter.Clear();
+                PackedCount = 0; // the array itself stays — it is the buffer the next build packs into
                 Bounds = default;
                 ColliderBounds = default;
                 _pooled = true;
@@ -1978,41 +1994,194 @@ namespace BlocksBeyondTheStars.Client
             }
         }
 
-        /// <summary>Uploads the data into a render mesh (opaque + see-through submeshes) and a separate
-        /// fluid-excluded collision mesh. MUST run on the main thread (the Unity Mesh API is not thread-safe).</summary>
-        public (Mesh Render, Mesh Collider) ToMeshes(Mesh reuseRender = null)
+        /// <summary>One vertex in the compact GPU layout (#966). The default Mesh API stores every channel as
+        /// full floats — position + normal + tangent + colour + five UV sets came to 112 B/vertex, which at the
+        /// ~1200 chunks a view distance of 8 keeps resident was the single largest block of client memory.
+        /// Quantising the channels that do not need float precision brings that to 56 B; combined with
+        /// <see cref="Mesh.UploadMeshData"/> dropping the system-RAM copy (see <see cref="ToMeshes"/>), chunk
+        /// mesh memory falls to roughly a quarter of what it was.
+        ///
+        /// The field order MUST match <see cref="VertexLayout"/> — Unity derives each attribute's byte offset
+        /// from the order of the descriptors within the stream. Shaders need no change: the GPU expands
+        /// SNorm8/UNorm8/Float16 to float on read, exactly like the CPU-side floats it replaces.</summary>
+        [StructLayout(LayoutKind.Sequential, Pack = 1)]
+        public struct PackedVertex
         {
-            // Reuse the chunk's existing render Mesh on a rebuild (A3): Clear()+refill avoids allocating a fresh
-            // Mesh — and leaking the old one — on every remesh. The collider mesh is always fresh, because it is
-            // cooked asynchronously by Physics.BakeMesh and reusing a mesh mid-bake would be unsafe.
-            var mesh = reuseRender != null ? reuseRender : new Mesh { indexFormat = UnityEngine.Rendering.IndexFormat.UInt32 };
-            if (reuseRender != null)
+            public Vector3 Position;              // Float32x3 — block-local position, needs full precision
+            public sbyte Nx, Ny, Nz, Nw;          // SNorm8x4  — unit face normal (w unused)
+            public sbyte Tx, Ty, Tz, Tw;          // SNorm8x4  — tangent xyz + handedness (all exactly ±1/0)
+            public byte Cr, Cg, Cb, Ca;           // UNorm8x4  — gloss / metal / shade×AO / emission, all 0..1
+            public Vector2 Uv;                    // Float32x2 — atlas coordinates, kept float (tile precision)
+            public ushort SkyX, SkyY;             // Float16x2 — skylight 0..1, tint/face mode (small integer)
+            public ushort LeafX, LeafY, LeafZ, LeafW;  // Float16x4 — foliage flag + tint, or the water-body data
+            public ushort BlX, BlY, BlZ, BlW;     // Float16x4 — propagated block-light colour (may exceed 1)
+            public sbyte Dx, Dy, Dz, Dw;          // SNorm8x4  — block-light direction (unit or zero)
+        }
+
+        /// <summary>The vertex stream layout matching <see cref="PackedVertex"/>, in VertexAttribute enum order
+        /// (Unity requires that within a stream). 56 B/vertex against the 112 B the plain Mesh setters use.</summary>
+        private static readonly Rendering.VertexAttributeDescriptor[] VertexLayout =
+        {
+            new Rendering.VertexAttributeDescriptor(Rendering.VertexAttribute.Position, Rendering.VertexAttributeFormat.Float32, 3),
+            new Rendering.VertexAttributeDescriptor(Rendering.VertexAttribute.Normal, Rendering.VertexAttributeFormat.SNorm8, 4),
+            new Rendering.VertexAttributeDescriptor(Rendering.VertexAttribute.Tangent, Rendering.VertexAttributeFormat.SNorm8, 4),
+            new Rendering.VertexAttributeDescriptor(Rendering.VertexAttribute.Color, Rendering.VertexAttributeFormat.UNorm8, 4),
+            new Rendering.VertexAttributeDescriptor(Rendering.VertexAttribute.TexCoord0, Rendering.VertexAttributeFormat.Float32, 2),
+            new Rendering.VertexAttributeDescriptor(Rendering.VertexAttribute.TexCoord1, Rendering.VertexAttributeFormat.Float16, 2),
+            new Rendering.VertexAttributeDescriptor(Rendering.VertexAttribute.TexCoord2, Rendering.VertexAttributeFormat.Float16, 4),
+            new Rendering.VertexAttributeDescriptor(Rendering.VertexAttribute.TexCoord3, Rendering.VertexAttributeFormat.Float16, 4),
+            new Rendering.VertexAttributeDescriptor(Rendering.VertexAttribute.TexCoord4, Rendering.VertexAttributeFormat.SNorm8, 4),
+        };
+
+        // Nothing downstream re-reads or re-validates what we just built: the indices come from our own
+        // emitters and the bounds are computed analytically, so skip both checks on every upload.
+        private const Rendering.MeshUpdateFlags UploadFlags =
+            Rendering.MeshUpdateFlags.DontRecalculateBounds | Rendering.MeshUpdateFlags.DontValidateIndices;
+
+        /// <summary>Interleaves the per-attribute build lists into <see cref="Packed"/>. Pure struct maths — safe
+        /// on the build worker thread, and kept off the main thread on purpose (the upload is already there).
+        /// The emitters fill every channel in lockstep with <see cref="Verts"/>, so all lists have equal length.
+        /// </summary>
+        public void Pack()
+        {
+            int n = Verts.Count;
+            if (Packed.Length < n)
             {
-                mesh.Clear();
+                // Geometric growth, so a chunk that keeps re-meshing at a similar size stops reallocating.
+                Packed = new PackedVertex[Mathf.NextPowerOfTwo(Mathf.Max(n, 1024))];
             }
 
-            mesh.SetVertices(Verts);
+            var packed = Packed;
+            for (int i = 0; i < n; i++)
+            {
+                Vector3 nrm = Normals[i];
+                Vector4 tan = Tangents[i];
+                Color col = Colors[i];
+                Vector2 sky = SkyUv[i];
+                Vector4 leaf = LeafUv[i];
+                Vector3 bl = BlockLight[i];
+                Vector3 dir = BlockLightDir[i];
+
+                packed[i] = new PackedVertex
+                {
+                    Position = Verts[i],
+                    Nx = SNorm(nrm.x), Ny = SNorm(nrm.y), Nz = SNorm(nrm.z), Nw = 0,
+                    Tx = SNorm(tan.x), Ty = SNorm(tan.y), Tz = SNorm(tan.z), Tw = SNorm(tan.w),
+                    Cr = UNorm(col.r), Cg = UNorm(col.g), Cb = UNorm(col.b), Ca = UNorm(col.a),
+                    Uv = Uvs[i],
+                    SkyX = Half(sky.x), SkyY = Half(sky.y),
+                    LeafX = Half(leaf.x), LeafY = Half(leaf.y), LeafZ = Half(leaf.z), LeafW = Half(leaf.w),
+                    BlX = Half(bl.x), BlY = Half(bl.y), BlZ = Half(bl.z), BlW = 0,
+                    Dx = SNorm(dir.x), Dy = SNorm(dir.y), Dz = SNorm(dir.z), Dw = 0,
+                };
+            }
+
+            PackedCount = n;
+        }
+
+        /// <summary>Quantises a -1..1 value to the SNorm8 the GPU expands back by dividing by 127.</summary>
+        public static sbyte SNorm(float v) => (sbyte)Mathf.Clamp(Mathf.RoundToInt(v * 127f), -127, 127);
+
+        /// <summary>Quantises a 0..1 value to the UNorm8 the GPU expands back by dividing by 255.</summary>
+        public static byte UNorm(float v) => (byte)Mathf.Clamp(Mathf.RoundToInt(v * 255f), 0, 255);
+
+        [StructLayout(LayoutKind.Explicit)]
+        private struct FloatBits
+        {
+            [FieldOffset(0)] public float F;
+            [FieldOffset(0)] public uint U;
+        }
+
+        /// <summary>IEEE-754 float → half (binary16), round-to-nearest-even. Hand-rolled rather than
+        /// <c>Mathf.FloatToHalf</c> so it is unambiguously pure managed maths on the build worker thread.
+        /// Sub-normals flush to zero and overflow clamps to the largest finite half — both are far outside the
+        /// 0..~8 range these channels carry, and a NaN/Inf leaking into a vertex buffer would be far worse.
+        /// </summary>
+        public static ushort Half(float value)
+        {
+            FloatBits bits = default;
+            bits.F = value;
+            uint x = bits.U;
+            uint sign = (x >> 16) & 0x8000u;
+            uint magnitude = x & 0x7FFFFFFFu;
+
+            if (magnitude >= 0x7F800000u)
+            {
+                return (ushort)(sign | (magnitude > 0x7F800000u ? 0u : 0x7BFFu)); // NaN → ±0, Inf → max finite
+            }
+
+            int exp = (int)((x >> 23) & 0xFFu) - 127 + 15;
+            uint mant = x & 0x7FFFFFu;
+            if (exp <= 0)
+            {
+                return (ushort)sign; // sub-normal/underflow → signed zero
+            }
+
+            uint half = ((uint)exp << 10) | (mant >> 13);
+            if ((mant & 0x1000u) != 0 && ((mant & 0xFFFu) != 0 || (half & 1u) != 0))
+            {
+                half++; // round half to even; a carry into the exponent is the correct rounded result
+            }
+
+            return (ushort)(sign | (half >= 0x7C00u ? 0x7BFFu : half));
+        }
+
+        /// <summary>Uploads the data into a render mesh (opaque + see-through submeshes) and a separate
+        /// fluid-excluded collision mesh. MUST run on the main thread (the Unity Mesh API is not thread-safe).
+        ///
+        /// The render mesh is built through the low-level buffer API so it gets the compact
+        /// <see cref="PackedVertex"/> layout, and is then uploaded with <c>markNoLongerReadable: true</c> —
+        /// without that Unity keeps a full system-RAM copy of every chunk mesh next to the GPU one, doubling
+        /// their cost (#966). Nothing reads a chunk mesh back: the collider has its own mesh, and the ship/
+        /// speeder meshers only ever assign the render mesh to a MeshFilter.
+        ///
+        /// A consequence of the non-readable upload is that the previous mesh can no longer be Clear()ed and
+        /// refilled, so every build returns a FRESH mesh — callers must destroy the one they replace (Unity does
+        /// not collect Mesh objects), which is what <c>GameBootstrap.ApplyChunkMesh</c> does.</summary>
+        public (Mesh Render, Mesh Collider) ToMeshes()
+        {
+            var mesh = new Mesh { indexFormat = Rendering.IndexFormat.UInt32 };
+            mesh.SetVertexBufferParams(PackedCount, VertexLayout);
+            if (PackedCount > 0)
+            {
+                mesh.SetVertexBufferData(Packed, 0, 0, PackedCount, 0, UploadFlags);
+            }
+
             // Three submeshes sharing one vertex buffer: 0 = opaque (BlockAtlas), 1 = see-through
             // (BlockAtlasTransparent), 2 = player-painted design faces (paint atlas). The renderer is given
             // the materials in the same order. An empty submesh just draws nothing — chunks without glass or
-            // paint pay no extra draw call.
+            // paint pay no extra draw call. They share one index buffer, laid out opaque | transparent | paint.
+            int nOpaque = OpaqueTris.Count, nTransparent = TransparentTris.Count, nPaint = PaintTris.Count;
+            mesh.SetIndexBufferParams(nOpaque + nTransparent + nPaint, Rendering.IndexFormat.UInt32);
+            if (nOpaque > 0)
+            {
+                mesh.SetIndexBufferData(OpaqueTris, 0, 0, nOpaque, UploadFlags);
+            }
+
+            if (nTransparent > 0)
+            {
+                mesh.SetIndexBufferData(TransparentTris, 0, nOpaque, nTransparent, UploadFlags);
+            }
+
+            if (nPaint > 0)
+            {
+                mesh.SetIndexBufferData(PaintTris, 0, nOpaque + nTransparent, nPaint, UploadFlags);
+            }
+
             mesh.subMeshCount = 3;
-            mesh.SetTriangles(OpaqueTris, 0);
-            mesh.SetTriangles(TransparentTris, 1);
-            mesh.SetTriangles(PaintTris, 2);
-            mesh.SetColors(Colors);
-            mesh.SetUVs(0, Uvs);
-            mesh.SetUVs(1, SkyUv);
-            mesh.SetUVs(2, LeafUv);
-            mesh.SetUVs(3, BlockLight);
-            mesh.SetUVs(4, BlockLightDir);
-            mesh.SetTangents(Tangents);
-            mesh.SetNormals(Normals);
+            // Every submesh gets the whole chunk's bounds: conservative (never culls something that is visible)
+            // and free, where a per-submesh sweep would be another pass over the vertices.
+            mesh.SetSubMesh(0, new Rendering.SubMeshDescriptor(0, nOpaque) { bounds = Bounds }, UploadFlags);
+            mesh.SetSubMesh(1, new Rendering.SubMeshDescriptor(nOpaque, nTransparent) { bounds = Bounds }, UploadFlags);
+            mesh.SetSubMesh(2, new Rendering.SubMeshDescriptor(nOpaque + nTransparent, nPaint) { bounds = Bounds }, UploadFlags);
             mesh.bounds = Bounds;
+            mesh.UploadMeshData(true); // drop the system-RAM copy — the mesh is render-only from here on
 
             // Collision mesh: its OWN vertex list (greedy-merged solid faces + shaped-block geometry, fluids
             // excluded so water is passable) — far fewer verts/tris than the render mesh, which is exactly
-            // what makes the WebGL cook and the desktop Physics.BakeMesh cheap.
+            // what makes the WebGL cook and the desktop Physics.BakeMesh cheap. Deliberately left readable and
+            // on the plain float layout: Physics.BakeMesh/MeshCollider read this mesh back to cook it, and its
+            // vertex count is a fraction of the render mesh's, so it is not where the memory sits.
             Mesh collider = null;
             if (ColliderTris.Count > 0)
             {

--- a/client/Assets/BlocksBeyondTheStars/Scripts/GameBootstrap.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/GameBootstrap.cs
@@ -2708,11 +2708,11 @@ namespace BlocksBeyondTheStars.Client
         /// collider bake (P2). A null collider (only fluids/air) clears the collider immediately.</summary>
         private void ApplyChunkMesh(ChunkCoord coord, ChunkMeshData data)
         {
-            // Reuse this chunk's existing render mesh on a rebuild (A3) — avoids a per-remesh Mesh allocation and
-            // the leak of the previous one (A2 raises the rebuild rate, which would otherwise grow that leak).
+            // The render mesh is uploaded non-readable (#966), which rules out the old Clear()+refill reuse — a
+            // non-readable mesh cannot be rewritten. So every rebuild gets a fresh mesh and the outgoing one is
+            // destroyed below; Unity never collects Mesh objects, and A2's rebuild rate would grow that leak fast.
             bool exists = _chunkObjects.TryGetValue(coord, out var view) && view?.Go != null;
-            var reuse = exists ? view!.Filter.sharedMesh : null;
-            var (mesh, collider) = data.ToMeshes(reuse);
+            var (mesh, collider) = data.ToMeshes();
 
             if (!exists)
             {
@@ -2734,7 +2734,12 @@ namespace BlocksBeyondTheStars.Client
                 _chunkObjects[coord] = view;
             }
 
-            view!.Filter.sharedMesh = mesh;
+            var staleMesh = view!.Filter.sharedMesh; // the mesh this rebuild replaces (null on the first build)
+            view.Filter.sharedMesh = mesh;
+            if (staleMesh != null && staleMesh != mesh)
+            {
+                Destroy(staleMesh);
+            }
 
             // Ground-detail scatter (T0): (re)build this chunk's instanced tuft/pebble decoration. Render-only,
             // distance-culled + quality-gated inside the component; a chunk with no scatter points disables it.

--- a/client/Assets/Tests/EditMode/ChunkMeshPackingEditModeTests.cs
+++ b/client/Assets/Tests/EditMode/ChunkMeshPackingEditModeTests.cs
@@ -1,0 +1,217 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using BlocksBeyondTheStars.Client;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace BlocksBeyondTheStars.Client.Tests.EditMode
+{
+    /// <summary>
+    /// Covers the compact chunk-mesh vertex format (#966): the quantisers that turn the build lists into
+    /// <see cref="ChunkMeshData.PackedVertex"/>, and the upload that hands them to the GPU as a non-readable
+    /// mesh. Both are pure memory optimisations, so what has to hold is that nothing about the mesh's SHAPE
+    /// changes — same vertex count, same submesh split, same index order, positions and atlas UVs bit-identical
+    /// — and that the mesh really did drop its system-RAM copy.
+    /// </summary>
+    public sealed class ChunkMeshPackingEditModeTests
+    {
+        private static float Unpack(sbyte v) => v / 127f;
+
+        private static float Unpack(byte v) => v / 255f;
+
+        /// <summary>A minimal hand-built mesh data instance with distinctive per-channel values, so a swapped
+        /// or dropped channel shows up rather than reading as "some plausible number".</summary>
+        private static ChunkMeshData MakeData(int verts)
+        {
+            var data = ChunkMeshData.Rent();
+            for (int i = 0; i < verts; i++)
+            {
+                data.Verts.Add(new Vector3(i * 0.5f, i * 0.25f, -i));
+                data.Normals.Add(new Vector3(0f, 1f, 0f));
+                data.Tangents.Add(new Vector4(1f, 0f, 0f, -1f));
+                data.Colors.Add(new Color(0.2f, 0.4f, 0.6f, 0.8f));
+                data.Uvs.Add(new Vector2(0.123456f, 0.987654f));
+                data.SkyUv.Add(new Vector2(0.5f, 4f));
+                data.LeafUv.Add(new Vector4(1f, 0.25f, 0.5f, 0.75f));
+                data.BlockLight.Add(new Vector3(0.125f, 1.5f, 3f));
+                data.BlockLightDir.Add(new Vector3(0f, -1f, 0f));
+            }
+
+            return data;
+        }
+
+        [Test]
+        public void Half_RoundTripsTheValuesVertexChannelsCarry()
+        {
+            // Skylight/tints (0..1) and block-light intensities (can exceed 1) — the range these channels use.
+            foreach (float v in new[] { 0f, 1f, 0.5f, 0.25f, -1f, 2f, 4f, 6f, 0.1f, 12.5f })
+            {
+                float back = Mathf.HalfToFloat(ChunkMeshData.Half(v));
+                Assert.That(back, Is.EqualTo(v).Within(Mathf.Max(Mathf.Abs(v), 1f) * 0.001f), $"half round-trip of {v}");
+            }
+
+            // Small integers (the face/tint MODES the shader branches on) must survive exactly, not "close".
+            for (int mode = 0; mode <= 6; mode++)
+            {
+                Assert.AreEqual((float)mode, Mathf.HalfToFloat(ChunkMeshData.Half(mode)), $"mode {mode} must be exact");
+            }
+
+            // A NaN or Inf must never reach a vertex buffer — it would poison the whole triangle's interpolation.
+            Assert.AreEqual(0f, Mathf.HalfToFloat(ChunkMeshData.Half(float.NaN)));
+            Assert.IsFalse(float.IsInfinity(Mathf.HalfToFloat(ChunkMeshData.Half(float.PositiveInfinity))));
+        }
+
+        [Test]
+        public void Norms_QuantiseWithinOneQuantumAndHitTheEndpointsExactly()
+        {
+            Assert.AreEqual(127, ChunkMeshData.SNorm(1f));
+            Assert.AreEqual(-127, ChunkMeshData.SNorm(-1f));
+            Assert.AreEqual(0, ChunkMeshData.SNorm(0f));
+            Assert.AreEqual(255, ChunkMeshData.UNorm(1f));
+            Assert.AreEqual(0, ChunkMeshData.UNorm(0f));
+
+            // Out-of-range input clamps instead of wrapping (a wrapped normal would flip a face's lighting).
+            Assert.AreEqual(127, ChunkMeshData.SNorm(3f));
+            Assert.AreEqual(255, ChunkMeshData.UNorm(2f));
+            Assert.AreEqual(0, ChunkMeshData.UNorm(-1f));
+
+            for (float v = 0f; v <= 1f; v += 0.05f)
+            {
+                Assert.That(Unpack(ChunkMeshData.UNorm(v)), Is.EqualTo(v).Within(1f / 255f));
+                Assert.That(Unpack(ChunkMeshData.SNorm(v)), Is.EqualTo(v).Within(1f / 127f));
+            }
+        }
+
+        [Test]
+        public void Pack_KeepsPositionsAndAtlasUvsBitExactAndEveryChannelInPlace()
+        {
+            var data = MakeData(4);
+            try
+            {
+                data.Pack();
+                Assert.AreEqual(4, data.PackedCount);
+
+                for (int i = 0; i < 4; i++)
+                {
+                    var p = data.Packed[i];
+                    // Position and atlas UV stay Float32 — a UV off by a quantum bleeds the neighbouring tile in.
+                    Assert.AreEqual(data.Verts[i], p.Position, $"position {i}");
+                    Assert.AreEqual(data.Uvs[i], p.Uv, $"uv {i}");
+
+                    Assert.AreEqual(0f, Unpack(p.Nx));
+                    Assert.AreEqual(1f, Unpack(p.Ny));
+                    Assert.AreEqual(0f, Unpack(p.Nz));
+                    Assert.AreEqual(1f, Unpack(p.Tx));
+                    Assert.AreEqual(-1f, Unpack(p.Tw), "tangent handedness");
+                    Assert.That(Unpack(p.Cr), Is.EqualTo(0.2f).Within(1f / 255f));
+                    Assert.That(Unpack(p.Ca), Is.EqualTo(0.8f).Within(1f / 255f), "emission lives in colour.a");
+                    Assert.AreEqual(0.5f, Mathf.HalfToFloat(p.SkyX), "skylight");
+                    Assert.AreEqual(4f, Mathf.HalfToFloat(p.SkyY), "tint mode");
+                    Assert.AreEqual(0.75f, Mathf.HalfToFloat(p.LeafW));
+                    Assert.AreEqual(3f, Mathf.HalfToFloat(p.BlZ), "block light above 1 must not clamp");
+                    Assert.AreEqual(-1f, Unpack(p.Dy), "block-light direction");
+                }
+            }
+            finally
+            {
+                data.Release();
+            }
+        }
+
+        [Test]
+        public void Pack_ReusesItsBufferAcrossBuildsAndTracksTheCurrentCount()
+        {
+            var data = MakeData(6);
+            try
+            {
+                data.Pack();
+                var buffer = data.Packed;
+                int capacity = buffer.Length;
+                Assert.AreEqual(6, data.PackedCount);
+
+                // A smaller follow-up build must keep the array and only shrink the valid count — otherwise every
+                // remesh would allocate a fresh multi-hundred-KB array, exactly the churn the buffer pool avoids.
+                data.Verts.RemoveRange(3, 3);
+                data.Pack();
+                Assert.AreEqual(3, data.PackedCount);
+                Assert.AreSame(buffer, data.Packed, "the packed buffer must be reused, not reallocated");
+                Assert.AreEqual(capacity, data.Packed.Length);
+            }
+            finally
+            {
+                data.Release();
+            }
+
+            Assert.AreEqual(0, data.PackedCount, "Release must invalidate the packed data");
+        }
+
+        [Test]
+        public void ToMeshes_KeepsTheSubmeshSplitAndUploadsANonReadableMesh()
+        {
+            var data = MakeData(8);
+            // 0 = opaque, 1 = see-through, 2 = paint — one triangle each, into one shared index buffer.
+            data.OpaqueTris.AddRange(new[] { 0, 1, 2 });
+            data.TransparentTris.AddRange(new[] { 3, 4, 5 });
+            data.PaintTris.AddRange(new[] { 5, 6, 7 });
+            data.Bounds = new Bounds(new Vector3(8f, 8f, 8f), new Vector3(16f, 16f, 16f));
+            data.Pack();
+
+            Mesh mesh = null;
+            try
+            {
+                var built = data.ToMeshes();
+                mesh = built.Render;
+
+                Assert.AreEqual(8, mesh.vertexCount);
+                Assert.AreEqual(3, mesh.subMeshCount);
+                Assert.AreEqual(data.Bounds, mesh.bounds, "analytic bounds must survive the upload");
+
+                // Index ranges: opaque first, then see-through, then paint — the order the materials come in.
+                Assert.AreEqual(0, (int)mesh.GetIndexStart(0));
+                Assert.AreEqual(3, (int)mesh.GetIndexCount(0));
+                Assert.AreEqual(3, (int)mesh.GetIndexStart(1));
+                Assert.AreEqual(3, (int)mesh.GetIndexCount(1));
+                Assert.AreEqual(6, (int)mesh.GetIndexStart(2));
+                Assert.AreEqual(3, (int)mesh.GetIndexCount(2));
+
+                // The point of the exercise: no system-RAM copy alongside the GPU one.
+                Assert.IsFalse(mesh.isReadable, "the chunk render mesh must be uploaded with markNoLongerReadable");
+            }
+            finally
+            {
+                data.Release();
+                if (mesh != null)
+                {
+                    Object.DestroyImmediate(mesh);
+                }
+            }
+        }
+
+        [Test]
+        public void ToMeshes_HandlesAnEmptyChunkWithoutProducingGeometry()
+        {
+            // All-air chunks reach this path constantly (the streamer meshes every coord in range), and the
+            // callers key off vertexCount == 0 to destroy the mesh again — so it must be exactly that, not a throw.
+            var data = ChunkMeshData.Rent();
+            data.Pack();
+
+            Mesh mesh = null;
+            try
+            {
+                var built = data.ToMeshes();
+                mesh = built.Render;
+                Assert.AreEqual(0, mesh.vertexCount);
+                Assert.IsNull(built.Collider, "no collider triangles → no collision mesh to cook");
+            }
+            finally
+            {
+                data.Release();
+                if (mesh != null)
+                {
+                    Object.DestroyImmediate(mesh);
+                }
+            }
+        }
+    }
+}

--- a/client/Assets/Tests/EditMode/ChunkMeshPackingEditModeTests.cs.meta
+++ b/client/Assets/Tests/EditMode/ChunkMeshPackingEditModeTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 516e448834a329c45b2d37df2425f54e


### PR DESCRIPTION
Closes the remaining half of #966 — the chunk meshes themselves. (#967 already
destroyed the minimap/shape-icon textures and put the chunk unload pass on a
timer; the vertex work was deliberately left out of it as the bigger change.)

Chunk meshes are the largest block of client memory: at view distance 8 roughly
1200 chunks stay resident, and each one paid twice over.

## What changed

**The system-RAM copy is gone.** Unity keeps a full CPU-side copy of every mesh
next to the GPU one unless told otherwise, and `UploadMeshData(markNoLongerReadable: true)`
appeared nowhere in `client/`. The render mesh is uploaded non-readable now.

That rules out the old `Clear()`+refill reuse (a non-readable mesh cannot be
rewritten), so every rebuild returns a **fresh** mesh and `ApplyChunkMesh`
destroys the one it replaces — without that, A2's rebuild rate would leak a mesh
per remesh. Nothing reads a chunk mesh back: collision has its own mesh, and the
ship/speeder meshers only ever assign the render mesh to a `MeshFilter`. The
**collision** mesh stays readable on purpose — `Physics.BakeMesh`/`MeshCollider`
cook from it, and its vertex count is a fraction of the render mesh's.

**The vertex format is packed: 112 → 56 B/vertex.** The plain `Mesh` setters store
every channel as floats — position, normal, tangent, colour and five UV sets.
`ChunkMeshData.Pack` now interleaves the build lists into a `PackedVertex`
uploaded through `SetVertexBufferParams`/`SetVertexBufferData`:

| channel | was | now |
| --- | --- | --- |
| position | Float32x3 | Float32x3 |
| normal / tangent / block-light dir | Float32x3/x4 | **SNorm8x4** (unit vectors) |
| colour (gloss, metal, shade×AO, emission) | Float32x4 | **UNorm8x4** (all 0..1) |
| atlas UV | Float32x2 | Float32x2 — a UV off by a quantum bleeds the neighbouring tile in |
| sky / leaf / block-light | Float32x2/x4/x3 | **Float16** |

Packing runs on the build worker thread, not next to the main-thread upload.
**Shaders are untouched:** the GPU expands these formats to float on read, and
every mode comparison in `BlockAtlas`/`BlockAtlasTransparent` is a threshold
(`> 3.5`), not an equality.

Together: chunk mesh memory drops to roughly a quarter.

## Verification

- **EditMode tests 24/24** (`client/Assets/Tests/EditMode`), including 5 new ones in
  `ChunkMeshPackingEditModeTests`: half/SNorm/UNorm round-trips (small integer modes
  exact, NaN/Inf never reach a vertex buffer), positions + atlas UVs bit-exact,
  the packed buffer reused across builds, and the upload keeping the three-submesh
  index split while reporting `isReadable == false`.
- **.NET suites green** — 1826 + 201, `dotnet format` clean. Unchanged by this PR
  (Unity-only change), run per AGENTS.md.
- **Local Windows player build** clean, 0 warnings — PR CI never builds Unity.
- **A/B render check.** Same worktree, same seed, one build with the change and one
  without: cockpit interior and jungle surface render identically (the cockpit also
  matches the committed reference screenshot pixel for pixel).

## Left open from the issue

Greedy-meshing the **render** mesh (the collider path already does it) — that is a
change to the geometry itself rather than to how it is stored, so it is out of
scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)