### PR TITLE
fix(landing): put the player back in their ship when landing on the same planet (#971)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@ the richer, screenshot-laden versions live there. `(#123)` references the pull r
   distance was reaching 1.8 GB; the terrain part of that is now a fraction.
 - Nothing about how the world looks changes — same geometry, same lighting, same colours.
 
+### 🐞 Fixed
+
+- **Landing back on the planet you launched from puts you back in your ship (#971).** Picking a
+  different landing pad in the chooser parked the ship there but left *you* standing at the pad you
+  launched from — often thousands of blocks away, so it looked like the ship had vanished. The
+  touchdown now moves you with your ship, exactly as a landing on another planet already did.
+
 ## [2026.8.12] — 2026-08-13
 
 The shipwright release. Until now the ship you flew was one the game handed you; from this version

--- a/TODO.md
+++ b/TODO.md
@@ -7738,6 +7738,28 @@ is **pre-approved** (keys in `tools/ai-assets/.env`, run via `uv`).
 
 ---
 
+## ✅ Done (2026-08-13): landing back on the same planet puts you back in your ship (#971)
+
+Found in a singleplayer playtest of the released v2026.8.12 build: launch from the starter planet, land
+back on it, pick a **different pad** in the chooser — the ship parks on the chosen pad, but the player is
+still standing at the pad they launched from. It reads as *"I landed and my ship isn't there"*.
+
+The savegame proves the split: the player row's `RespawnPoint` (server-only) had moved to the new ship's
+heal-tank at `(2489, 89, -369)`, while `Position` (client-writable) was still at the old ship's
+`(10232, 75, -3)`. `RelocateToAssignedPad` set the position and called `SendPlayerState` — but the client
+**discards** a position arriving on `PlayerStateUpdate` (the rule the suit teleporter already documents,
+#414 N17), and unlike the cross-body travel path there is no `WorldReset` here to re-arm its spawn snap.
+`AwaitingSpawnAdopt` was not set either, so the client's next stale `MoveIntent` overwrote the
+authoritative touchdown server-side — and that is what the checkpoint save persisted.
+
+Fix: the same-body landing now sends a `RespawnNotice` (`Died = false`, new `srv.land.touchdown`) with the
+computed spawn and arms the #865 spawn-adoption gate — the same two things the cross-body landing does.
+Server-side only, no protocol change. It stayed hidden until the pad chooser shipped because the auto-pick
+path (`padIndex = -1`) counts the player's own pad as free, so a solo pilot normally lands back on the pad
+they launched from. Two new regression tests in `LanPlaytestRegressionTests` (both fail without the fix).
+
+---
+
 ## ✅ Done (2026-08-13): chunk-mesh memory — packed vertex format + non-readable upload (#966)
 
 Closes the part of #966 that the previous round deliberately left open: the chunk meshes themselves.

--- a/data/locales/de.json
+++ b/data/locales/de.json
@@ -2892,6 +2892,7 @@
   "srv.land.full": "Alle Landezonen sind belegt.",
   "srv.land.no_pad": "Diesen Landeplatz gibt es nicht.",
   "srv.land.pad_taken": "Dieser Landeplatz ist schon belegt.",
+  "srv.land.touchdown": "Gelandet — du bist wieder an Bord deines Schiffs.",
   "srv.loot.no_container": "Diesen Behälter gibt es nicht.",
   "srv.loot.no_crate": "Diese Kiste gibt es nicht.",
   "srv.loot.nothing_to_stash": "Keine losen Materialien zum Einlagern.",

--- a/data/locales/en.json
+++ b/data/locales/en.json
@@ -2892,6 +2892,7 @@
   "srv.land.full": "All landing zones are taken.",
   "srv.land.no_pad": "That landing pad doesn't exist.",
   "srv.land.pad_taken": "That landing pad is already taken.",
+  "srv.land.touchdown": "Touchdown — you are back aboard your ship.",
   "srv.loot.no_container": "No such container.",
   "srv.loot.no_crate": "No such crate.",
   "srv.loot.nothing_to_stash": "No loose materials to store.",

--- a/src/BlocksBeyondTheStars.GameServer/GameServerSpace.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerSpace.cs
@@ -503,6 +503,7 @@ public sealed partial class GameServer
         session.State.Position = spawn;
         session.State.RespawnPoint = _shipPlaced ? _healTank : spawn;
         session.State.AboardShip = true;
+        session.AwaitingSpawnAdopt = true; // #865: the client keeps streaming its pre-launch pose for a beat
 
         // While this player was away (space / a station world), block changes on THIS body were only
         // broadcast to the players present on it — their client's chunk view is stale now (the #957
@@ -510,6 +511,12 @@ public sealed partial class GameServer
         // client-side, so this self-heals whatever drifted, exactly like the cross-body travel path.
         session.SentChunks.Clear();
 
+        // The touchdown must ride the RespawnNotice snap channel (Died=false → no death feedback): the
+        // client DISCARDS a position that arrives on PlayerStateUpdate (same rule as the suit teleporter,
+        // #414 N17), and unlike the cross-body travel path there is no WorldReset here to re-arm its spawn
+        // snap. Without this the body stayed at the pad it launched from while the ship parked on the pad
+        // the player picked in the chooser — "I landed and my ship isn't there" (#971).
+        Send(session, new RespawnNotice { X = spawn.X, Y = spawn.Y, Z = spawn.Z, Reason = "@srv.land.touchdown" });
         SendPlayerState(session);
         SendLandedShips(session); // the landing world's parked ship objects (incl. the player's own)
         SendLandingPads(session);

--- a/tests/BlocksBeyondTheStars.Tests/LanPlaytestRegressionTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/LanPlaytestRegressionTests.cs
@@ -163,6 +163,85 @@ public sealed class LanPlaytestRegressionTests : IDisposable
         Assert.Empty(pilot.SentChunks); // cleared → the world re-streams fresh (stale-view self-heal)
     }
 
+    // ---------------- #971: the same-body landing must also MOVE the player ----------------
+
+    /// <summary>Lands the pilot back on a pad that is NOT the one they launched from and returns both the
+    /// pad they left and the messages the server sent them, so a test can assert where they ended up.</summary>
+    private static (int LaunchPad, int ChosenPad, object[] ToPilot) LandOnAnotherPad(
+        SvGameServer server, RecordingTransport transport, PlayerSession pilot)
+    {
+        int launchPad = pilot.AssignedPadIndex;
+        int chosenPad = launchPad == 0 ? 1 : 0; // the chooser's "some other pad on this planet"
+        server.EnterSpace(pilot.State.PlayerId);
+
+        transport.Sent.Clear();
+        server.LandOnCurrentBodyForTest(pilot, chosenPad);
+
+        return (launchPad, chosenPad,
+            transport.Sent.Where(x => x.Conn == pilot.ConnectionId).Select(x => x.Msg).ToArray());
+    }
+
+    [Fact]
+    public void LandingBackOnTheSameBody_SnapsThePlayerOntoTheClaimedPad()
+    {
+        // Landing back on the same planet parked the ship on the chosen pad but left the PLAYER standing at
+        // the pad they launched from, thousands of blocks away: "I landed and my ship isn't there" (#971).
+        // The position must ride the RespawnNotice snap channel — the client discards a position that
+        // arrives on PlayerStateUpdate (#414 N17), and there is no WorldReset here to re-arm its spawn snap.
+        var transport = new RecordingTransport();
+        var server = NewServer("land_snap", transport);
+        var pilot = server.AddLocalPlayer("Pilot");
+        Assert.True(server.LandingPadCount >= 2, "the same-body landing bug needs a second pad to choose");
+
+        var (launchPad, chosenPad, toPilot) = LandOnAnotherPad(server, transport, pilot);
+        Assert.NotEqual(launchPad, chosenPad);
+
+        var snap = toPilot.OfType<RespawnNotice>().LastOrDefault();
+        Assert.NotNull(snap);
+        Assert.False(snap!.Died); // a touchdown, not a death — no red flash on the client
+
+        // The snap and the authoritative position agree, and both sit on the ship that just parked.
+        var anchor = server.ShipAnchorOf("Pilot");
+        Assert.Equal(pilot.State.Position.X, snap.X);
+        Assert.Equal(pilot.State.Position.Y, snap.Y);
+        Assert.Equal(pilot.State.Position.Z, snap.Z);
+        Assert.InRange(snap.X, anchor.X - 32, anchor.X + 32);
+        Assert.InRange(snap.Z, anchor.Z - 32, anchor.Z + 32);
+        Assert.True(pilot.State.AboardShip);
+    }
+
+    [Fact]
+    public void AfterLandingBackOnTheSameBody_TheStalePreLaunchPoseIsDropped()
+    {
+        // The client keeps streaming its pre-launch pose for a beat after the landing. Without the #865
+        // spawn-adoption gate the server TRUSTED it and dragged the player straight back to the old pad —
+        // which is the position the checkpoint save then persisted (the savegame that reported #971).
+        var transport = new RecordingTransport();
+        var server = NewServer("land_stale", transport);
+        var pilot = server.AddLocalPlayer("Pilot");
+        var preLaunch = pilot.State.Position; // standing in the ship on the pad they are about to leave
+
+        // The pilot has been playing for a while: their client adopted the join spawn long ago, so the gate
+        // is clear and the server trusts them — exactly the state a real launch happens from.
+        server.HandlePayloadForTest(pilot.ConnectionId, NetCodec.Encode(
+            new MoveIntent { X = preLaunch.X, Y = preLaunch.Y, Z = preLaunch.Z }));
+        Assert.False(pilot.AwaitingSpawnAdopt);
+
+        LandOnAnotherPad(server, transport, pilot);
+        var landed = pilot.State.Position;
+
+        server.HandlePayloadForTest(pilot.ConnectionId, NetCodec.Encode(
+            new MoveIntent { X = preLaunch.X, Y = preLaunch.Y, Z = preLaunch.Z }));
+
+        Assert.Equal(landed.X, pilot.State.Position.X); // the authoritative touchdown stands
+        Assert.Equal(landed.Z, pilot.State.Position.Z);
+
+        // …and once the client has adopted the snap, normal movement is trusted again.
+        server.HandlePayloadForTest(pilot.ConnectionId, NetCodec.Encode(
+            new MoveIntent { X = landed.X + 1f, Y = landed.Y, Z = landed.Z }));
+        Assert.Equal(landed.X + 1f, pilot.State.Position.X);
+    }
+
     // ---------------- #954: SwitchShip must not replace OTHER players' own hulls ----------------
 
     [Fact]


### PR DESCRIPTION
Fixes the singleplayer playtest report on the released v2026.8.12 build: launch from the starter planet, land back on it, pick a **different pad** in the chooser — the ship parks on the chosen pad, but the player is left standing at the pad they launched from. It reads as *"I landed and my ship isn't there."*

## Evidence

Server log of the reported session:

```
15:55:11 [INFO] Ship parked at (10232, 75, -3)     <- join
15:56:34 [INFO] Ship parked at (2489, 89, -369)    <- landing
15:56:34 [INFO] Checkpoint save (landed (returned to surface)).
```

The saved `player` row splits cleanly along "who may write this field":

| field | value | belongs to |
| --- | --- | --- |
| `RespawnX/Y/Z` (server-only) | `2491.5 / 90 / -365.5` | the **new** ship's heal-tank |
| `X/Y/Z` (client-writable) | `10235.4 / 75.03 / 2.61` | the **old** ship |

## Root cause

`RelocateToAssignedPad` set `session.State.Position` and called `SendPlayerState`, but:

1. **The client discards a position that arrives on `PlayerStateUpdate`** — `GameBootstrap.OnPlayerState` only does `ServerSpawn ??= …` (one-time, at join) plus a station-change snap. The snap channel is `RespawnNotice` with `Died = false`, exactly as `GameServerTeleport` documents for the suit teleporter (#414 N17) and as the void-fall rescue uses.
2. **`AwaitingSpawnAdopt` was never set**, so the #865 gate in `HandleMove` did not drop the client's stale pre-launch pose — the next `MoveIntent` overwrote the authoritative touchdown, and that is what the checkpoint save persisted.

The cross-body travel path does both (its `WorldReset` re-arms the client's spawn snap, and it sets the gate). Only the same-body path was missing them; #957 touched this method but fixed just the marker/door/chunk resync.

It stayed hidden until the pad chooser shipped because the auto-pick path (`padIndex = -1`) counts the player's own pad as free, so a solo pilot normally lands back on the pad they launched from.

## Change

- `RelocateToAssignedPad`: `AwaitingSpawnAdopt = true` + a `RespawnNotice { Died = false, Reason = "@srv.land.touchdown" }` carrying the computed spawn, sent before `SendPlayerState`.
- New `srv.land.touchdown` string in `data/locales/{en,de}.json`.
- Two regression tests in `LanPlaytestRegressionTests`, **both verified to fail without the fix**: the touchdown snap lands on the parked ship, and a stale pre-launch pose arriving after the landing is dropped (while normal movement is trusted again immediately after).
- `TODO.md` + `CHANGELOG.md` (Unreleased).

Server-side only — `RespawnNotice` already exists and the client already handles it, so **no protocol change** and no client rebuild needed for the mechanism.

## Verification

Full non-Slow server suite locally: **1828 passed, 0 failed**.

closes #971

🤖 Generated with [Claude Code](https://claude.com/claude-code)
