### PR TITLE
fix(admin): take the whole rest of the line as a player name (#980)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ the richer, screenshot-laden versions live there. `(#123)` references the pull r
 
 ## [Unreleased]
 
+### 🧑‍🚀 Admin commands finally accept player names with a space (#980)
+
+- **`/tpp mincraft Fan` works.** Commands that take a player name only ever read the first word of it,
+  so any name with a space came back as "target player not found" — as if that player did not exist.
+  The name is now simply the rest of the line, for `/tpp`, `/where`, `/builds`, `/kick`, `/paintwipe`
+  and the trailing name in `/give iron_plate 5 mincraft Fan`.
+- **Capitalisation no longer matters** for `/tpp` and `/give`: `/tpp marcel` finds *Marcel*, the way
+  `/where` and `/goto` always did. Quoted names (`/tpp "mincraft Fan"`) and the `@Name` habit from
+  other games are accepted everywhere too.
+
 ### ⏸️ Multiplayer pauses too — once everybody is in the menu (#973)
 
 - **A break is a break for the whole crew.** Until now only a player alone in a world could pause it;

--- a/TODO.md
+++ b/TODO.md
@@ -7784,6 +7784,35 @@ is **pre-approved** (keys in `tools/ai-assets/.env`, run via `uv`).
 
 ---
 
+## ✅ Done (2026-08-13): admin commands accept player names with spaces — and any capitalisation (#980)
+
+Reported from a hosted world: teleporting to the player `mincraft Fan` was impossible. `/tpp mincraft Fan`
+answered *"target player not found"*, which reads like the player does not exist rather than like the name
+got cut in half.
+
+`ChatUi.TryAdminCommand` splits the typed line on whitespace and passed only `p[1]` on — so the server
+received `mincraft`. The same truncation hit `/where`, `/builds`, `/kick`, `/paintwipe` and the target
+of `/give` (`p[3]`), where the miss is silent: `give_item` falls back to the admin's own inventory when
+the target does not resolve. `/tp` and `/goto` were already right (they forward the whole rest of the
+line), which is why `/goto mincraft Fan` was the only way in — fleet-admin only.
+
+Fix: the parsing moved into `AdminChatCommand` in **Client.Core** (Unity-free, like `ReportChatCommand`
+for `/report`, so the headless suite covers it). `PlayerArgument(line, skipTokens)` returns everything
+after the verb — `skipTokens: 3` for `/give <item> <count> <name…>` — and strips surrounding quotes plus
+a leading `@`. `/spectate` deliberately keeps taking one token: its argument is `on|off`, not a name.
+
+Second, smaller defect in the same path: `GameServer.FindSessionByName` (backing `teleport_to_player`
+and `give_item`) compared names with `==`, so `/tpp marcel` missed the player `Marcel` — while every
+other admin lookup (`/where`, `/builds`, `/goto`, `/kick`, `/paintwipe`) has always been
+`OrdinalIgnoreCase`. Now it trims and matches case-insensitively like the rest, and an empty target
+still resolves to nobody instead of to "some session".
+
+New tests: `AdminChatCommandTests` (client, 18 cases incl. `#designId` passing through untouched) and
+three additions to `AdminCheatTests` — spaced/differently-cased/quoted teleport targets, unknown targets
+still rejected, and `/give` to a spaced name landing in *that* player's inventory. No protocol change.
+
+---
+
 ## ✅ Done (2026-08-13): landing back on the same planet puts you back in your ship (#971)
 
 Found in a singleplayer playtest of the released v2026.8.12 build: launch from the starter planet, land

--- a/client/Assets/BlocksBeyondTheStars/Scripts/ChatUi.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/ChatUi.cs
@@ -424,7 +424,9 @@ namespace BlocksBeyondTheStars.Client
                 case "/give":
                     if (p.Length < 2) { LocalLine(L("ui.cmd.usage_give")); return true; }
                     int count = p.Length >= 3 && int.TryParse(p[2], out var c) ? c : 1;
-                    string who = p.Length >= 4 ? p[3].TrimStart('@') : null;
+                    // The target is the LAST argument, so it takes the rest of the line — a name may hold
+                    // spaces (#980) and only the item and the count are single tokens.
+                    string who = p.Length >= 4 ? AdminChatCommand.PlayerArgument(t, 3) : null;
                     net.SendAdminCommand("give_item", stringArg: p[1], intArg: count, targetPlayer: who);
                     return true;
 
@@ -443,9 +445,12 @@ namespace BlocksBeyondTheStars.Client
 
                     return true;
 
+                // Every command below whose argument is a PLAYER NAME takes the whole rest of the line, not
+                // the next token: names contain spaces ("mincraft Fan"), and passing the first word alone
+                // made the server answer "target player not found" (#980).
                 case "/tpp":
                     if (p.Length < 2) { LocalLine(L("ui.cmd.usage_tpp")); return true; }
-                    net.SendAdminCommand("teleport_to_player", targetPlayer: p[1]);
+                    net.SendAdminCommand("teleport_to_player", targetPlayer: AdminChatCommand.PlayerArgument(t));
                     return true;
 
                 case "/settime":
@@ -468,14 +473,15 @@ namespace BlocksBeyondTheStars.Client
 
                 case "/builds":
                     // Optional player filter: "/builds Justus" lists only that player's structures.
-                    net.SendAdminCommand("builds", stringArg: p.Length >= 2 ? p[1].TrimStart('@') : null);
+                    net.SendAdminCommand("builds", stringArg: p.Length >= 2 ? AdminChatCommand.PlayerArgument(t) : null);
                     return true;
 
                 case "/where":
                     if (p.Length < 2) { LocalLine(L("ui.cmd.usage_where")); return true; }
-                    net.SendAdminCommand("where", stringArg: p[1].TrimStart('@'));
+                    net.SendAdminCommand("where", stringArg: AdminChatCommand.PlayerArgument(t));
                     return true;
 
+                // Not part of the name rule above: the argument here is on|off, never a player.
                 case "/spectate":
                 case "/observe":
                     net.SendAdminCommand("spectate", stringArg: p.Length >= 2 ? p[1] : null);
@@ -547,7 +553,7 @@ namespace BlocksBeyondTheStars.Client
                             return true;
                         }
 
-                        net.SendAdminCommand("kick", stringArg: p[1].TrimStart('@'));
+                        net.SendAdminCommand("kick", stringArg: AdminChatCommand.PlayerArgument(t));
                         return true;
                     }
 
@@ -563,7 +569,8 @@ namespace BlocksBeyondTheStars.Client
                             return true;
                         }
 
-                        net.SendAdminCommand("paintwipe", stringArg: p[1].TrimStart('@'));
+                        // "#42" (a design id) survives this untouched — only quotes and a leading '@' go.
+                        net.SendAdminCommand("paintwipe", stringArg: AdminChatCommand.PlayerArgument(t));
                         return true;
                     }
 

--- a/docs/user/USER_MANUAL.md
+++ b/docs/user/USER_MANUAL.md
@@ -936,6 +936,12 @@ rejections) appear in the **chat scrollback**, not just the brief HUD toast.
 | `/ai Prompt` | Generate an AI mission (content tool, not a cheat; needs the optional AI backend — see §5 → *Dynamic AI text* and [SELF_HOSTING.md](../developer/SELF_HOSTING.md) §8) |
 | `/help admin` | List the admin commands in chat (`/admin` does the same) |
 
+**Player names with spaces** work everywhere a command takes one: the name is simply the rest of the
+line, so `/tpp mincraft Fan` teleports you to *mincraft Fan*. Capitalisation does not matter, quoting
+the name is allowed (`/tpp "mincraft Fan"`) and a leading `@` is ignored. In `/give` the name comes
+last for the same reason — `/give iron_plate 5 mincraft Fan`. Don't know the exact spelling? `/players`
+lists everyone.
+
 #### Named teleport targets
 
 Typing coordinates to get to the village you can see on the map is silly, so `/tp` also takes a **target

--- a/src/BlocksBeyondTheStars.Client.Core/AdminChatCommand.cs
+++ b/src/BlocksBeyondTheStars.Client.Core/AdminChatCommand.cs
@@ -1,0 +1,59 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using System;
+
+namespace BlocksBeyondTheStars.Client
+{
+    /// <summary>
+    /// Argument parsing for the admin slash commands typed in chat. Unity-free so the headless test suite
+    /// covers it — the Unity side (<c>ChatUi</c>) only recognises the verb and ships the result — the same
+    /// split <see cref="Portal.ReportChatCommand"/> uses for <c>/report</c>.
+    ///
+    /// <para>The one rule here: <b>a player name is the whole rest of the line</b>. Names may contain
+    /// spaces ("mincraft Fan"), so reading the single token after the verb truncated the name and the
+    /// server answered "target player not found" — a message that looks like the player does not exist
+    /// rather than like the name got cut in half (issue #980).</para>
+    /// </summary>
+    public static class AdminChatCommand
+    {
+        /// <summary>
+        /// The rest of <paramref name="line"/> after the first <paramref name="skipTokens"/> whitespace-
+        /// separated tokens, as ONE argument: <c>"/tpp mincraft Fan"</c> with <c>skipTokens: 1</c> yields
+        /// <c>mincraft Fan</c>. Surrounding quotes and the <c>@Name</c> habit from other games are stripped,
+        /// so <c>/tpp "@mincraft Fan"</c> resolves too. Returns an empty string when nothing follows — the
+        /// caller prints its usage line.
+        /// </summary>
+        /// <param name="line">The raw typed line, verb included.</param>
+        /// <param name="skipTokens">How many leading tokens are not part of the name: 1 for
+        /// <c>/tpp &lt;name&gt;</c>, 3 for <c>/give &lt;item&gt; &lt;count&gt; &lt;name&gt;</c>.</param>
+        public static string PlayerArgument(string? line, int skipTokens = 1)
+        {
+            string t = line ?? string.Empty;
+
+            // Walk the raw line token by token instead of re-joining the split parts: the rest has to come
+            // out exactly as typed (a name may carry any run of spaces), and the caller already split.
+            int i = 0;
+            for (int n = 0; n < skipTokens; n++)
+            {
+                while (i < t.Length && char.IsWhiteSpace(t[i]))
+                {
+                    i++;
+                }
+
+                while (i < t.Length && !char.IsWhiteSpace(t[i]))
+                {
+                    i++;
+                }
+            }
+
+            return CleanName(t.Substring(Math.Min(i, t.Length)));
+        }
+
+        /// <summary>Trims a typed name down to what the server stores: no surrounding whitespace, no quotes
+        /// around it, no leading <c>@</c>. Order matters — <c>"@mincraft Fan"</c> has to lose the quotes
+        /// before the <c>@</c> is even reachable.</summary>
+        public static string CleanName(string? name)
+            => (name ?? string.Empty).Trim().Trim('"').Trim().TrimStart('@').Trim();
+    }
+}

--- a/src/BlocksBeyondTheStars.GameServer/GameServer.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServer.cs
@@ -4794,16 +4794,22 @@ public sealed partial class GameServer
         }
     }
 
+    /// <summary>The joined session playing under <paramref name="name"/>. Matched case-insensitively and
+    /// with surrounding whitespace/quotes ignored, like every other admin-side player lookup
+    /// (<c>/where</c>, <c>/builds</c>, <c>/goto</c>, <c>/kick</c>) — an exact-case compare made
+    /// <c>/tpp marcel</c> fail for <c>Marcel</c> with a message that read like the player did not exist
+    /// (#980).</summary>
     private PlayerSession? FindSessionByName(string? name)
     {
-        if (string.IsNullOrEmpty(name))
+        string wanted = (name ?? string.Empty).Trim().Trim('"').Trim();
+        if (wanted.Length == 0)
         {
             return null;
         }
 
         foreach (var s in _sessions.Values)
         {
-            if (s.Joined && s.State.Name == name)
+            if (s.Joined && string.Equals(s.State.Name, wanted, StringComparison.OrdinalIgnoreCase))
             {
                 return s;
             }

--- a/tests/BlocksBeyondTheStars.Client.Tests/AdminChatCommandTests.cs
+++ b/tests/BlocksBeyondTheStars.Client.Tests/AdminChatCommandTests.cs
@@ -1,0 +1,59 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using Xunit;
+
+namespace BlocksBeyondTheStars.Client.Tests;
+
+/// <summary>
+/// Argument parsing for the admin slash commands (issue #980). The rule under test: a player name is
+/// the whole rest of the line, because names contain spaces — taking the token after the verb turned
+/// "mincraft Fan" into "mincraft" and the server answered "target player not found".
+/// </summary>
+public sealed class AdminChatCommandTests
+{
+    [Theory]
+    [InlineData("/tpp mincraft Fan", "mincraft Fan")]
+    [InlineData("/tpp Marcel", "Marcel")]
+    [InlineData("/where   mincraft   Fan  ", "mincraft   Fan")] // inner spacing is part of the name
+    [InlineData("/tpp \"mincraft Fan\"", "mincraft Fan")]       // quoting a name is tolerated
+    [InlineData("/tpp @mincraft Fan", "mincraft Fan")]          // the @Name habit from other games
+    [InlineData("/tpp \"@mincraft Fan\"", "mincraft Fan")]      // …even both at once
+    [InlineData("/paintwipe #42", "#42")]                       // a design id must survive untouched
+    public void PlayerArgument_TakesTheWholeRestOfTheLine(string line, string expected)
+    {
+        Assert.Equal(expected, AdminChatCommand.PlayerArgument(line));
+    }
+
+    [Theory]
+    [InlineData("/tpp")]
+    [InlineData("/tpp   ")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void PlayerArgument_IsEmpty_WhenNothingFollowsTheVerb(string? line)
+    {
+        Assert.Equal(string.Empty, AdminChatCommand.PlayerArgument(line));
+    }
+
+    /// <summary>"/give &lt;item&gt; &lt;count&gt; &lt;name…&gt;" — only the trailing token run is the name.</summary>
+    [Theory]
+    [InlineData("/give iron_plate 5 mincraft Fan", "mincraft Fan")]
+    [InlineData("/give iron_plate 5 @Justus", "Justus")]
+    [InlineData("/give iron_plate 5", "")]
+    public void PlayerArgument_SkipsLeadingTokens_ForGive(string line, string expected)
+    {
+        Assert.Equal(expected, AdminChatCommand.PlayerArgument(line, 3));
+    }
+
+    /// <summary>The client cleans the name the same way the server matches it, so a pasted "@Name" or a
+    /// quoted name resolves instead of silently missing.</summary>
+    [Theory]
+    [InlineData("  Marcel  ", "Marcel")]
+    [InlineData("\"mincraft Fan\"", "mincraft Fan")]
+    [InlineData("@Justus", "Justus")]
+    [InlineData(null, "")]
+    public void CleanName_StripsWhitespaceQuotesAndAt(string? raw, string expected)
+    {
+        Assert.Equal(expected, AdminChatCommand.CleanName(raw));
+    }
+}

--- a/tests/BlocksBeyondTheStars.Tests/AdminCheatTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/AdminCheatTests.cs
@@ -156,6 +156,80 @@ public sealed class AdminCheatTests : IDisposable
         Assert.False(snap.Died);
     }
 
+    /// <summary>Names with spaces and a different capitalisation still resolve (#980): the client now sends
+    /// the whole rest of the typed line, and the server matches it the way every other admin lookup does.
+    /// An exact-case compare used to answer "target player not found" for a player who was right there.</summary>
+    [Theory]
+    [InlineData("mincraft Fan", "exact")]
+    [InlineData("MINCRAFT fan", "case")]
+    [InlineData("  \"mincraft Fan\"  ", "quoted")]
+    public void Teleport_ToPlayer_MatchesSpacedAndDifferentlyCasedNames(string typed, string world)
+    {
+        var rules = new GameRules { AdminCheats = true, AllowCheatsInSurvival = true };
+        var (server, client) = Start(rules, "tpname_" + world);
+
+        var target = server.AddLocalPlayer("mincraft Fan");
+        target.State.Position = new Shared.Geometry.Vector3f(321, 70, 123);
+
+        RespawnNotice? snap = null;
+        client.PayloadReceived += pl => { if (NetCodec.Decode(pl) is RespawnNotice r) snap = r; };
+
+        client.Send(NetCodec.Encode(new AdminCommandIntent { Command = "teleport_to_player", TargetPlayer = typed }),
+            DeliveryMode.ReliableOrdered);
+        server.Tick(0.1);
+        client.Poll();
+
+        Assert.NotNull(snap);
+        Assert.Equal(321f, snap!.X);
+        Assert.Equal(123f, snap.Z);
+    }
+
+    /// <summary>An empty or unknown target still has to be refused — the tolerant match must not fall
+    /// back to "some session" (or to the admin's own).</summary>
+    [Theory]
+    [InlineData("", "empty")]
+    [InlineData("   ", "blank")]
+    [InlineData("Nobody", "unknown")]
+    public void Teleport_ToPlayer_RejectsUnknownTarget(string typed, string world)
+    {
+        var rules = new GameRules { AdminCheats = true, AllowCheatsInSurvival = true };
+        var (server, client) = Start(rules, "tpmiss_" + world);
+        var before = server.Sessions[1].State.Position;
+
+        ActionRejected? rejected = null;
+        client.PayloadReceived += pl => { if (NetCodec.Decode(pl) is ActionRejected r) rejected = r; };
+
+        client.Send(NetCodec.Encode(new AdminCommandIntent { Command = "teleport_to_player", TargetPlayer = typed }),
+            DeliveryMode.ReliableOrdered);
+        server.Tick(0.1);
+        client.Poll();
+
+        Assert.NotNull(rejected);
+        Assert.Equal(before, server.Sessions[1].State.Position);
+    }
+
+    /// <summary><c>/give</c> resolves its target through the same lookup, so a spaced name must land in
+    /// THAT player's inventory rather than silently in the admin's own (the null fallback).</summary>
+    [Fact]
+    public void GiveItem_ToSpacedName_ReachesThatPlayer()
+    {
+        var rules = new GameRules { AdminCheats = true, AllowCheatsInSurvival = true };
+        var (server, client) = Start(rules, "givename");
+        var target = server.AddLocalPlayer("mincraft Fan");
+
+        client.Send(NetCodec.Encode(new AdminCommandIntent
+        {
+            Command = "give_item",
+            StringArg = "titanium_plate",
+            IntArg = 5,
+            TargetPlayer = "MINCRAFT Fan",
+        }), DeliveryMode.ReliableOrdered);
+        server.Tick(0.1);
+
+        Assert.Equal(5, target.State.Inventory.CountOf("titanium_plate"));
+        Assert.Equal(0, server.Sessions[1].State.Inventory.CountOf("titanium_plate"));
+    }
+
     [Fact]
     public void GodMode_PreventsDeath()
     {


### PR DESCRIPTION
Fixes the report from a hosted world: **teleporting to the player `mincraft Fan` was impossible.**

## The bug

`ChatUi.TryAdminCommand` splits the typed line on whitespace and passed only the token after the verb
to the server, so `/tpp mincraft Fan` asked for `mincraft` and came back as *"target player not
found"* — which reads like the player does not exist, not like the name got cut in half.

The same truncation hit `/where`, `/builds`, `/kick`, `/paintwipe` and the target of `/give`, where
the miss is **silent**: `give_item` falls back to the admin's own inventory when the target does not
resolve. `/tp` and `/goto` were already right (they forward the rest of the line), which is why
`/goto mincraft Fan` was the only workaround — and that one is fleet-admin only.

Second, smaller defect in the same path: `GameServer.FindSessionByName` (backing `teleport_to_player`
and `give_item`) compared names with `==`, so `/tpp marcel` missed the player `Marcel` — while every
other admin lookup (`/where`, `/builds`, `/goto`, `/kick`, `/paintwipe`) has always been
`OrdinalIgnoreCase`.

## The fix

- New `AdminChatCommand` in **Client.Core** — Unity-free, like `ReportChatCommand` for `/report`, so
  the headless suite covers the parsing. `PlayerArgument(line, skipTokens)` returns everything after
  the verb (`skipTokens: 3` for `/give <item> <count> <name…>`) and strips surrounding quotes plus a
  leading `@`.
- `ChatUi` uses it for `/tpp`, `/where`, `/builds`, `/kick`, `/paintwipe` and the `/give` target.
  `/spectate` deliberately keeps reading one token — its argument is `on|off`, not a name.
- `FindSessionByName` trims and matches case-insensitively; an empty target still resolves to nobody
  rather than to "some session".

No protocol change.

## Tests

- `AdminChatCommandTests` (client): spaced names, inner spacing preserved, quotes, `@Name`, both at
  once, `#designId` passing through untouched, the `/give` token skip, and the empty cases.
- `AdminCheatTests` (server): spaced/differently-cased/quoted teleport targets resolve, unknown and
  empty targets are still rejected without moving the admin, and `/give` to a spaced name lands in
  *that* player's inventory instead of the admin's.

## Verification

- `dotnet build -c Release --no-incremental`: 0 warnings, 0 errors
- server suite (`Category!=Slow`): 1884 passed · client suite: 219 passed
- local Unity Windows player build (PR CI never builds Unity)

## Docs

CHANGELOG (Unreleased), TODO.md work-log entry, and a note in the user manual that a player name is
simply the rest of the line — capitalisation, quotes and `@` all tolerated.

closes #980

🤖 Generated with [Claude Code](https://claude.com/claude-code)
