### PR TITLE
fix(multiplayer): per-pilot space actions, real pause freeze, observer + join hygiene (#994-#999)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,29 @@ the richer, screenshot-laden versions live there. `(#123)` references the pull r
 
 ## [Unreleased]
 
+### Fixed
+
+- **Space actions now act from *your* ship.** With two pilots over the same planet, firing, tractor
+  pulls, salvage collection, station boarding and EVA structure edits were range-checked from whichever
+  ship reported its position last — shots next to an asteroid could come back "out of range" while your
+  wingman flew far away. Every player-triggered space action now uses the acting pilot's own position;
+  the passive tractor also collects into each pilot's own cargo hold. (#994)
+- **The group pause now freezes actions, not just the clock.** While every player holds the world
+  paused, gameplay intents (mining, building, moving, combat…) are dropped server-side; resume, chat,
+  saves and admin commands stay live. A stock client never sent them anyway — a modified one could farm
+  a frozen world for the whole hold. (#995)
+- **Watching admins survive a group pause** — observers keep receiving terrain while the world is held
+  instead of flying into void, and landing an observer on the same body no longer claims a communal
+  landing pad or marks them aboard a ship. (#996)
+- **A brand-new player's respawn anchor is their own** — on worlds without a starter ship it could be
+  persisted as the *host's* heal tank, respawning them inside the host's ship. (#997)
+- **A failed join cleans up after itself** — the freshly parked ship of a join that died mid-handshake
+  no longer stays behind as an ownerless prop. (#998)
+- **Multiplayer polish:** a frozen remote avatar's nameplate disappears with the body instead of
+  floating in mid-air; the star map no longer says "pads full" when the last pad is your own
+  reservation; pad number keys pick the pad by its label; the server's chunk-stream rate clamps to what
+  clients can absorb per frame. (#999)
+
 ## [2026.8.13] — 2026-08-13
 
 The crewmate release. The last version put several players into one world for the first time; this one

--- a/TODO.md
+++ b/TODO.md
@@ -105,6 +105,30 @@ Per-item detail lives in the dated work log below. **Since 2026-07 versions are 
 
 ---
 
+### ★ Multiplayer-audit follow-ups: per-pilot space actions, a real pause, observer + join hygiene (#994–#999, 2026-08-14, branch fix/mp-audit-findings)
+A code audit of every multiplayer fix shipped since v2026.8.12 confirmed all of them — and surfaced six
+new findings, fixed together here. **#994 (the real gameplay bug):** space instances are shared per body
+and `instance.ShipPosition` is last-writer-wins across pilots; #955 moved collision/incoming fire to
+per-pilot `PilotSims` but left the *player-triggered* actions on the shared field — weapon range + aim,
+salvage auto-collect, tractor reach, station boarding, structure-edit range, EVA dock/interior return
+spots. All of those now read the acting pilot's own pose (`PilotPositionIn`, falls back to the shared
+field until the first pose arrives); the passive tractor tick collects per pilot into their own cargo.
+**#995:** the all-players pause froze the simulation but the dispatcher kept serving gameplay intents —
+a modified client could mine/build/move for the whole hold with every threat suspended. `PausedMayHandle`
+now gates dispatch while held (resume/chat/saves/read-only/admin stay live; spectators exempt).
+**#996:** observers got no chunks during a group pause (streaming lived below the paused early-return —
+they flew into void) and the same-body landing path claimed a communal pad + set AboardShip/RespawnPoint
+for them; both now mirror HandleTravel's #487 exemptions, and `StreamChunksToSpectators` runs in the held
+tick. **#997:** `CreateNewPlayer` read `_shipPlaced`/`_healTank` under the stale ship cursor — with
+`PlaceStarterShip=false` a brand-new player persisted the *host's* heal tank as respawn anchor. **#998:**
+the #964 join-failure guard removed only the session; it now also tears down the freshly parked ship (no
+save — half-restored state must not clobber the real one). **#999 polish:** stale-avatar nameplates now
+hide with the body (3 s, #958), the star map's free-pad count excludes your own reservation (matching
+#977), pad number keys select by pad *label* not array slot, and `ChunkStreamPerTick` clamps to a shared
+ceiling (20) so an operator config can't out-send the client's 24/frame receive budget (#963). Seven new
+regression tests across `WorldPauseTests`, `LanPlaytestRegressionTests`, `SpaceCombatTests`,
+`ReceiveBudgetTests`.
+
 ### ★ No more water surfaces hanging in mid-water in the distance (#987, 2026-08-13, branch fix/987-water-lod-fake-surfaces)
 Diving in an ocean showed flat water planes floating at chunk-boundary heights far away, joined by thin
 bright vertical strips. Two bugs, one on each side. **Server:** the distance-based vertical LOD anchors a far

--- a/client/Assets/BlocksBeyondTheStars/Scripts/RemotePlayers.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/RemotePlayers.cs
@@ -308,7 +308,9 @@ namespace BlocksBeyondTheStars.Client
             var labels = ScreenLabelLayer.Instance;
             foreach (var r in _remotes.Values)
             {
-                if (!r.Hidden)
+                // #999: TimedOut hides the BODY within seconds (#958) — without checking it here the
+                // nameplate kept floating in mid-air over the hidden avatar until the destroy timeout.
+                if (!r.Hidden && !r.TimedOut)
                 {
                     // Fade names out between 30 m and 45 m — a bit further than NPCs so mates stay recognisable.
                     labels.World(cam, r.Go.transform.position + Vector3.up * 2.1f, r.Name, UiKit.TextCol, false, 30f, 45f);

--- a/client/Assets/BlocksBeyondTheStars/Scripts/SpaceView.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/SpaceView.cs
@@ -1086,9 +1086,13 @@ namespace BlocksBeyondTheStars.Client
                     ShowLandMap(pads);
                     for (int i = 0; i < pads.Length && i < 9; i++)
                     {
-                        if ((Input.GetKeyDown(KeyCode.Alpha1 + i) || Input.GetKeyDown(KeyCode.Keypad1 + i)) && !pads[i].Occupied)
+                        // #999: key N selects the pad LABELLED N (Index + 1), not array slot N — today the
+                        // server sends pads in index order so both agree, but any reordered/filtered list
+                        // would silently land the ship on the wrong pad.
+                        var pad = System.Array.Find(pads, p => p.Index == i);
+                        if (pad != null && (Input.GetKeyDown(KeyCode.Alpha1 + i) || Input.GetKeyDown(KeyCode.Keypad1 + i)) && !pad.Occupied)
                         {
-                            LandOnPad(pads[i].Index);
+                            LandOnPad(pad.Index);
                             break;
                         }
                     }

--- a/src/BlocksBeyondTheStars.GameServer/GameServer.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServer.cs
@@ -1298,6 +1298,10 @@ public sealed partial class GameServer
             // fleet polls, and freezing it would report a stale player count for as long as the pause lasts.
             // Safe to run here — with players joined it only republishes; the idle timer stays at zero.
             Guard("HostedLifecycle", deltaSeconds, TickHostedLifecycle);
+
+            // #996: an observer neither holds nor counts toward the pause (#973) and keeps flying — without
+            // streaming they run off the already-sent chunks into void until somebody resumes the world.
+            Guard("SpectatorChunks", StreamChunksToSpectators);
             return;
         }
         Guard("TickSpace", deltaSeconds, TickSpace); // space instances are keyed by location and handle their own players
@@ -1995,7 +1999,29 @@ public sealed partial class GameServer
             ? System.Math.Clamp(session.ViewDistance, 1, MaxClientViewDistanceChunks)
             : System.Math.Max(1, _config.ViewDistanceChunks);
 
-    private void StreamChunks()
+    private void StreamChunks() => StreamChunks(spectatorsOnly: false);
+
+    /// <summary>Chunk streaming for observers while the world is held paused (#996): spectators don't hold
+    /// the pause and keep moving, but the paused tick skips the per-world simulation loop (and with it
+    /// <see cref="StreamChunks()"/>) entirely. Non-spectators sit in their pause menus and have no use for
+    /// chunks until the world resumes.</summary>
+    private void StreamChunksToSpectators()
+    {
+        if (!_sessions.Values.Any(s => s.Joined && s.Spectating))
+        {
+            return; // the common case — nobody is observing
+        }
+
+        foreach (var locId in OccupiedLocations())
+        {
+            if (SetActiveWorld(locId))
+            {
+                StreamChunks(spectatorsOnly: true);
+            }
+        }
+    }
+
+    private void StreamChunks(bool spectatorsOnly)
     {
         int perTickBudget = System.Math.Max(1, _config.ChunkStreamPerTick);
 
@@ -2013,6 +2039,11 @@ public sealed partial class GameServer
 
         foreach (var session in JoinedInActiveWorld())
         {
+            if (spectatorsOnly && !session.Spectating)
+            {
+                continue; // paused-world streaming (#996) serves only the observers
+            }
+
             int radius = EffectiveViewRadius(session); // per-player: honour the client's View Distance slider
             int streamRadius = radius + LoadAheadRings; // load one hazed ring past the fog edge so it fades in, not pops (#388)
             var center = WorldConstants.WorldToChunk(session.State.Position.ToBlock());
@@ -2420,6 +2451,29 @@ public sealed partial class GameServer
             catch (Exception ex)
             {
                 _log.Error($"Join from connection {connectionId} threw: {ex}");
+                try
+                {
+                    // #998: the join burst may already have parked the player's ship object
+                    // (SetupPlayerShip) — plain session removal left it orphaned in the world with no
+                    // owner to ever clean it up. Tear the world half down, but deliberately do NOT
+                    // save: the session may be half-restored, and persisting partial state could
+                    // clobber the real save the retry-join is about to load.
+                    if (_sessions.TryGetValue(connectionId, out var half))
+                    {
+                        LeaveSpace(half.State.PlayerId);
+                        if (SetActiveWorld(half.CurrentLocationId))
+                        {
+                            RemoveLandedShip(half);
+                            RemoveConstructionSite(half);
+                            BroadcastToWorld(new PlayerLeft { PlayerId = half.State.PlayerId });
+                        }
+                    }
+                }
+                catch (Exception cleanupEx)
+                {
+                    _log.Error($"Join-failure cleanup for connection {connectionId} threw: {cleanupEx}");
+                }
+
                 _sessions.Remove(connectionId); // never leave a half-joined session holding the name
                 SendTo(connectionId, new JoinRejected { Reason = "@srv.join.failed" });
             }
@@ -2530,12 +2584,35 @@ public sealed partial class GameServer
         return true;
     }
 
+    /// <summary>Messages still served while the world is held paused (#995): the resume path itself, chat
+    /// and voice (players coordinating the resume), diagnostics, explicit saves, harmless UI state,
+    /// read-only requests and admin commands. Everything else — movement, mining, building, crafting,
+    /// combat, trading — would mutate a world whose simulation (threats, hunger, clock) is frozen.</summary>
+    private static bool PausedMayHandle(object message) => message switch
+    {
+        PauseIntent or ChatIntent or VoiceFrame or BumpReport or SaveGameIntent
+            or SelectHotbarIntent or AdminCommandIntent => true,
+        RequestStarMap or RequestMissions or RequestCompanionsIntent
+            or RequestAllianceListIntent or RequestLandingPadsIntent => true,
+        _ => false,
+    };
+
     private void Dispatch(PlayerSession session, object message)
     {
         // Observer mode is read-only apart from block removal (issue #487): an invisible admin who could
         // craft, loot, trade or shoot would change a world nobody can see them in. Dropped silently — the
         // client already hides the affordances, so a rejection toast would just be noise.
         if (session.Spectating && !SpectatorMayHandle(message))
+        {
+            return;
+        }
+
+        // #995: while every player holds the world paused, the simulation is frozen — so gameplay intents
+        // must not mutate the frozen world either. A stock client sends nothing from its pause menu, so this
+        // only stops a modified client from mining/building/moving while everyone else's clock stands still.
+        // Control-plane traffic stays live (the resume path, chat, saves, read-only requests, admin
+        // commands), and spectators are exempt: they never hold the pause and keep moving (#996).
+        if (_paused && !session.Spectating && !PausedMayHandle(message))
         {
             return;
         }
@@ -2952,7 +3029,11 @@ public sealed partial class GameServer
             PlayerId = name,
             Name = name,
             Position = spawn,
-            RespawnPoint = _shipPlaced ? _healTank : spawn, // the heal-tank in the ship's Medbay
+            // #997: this runs BEFORE the new session exists, so the per-player ship cursor (_shipPlaced /
+            // _healTank) still points at whoever the server processed last — with PlaceStarterShip=false
+            // the HOST's heal tank persisted as a brand-new player's respawn anchor. The pad spawn is the
+            // only anchor that is truly theirs here; SetupPlayerShip re-anchors to their own heal tank.
+            RespawnPoint = spawn,
             AboardShip = true,
             // The very first player to join becomes the world admin (world creator).
             Role = _repo.ListPlayerIds().Count == 0
@@ -5238,7 +5319,7 @@ public sealed partial class GameServer
             Name = sys.Name,
             MapX = sys.MapX,
             MapY = sys.MapY,
-            Bodies = sys.Bodies.Select(ToNetBody).ToArray(),
+            Bodies = sys.Bodies.Select(b => ToNetBody(b, session)).ToArray(),
         }).ToArray();
 
         var players = _sessions.Values
@@ -5314,8 +5395,10 @@ public sealed partial class GameServer
     }
 
     /// <summary>Projects a galaxy body to its network form, including its fixed-landing-pad capacity + how many
-    /// pads are currently free (item 38) so the star map can flag a full body. Non-surface bodies have 0 pads.</summary>
-    private NetBody ToNetBody(BlocksBeyondTheStars.Shared.World.CelestialBody b)
+    /// pads are currently free (item 38) so the star map can flag a full body. Non-surface bodies have 0 pads.
+    /// The free count is AS SEEN BY the receiver (#999): their own in-space reservation doesn't count against
+    /// them, matching the pad chooser (#977) and the landing itself.</summary>
+    private NetBody ToNetBody(BlocksBeyondTheStars.Shared.World.CelestialBody b, PlayerSession receiver)
     {
         int total = string.IsNullOrEmpty(b.PlanetType) ? 0 : PadCountFor(b.Id, b.PlanetType!, b.Kind);
         return new NetBody
@@ -5334,7 +5417,7 @@ public sealed partial class GameServer
             SizeBias = b.SizeBias, // #549: the client sizes this body with the same bias the server does
             RingSeed = b.RingSeed, // #596: 0 = no rings; the client renders the ring system from this
             PadsTotal = total,
-            PadsFree = total > 0 ? FreePadCount(b.Id, total) : 0,
+            PadsFree = total > 0 ? FreePadCount(b.Id, total, receiver.State.PlayerId) : 0,
         };
     }
 

--- a/src/BlocksBeyondTheStars.GameServer/GameServerPlayerStations.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerPlayerStations.cs
@@ -83,7 +83,7 @@ public sealed partial class GameServer
         // Place it a few units ahead of the suit, on its heading.
         float yaw = instance.PlayerPoses.TryGetValue(playerId, out var pose) ? pose.Yaw : 0f;
         double rad = yaw * System.Math.PI / 180.0;
-        var suit = instance.ShipPosition;
+        var suit = PilotPositionIn(instance, playerId); // #994: THIS suit, not whichever pilot moved last
         var at = new Vector3f(suit.X + (float)System.Math.Sin(rad) * 5f, suit.Y, suit.Z + (float)System.Math.Cos(rad) * 5f);
 
         var s = new SpaceStructure

--- a/src/BlocksBeyondTheStars.GameServer/GameServerShipInterior.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerShipInterior.cs
@@ -48,8 +48,8 @@ public sealed partial class GameServer
         }
 
         // Remember how to drop back into the flight view (and the ship's parked spot, even if the now-empty
-        // instance unloads while we're inside).
-        _inShipInterior[playerId] = new ShipInteriorReturn(instanceId, instance.ShipPosition, session.CurrentLocationId, _world.PlanetKey);
+        // instance unloads while we're inside). #994: THIS pilot's spot, not whichever pilot moved last.
+        _inShipInterior[playerId] = new ShipInteriorReturn(instanceId, PilotPositionIn(instance, playerId), session.CurrentLocationId, _world.PlanetKey);
 
         instance.Players.Remove(playerId);
         _playerInstance.Remove(playerId);
@@ -116,6 +116,10 @@ public sealed partial class GameServer
         {
             inst.ShipPosition = ret.ShipPos;
             inst.ShipLastPosition = ret.ShipPos;
+            // #994: per-pilot pose is the authority for player actions now — put it back too, so the first
+            // action after stepping out doesn't range-check against the pre-interior launch seed.
+            inst.PlayerPoses[playerId] = new SpacePlayerPose(ret.ShipPos, 0f, eva);
+            inst.PilotSims[playerId] = new PilotSim { LastPosition = ret.ShipPos };
         }
 
         if (eva)

--- a/src/BlocksBeyondTheStars.GameServer/GameServerSpace.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerSpace.cs
@@ -311,7 +311,10 @@ public sealed partial class GameServer
 
         foreach (var s in _sessions.Values)
         {
-            if (!s.Joined || s.State.PlayerId == exceptPlayerId)
+            // An observer never HOLDS a pad (#487/#996): occupancy is derived live from AssignedPadIndex,
+            // and the relocate path may stamp one on a spectating session — an invisible admin must not
+            // block a communal pad for the players.
+            if (!s.Joined || s.Spectating || s.State.PlayerId == exceptPlayerId)
             {
                 continue;
             }
@@ -339,13 +342,16 @@ public sealed partial class GameServer
         return -1;
     }
 
-    /// <summary>How many of a body's pads are currently free (live occupancy).</summary>
-    private int FreePadCount(string locationId, int total)
+    /// <summary>How many of a body's pads are currently free (live occupancy). <paramref name="exceptPlayerId"/>
+    /// is the player the count is FOR (#999): their own in-space reservation doesn't block them (#977), so it
+    /// must not read as "occupied" either — or the star map said "pads full" while the chooser one screen
+    /// later happily offered their own pad. Pass <see cref="string.Empty"/> for a neutral count (NPC traders).</summary>
+    private int FreePadCount(string locationId, int total, string exceptPlayerId)
     {
         int free = 0;
         for (int i = 0; i < total; i++)
         {
-            if (!PadOccupiedByOther(locationId, i, string.Empty))
+            if (!PadOccupiedByOther(locationId, i, exceptPlayerId))
             {
                 free++;
             }
@@ -365,7 +371,8 @@ public sealed partial class GameServer
         foreach (var s in _sessions.Values)
         {
             // A holder up in space still reserves the pad (#957) — the chooser shows it as taken.
-            if (s.Joined && s.AssignedPadIndex == padIndex && s.CurrentLocationId == locationId)
+            // Observers hold nothing (#487/#996), so their name must never label a pad.
+            if (s.Joined && !s.Spectating && s.AssignedPadIndex == padIndex && s.CurrentLocationId == locationId)
             {
                 return s.State.Name;
             }
@@ -510,7 +517,9 @@ public sealed partial class GameServer
             _ship.CurrentLocationId = session.CurrentLocationId; // keep the ship's body in sync so a later launch rises off THIS body (mirrors HandleTravel; B48) — fixes launching off an asteroid landing you adrift in the wrong orbit
         }
 
-        if (_config.PlaceStarterShip)
+        // An observer arrives with no ship, no pad and no respawn anchor (#487/#996) — mirrors HandleTravel,
+        // which has exempted spectators from the pad/ship half of a landing since day one.
+        if (_config.PlaceStarterShip && !session.Spectating)
         {
             PlaceLandedShip();
         }
@@ -519,8 +528,12 @@ public sealed partial class GameServer
         int surfaceY = PadGroundY(pad.CenterX, pad.CenterZ); // matches the ship placement's median footprint height
         var spawn = _shipPlaced ? _healTank : new Vector3f(pad.CenterX + 0.5f, surfaceY + 2f, pad.CenterZ + 0.5f);
         session.State.Position = spawn;
-        session.State.RespawnPoint = _shipPlaced ? _healTank : spawn;
-        session.State.AboardShip = true;
+        if (!session.Spectating)
+        {
+            session.State.RespawnPoint = _shipPlaced ? _healTank : spawn;
+            session.State.AboardShip = true;
+        }
+
         session.AwaitingSpawnAdopt = true; // #865: the client keeps streaming its pre-launch pose for a beat
 
         // While this player was away (space / a station world), block changes on THIS body were only
@@ -699,7 +712,7 @@ public sealed partial class GameServer
     }
 
     /// <summary>Test hook: how many of the active world's pads are currently free.</summary>
-    public int FreePadCountForTest() => FreePadCount(_world.LocationId, _landingPads.Count);
+    public int FreePadCountForTest(string exceptPlayerId = "") => FreePadCount(_world.LocationId, _landingPads.Count, exceptPlayerId);
 
     /// <summary>Test hook: runs the landing-pad claim for a player (mirrors a landing). Returns the chosen pad
     /// index (or -1 with a reason if the pad is taken / the body is full).</summary>

--- a/src/BlocksBeyondTheStars.GameServer/GameServerSpaceCombat.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerSpaceCombat.cs
@@ -146,8 +146,9 @@ public sealed class SpaceInstance
     public List<CombatEntity> Entities { get; set; } = new();
     public HashSet<string> Players { get; set; } = new();
 
-    /// <summary>The acting player's last reported position — ambient NPC targeting (traders/bandits) and
-    /// single-pilot legacy paths. Collision and incoming fire run per pilot via <see cref="PilotSims"/> (#955).</summary>
+    /// <summary>The last reported position of ANY pilot — ambient NPC targeting (traders/bandits) only.
+    /// Player-triggered actions (fire/tractor/board/structure edits) resolve per pilot via
+    /// <see cref="PlayerPoses"/> (#994); collision and incoming fire via <see cref="PilotSims"/> (#955).</summary>
     public Vector3f ShipPosition { get; set; }
     public Vector3f ShipLastPosition { get; set; }
 
@@ -280,6 +281,13 @@ public sealed partial class GameServer
 
     /// <summary>True while the player is flying in a space instance.</summary>
     public bool InSpace(string playerId) => _playerInstance.ContainsKey(playerId);
+
+    /// <summary>The acting pilot's OWN position in the instance (#994). Instances are shared per body and
+    /// <see cref="SpaceInstance.ShipPosition"/> is last-writer-wins across all pilots, so range checks and
+    /// aim for player-triggered actions must read the pilot's pose instead. Falls back to the shared field
+    /// only while no pose has arrived yet (the client reports one within its first ~0.1 s in space).</summary>
+    private static Vector3f PilotPositionIn(SpaceInstance instance, string playerId)
+        => instance.PlayerPoses.TryGetValue(playerId, out var pose) ? pose.Pos : instance.ShipPosition;
 
     /// <summary>The combat entities in the player's current space instance (empty if not in space).</summary>
     public IReadOnlyList<CombatEntity> SpaceEntitiesFor(string playerId)
@@ -936,13 +944,14 @@ public sealed partial class GameServer
             return;
         }
 
-        if (target.Position.DistanceSquared(instance.ShipPosition) > weapon.Range * weapon.Range)
+        var shipPos = PilotPositionIn(instance, playerId); // #994: THIS pilot's ship, not whoever moved last
+        if (target.Position.DistanceSquared(shipPos) > weapon.Range * weapon.Range)
         {
             RejectSpace(session, "@srv.space.out_of_range");
             return;
         }
 
-        if (!ValidateSpaceAim(session, instance, target, dirX, dirY, dirZ))
+        if (!ValidateSpaceAim(session, shipPos, target, dirX, dirY, dirZ))
         {
             return;
         }
@@ -1045,7 +1054,7 @@ public sealed partial class GameServer
     /// target (#693). Mirrors the on-foot <c>ValidateAim</c>: generous tolerances (latency, drifting
     /// targets), zero direction = older client = skip. AutoAim ON needs the target roughly ahead;
     /// AutoAim OFF needs a genuine boresight line — the nose ray must pass near the target's body.</summary>
-    private bool ValidateSpaceAim(PlayerSession? session, SpaceInstance instance, CombatEntity target, float dirX, float dirY, float dirZ)
+    private bool ValidateSpaceAim(PlayerSession? session, Vector3f shipPos, CombatEntity target, float dirX, float dirY, float dirZ)
     {
         float dirLenSq = dirX * dirX + dirY * dirY + dirZ * dirZ;
         if (dirLenSq < 0.0001f)
@@ -1053,9 +1062,9 @@ public sealed partial class GameServer
             return true; // no aim data (older client) — keep the legacy range-only behaviour
         }
 
-        float tx = target.Position.X - instance.ShipPosition.X;
-        float ty = target.Position.Y - instance.ShipPosition.Y;
-        float tz = target.Position.Z - instance.ShipPosition.Z;
+        float tx = target.Position.X - shipPos.X;
+        float ty = target.Position.Y - shipPos.Y;
+        float tz = target.Position.Z - shipPos.Z;
         float dist = (float)System.Math.Sqrt(tx * tx + ty * ty + tz * tz);
         if (dist < 3f)
         {
@@ -1276,19 +1285,21 @@ public sealed partial class GameServer
     // before you've learned to nose right into the wreck). Widened so flying near the wreck reliably collects it.
     private const float TractorRange = 16f;
 
-    /// <summary>Tractor beam: pulls salvage drops within <paramref name="range"/> into the ship's cargo hold
-    /// (until full). The passive tick uses a short range; a manual pull (quick-bar) sweeps a wider one.</summary>
-    private void CollectSalvage(SpaceInstance instance, float range)
+    /// <summary>Tractor beam: pulls salvage drops within <paramref name="range"/> of the COLLECTING pilot's
+    /// ship into that ship's cargo hold (until full). The passive tick uses a short range; a manual pull
+    /// (quick-bar) sweeps a wider one. The caller must have pinned the ship cursor to the collector (#994).</summary>
+    private void CollectSalvage(SpaceInstance instance, float range, string playerId)
     {
         if (!_ship.HasModule(TractorModule))
         {
             return;
         }
 
+        var shipPos = PilotPositionIn(instance, playerId); // #994: sweep around the collector's own ship
         bool changed = false;
         foreach (var drop in instance.Entities.Where(e => e.Kind == CombatEntityKind.ResourceDrop).ToList())
         {
-            if (drop.Position.DistanceSquared(instance.ShipPosition) > range * range)
+            if (drop.Position.DistanceSquared(shipPos) > range * range)
             {
                 continue;
             }
@@ -1302,9 +1313,9 @@ public sealed partial class GameServer
         if (changed)
         {
             BroadcastSpaceState(instance);
-            foreach (var playerId in instance.Players)
+            foreach (var presentId in instance.Players)
             {
-                if (FindSessionByPlayerId(playerId) is { } s)
+                if (FindSessionByPlayerId(presentId) is { } s)
                 {
                     SendInventory(s); // cargo is part of the inventory update when aboard
                 }
@@ -1372,7 +1383,7 @@ public sealed partial class GameServer
                 return; // already collected / gone — no need to nag
             }
 
-            if (drop.Position.DistanceSquared(instance.ShipPosition) > TractorReach * TractorReach)
+            if (drop.Position.DistanceSquared(PilotPositionIn(instance, playerId)) > TractorReach * TractorReach)
             {
                 RejectSpace(session, Localize(session?.Locale ?? "en", "space.tractor.out_of_range"));
                 return;
@@ -1396,7 +1407,7 @@ public sealed partial class GameServer
             return;
         }
 
-        CollectSalvage(instance, TractorPullRange);
+        CollectSalvage(instance, TractorPullRange, playerId);
     }
 
     private void HandleTractorPull(PlayerSession session, TractorPullIntent intent)
@@ -1444,8 +1455,16 @@ public sealed partial class GameServer
             }
 
             // Tractor beam: pull nearby salvage drops into the cargo hold (before collision, so the
-            // collision bounce doesn't move the ship away from the drop first).
-            CollectSalvage(instance, TractorRange);
+            // collision bounce doesn't move the ship away from the drop first). Per pilot (#994): each
+            // fitted tractor sweeps around its OWN ship into its own cargo, not the shared position.
+            foreach (var collectorId in instance.Players.ToList())
+            {
+                if (FindSessionByPlayerId(collectorId) is { Joined: true } collector)
+                {
+                    SetCurrent(collector); // module check + cargo below resolve to this pilot's ship
+                    CollectSalvage(instance, TractorRange, collectorId);
+                }
+            }
 
             // Hostile movement: drones/UFOs/cruisers patrol around their post and CHASE the ship when it
             // comes in range (they used to hang motionless at their spawn points forever).
@@ -2150,8 +2169,9 @@ public sealed partial class GameServer
         if (string.IsNullOrEmpty(dest) || dest == session.CurrentLocationId)
         {
             // Land back on the current body — claim a free landing pad first (item 38); a full body refuses.
+            // An observer takes no pad (#487/#996): pads are finite and communal — same rule as HandleTravel.
             SetActiveWorld(session.CurrentLocationId);
-            if (!ClaimPadOrReject(session, session.CurrentLocationId, intent.PadIndex))
+            if (!session.Spectating && !ClaimPadOrReject(session, session.CurrentLocationId, intent.PadIndex))
             {
                 return;
             }

--- a/src/BlocksBeyondTheStars.GameServer/GameServerSpaceStations.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerSpaceStations.cs
@@ -199,9 +199,9 @@ public sealed partial class GameServer
             return;
         }
 
-        if (contact.Position.DistanceSquared(instance.ShipPosition) > StationBoardRange * StationBoardRange)
+        if (contact.Position.DistanceSquared(PilotPositionIn(instance, playerId)) > StationBoardRange * StationBoardRange)
         {
-            Reject(session, "station", "@srv.station.closer");
+            Reject(session, "station", "@srv.station.closer"); // #994: measured from THIS pilot's ship
             return;
         }
 
@@ -218,7 +218,7 @@ public sealed partial class GameServer
         // to the float next to it, rather than re-launching.
         if (session.State.InEva)
         {
-            _dockedFromEva[playerId] = instance.ShipPosition;
+            _dockedFromEva[playerId] = PilotPositionIn(instance, playerId); // #994: THIS pilot's float spot
         }
 
         instance.Players.Remove(playerId);

--- a/src/BlocksBeyondTheStars.GameServer/GameServerSpaceStructure.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerSpaceStructure.cs
@@ -509,7 +509,7 @@ public sealed partial class GameServer
         // near it, so you can't mine/build across the whole zone. (The own ship rides the pilot, so skip it.)
         if (s.Kind != "ship")
         {
-            var suit = instance.ShipPosition;
+            var suit = PilotPositionIn(instance, p.PlayerId); // #994: range from THIS pilot's suit/ship
             float ex = suit.X - s.Position.X, ey = suit.Y - s.Position.Y, ez = suit.Z - s.Position.Z;
             if (ex * ex + ey * ey + ez * ez > StructureEditRange * StructureEditRange)
             {

--- a/src/BlocksBeyondTheStars.GameServer/GameServerSpaceTraders.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerSpaceTraders.cs
@@ -855,6 +855,6 @@ public sealed partial class GameServer
         var body = _galaxy.FindBody(bodyId);
         string planetKey = body?.PlanetType ?? _meta.DefaultPlanetType;
         int total = PadCountFor(bodyId, planetKey, body?.Kind ?? CelestialKind.Planet);
-        return FreePadCount(bodyId, total);
+        return FreePadCount(bodyId, total, string.Empty);
     }
 }

--- a/src/BlocksBeyondTheStars.Shared/Configuration/ServerConfig.cs
+++ b/src/BlocksBeyondTheStars.Shared/Configuration/ServerConfig.cs
@@ -58,7 +58,20 @@ public sealed class ServerConfig
     /// chunks to send, so a too-small budget makes terrain "thaw in" slowly at the horizon. Each freshly streamed
     /// chunk that isn't cached is generated synchronously in the tick, so this also bounds first-visit gen cost:
     /// a host seeing tick overruns on weak hardware can lower it; a strong host can raise it for snappier fill.</summary>
-    public int ChunkStreamPerTick { get; set; } = 16;
+    public int ChunkStreamPerTick
+    {
+        get => _chunkStreamPerTick;
+        set => _chunkStreamPerTick = Math.Clamp(value, 1, ChunkStreamPerTickCeiling);
+    }
+
+    private int _chunkStreamPerTick = 16;
+
+    /// <summary>Hard ceiling for <see cref="ChunkStreamPerTick"/> (#999): the client's receive budget drains
+    /// a bounded number of chunks per frame (NetworkClient.MaxChunksPerPoll, 24 — asserted to stay above this
+    /// in ReceiveBudgetTests), so a server configured to push more could out-send a low-fps client
+    /// indefinitely — recreating exactly the backlog #963 removed. The setter clamps so the invariant holds
+    /// for every config source (file, env var, code), not just the default value.</summary>
+    public const int ChunkStreamPerTickCeiling = 20;
 
     /// <summary>Optional wall-clock budget (milliseconds) for chunk streaming per tick; 0 = off. When set,
     /// StreamChunks stops sending once the budget is spent — remaining chunks come next tick, nearest-first

--- a/tests/BlocksBeyondTheStars.Client.Tests/ReceiveBudgetTests.cs
+++ b/tests/BlocksBeyondTheStars.Client.Tests/ReceiveBudgetTests.cs
@@ -133,6 +133,24 @@ public sealed class ReceiveBudgetTests
     }
 
     [Fact]
+    public void TheChunkCap_HoldsForEveryConfiguredStreamRate()
+    {
+        // #999: ChunkStreamPerTick is operator-configurable (config file + BBS_CHUNK_STREAM_PER_TICK), so
+        // the invariant above only guarded the DEFAULT. The setter clamps to a shared ceiling now — an
+        // operator pushing the rate above the client's per-frame cap would put slow clients into exactly
+        // the unbounded backlog #963 removed.
+        var cfg = new ServerConfig { ChunkStreamPerTick = 999 };
+        Assert.Equal(ServerConfig.ChunkStreamPerTickCeiling, cfg.ChunkStreamPerTick);
+
+        cfg.ChunkStreamPerTick = 0; // nonsense low values clamp up to a working minimum
+        Assert.Equal(1, cfg.ChunkStreamPerTick);
+
+        using var client = new NetworkClient(new BatchTransport());
+        Assert.True(client.MaxChunksPerPoll > ServerConfig.ChunkStreamPerTickCeiling,
+            "the per-frame chunk cap must stay above the config ceiling, not just the default");
+    }
+
+    [Fact]
     public void IsMessageType_RecognisesChunks_WithoutDecodingTheBody()
     {
         Assert.True(NetCodec.IsMessageType<ChunkDataMessage>(Chunk(3)));

--- a/tests/BlocksBeyondTheStars.Tests/LanPlaytestRegressionTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/LanPlaytestRegressionTests.cs
@@ -379,6 +379,85 @@ public sealed class LanPlaytestRegressionTests : IDisposable
             && x.Msg is SpaceShipDesign d && d.Id == "ship:Ann" && d.Kind == "ship");
     }
 
+    // ---------------- 2026-08-13 audit follow-ups (#996/#997/#999) ----------------
+
+    [Fact]
+    public void TheStarMapsFreePadCount_DoesNotCountYourOwnReservationAgainstYou()
+    {
+        // #999: a pilot in space keeps their pad reserved (#957) and the chooser already excludes that
+        // reservation for its holder (#977) — but the star map's free-pad count did not, so the last pad
+        // being your OWN made the map say "pads full" one screen before the chooser happily offered it.
+        var transport = new RecordingTransport();
+        var server = NewServer("pad_count", transport);
+
+        var ann = server.AddLocalPlayer("Ann");
+        Assert.True(ann.AssignedPadIndex >= 0);
+        int freeBefore = server.FreePadCountForTest();
+        server.EnterSpace("Ann"); // the reservation is held while she is up in space (#957)
+
+        Assert.Equal(freeBefore, server.FreePadCountForTest());        // neutral: still reserved
+        Assert.Equal(freeBefore + 1, server.FreePadCountForTest("Ann")); // as seen by the holder (#999)
+    }
+
+    [Fact]
+    public void AnObserverLandingBackOnTheSameBody_ClaimsNoPadAndNoAnchor()
+    {
+        // #996: HandleTravel has exempted spectators from the pad/ship half of a landing since #487 —
+        // the same-body path did not: it claimed a communal pad for the invisible observer and set
+        // AboardShip/RespawnPoint as if they had a ship parked there.
+        var transport = new RecordingTransport();
+        var server = NewServer("observer_land", transport, placeShip: false);
+
+        var watcher = server.AddLocalPlayer("Watcher");
+        watcher.Spectating = true;
+        watcher.State.AboardShip = false;
+        var anchorBefore = watcher.State.RespawnPoint;
+        server.EnterSpace("Watcher");
+        int freeBefore = server.FreePadCountForTest();
+
+        server.LandOnCurrentBodyForTest(watcher, 1); // an explicit pad pick, like the chooser sends
+
+        Assert.Equal(freeBefore, server.FreePadCountForTest()); // no pad claimed by the observer
+        Assert.False(watcher.State.AboardShip);
+        Assert.Equal(anchorBefore.X, watcher.State.RespawnPoint.X); // anchor untouched
+        Assert.Equal(anchorBefore.Z, watcher.State.RespawnPoint.Z);
+    }
+
+    [Fact]
+    public void ANewPlayersRespawnAnchor_IsTheirOwnSpawn_NotTheLastServedShips()
+    {
+        // #997: CreateNewPlayer runs BEFORE the new session exists, so _shipPlaced/_healTank still
+        // resolve under the last served player's ship cursor. With PlaceStarterShip=false nothing
+        // overwrites the anchor afterwards — a brand-new player persisted the HOST's heal tank and
+        // respawned inside the host's ship.
+        var transport = new RecordingTransport();
+        var repo = new SqliteWorldRepository(new SaveGamePaths(_root, "respawn_anchor"));
+        _repos.Add(repo);
+        var config = new ServerConfig
+        {
+            WorldName = "respawn_anchor",
+            Seed = 1,
+            StartPlanet = "rocky",
+            AutoSaveIntervalMinutes = 9999,
+            PlaceStarterShip = true,
+        };
+        config.Rules.FreeSpaceFlight = true;
+        var server = new SvGameServer(config, _content, transport, repo);
+        server.Start();
+
+        var host = server.AddLocalPlayer("Host"); // ship parked → cursor + heal tank point at the host
+        config.PlaceStarterShip = false;          // a shipwright world for everyone joining after (#949)
+        var newbie = server.AddLocalPlayer("Newbie");
+
+        // The newbie's anchor is at their own pad, not at the host's heal tank (pads sit far apart).
+        Assert.InRange(newbie.State.RespawnPoint.X, newbie.State.Position.X - 8, newbie.State.Position.X + 8);
+        Assert.InRange(newbie.State.RespawnPoint.Z, newbie.State.Position.Z - 8, newbie.State.Position.Z + 8);
+        Assert.True(
+            System.Math.Abs(newbie.State.RespawnPoint.X - host.State.RespawnPoint.X) > 8
+            || System.Math.Abs(newbie.State.RespawnPoint.Z - host.State.RespawnPoint.Z) > 8,
+            "the new player's respawn anchor must not be the host's heal tank");
+    }
+
     public void Dispose()
     {
         foreach (var repo in _repos)

--- a/tests/BlocksBeyondTheStars.Tests/ServerConfigTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/ServerConfigTests.cs
@@ -48,11 +48,11 @@ public sealed class ServerConfigTests
         var config = new ServerConfig();
         var applied = config.ApplyCommandLine(new[]
         {
-            "--chunk-stream-per-tick", "24",
+            "--chunk-stream-per-tick", "18", // stays under the #999 ceiling (values above clamp to it)
             "--chunk-stream-budget-ms", "12.5", // invariant decimal point, must parse regardless of host locale
         });
 
-        Assert.Equal(24, config.ChunkStreamPerTick);
+        Assert.Equal(18, config.ChunkStreamPerTick);
         Assert.Equal(12.5, config.ChunkStreamBudgetMs);
         Assert.Contains("chunk-stream-per-tick", applied);
         Assert.Contains("chunk-stream-budget-ms", applied);

--- a/tests/BlocksBeyondTheStars.Tests/SpaceCombatTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/SpaceCombatTests.cs
@@ -640,6 +640,38 @@ public sealed class SpaceCombatTests : IDisposable
     }
 
     [Fact]
+    public void FireWeapon_RangeChecksTheActingPilotsOwnShip_NotTheLastMover()
+    {
+        // #994: space instances are shared per body and instance.ShipPosition is last-writer-wins across
+        // all pilots. The range check (and aim) must use the ACTING pilot's own pose — with the shared
+        // field, a wingman reporting from far away made the gunner's point-blank shot "out of range".
+        var server = NewServer("perpilot_range", r =>
+        {
+            r.FreeSpaceFlight = true;
+            r.AsteroidDestruction = AsteroidDestructionMode.MiningOnly;
+        }, out var repo);
+        using (repo)
+        {
+            server.AddLocalPlayer("Gunner");
+            server.Ship.Modules.Add("asteroid_breaker"); // cursor still points at the just-added Gunner
+            server.EnterSpace("Gunner");
+            var ast = server.SpaceEntitiesFor("Gunner").First(e => e.Kind == CombatEntityKind.Asteroid);
+
+            server.AddLocalPlayer("Wingman");
+            server.EnterSpace("Wingman"); // same body → same instance
+
+            // The gunner parks next to the rock; the wingman reports LAST, from far beyond weapon range.
+            server.ShipMove("Gunner", ast.Position.X + 4f, ast.Position.Y, ast.Position.Z);
+            server.ShipMove("Wingman", ast.Position.X + 800f, ast.Position.Y, ast.Position.Z + 800f);
+
+            float hullBefore = ast.Hull;
+            server.FireWeapon("Gunner", "asteroid_breaker", ast.Id);
+            Assert.True(ast.Hull < hullBefore,
+                "the shot must range-check against the gunner's own ship, not the last pose that arrived");
+        }
+    }
+
+    [Fact]
     public void Shoot_CarvesVoxelAsteroid_ThenDestroysIt()
     {
         // item 20 S3: voxel ore asteroids carve down as you shoot them (no splitting), then yield loot + vanish.

--- a/tests/BlocksBeyondTheStars.Tests/WorldPauseTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/WorldPauseTests.cs
@@ -194,6 +194,79 @@ public sealed class WorldPauseTests : IDisposable
     }
 
     [Fact]
+    public void WhileHeld_GameplayIntentsAreDropped_ButTheResumePathStaysLive()
+    {
+        // #995: the hold froze the SIMULATION but the dispatcher kept serving gameplay intents — a stock
+        // client sends nothing from its pause menu, but a modified one could mine/build/move for the whole
+        // hold with every threat (and everyone else's clock) suspended.
+        var server = Started(out var repo);
+        using (repo)
+        {
+            var p = server.AddLocalPlayer("Justus");
+            var start = p.State.Position;
+            server.HandlePayloadForTest(p.ConnectionId, NetCodec.Encode( // clear the join adopt gate (#865)
+                new MoveIntent { X = start.X, Y = start.Y, Z = start.Z }));
+
+            server.PauseForTest(p, true);
+            Assert.True(server.IsPaused);
+
+            server.HandlePayloadForTest(p.ConnectionId, NetCodec.Encode(
+                new MoveIntent { X = start.X + 1f, Y = start.Y, Z = start.Z }));
+            Assert.Equal(start.X, p.State.Position.X); // the frozen world ignored the movement
+
+            server.HandlePayloadForTest(p.ConnectionId, NetCodec.Encode(new PauseIntent { Paused = false }));
+            Assert.False(server.IsPaused); // the resume path must stay live through the gate
+
+            server.HandlePayloadForTest(p.ConnectionId, NetCodec.Encode(
+                new MoveIntent { X = start.X + 1f, Y = start.Y, Z = start.Z }));
+            Assert.Equal(start.X + 1f, p.State.Position.X); // …and movement is trusted again
+        }
+    }
+
+    [Fact]
+    public void WhileHeld_NoChunksStreamToThePausedPlayers()
+    {
+        // The paused tick skips the simulation loop entirely — holders sit in their menus and have no use
+        // for chunks. (The observer case below is the exception, #996.)
+        var transport = new RecordingTransport();
+        var server = Started(out var repo, transport);
+        using (repo)
+        {
+            var p = server.AddLocalPlayer("Justus");
+            server.PauseForTest(p, true);
+
+            transport.Sent.Clear();
+            server.TickForTest(0.1);
+            Assert.True(server.IsPaused);
+            Assert.DoesNotContain(transport.Sent, m => m is ChunkDataMessage);
+        }
+    }
+
+    [Fact]
+    public void WhileHeld_AnObserverStillReceivesChunks()
+    {
+        // #996: a spectator neither holds nor counts toward the pause and keeps flying — but chunk
+        // streaming lived below the paused early-return, so an admin moving through a held world ran off
+        // the already-streamed radius into void for up to the whole hold.
+        var transport = new RecordingTransport();
+        var server = Started(out var repo, transport);
+        using (repo)
+        {
+            var p = server.AddLocalPlayer("Justus");
+            var admin = server.AddLocalPlayer("Marcel");
+            admin.Spectating = true; // observer mode (#487)
+
+            server.PauseForTest(p, true);
+            Assert.True(server.IsPaused);
+
+            transport.Sent.Clear();
+            server.TickForTest(0.1);
+            Assert.True(server.IsPaused);
+            Assert.Contains(transport.Sent, m => m is ChunkDataMessage); // streamed to the observer
+        }
+    }
+
+    [Fact]
     public void APauseIsLifted_WhenSomeoneElseJoins()
     {
         var server = Started(out var repo);


### PR DESCRIPTION
Follow-ups from the 2026-08-13 audit of every multiplayer fix shipped since v2026.8.12. The audit confirmed all shipped fixes and surfaced six new findings — all fixed here.

## What changed

**#994 — space actions act from *your* ship.** Space instances are shared per body and `instance.ShipPosition` is last-writer-wins across pilots. #955 moved collision/incoming fire to per-pilot `PilotSims` but left the player-triggered actions on the shared field. New `PilotPositionIn(instance, playerId)` (falls back to the shared field until the first pose arrives) now feeds: `FireWeapon` range + `ValidateSpaceAim`, salvage auto-collect (per pilot, into their own cargo), `TractorPull` reach, station boarding range, EVA structure-edit range, and the EVA-dock / ship-interior return spots.

**#995 — the pause freezes actions, not just the clock.** `PausedMayHandle` gates `Dispatch` while the world is held: gameplay intents are dropped, the resume path, chat/voice, saves, harmless UI state, read-only requests and admin commands stay live. Spectators are exempt (they never hold the pause and keep moving).

**#996 — observers survive a group pause and a same-body landing.** `StreamChunksToSpectators` runs inside the held tick so an observer no longer flies into void; the same-body landing path mirrors `HandleTravel`'s #487 exemptions (no pad claim, no ship park, no AboardShip/RespawnPoint). Spectators are now excluded from pad occupancy at the single derivation point (`PadOccupiedByOther` / `PadOccupantName`), which also covers the travel path's latent variant of the same leak.

**#997 — a new player's respawn anchor is their own.** `CreateNewPlayer` read `_shipPlaced`/`_healTank` under the stale ship cursor; with `PlaceStarterShip=false` a brand-new player persisted the *host's* heal tank. The anchor is now the pad spawn; `SetupPlayerShip` re-anchors to their own heal tank when a starter ship is placed.

**#998 — a failed join cleans up its parked ship.** The #964 catch removed only the session; it now also runs `LeaveSpace` + `RemoveLandedShip` + `RemoveConstructionSite` + `PlayerLeft` — deliberately without saving, so half-restored state can never clobber the real save.

**#999 — polish.** Stale-avatar nameplates hide with the body (3 s, #958); the star map's free-pad count excludes your own reservation (matching #977); pad number keys select by pad label, not array slot; `ChunkStreamPerTick` clamps to a shared ceiling (20) below the client's 24/frame receive budget (#963).

## Verification

- Full fast tier green: **1913 server + 239 client tests** (7 new regression tests across `WorldPauseTests`, `LanPlaytestRegressionTests`, `SpaceCombatTests`, `ReceiveBudgetTests`).
- Solution builds with 0 warnings; local Unity Windows player build clean (client changes: `RemotePlayers.cs`, `SpaceView.cs`).
- No protocol bump; no locale changes.
- #998 has no dedicated test (forcing a mid-join throw needs an artificial seam); covered by review + the existing join tests.

closes #994
closes #995
closes #996
closes #997
closes #998
closes #999

🤖 Generated with [Claude Code](https://claude.com/claude-code)
