### PR TITLE
fix(client): gate ranged attack effects on line of sight

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -105,6 +105,16 @@ Per-item detail lives in the dated work log below. **Since 2026-07 versions are 
 
 ---
 
+### ★ Scan-drones no longer visibly shoot through solid terrain (#1004, 2026-08-14, branch fix/drone-fire-los)
+Playtest report: hiding in a cave, a guard scan-drone hovering outside appeared to fire at the player
+straight through the rock. The shooting was cosmetic — the server gates both the hunt lock and the
+proximity damage on `HasLineOfSight`, so no health ever moved — but the client played the laser beam +
+attack zap on `Hostile` + range alone (`DroneFireRange` 16), and `WeaponFx.Shoot` draws the beam
+unclipped, so the bolt visibly penetrated the cave wall. Ranged attack effects (scan-drone laser AND the
+bandit gunner tracer) are now gated on a render-side sight march that mirrors the server's rule:
+solid-or-fluid cells occlude, endpoints skipped, unloaded chunks read as clear. The march lives in
+`Client.Core` (`SightLine`, CinematicStageScan pattern) with five unit tests.
+
 ### ★ Multiplayer-audit follow-ups: per-pilot space actions, a real pause, observer + join hygiene (#994–#999, 2026-08-14, branch fix/mp-audit-findings)
 A code audit of every multiplayer fix shipped since v2026.8.12 confirmed all of them — and surfaced six
 new findings, fixed together here. **#994 (the real gameplay bug):** space instances are shared per body

--- a/client/Assets/BlocksBeyondTheStars/Scripts/WorldEntities.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/WorldEntities.cs
@@ -135,7 +135,7 @@ namespace BlocksBeyondTheStars.Client
                     {
                         if (en.IsDrone)
                         {
-                            if (toPlayer.sqrMagnitude < DroneFireRange * DroneFireRange)
+                            if (toPlayer.sqrMagnitude < DroneFireRange * DroneFireRange && CanSeePlayer(scenePos))
                             {
                                 en.NextAttack = Game.WorldTime + Random.Range(0.7f, 1.3f);
                                 en.AttackUntil = Game.WorldTime + 0.18f; // brief charge/recoil tic
@@ -145,7 +145,7 @@ namespace BlocksBeyondTheStars.Client
                         else if (en.IsGunner)
                         {
                             // Bandit gunner: tracer shots at aura range (cosmetic — the server aura damages).
-                            if (toPlayer.sqrMagnitude < BanditGunFireRange * BanditGunFireRange)
+                            if (toPlayer.sqrMagnitude < BanditGunFireRange * BanditGunFireRange && CanSeePlayer(scenePos))
                             {
                                 en.NextAttack = Game.WorldTime + Random.Range(0.8f, 1.5f);
                                 en.AttackUntil = Game.WorldTime + 0.2f;
@@ -198,6 +198,38 @@ namespace BlocksBeyondTheStars.Client
             {
                 ClientAudio.Instance?.At("enemy_die", en.Root.transform.position, en.Pitch * MachineJitter());
             }
+        }
+
+        /// <summary>Whether a ranged attacker at <paramref name="shooter"/> has a clear sight line to the
+        /// player's chest (#1004). The server gates its hunt lock AND its damage on line-of-sight, so a
+        /// player who ducks into a cave takes no hits — but the ranged fire effect used to key on range
+        /// alone, so a drone hovering outside visibly sniped them straight through the rock. Mirrors the
+        /// server's sight rule: a non-air block whose definition is missing or <c>Solid</c> occludes, and
+        /// so do water/lava; endpoint cells are skipped (the bodies aren't occluders).</summary>
+        private bool CanSeePlayer(Vector3 shooter)
+        {
+            if (Game?.World == null)
+            {
+                return true; // no world to sample — keep the effect rather than silently muting combat
+            }
+
+            Vector3 chest = Game.PlayerPosition + Vector3.up * 0.9f; // where the beam aims
+            return SightLine.Clear(IsSightBlockingCell, shooter.x, shooter.y, shooter.z, chest.x, chest.y, chest.z);
+        }
+
+        /// <summary>Sight-blocking test for one world cell — the client twin of the server's
+        /// <c>IsSightBlockingCell</c>. <c>GetBlock</c> canonicalises seam coordinates and reads unloaded
+        /// chunks as air (clear), which is the right lenient default for a cosmetic effect.</summary>
+        private bool IsSightBlockingCell(int wx, int wy, int wz)
+        {
+            var id = Game.World.GetBlock(wx, wy, wz);
+            if (id.IsAir)
+            {
+                return false;
+            }
+
+            var def = Game.Content?.BlockById(id);
+            return def == null || def.Solid || def.Key is "water" or "lava";
         }
 
         /// <summary>A ranged attacker's shot: a short laser beam to the player (with a little scatter) plus the

--- a/src/BlocksBeyondTheStars.Client.Core/SightLine.cs
+++ b/src/BlocksBeyondTheStars.Client.Core/SightLine.cs
@@ -1,0 +1,54 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+
+using System;
+
+namespace BlocksBeyondTheStars.Client
+{
+    /// <summary>
+    /// Unity-free line-of-sight march for render-side combat effects (#1004): the scan-drone's laser and
+    /// the bandit gunner's tracer are cosmetic mirrors of the server's proximity damage, but they used to
+    /// fire on range alone — a drone hovering outside a cave visibly sniped the player straight through
+    /// the rock while the server (whose damage and hunt lock are both sight-gated) never dealt a point.
+    /// Client mirror of the server's <c>HasLineOfSight</c>: same step size, endpoints skipped. Lives here
+    /// (not in the MonoBehaviour) so the march is covered by plain .NET tests.
+    /// </summary>
+    public static class SightLine
+    {
+        /// <summary>True = the cell BLOCKS sight. Callers mirror the server's rule: a non-air block whose
+        /// definition is missing or flagged <c>Solid</c> occludes (hiding in tall grass works), and so do
+        /// water/lava (no aggro through a lake). An unloaded chunk should read as clear — near the player
+        /// the world is streamed, and a cosmetic effect must not pop off over a chunk-load hiccup.</summary>
+        public delegate bool BlockingSampler(int wx, int wy, int wz);
+
+        /// <summary>Sample spacing of the march, in blocks — matches the server's sight march.</summary>
+        private const float MarchStep = 0.25f;
+
+        /// <summary>
+        /// Whether nothing sight-blocking stands strictly between the two points. Endpoint cells are
+        /// skipped — the shooter's and the target's own bodies aren't occluders. Both points must already
+        /// be in the same (unwrapped) frame; cells are handed to the sampler raw, so a sampler backed by
+        /// the client world canonicalises seam coordinates itself.
+        /// </summary>
+        public static bool Clear(BlockingSampler blocking,
+            float fromX, float fromY, float fromZ, float toX, float toY, float toZ)
+        {
+            float dx = toX - fromX, dy = toY - fromY, dz = toZ - fromZ;
+            float length = (float)Math.Sqrt(dx * dx + dy * dy + dz * dz);
+            int steps = Math.Max(1, (int)Math.Ceiling(length / MarchStep));
+            for (int i = 1; i < steps; i++)
+            {
+                float t = (float)i / steps;
+                if (blocking(Floor(fromX + dx * t), Floor(fromY + dy * t), Floor(fromZ + dz * t)))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private static int Floor(float v) => (int)Math.Floor(v);
+    }
+}

--- a/tests/BlocksBeyondTheStars.Client.Tests/SightLineTests.cs
+++ b/tests/BlocksBeyondTheStars.Client.Tests/SightLineTests.cs
@@ -1,0 +1,55 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using Xunit;
+
+namespace BlocksBeyondTheStars.Client.Tests;
+
+/// <summary>
+/// Render-side sight march for ranged attack effects (#1004): a scan-drone hovering outside a cave must
+/// not visibly fire its laser at a player behind solid rock (the server's damage is sight-gated, so the
+/// shot was always a lie), while a clear line — including one only broken by the endpoints' own cells —
+/// keeps firing.
+/// </summary>
+public sealed class SightLineTests
+{
+    [Fact]
+    public void Clear_OpenAir_IsClear()
+    {
+        static bool Nothing(int x, int y, int z) => false;
+        Assert.True(SightLine.Clear(Nothing, 0f, 5f, 0f, 14f, 8f, 3f));
+    }
+
+    [Fact]
+    public void Clear_WallBetween_IsBlocked()
+    {
+        // A one-block-thick wall at x == 6 spans the segment at every height: the cave scenario.
+        static bool Wall(int x, int y, int z) => x == 6;
+        Assert.False(SightLine.Clear(Wall, 0f, 5f, 0f, 14f, 5f, 0f));
+    }
+
+    [Fact]
+    public void Clear_PointBlank_SkipsTheEndpointSamples()
+    {
+        // At point-blank range (one march step or less) the only samples are the endpoints themselves —
+        // both skipped, since the shooter's and the target's own bodies aren't occluders.
+        static bool Everything(int x, int y, int z) => true;
+        Assert.True(SightLine.Clear(Everything, 0.9f, 2.5f, 0.5f, 1.1f, 2.5f, 0.5f));
+    }
+
+    [Fact]
+    public void Clear_DiagonalThroughCeiling_IsBlocked()
+    {
+        // A hovering drone above a roofed player: a horizontal slab at y == 4 cuts the steep segment.
+        static bool Slab(int x, int y, int z) => y == 4;
+        Assert.False(SightLine.Clear(Slab, 2f, 9f, 2f, 3f, 1.5f, 4f));
+    }
+
+    [Fact]
+    public void Clear_ZeroLengthSegment_IsClear()
+    {
+        // Degenerate but must not throw or scan anything: shooter and target in the same spot.
+        static bool Everything(int x, int y, int z) => true;
+        Assert.True(SightLine.Clear(Everything, 3f, 3f, 3f, 3f, 3f, 3f));
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the playtest report behind #1004: hiding in a cave, a guard scan-drone hovering outside visibly fired red laser bolts at the player straight through solid rock.

The shooting was cosmetic — the server gates both the hunt lock and the proximity damage on `HasLineOfSight`, so no damage was ever dealt — but the client played the drone laser (and the bandit gunner tracer) on `Hostile` + range alone, and `WeaponFx.Shoot` draws the beam unclipped, so the bolt penetrated the cave wall complete with the attack zap audio.

## Changes

- **`Client.Core/SightLine.cs` (new)** — Unity-free sight march (0.25-block steps, endpoints skipped), following the `CinematicStageScan` pattern so it's covered by plain .NET tests.
- **`WorldEntities.cs`** — both ranged fire branches (scan-drone, bandit gunner) now hold fire unless the shooter has a clear sight line to the player's chest. The blocking rule mirrors the server's `IsSightBlockingCell`: non-air with a missing-or-`Solid` definition occludes, water/lava occlude; unloaded chunks read as clear (lenient default for a cosmetic effect — near the player the world is streamed).
- **`SightLineTests.cs` (new)** — 5 tests: open air, wall between, ceiling on a steep diagonal, point-blank endpoint skipping, zero-length segment.
- **TODO.md** work-log entry.

## Verification

- `dotnet build` Release: 0 warnings / 0 errors
- Client.Tests: 244 passed (5 new)
- Local Unity Windows build (batch mode): success, no generated files left uncommitted

Closes #1004

🤖 Generated with [Claude Code](https://claude.com/claude-code)