### PR TITLE
fix(scanner): aim-gated scan targeting + feedback for empty and rejected scans

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -105,6 +105,19 @@ Per-item detail lives in the dated work log below. **Since 2026-07 versions are 
 
 ---
 
+### ★ Scanner: aim-gated targeting + feedback for empty/rejected scans (#1005, 2026-08-14, branch fix/scanner-stuck-1005)
+Playtest report: the scanner sometimes "sticks" — it keeps showing the last scanned subject until the
+player walks away and does something else. Root cause was proximity-only target selection:
+`ScanTarget()` picked the nearest creature within reach (8 m) with no aim or line check, so a creature
+idling anywhere nearby — behind the player, through a wall — captured every scan press; micro-fauna
+(5 m) behaved the same. Every miss was silent on top: the client sent nothing on an empty aim and the
+server built rejections but never sent them (`Rejected(...)` was returned, `HandleScan` discarded it),
+while the scan panel stays pinned on the last readout for as long as the scanner is held (#482). Now:
+creature/critter targets must sit inside a 25° aim cone (point-blank ≤ 2 m always passes), an empty
+scan shows "Scanner: no target in view." (new `ui.scan.no_target`, all 14 locales), and the server
+sends rejected scans over the existing `ScanResult` message — no protocol bump; an old client shows the
+legacy English info string. New regression test `RejectedScan_IsSentToTheClient`.
+
 ### ★ Ship function blocks now look like function blocks (#1009, 2026-08-14, branch fix/1009-station-marker-blocks)
 The station marker blocks aboard ships stamped as generic world blocks — workshop as `stone`, quarters
 as `carbon`, medbay as `ice`, and the cargo hold as plain `iron_wall` (invisible against the hull) — so

--- a/client/Assets/BlocksBeyondTheStars/Scripts/MicroFaunaView.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/MicroFaunaView.cs
@@ -69,8 +69,10 @@ namespace BlocksBeyondTheStars.Client
 
         /// <summary>Nearest live critter within <paramref name="reach"/> of a WORLD position (#757), for the
         /// handheld scanner. Critter positions are canonical world coordinates (same frame as
-        /// <see cref="GameBootstrap.PlayerPosition"/>).</summary>
-        public bool NearestCritter(Vector3 worldPos, float reach, out string kindKey, out Vector3 worldAt)
+        /// <see cref="GameBootstrap.PlayerPosition"/>). The optional <paramref name="filter"/> (world position →
+        /// eligible) lets the scanner keep off-aim critters from answering the scan (#1005).</summary>
+        public bool NearestCritter(Vector3 worldPos, float reach, out string kindKey, out Vector3 worldAt,
+            System.Func<Vector3, bool> filter = null)
         {
             kindKey = null;
             worldAt = default;
@@ -78,7 +80,7 @@ namespace BlocksBeyondTheStars.Client
             foreach (var c in _alive)
             {
                 float d = (c.WorldPos - worldPos).sqrMagnitude;
-                if (d < bestSq)
+                if (d < bestSq && (filter == null || filter(c.WorldPos)))
                 {
                     bestSq = d;
                     kindKey = c.Kind.Key;

--- a/client/Assets/BlocksBeyondTheStars/Scripts/PlayerController.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/PlayerController.cs
@@ -1117,13 +1117,29 @@ namespace BlocksBeyondTheStars.Client
             return true;
         }
 
-        /// <summary>Scans the nearest creature (threat assessment) or, failing that, the block in view.</summary>
+        private const float ScanConeDegrees = 25f;      // generous — creatures move; still excludes behind/beside
+        private const float ScanPointBlankSq = 2f * 2f; // this close the angle test degenerates — always scannable
+
+        /// <summary>Whether a scan target is inside the aim cone around the view direction, or point-blank
+        /// (standing on it). Proximity alone must not qualify a target: a creature idling anywhere within
+        /// reach — behind the player, through a wall — used to capture every scan press, which read as
+        /// "the scanner is stuck on the last readout" (#1005).</summary>
+        private static bool InScanCone(Vector3 eye, Vector3 fwd, Vector3 at)
+        {
+            var to = at - eye;
+            return to.sqrMagnitude <= ScanPointBlankSq || Vector3.Angle(fwd, to) <= ScanConeDegrees;
+        }
+
+        /// <summary>Scans the aimed-at creature (threat assessment) or, failing that, the block in view.</summary>
         private void ScanTarget()
         {
             if (Game?.Network == null || Camera == null)
             {
                 return;
             }
+
+            Vector3 eye = Camera.transform.position;
+            Vector3 fwd = Camera.transform.forward;
 
             string speciesId = null;
             Vector3 scanPos = default;
@@ -1132,7 +1148,7 @@ namespace BlocksBeyondTheStars.Client
             {
                 var cp = Game.ScenePos(c.X, c.Y, c.Z); // seam-aware (longitude wraps)
                 float d = (cp - transform.position).sqrMagnitude;
-                if (d < bestSq)
+                if (d < bestSq && InScanCone(eye, fwd, cp))
                 {
                     bestSq = d;
                     speciesId = c.SpeciesId;
@@ -1147,11 +1163,12 @@ namespace BlocksBeyondTheStars.Client
                 return;
             }
 
-            // Micro-fauna (#757): when no real creature is in reach, the nearest ambient critter answers.
+            // Micro-fauna (#757): when no real creature is in view, the nearest aimed-at critter answers.
             // Critters are client-local, so the kind is resolved here and the server only validates that it
             // exists (same trust level as the creature scan above). Shorter reach — they're tiny.
             if (MicroFaunaView.Instance != null
-                && MicroFaunaView.Instance.NearestCritter(Game.PlayerPosition, 5f, out string critterKey, out var critterAt))
+                && MicroFaunaView.Instance.NearestCritter(Game.PlayerPosition, 5f, out string critterKey, out var critterAt,
+                    world => InScanCone(eye, fwd, Game.ScenePos(world.x, world.y, world.z))))
             {
                 Game.Network.SendScan("microfauna", critterKey);
                 Weapons?.Pulse(Game.ScenePos(critterAt.x, critterAt.y, critterAt.z), new Color(0.4f, 0.85f, 1f));
@@ -1160,17 +1177,17 @@ namespace BlocksBeyondTheStars.Client
 
             // Voxel ray-march INCLUDING fluids, so you can scan a water/lava block too (they have no collider, so
             // a Physics.Raycast passes straight through them — that's why water "couldn't be scanned", B26).
-            if (!AimBlock(out var b, out _, includeFluids: true))
-            {
-                return;
-            }
-
-            var def = Game.Content?.BlockById(Game.World.GetBlock(b.x, b.y, b.z));
-            if (def != null)
+            if (AimBlock(out var b, out _, includeFluids: true)
+                && Game.Content?.BlockById(Game.World.GetBlock(b.x, b.y, b.z)) is { } def)
             {
                 Game.Network.SendScan("block", def.Key);
                 Weapons?.Pulse(new Vector3(b.x + 0.5f, b.y + 0.5f, b.z + 0.5f), new Color(0.4f, 0.85f, 1f));
+                return;
             }
+
+            // Nothing scannable in view — say so. The scan panel stays pinned on the previous readout while
+            // the scanner is held, so a silent miss looks like the scanner stopped working (#1005).
+            Game.ShowMessage(Game.Localizer?.Get("ui.scan.no_target") ?? "Scanner: no target in view.");
         }
 
         private BinocularOptic _optic;

--- a/data/locales/de.json
+++ b/data/locales/de.json
@@ -1767,6 +1767,7 @@
   "ui.scan.unknown": "Unbekanntes Ziel.",
   "ui.scan.no_scanner": "Kein Scanner.",
   "ui.scan.not_scannable": "Kein scanbares Objekt.",
+  "ui.scan.no_target": "Scanner: kein Ziel im Blick.",
   "ui.scan.subject.asteroid": "Asteroid",
   "ui.scan.subject.monument_arcade": "Verfallene Arkade",
   "ui.scan.subject.monument_gate": "Uraltes Tor",

--- a/data/locales/en.json
+++ b/data/locales/en.json
@@ -1767,6 +1767,7 @@
   "ui.scan.unknown": "Unknown subject.",
   "ui.scan.no_scanner": "No scanner.",
   "ui.scan.not_scannable": "Not a scannable object.",
+  "ui.scan.no_target": "Scanner: no target in view.",
   "ui.scan.subject.asteroid": "Asteroid",
   "ui.scan.subject.monument_arcade": "Fallen Arcade",
   "ui.scan.subject.monument_gate": "Ancient Gate",

--- a/data/locales/es.json
+++ b/data/locales/es.json
@@ -1766,6 +1766,7 @@
   "ui.scan.unknown": "Objeto desconocido.",
   "ui.scan.no_scanner": "No hay escáner.",
   "ui.scan.not_scannable": "No es un objeto escaneable.",
+  "ui.scan.no_target": "Escáner: ningún objetivo a la vista.",
   "ui.scan.subject.asteroid": "Asteroide",
   "ui.scan.subject.monument_arcade": "Arcada Caída",
   "ui.scan.subject.monument_gate": "Puerta Antigua",

--- a/data/locales/fr.json
+++ b/data/locales/fr.json
@@ -1766,6 +1766,7 @@
   "ui.scan.unknown": "Sujet inconnu.",
   "ui.scan.no_scanner": "Pas de scanner.",
   "ui.scan.not_scannable": "Objet non scannable.",
+  "ui.scan.no_target": "Scanner : aucune cible en vue.",
   "ui.scan.subject.asteroid": "Astéroïde",
   "ui.scan.subject.monument_arcade": "Arcade effondrée",
   "ui.scan.subject.monument_gate": "Porte ancienne",

--- a/data/locales/it.json
+++ b/data/locales/it.json
@@ -1766,6 +1766,7 @@
   "ui.scan.unknown": "Soggetto sconosciuto.",
   "ui.scan.no_scanner": "Nessuno scanner.",
   "ui.scan.not_scannable": "Oggetto non scansionabile.",
+  "ui.scan.no_target": "Scanner: nessun bersaglio in vista.",
   "ui.scan.subject.asteroid": "Asteroide",
   "ui.scan.subject.monument_arcade": "Arcade Caduta",
   "ui.scan.subject.monument_gate": "Portale Antico",

--- a/data/locales/ja.json
+++ b/data/locales/ja.json
@@ -1766,6 +1766,7 @@
   "ui.scan.unknown": "未確認の対象。",
   "ui.scan.no_scanner": "スキャナーがない。",
   "ui.scan.not_scannable": "スキャンできないオブジェクト。",
+  "ui.scan.no_target": "スキャナー：視界内に対象がありません。",
   "ui.scan.subject.asteroid": "小惑星",
   "ui.scan.subject.monument_arcade": "堕ちたアーケード",
   "ui.scan.subject.monument_gate": "古代の門",

--- a/data/locales/ko.json
+++ b/data/locales/ko.json
@@ -1766,6 +1766,7 @@
   "ui.scan.unknown": "알 수 없는 대상.",
   "ui.scan.no_scanner": "스캐너 없음.",
   "ui.scan.not_scannable": "스캔 가능한 대상이 아님.",
+  "ui.scan.no_target": "스캐너: 시야에 대상이 없습니다.",
   "ui.scan.subject.asteroid": "소행성",
   "ui.scan.subject.monument_arcade": "폐허가 된 아케이드",
   "ui.scan.subject.monument_gate": "고대 관문",

--- a/data/locales/nl.json
+++ b/data/locales/nl.json
@@ -1766,6 +1766,7 @@
   "ui.scan.unknown": "Onbekend object.",
   "ui.scan.no_scanner": "Geen scanner.",
   "ui.scan.not_scannable": "Niet scanbaar.",
+  "ui.scan.no_target": "Scanner: geen doelwit in zicht.",
   "ui.scan.subject.asteroid": "Asteroïde",
   "ui.scan.subject.monument_arcade": "Gevallen Arcade",
   "ui.scan.subject.monument_gate": "Oude Poort",

--- a/data/locales/pl.json
+++ b/data/locales/pl.json
@@ -1766,6 +1766,7 @@
   "ui.scan.unknown": "Nieznany obiekt.",
   "ui.scan.no_scanner": "Brak skanera.",
   "ui.scan.not_scannable": "Obiekt niepodlegający skanowaniu.",
+  "ui.scan.no_target": "Skaner: brak celu w polu widzenia.",
   "ui.scan.subject.asteroid": "Asteroida",
   "ui.scan.subject.monument_arcade": "Upadła sala gier",
   "ui.scan.subject.monument_gate": "Starożytna Brama",

--- a/data/locales/pt.json
+++ b/data/locales/pt.json
@@ -1766,6 +1766,7 @@
   "ui.scan.unknown": "Assunto desconhecido.",
   "ui.scan.no_scanner": "Sem scanner.",
   "ui.scan.not_scannable": "Objeto não escaneável.",
+  "ui.scan.no_target": "Scanner: nenhum alvo à vista.",
   "ui.scan.subject.asteroid": "Asteroide",
   "ui.scan.subject.monument_arcade": "Arcade Caído",
   "ui.scan.subject.monument_gate": "Portão Antigo",

--- a/data/locales/ru.json
+++ b/data/locales/ru.json
@@ -1766,6 +1766,7 @@
   "ui.scan.unknown": "Неизвестный объект.",
   "ui.scan.no_scanner": "Нет сканера.",
   "ui.scan.not_scannable": "Нельзя отсканировать.",
+  "ui.scan.no_target": "Сканер: нет цели в поле зрения.",
   "ui.scan.subject.asteroid": "Астероид",
   "ui.scan.subject.monument_arcade": "Павший Аркад",
   "ui.scan.subject.monument_gate": "Древние Врата",

--- a/data/locales/tr.json
+++ b/data/locales/tr.json
@@ -1766,6 +1766,7 @@
   "ui.scan.unknown": "Bilinmeyen konu.",
   "ui.scan.no_scanner": "Tarayıcı yok.",
   "ui.scan.not_scannable": "Tarayılamaz nesne.",
+  "ui.scan.no_target": "Tarayıcı: görüş alanında hedef yok.",
   "ui.scan.subject.asteroid": "Asteroid",
   "ui.scan.subject.monument_arcade": "Düşmüş Arcade",
   "ui.scan.subject.monument_gate": "Antik Kapı",

--- a/data/locales/uk.json
+++ b/data/locales/uk.json
@@ -1766,6 +1766,7 @@
   "ui.scan.unknown": "Невідомий об'єкт.",
   "ui.scan.no_scanner": "Немає сканера.",
   "ui.scan.not_scannable": "Не підлягає скануванню.",
+  "ui.scan.no_target": "Сканер: немає цілі в полі зору.",
   "ui.scan.subject.asteroid": "Астероїд",
   "ui.scan.subject.monument_arcade": "Покинутий Аркад",
   "ui.scan.subject.monument_gate": "Стародавні Ворота",

--- a/data/locales/zh.json
+++ b/data/locales/zh.json
@@ -1766,6 +1766,7 @@
   "ui.scan.unknown": "未知对象。",
   "ui.scan.no_scanner": "无扫描器。",
   "ui.scan.not_scannable": "不可扫描的对象。",
+  "ui.scan.no_target": "扫描仪：视野内没有目标。",
   "ui.scan.subject.asteroid": "小行星",
   "ui.scan.subject.monument_arcade": "倒塌的街机",
   "ui.scan.subject.monument_gate": "远古之门",

--- a/src/BlocksBeyondTheStars.GameServer/GameServerScanning.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerScanning.cs
@@ -34,7 +34,7 @@ public sealed partial class GameServer
         var session = FindSessionByPlayerId(playerId);
         if (session is null)
         {
-            return Rejected(subjectKey, "ui.scan.no_scanner", "No scanner.");
+            return Rejected(null, subjectKey, "ui.scan.no_scanner", "No scanner.");
         }
 
         var readout = new ScanReadout { Kind = subjectType, SubjectKey = subjectKey, Display = subjectKey };
@@ -129,7 +129,7 @@ public sealed partial class GameServer
         }
         else
         {
-            return Rejected(subjectKey, "ui.scan.unknown", "Unknown subject.");
+            return Rejected(session, subjectKey, "ui.scan.unknown", "Unknown subject.");
         }
 
         // Ledger key tracks the first scan (per species/block, or shared per tree); the readout shows `Display`.
@@ -160,9 +160,19 @@ public sealed partial class GameServer
         public string LegacyThreat = "—";
     }
 
-    /// <summary>A scan that produced nothing to award (no session / unscannable subject).</summary>
-    private static ScanResult Rejected(string subjectKey, string infoKey, string legacyInfo)
-        => new() { Subject = subjectKey, SubjectKey = subjectKey, InfoKey = infoKey, Info = legacyInfo, Threat = "—" };
+    /// <summary>A scan that produced nothing to award (no session / unscannable subject). The result is
+    /// still SENT when a session exists: a silently dropped scan leaves the client's readout pinned on the
+    /// previous subject, which reads as "the scanner is stuck" (#1005).</summary>
+    private ScanResult Rejected(PlayerSession? session, string subjectKey, string infoKey, string legacyInfo)
+    {
+        var result = new ScanResult { Subject = subjectKey, SubjectKey = subjectKey, InfoKey = infoKey, Info = legacyInfo, Threat = "—" };
+        if (session is not null)
+        {
+            Send(session, result);
+        }
+
+        return result;
+    }
 
     /// <summary>Ship scan of a space asteroid — reveals whether it holds resources (server knows the loot).</summary>
     public ScanResult ScanSpaceEntity(string playerId, string entityId)
@@ -170,7 +180,7 @@ public sealed partial class GameServer
         var session = FindSessionByPlayerId(playerId);
         if (session is null)
         {
-            return new ScanResult { Subject = entityId, Info = "No scanner.", Threat = "—" };
+            return Rejected(null, entityId, "ui.scan.no_scanner", "No scanner.");
         }
 
         if (!_playerInstance.TryGetValue(playerId, out var instanceId)
@@ -178,7 +188,7 @@ public sealed partial class GameServer
             || instance.Entities.FirstOrDefault(e => e.Id == entityId) is not { } target
             || target.Kind != CombatEntityKind.Asteroid)
         {
-            return Rejected(entityId, "ui.scan.not_scannable", "Not a scannable object.");
+            return Rejected(session, entityId, "ui.scan.not_scannable", "Not a scannable object.");
         }
 
         // Asteroids break down to mineral drops; report the resource types they ultimately yield.

--- a/tests/BlocksBeyondTheStars.Tests/ScanningTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/ScanningTests.cs
@@ -2,8 +2,11 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using BlocksBeyondTheStars.GameServer;
+using BlocksBeyondTheStars.Networking;
+using BlocksBeyondTheStars.Networking.Messages;
 using BlocksBeyondTheStars.Networking.Transport;
 using BlocksBeyondTheStars.Persistence;
 using BlocksBeyondTheStars.Shared.Configuration;
@@ -384,6 +387,46 @@ public sealed class ScanningTests : IDisposable
             Assert.Equal(20, p.State.KnowledgePoints);
             server.ReportMinigameResultForTest("Gamer", "", rating: 3);
             Assert.Equal(20, p.State.KnowledgePoints);
+        }
+    }
+
+    [Fact]
+    public void RejectedScan_IsSentToTheClient()
+    {
+        // A rejected scan must still reach the client: HandleScan used to drop the rejection, so the
+        // HUD stayed pinned on the previous readout — "the scanner is stuck" (#1005).
+        var link = new LoopbackLink();
+        var st = new LoopbackServerTransport(link);
+        var config = new ServerConfig { WorldName = "rocky", Seed = 4242, StartPlanet = "rocky", AutoSaveIntervalMinutes = 9999, PlaceStarterShip = false };
+        var repo = new SqliteWorldRepository(new SaveGamePaths(_root, "rocky"));
+        using (repo)
+        {
+            var server = new SvGameServer(config, _content, st, repo);
+            server.Start();
+
+            var results = new List<ScanResult>();
+            var client = new LoopbackClientTransport(link);
+            client.PayloadReceived += payload =>
+            {
+                if (NetCodec.Decode(payload) is ScanResult r)
+                {
+                    results.Add(r);
+                }
+            };
+            client.Connect("loopback", 0);
+            client.Send(NetCodec.Encode(new JoinRequest { PlayerName = "Scout" }), DeliveryMode.ReliableOrdered);
+            server.Tick(0.1);
+            client.Poll();
+            results.Clear(); // ignore anything the join itself pushed
+
+            client.Send(NetCodec.Encode(new ScanIntent { SubjectType = "block", SubjectKey = "definitely_not_a_block" }), DeliveryMode.ReliableOrdered);
+            server.Tick(0.1);
+            client.Poll();
+
+            var rejection = Assert.Single(results);
+            Assert.Equal("ui.scan.unknown", rejection.InfoKey);
+            Assert.False(rejection.FirstTime);
+            Assert.Equal(0, rejection.KnowledgeGained);
         }
     }
 


### PR DESCRIPTION
Closes #1005

## Problem

Playtest report: the scanner sometimes looks stuck — it keeps showing the last scanned subject no matter what you aim at, until the player walks somewhere else.

Root cause (see #1005 for the full analysis):

1. `ScanTarget()` picked the **nearest creature within reach (8 m) by pure distance** — no aim direction, no line check. Any creature idling nearby (behind the player, through a wall) captured every scan press; walking out of its radius "fixed" the scanner. Micro-fauna (5 m) behaved the same.
2. Misses were **silent**: the client sent nothing on an empty aim, and the server built `Rejected(...)` results but never sent them (`HandleScan` discarded the return value). Meanwhile the scan panel stays pinned on the last readout for as long as the scanner is held (#482) — so a failed scan was indistinguishable from a dead scanner.

## Fix

- **Aim-gated targeting**: creature/critter scan targets must sit inside a 25° cone around the view direction; point-blank (≤ 2 m) always passes so you can still scan something you are standing on. Otherwise the scan falls through to the block under the crosshair.
- **"No target" feedback**: an empty scan now shows a localized toast — new `ui.scan.no_target` key in all 14 locales.
- **Server sends rejections**: rejected scans go out over the existing `ScanResult` message. No protocol bump; an old client shows the legacy English info string.

## Tests

- New `RejectedScan_IsSentToTheClient` (loopback client, decodes the sent `ScanResult`, asserts `ui.scan.unknown` + no knowledge awarded).
- Scanning + locale suites green; full non-Slow suite + clean Release build (0 warnings) + local Unity client build run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
