### PR TITLE
feat(ship): themed station marker blocks so ship rooms read as functions

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -105,6 +105,17 @@ Per-item detail lives in the dated work log below. **Since 2026-07 versions are 
 
 ---
 
+### ★ Ship function blocks now look like function blocks (#1009, 2026-08-14, branch fix/1009-station-marker-blocks)
+The station marker blocks aboard ships stamped as generic world blocks — workshop as `stone`, quarters
+as `carbon`, medbay as `ice`, and the cargo hold as plain `iron_wall` (invisible against the hull) — so
+nothing in a room read as "the thing you press E on". `StationBlockKey` now maps each station to the
+existing themed machine block whose *world* function already matches the station's: medbay → `heal_tank`
+(emissive tank), workshop → `workbench`, quarters → `bed`, cargo → `crate`. No new blocks, textures or
+protocol; both the authored-layout path and the code-box starter hull share the one mapping, station
+cells stay baseline-protected (never minable), and existing saves pick the new markers up on the next
+structure rebuild. `lab`/`console` markers still default to `iron_wall` (no matching textured block yet)
+— left as a follow-up.
+
 ### ★ Scan-drones no longer visibly shoot through solid terrain (#1004, 2026-08-14, branch fix/drone-fire-los)
 Playtest report: hiding in a cave, a guard scan-drone hovering outside appeared to fire at the player
 straight through the rock. The shooting was cosmetic — the server gates both the hunt lock and the

--- a/src/BlocksBeyondTheStars.GameServer/GameServerShipStructure.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerShipStructure.cs
@@ -233,12 +233,18 @@ public sealed partial class GameServer
         }
     }
 
+    /// <summary>The block a station cell stamps as (#1009). Each marker is the themed machine block whose
+    /// WORLD function matches the station's — heal tank heals/anchors spawn like the medbay, the workbench
+    /// crafts like the workshop, the bed is the home-spawn quarters analogue, the crate the storage box —
+    /// so the rooms read at a glance instead of stamping as generic stone/carbon/ice. Station cells sit in
+    /// the structure baseline (never minable), so the blocks' hardness/drops/flammability never apply.</summary>
     private static string StationBlockKey(string station) => station switch
     {
-        "medbay" => "ice",
+        "medbay" => "heal_tank",
         "cockpit" => "data_cache",
-        "workshop" => "stone",
-        "quarters" => "carbon",
+        "workshop" => "workbench",
+        "quarters" => "bed",
+        "cargo" => "crate",
         _ => "iron_wall",
     };
 


### PR DESCRIPTION
## What

The station marker blocks aboard ships stamped as generic world blocks — workshop = `stone`, quarters = `carbon`, medbay = `ice`, cargo hold = plain `iron_wall` (invisible against the hull) — so nothing in a room read as "the thing you press E on".

`StationBlockKey()` now maps each station to the existing themed, textured machine block whose **world** function already matches the station's function:

| Station | Before | After | Affordance match |
|---|---|---|---|
| medbay (heal tank) | `ice` | `heal_tank` | the world heal tank is the heal/spawn block (emissive) |
| workshop | `stone` | `workbench` | the world workbench is the crafting block |
| quarters | `carbon` | `bed` | the world bed is the home-spawn block; quarters E sets spawn |
| cargo hold | `iron_wall` | `crate` | the world crate is the storage container; cargo E opens the hold |

`cockpit` stays `data_cache`; the `iron_wall` default remains for weapon mounts. `lab`/`console` are left for a follow-up (no matching textured block yet).

## Why it's safe

- One mapping feeds both the authored-layout path and the code-box starter hull — a single-site change.
- Station cells live in the structure **baseline** (never minable) → hardness/drops/flammability of the new blocks never apply; fire never touches structures (#787).
- Server-only: all four blocks already have bundled textures; no new blocks, no atlas slots, no protocol change. Existing saves rebuild their ship structures on load and pick the markers up automatically.
- Client E-priority checks for `heal_tank`/`bed`/`crate` read **world** blocks, not structure cells — no interaction conflict aboard.

## Tests

Full non-Slow suite locally in Release: **1913 server + 244 client passing, 0 failures**. No test asserts the marker block keys (they use `StationPosition()`).

Closes #1009

🤖 Generated with [Claude Code](https://claude.com/claude-code)
