### PR TITLE
fix(client): keep sending position behind menus so the 90 s heartbeat stops kicking players

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -105,6 +105,18 @@ Per-item detail lives in the dated work log below. **Since 2026-07 versions are 
 
 ---
 
+### ★ Browsing a menu no longer gets you kicked after 90 s (#1008, 2026-08-14, branch fix/menu-heartbeat-keepalive)
+Tonight's 3-player LAN session dropped every player repeatedly — seven `sent nothing for 90s — dropping
+the session` kicks in ~80 minutes in the host's log. The #964 heartbeat assumes "a playing client sends
+movement updates continuously", but the client went completely silent in several alive states: on foot
+with any UI panel open (crafting, map, inventory, paint editor, chat, cinematic —
+`PlayerController.Update` returned before `SendMovement()`), in space behind the star map / pad chooser /
+ship-destruction prompt (`UpdateCruise` early-outs before the 12 Hz `SendShipMove`), and on EVA with a
+menu open. Only the Esc pause menu had a keep-alive (#973). The position streams now keep flowing
+(position simply frozen) in all those states — sent before the early-outs — so the sweep only catches
+actually-dead clients. No protocol change; the server side is untouched. Cosmetic side-finding logged in
+#1008: a heartbeat kick logs `Connection N closed.` twice.
+
 ### ★ Scan-drones no longer visibly shoot through solid terrain (#1004, 2026-08-14, branch fix/drone-fire-los)
 Playtest report: hiding in a cave, a guard scan-drone hovering outside appeared to fire at the player
 straight through the rock. The shooting was cosmetic — the server gates both the hunt lock and the

--- a/client/Assets/BlocksBeyondTheStars/Scripts/PlayerController.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/PlayerController.cs
@@ -362,6 +362,10 @@ namespace BlocksBeyondTheStars.Client
                     ApplyGravityOnly(); // seated: the controller is disabled and the chair holds us anyway
                 }
 
+                // Keep the position stream flowing (position simply frozen): behind an open panel this is
+                // the client's ONLY payload, and the server drops sessions silent for 90 s (#964) — browsing
+                // the crafting menu or painting an avatar must not read as a dead client (#1008).
+                SendMovement();
                 return;
             }
 

--- a/client/Assets/BlocksBeyondTheStars/Scripts/SpaceView.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/SpaceView.cs
@@ -1041,6 +1041,19 @@ namespace BlocksBeyondTheStars.Client
                 return;
             }
 
+            // Report our position so the server runs authoritative collisions against asteroids/entities and
+            // the other players in this instance can see our ship. Sent BEFORE the menu/prompt early-outs
+            // below: behind the star map, the pad chooser or the destruction prompt this is the client's only
+            // payload, and the server drops sessions silent for 90 s (#964/#1008). After the ship was
+            // destroyed the server has already removed us from the instance and ignores the intent — but
+            // receiving it still stamps the heartbeat.
+            _moveSendTimer -= Time.deltaTime;
+            if (_moveSendTimer <= 0f)
+            {
+                _moveSendTimer = 0.08f; // ~12 Hz
+                Game.Network?.SendShipMove(_ship.transform.localPosition, _yaw);
+            }
+
             // Hold position while a menu is open (e.g. the Tab star map, used to hyperspace-jump to another
             // system), or while the ship-destruction "Weiter" prompt is up, so flight input doesn't fight
             // the UI / swing the camera behind the modal.
@@ -1242,15 +1255,6 @@ namespace BlocksBeyondTheStars.Client
                     _landTargetName = body.Name;
                     _landTargetSq = sq;
                 }
-            }
-
-            // Report our position so the server runs authoritative collisions against asteroids/entities and
-            // the other players in this instance can see our ship.
-            _moveSendTimer -= Time.deltaTime;
-            if (_moveSendTimer <= 0f)
-            {
-                _moveSendTimer = 0.08f; // ~12 Hz
-                Game.Network?.SendShipMove(_ship.transform.localPosition, _yaw);
             }
 
             // Boarding: find the nearest station in range; E boards it (the server validates the range).
@@ -1784,7 +1788,22 @@ namespace BlocksBeyondTheStars.Client
         /// Float up to the parked ship (or a station) and press E to board — no take-off animation.</summary>
         private void UpdateEva()
         {
-            if (_ship == null || Game.MenuOpen)
+            if (_ship == null)
+            {
+                return;
+            }
+
+            // Report the suit's pose so the other players in this instance see us floating (the server tags
+            // it as an EVA from our InEva state). Sent BEFORE the menu early-out below — behind an open panel
+            // this is the client's only payload, and the server drops sessions silent for 90 s (#964/#1008).
+            _moveSendTimer -= Time.deltaTime;
+            if (_moveSendTimer <= 0f)
+            {
+                _moveSendTimer = 0.08f;
+                Game.Network?.SendShipMove(_evaPos, _evaYaw);
+            }
+
+            if (Game.MenuOpen)
             {
                 return;
             }
@@ -1845,15 +1864,6 @@ namespace BlocksBeyondTheStars.Client
             if (!Game.MenuOpen && InputMap.Down(InputAction.EvaDeployStation))
             {
                 Game.Network?.SendDeployStationCore();
-            }
-
-            // Report the suit's pose so the other players in this instance see us floating (the server tags it
-            // as an EVA from our InEva state).
-            _moveSendTimer -= Time.deltaTime;
-            if (_moveSendTimer <= 0f)
-            {
-                _moveSendTimer = 0.08f;
-                Game.Network?.SendShipMove(_evaPos, _evaYaw);
             }
 
             // Board targets: the parked ship, or the nearest station in range (whichever is closer wins on E).


### PR DESCRIPTION
## Summary

Fixes the frequent disconnects from tonight's 3-player LAN session (seven `sent nothing for 90s - dropping the session` kicks in ~80 minutes in the host's `Player.log`).

The #964 heartbeat assumes a playing client streams movement continuously — but the client went completely silent in several alive states, and only the Esc pause menu had a keep-alive (#973):

- **On foot, any UI panel open** (crafting, map, inventory, paint editor, trade, chat, cinematic): `PlayerController.Update` returned before `SendMovement()`.
- **In space** behind the Tab star map, the landing-pad chooser or the ship-destruction respawn prompt: `UpdateCruise` early-outs before the ~12 Hz `SendShipMove`.
- **On EVA** with a menu open: same in `UpdateEva`.

The position streams now keep flowing (position simply frozen) before those early-outs, so the 90 s sweep only catches actually-dead clients. After ship destruction the server has already removed the pilot from the space instance and `ShipMove` no-ops on its instance guard — but receiving the intent still stamps the heartbeat, which is all we need.

No protocol change (reuses existing intents), server untouched, mixed versions stay compatible. The cosmetic double `Connection N closed.` log noted in #1008 is intentionally not addressed here.

## Verification

- Local Unity Windows build: clean (exit 0).
- `dotnet test -c Release --filter Category!=Slow`: 1913 server + 244 client, all passing.

closes #1008

🤖 Generated with [Claude Code](https://claude.com/claude-code)