### PR TITLE
fix(client): rename the Inventory tab's personal sidebar entry to "Backpack"

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -105,6 +105,13 @@ Per-item detail lives in the dated work log below. **Since 2026-07 versions are 
 
 ---
 
+### ★ Inventory tab: the personal-inventory sidebar entry is now "Backpack" (#1012, 2026-08-14, branch fix/inventory-backpack-label)
+The in-game menu's Inventory tab showed "Inventory" twice — as the tab label and again as the first
+sidebar entry (the `personal` category reused `ui.inventory.title`), even though other strings already
+call that container the backpack. The sidebar now reads **Backpack / Cargo Hold** (DE: Rucksack /
+Frachtraum) via a new `ui.inventory.backpack` key added to all 14 locales, wordings reused from the
+already-translated `ui.avatar.pack`. Client-only label change, no protocol impact.
+
 ### ★ Scanner: aim-gated targeting + feedback for empty/rejected scans (#1005, 2026-08-14, branch fix/scanner-stuck-1005)
 Playtest report: the scanner sometimes "sticks" — it keeps showing the last scanned subject until the
 player walks away and does something else. Root cause was proximity-only target selection:

--- a/client/Assets/BlocksBeyondTheStars/Scripts/CraftingTechShipUI.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/CraftingTechShipUI.cs
@@ -635,7 +635,7 @@ namespace BlocksBeyondTheStars.Client
                     break;
                 case Mode.Inventory:
                     list.Clear();
-                    list.Add(("personal", L("ui.inventory.title"), "cat_inventory"));
+                    list.Add(("personal", L("ui.inventory.backpack"), "cat_inventory"));
                     list.Add(("cargo", L("ui.cargo.title"), "cat_cargo"));
                     break;
                 case Mode.Missions:

--- a/data/locales/de.json
+++ b/data/locales/de.json
@@ -910,6 +910,7 @@
   "ui.hotbar_action.swap_title": "Slot tauschen",
   "ui.hotbar_action.title": "{0} — Slot {1}",
   "ui.inventory.title": "Inventar",
+  "ui.inventory.backpack": "Rucksack",
   "ui.inventory.quickbar": "Schnellleiste",
   "ui.inventory.quickbar_hint": "Wähle einen Slot, um diesen Gegenstand in die Schnellleiste zu legen.",
   "ui.inventory.remove_quickslot": "Aus Schnellleiste entfernen",

--- a/data/locales/en.json
+++ b/data/locales/en.json
@@ -910,6 +910,7 @@
   "ui.hotbar_action.swap_title": "Swap slot",
   "ui.hotbar_action.title": "{0} — slot {1}",
   "ui.inventory.title": "Inventory",
+  "ui.inventory.backpack": "Backpack",
   "ui.inventory.quickbar": "Quick-bar",
   "ui.inventory.quickbar_hint": "Pick a quick-slot to put this item on the quick-bar.",
   "ui.inventory.remove_quickslot": "Remove from quick-bar",

--- a/data/locales/es.json
+++ b/data/locales/es.json
@@ -910,6 +910,7 @@
   "ui.hotbar_action.swap_title": "Cambiar hueco",
   "ui.hotbar_action.title": "{0} — hueco {1}",
   "ui.inventory.title": "Inventario",
+  "ui.inventory.backpack": "Mochila",
   "ui.inventory.quickbar": "Barra rápida",
   "ui.inventory.quickbar_hint": "Elige una ranura rápida para poner este objeto en la barra rápida.",
   "ui.inventory.remove_quickslot": "Quitar de la barra rápida",

--- a/data/locales/fr.json
+++ b/data/locales/fr.json
@@ -910,6 +910,7 @@
   "ui.hotbar_action.swap_title": "Échanger l'emplacement",
   "ui.hotbar_action.title": "{0} — emplacement {1}",
   "ui.inventory.title": "Inventaire",
+  "ui.inventory.backpack": "Sac à dos",
   "ui.inventory.quickbar": "Barre rapide",
   "ui.inventory.quickbar_hint": "Choisis un emplacement rapide pour placer cet objet dans la barre rapide.",
   "ui.inventory.remove_quickslot": "Retirer de la barre rapide",

--- a/data/locales/it.json
+++ b/data/locales/it.json
@@ -910,6 +910,7 @@
   "ui.hotbar_action.swap_title": "Scambia slot",
   "ui.hotbar_action.title": "{0} — slot {1}",
   "ui.inventory.title": "Inventario",
+  "ui.inventory.backpack": "Zaino",
   "ui.inventory.quickbar": "Barra rapida",
   "ui.inventory.quickbar_hint": "Scegli uno slot rapido per mettere questo oggetto sulla barra rapida.",
   "ui.inventory.remove_quickslot": "Rimuovi dalla barra rapida",

--- a/data/locales/ja.json
+++ b/data/locales/ja.json
@@ -910,6 +910,7 @@
   "ui.hotbar_action.swap_title": "スロットを入れ替える",
   "ui.hotbar_action.title": "{0} — スロット{1}",
   "ui.inventory.title": "所持品",
+  "ui.inventory.backpack": "バックパック",
   "ui.inventory.quickbar": "クイックバー",
   "ui.inventory.quickbar_hint": "このアイテムをクイックバーのスロットに入れてください。",
   "ui.inventory.remove_quickslot": "クイックバーから外す",

--- a/data/locales/ko.json
+++ b/data/locales/ko.json
@@ -910,6 +910,7 @@
   "ui.hotbar_action.swap_title": "슬롯 교체",
   "ui.hotbar_action.title": "{0} — 슬롯 {1}",
   "ui.inventory.title": "인벤토리",
+  "ui.inventory.backpack": "배낭",
   "ui.inventory.quickbar": "퀵바",
   "ui.inventory.quickbar_hint": "이 아이템을 퀵바의 슬롯에 넣으세요.",
   "ui.inventory.remove_quickslot": "퀵바에서 제거",

--- a/data/locales/nl.json
+++ b/data/locales/nl.json
@@ -910,6 +910,7 @@
   "ui.hotbar_action.swap_title": "Vak wisselen",
   "ui.hotbar_action.title": "{0} — vak {1}",
   "ui.inventory.title": "Inventaris",
+  "ui.inventory.backpack": "Rugzak",
   "ui.inventory.quickbar": "Snelbalk",
   "ui.inventory.quickbar_hint": "Kies een snelvak om dit item op de snelbalk te zetten.",
   "ui.inventory.remove_quickslot": "Verwijder van snelbalk",

--- a/data/locales/pl.json
+++ b/data/locales/pl.json
@@ -910,6 +910,7 @@
   "ui.hotbar_action.swap_title": "Zamień slot",
   "ui.hotbar_action.title": "{0} — slot {1}",
   "ui.inventory.title": "Ekwipunek",
+  "ui.inventory.backpack": "Plecak",
   "ui.inventory.quickbar": "Szybki pasek",
   "ui.inventory.quickbar_hint": "Wybierz szybki slot, żeby umieścić w nim ten przedmiot.",
   "ui.inventory.remove_quickslot": "Usuń z szybkiego paska",

--- a/data/locales/pt.json
+++ b/data/locales/pt.json
@@ -910,6 +910,7 @@
   "ui.hotbar_action.swap_title": "Trocar espaço",
   "ui.hotbar_action.title": "{0} — espaço {1}",
   "ui.inventory.title": "Inventário",
+  "ui.inventory.backpack": "Mochila",
   "ui.inventory.quickbar": "Barra rápida",
   "ui.inventory.quickbar_hint": "Escolha um slot rápido para colocar este item na barra rápida.",
   "ui.inventory.remove_quickslot": "Remover da barra rápida",

--- a/data/locales/ru.json
+++ b/data/locales/ru.json
@@ -910,6 +910,7 @@
   "ui.hotbar_action.swap_title": "Обменять ячейку",
   "ui.hotbar_action.title": "{0} — ячейка {1}",
   "ui.inventory.title": "Инвентарь",
+  "ui.inventory.backpack": "Рюкзак",
   "ui.inventory.quickbar": "Быстрая панель",
   "ui.inventory.quickbar_hint": "Выбери быстрый слот, чтобы поместить этот предмет на быструю панель.",
   "ui.inventory.remove_quickslot": "Убрать с быстрой панели",

--- a/data/locales/tr.json
+++ b/data/locales/tr.json
@@ -910,6 +910,7 @@
   "ui.hotbar_action.swap_title": "Yuvayı değiştir",
   "ui.hotbar_action.title": "{0} — yuva {1}",
   "ui.inventory.title": "Envanter",
+  "ui.inventory.backpack": "Sırt çantası",
   "ui.inventory.quickbar": "Hızlı çubuk",
   "ui.inventory.quickbar_hint": "Bu öğeyi hızlı çubuğa koymak için bir hızlı yuva seç.",
   "ui.inventory.remove_quickslot": "Hızlı çubuktan çıkar",

--- a/data/locales/uk.json
+++ b/data/locales/uk.json
@@ -910,6 +910,7 @@
   "ui.hotbar_action.swap_title": "Обміняти комірку",
   "ui.hotbar_action.title": "{0} — комірка {1}",
   "ui.inventory.title": "Інвентар",
+  "ui.inventory.backpack": "Рюкзак",
   "ui.inventory.quickbar": "Швидка панель",
   "ui.inventory.quickbar_hint": "Оберіть слот швидкого доступу, щоб помістити туди цей предмет.",
   "ui.inventory.remove_quickslot": "Видалити з швидкої панелі",

--- a/data/locales/zh.json
+++ b/data/locales/zh.json
@@ -910,6 +910,7 @@
   "ui.hotbar_action.swap_title": "更换格子",
   "ui.hotbar_action.title": "{0} — 格子{1}",
   "ui.inventory.title": "物品栏",
+  "ui.inventory.backpack": "背包",
   "ui.inventory.quickbar": "快捷栏",
   "ui.inventory.quickbar_hint": "选择一个快捷栏位把此物品放入快捷栏。",
   "ui.inventory.remove_quickslot": "从快捷栏移除",


### PR DESCRIPTION
## Summary

Closes #1012.

The in-game menu's Inventory tab showed **Inventory** twice — as the tab label and again as the first sidebar entry, because the `personal` category reused `ui.inventory.title`. The sidebar inside the Inventory tab now reads:

- **Backpack** (DE: Rucksack) — new key `ui.inventory.backpack`
- **Cargo Hold** (DE: Frachtraum) — unchanged

The tab itself keeps the **Inventory** label (`ui.inventory.title`).

## Changes

- `CraftingTechShipUI.Categories()`: the `personal` sidebar entry now uses `L("ui.inventory.backpack")`.
- `data/locales/*.json` (all 14): added `ui.inventory.backpack`, wordings reused from the already-translated `ui.avatar.pack` ("Backpack") key.
- TODO.md work-log entry.

Client-only label change — no protocol impact, no server change.

## Verification

- All 155 locale-affected test classes pass in Release (`scripts/locale-test-filter.py` filter, fast tier).
- Local Unity client build succeeded with 0 warnings (`scripts/build-client.ps1`); fresh `BlocksBeyondTheStars.Client.dll` confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)