### PR TITLE
fix(client): VEGA hints and story pages stay until the player continues

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -105,6 +105,16 @@ Per-item detail lives in the dated work log below. **Since 2026-07 versions are 
 
 ---
 
+### ★ VEGA hints and story pages stay until the player continues (#1011, 2026-08-14, branch fix/vega-lines-persist)
+Every line in VEGA's speech panel — advisor hints, story/memory beats, onboarding, prologue pages —
+was auto-dismissed 25 s after it finished typing (`AutoAdvanceSeconds` in `VegaPanel`), so slow
+readers (and long German lines) lost hints before finishing them. The timeout is gone: a fully
+revealed page now stays until **[N]** is pressed; later lines simply wait in the queue, exactly as
+before. All the escape hatches are untouched — Esc still skips the whole prologue, the
+`VegaHints` settings mute still suppresses advisor lines, and unattended screenshot runs still
+clear the panel via `DismissSpeechForCapture()` (that hook is why the "unattended panel" fallback
+the timeout was built for is no longer needed). Client-only change, no protocol/locale impact.
+
 ### ★ Crafting menu says "no room for the result" up front instead of a missable toast (#1010, 2026-08-14, branch fix/craft-ui-inventory-full)
 LAN playtest: a player had unlocked the paint-tool blueprint and owned every ingredient, yet the craft
 kept failing — the backpack was full (24/24 slots), the inputs only shrink existing stacks without

--- a/client/Assets/BlocksBeyondTheStars/Scripts/PrologueCinematic.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/PrologueCinematic.cs
@@ -74,7 +74,7 @@ namespace BlocksBeyondTheStars.Client
         public bool Active => _active;
 
         /// <summary>True while <see cref="VegaPanel"/> should wait before dequeuing ANY line: the world
-        /// is behind the loading veil, so a page would type into blackness and burn its auto-advance.
+        /// is behind the loading veil, so a page would type into blackness, unseen and unheard.
         /// The timeout measures the CONTINUOUS hold (it resets whenever the veil is down), so later
         /// landings/boardings hold correctly too. The veil's own MaxShow (25 s) caps it in practice.</summary>
         public bool HoldQueue

--- a/client/Assets/BlocksBeyondTheStars/Scripts/VegaPanel.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/VegaPanel.cs
@@ -11,8 +11,10 @@ namespace BlocksBeyondTheStars.Client
     /// <summary>
     /// The HUD companion panel for the ship AI "VEGA": shows her lines with a typewriter effect (queued,
     /// radio blip per line) and a persistent objective chip while the onboarding chain is active, with a
-    /// skip button. Lines arrive as locale KEYS (<see cref="ShipAiLine"/>) and are localized here, so the
-    /// companion is fully bilingual and offline-safe. Advisor hints (Kind 1) respect the settings mute.
+    /// skip button. A revealed page stays until the player presses the continue key — there is no
+    /// auto-dismiss timeout (#1011). Lines arrive as locale KEYS (<see cref="ShipAiLine"/>) and are
+    /// localized here, so the companion is fully bilingual and offline-safe. Advisor hints (Kind 1)
+    /// respect the settings mute.
     /// </summary>
     public sealed class VegaPanel : MonoBehaviour
     {
@@ -28,7 +30,6 @@ namespace BlocksBeyondTheStars.Client
         public MemoryFlashback Flashback;
 
         private const float CharsPerSecond = 42f;
-        private const float AutoAdvanceSeconds = 25f; // fallback so an unattended line never blocks forever
         private const KeyCode ContinueKey = KeyCode.N;
 
         // Left-column layout in HUD reference units (1536×864). The column is full: vitals end at y 260,
@@ -51,7 +52,6 @@ namespace BlocksBeyondTheStars.Client
         private readonly Queue<(string Text, bool Prologue)> _queue = new Queue<(string, bool)>();
         private string _current = string.Empty;  // the page being typed/read (not the whole line)
         private float _shown;     // characters revealed so far
-        private float _holdLeft;  // auto-advance fallback once fully revealed
 
         // Long lines are split into panel-sized pages, advanced with the same continue key (#736). German
         // runs 12–20 % longer than English, so the bandit briefing and several hints exceed the ~4 visible
@@ -356,7 +356,7 @@ namespace BlocksBeyondTheStars.Client
             if (_current.Length == 0 && _queue.Count > 0)
             {
                 // No line starts behind the loading curtain (#760/#761): a page typing into blackness
-                // is inaudible-invisible and burns its auto-advance window. Bounded inside HoldQueue.
+                // is inaudible-invisible. Bounded inside HoldQueue.
                 if (Cinematic != null && Cinematic.HoldQueue)
                 {
                     return;
@@ -479,10 +479,11 @@ namespace BlocksBeyondTheStars.Client
                 return;
             }
 
-            // Fully revealed: wait for the continue key (the lines used to run into each other —
-            // unreadable); a generous timeout still auto-advances an unattended panel.
-            _holdLeft -= Time.deltaTime;
-            if (pressed || _holdLeft <= 0f)
+            // Fully revealed: wait for the continue key — and ONLY the key (#1011). The old 25 s
+            // auto-advance made hints and story pages vanish before slow readers got through them;
+            // nothing gameplay-critical blocks on the panel (later lines just queue), and unattended
+            // capture runs clear it via DismissSpeechForCapture.
+            if (pressed)
             {
                 if (_page < _pages.Count - 1)
                 {
@@ -503,7 +504,6 @@ namespace BlocksBeyondTheStars.Client
             _page = index;
             _current = _pages.Count > 0 ? _pages[index] : string.Empty;
             _shown = 0f;
-            _holdLeft = AutoAdvanceSeconds;
             _speechText.text = string.Empty;
             _continueHint.gameObject.SetActive(false);
         }

--- a/docs/user/USER_MANUAL.md
+++ b/docs/user/USER_MANUAL.md
@@ -188,7 +188,8 @@ separate unlock; admins can still disable it through server world rules.
 - **HUD** — health/oxygen/hunger/energy, hotbar, location, compass, scan readout (bottom-left), and the
   wreck panel (right) when near a repairable wreck.
 - **VEGA panel** — the ship AI speaks through a typewriter speech panel with a persistent **objective
-  chip** (live progress, e.g. "mine 1/3") during onboarding. Advance lines with **N**. Advisor hints can
+  chip** (live progress, e.g. "mine 1/3") during onboarding. Advance lines with **N** — a line stays on
+  screen until you do (no auto-dismiss), and further lines wait in the queue. Advisor hints can
   be muted (Settings → VEGA hints); the tutorial can be skipped or **restarted** from the Settings tab.
 
 ---


### PR DESCRIPTION
## Summary

Closes #1011.

VEGA advisor hints and story pages were auto-dismissed 25 s after the typewriter finished
(`AutoAdvanceSeconds` in `VegaPanel`), so a hint or story beat could disappear before it was read —
especially the longer German lines and for younger/slower readers. This removes the timeout: a fully
revealed page now stays on screen until the player presses the continue key (**N**). Later lines
simply wait in the queue, exactly as before.

Unchanged escape hatches:
- **Esc** still skips the whole prologue chain.
- Settings → **VEGA hints** still mutes advisor lines (Kind 1).
- `DismissSpeechForCapture()` still clears the panel for unattended screenshot runs — which is the
  case the old "unattended panel" fallback was built for.

Client-only change — no protocol, locale or server impact. Docs updated (TODO.md work log entry,
USER_MANUAL VEGA panel note).

## Verification

- `dotnet test tests/BlocksBeyondTheStars.Client.Tests -c Release` — 251/251 green.
- Local Unity Windows build (`scripts/build-client.ps1`) — completed, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
