### PR TITLE
fix(client): gate the craft button on the result actually fitting

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -105,6 +105,16 @@ Per-item detail lives in the dated work log below. **Since 2026-07 versions are 
 
 ---
 
+### ★ Crafting menu says "no room for the result" up front instead of a missable toast (#1010, 2026-08-14, branch fix/craft-ui-inventory-full)
+LAN playtest: a player had unlocked the paint-tool blueprint and owned every ingredient, yet the craft
+kept failing — the backpack was full (24/24 slots), the inputs only shrink existing stacks without
+freeing one, and the new tool needs a fresh slot. The server refused correctly (`MaterialPool.CanFit`,
+the #600 protection) but the crafting UI still presented the recipe as craftable: green card, live
+button, and the only feedback was the post-click toast. `CraftingTechShipUI.CanCraft` now runs a
+client-side dry-run mirroring the server's fit check (stack top-up at max-stack, then free slots,
+cargo-hold spill only while aboard), disables the craft button and shows the existing localized
+`ui.craft.inventory_full` line in the detail pane. Client-only; the server check stays authoritative.
+
 ### ★ Inventory tab: the personal-inventory sidebar entry is now "Backpack" (#1012, 2026-08-14, branch fix/inventory-backpack-label)
 The in-game menu's Inventory tab showed "Inventory" twice — as the tab label and again as the first
 sidebar entry (the `personal` category reused `ui.inventory.title`), even though other strings already

--- a/client/Assets/BlocksBeyondTheStars/Scripts/CraftingTechShipUI.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/CraftingTechShipUI.cs
@@ -54,6 +54,10 @@ namespace BlocksBeyondTheStars.Client
         // Quick-bar = the first N personal-inventory slots (must match the server's HotbarSlots / HudUi Slots).
         private const int QuickSlots = 9;
 
+        // The personal inventory's fixed size (quick-bar 0..8 + backpack 9..23) — must match the server's
+        // PlayerState inventory; the snapshot only carries occupied slots, so free slots derive from this.
+        private const int PersonalSlotTotal = 24;
+
         private Canvas _canvas;
         private RectTransform _sidebar, _listContent, _detail, _header;
         private Text _footer, _hint, _feedback;
@@ -3436,8 +3440,107 @@ namespace BlocksBeyondTheStars.Client
                 return false;
             }
 
+            // The result must also FIT somewhere (server: MaterialPool.CanFit, #600) — otherwise the card
+            // reads "craftable" and the button is live, but the server refuses with @inventory_full and the
+            // only feedback is an easy-to-miss toast (LAN playtest: full 24-slot backpack, the inputs only
+            // shrink stacks without freeing a slot, and the new tool needs a fresh one).
+            if (!ResultFits(r))
+            {
+                reason = L("ui.craft.inventory_full");
+                return false;
+            }
+
             reason = string.Empty;
             return true;
+        }
+
+        /// <summary>Client-side dry-run of the server's <c>MaterialPool.CanFit</c> for a single craft:
+        /// every output must fit on top of what is held right now — stack top-up first, then free slots,
+        /// spilling into the ship's cargo hold only while aboard (the exact pool the server hands the
+        /// crafted items to). Deliberately as pessimistic as the server: inputs are NOT removed first, so
+        /// a craft whose inputs would free a slot still reads as blocked — the server refuses it too.</summary>
+        private bool ResultFits(RecipeDefinition r)
+        {
+            var personal = SimStacks(Game.Personal);
+            var cargo = Game.Aboard ? SimStacks(Game.Cargo) : null;
+            int freePersonal = Mathf.Max(0, PersonalSlotTotal - personal.Count);
+            int freeCargo = cargo != null ? Mathf.Max(0, Game.CargoSlots - cargo.Count) : 0;
+
+            foreach (var output in r.Outputs)
+            {
+                if (output.Count <= 0)
+                {
+                    continue;
+                }
+
+                int maxStack = Game.Content.MaxStackOf(output.Item);
+                int remaining = SimAdd(personal, ref freePersonal, output.Item, output.Count, maxStack);
+                if (remaining > 0 && cargo != null)
+                {
+                    remaining = SimAdd(cargo, ref freeCargo, output.Item, remaining, maxStack);
+                }
+
+                if (remaining > 0)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>Mutable copy of an inventory snapshot for the fit dry-run (occupied slots only).</summary>
+        private sealed class SimStack
+        {
+            public string Item = string.Empty;
+            public int Count;
+        }
+
+        private static List<SimStack> SimStacks(BlocksBeyondTheStars.Networking.Messages.NetItemStack[] slots)
+        {
+            var list = new List<SimStack>();
+            if (slots != null)
+            {
+                foreach (var s in slots)
+                {
+                    list.Add(new SimStack { Item = s.Item, Count = s.Count });
+                }
+            }
+
+            return list;
+        }
+
+        /// <summary>Adds <paramref name="count"/> of an item to the simulated stacks the way the server's
+        /// <c>Inventory.Add</c> does (top up same-item stacks, then open new stacks in free slots) and
+        /// returns what found no room. Outputs of one recipe compete for the same free slots.</summary>
+        private static int SimAdd(List<SimStack> stacks, ref int freeSlots, string item, int count, int maxStack)
+        {
+            foreach (var s in stacks)
+            {
+                if (count <= 0)
+                {
+                    break;
+                }
+
+                if (s.Item != item || s.Count >= maxStack)
+                {
+                    continue;
+                }
+
+                int put = System.Math.Min(maxStack - s.Count, count);
+                s.Count += put;
+                count -= put;
+            }
+
+            while (count > 0 && freeSlots > 0)
+            {
+                int put = System.Math.Min(maxStack, count);
+                stacks.Add(new SimStack { Item = item, Count = put });
+                freeSlots--;
+                count -= put;
+            }
+
+            return count;
         }
 
         /// <summary>Reachability tier for the list ordering (#826): 0 = craftable now (blueprint unlocked +


### PR DESCRIPTION
closes #1010

## Problem

LAN playtest 2026-08-14: a player with the `paint_tool` blueprint unlocked and every ingredient in stock could not craft it — the backpack was full (24/24 slots), the inputs only shrink existing stacks without freeing one, and the new tool needs a fresh slot. The server refused correctly (`MaterialPool.CanFit`, #600), but the crafting UI presented the recipe as craftable: green card, live craft button, and the only feedback was an easy-to-miss post-click toast.

## Fix

`CraftingTechShipUI.CanCraft` now runs a client-side dry-run mirroring the server's fit check:

- outputs must fit **on top of** what is held (same pessimism as the server — inputs are not removed first),
- stack top-up at `MaxStackOf` first, then free slots (personal 24-slot inventory; the snapshot only carries occupied slots),
- spill into the ship's cargo hold only while aboard (`Aboard` + `CargoSlots`), the exact pool the server hands crafted items to,
- outputs of one recipe compete for the same free slots (market barter recipes with two outputs).

On failure the craft button is disabled and the detail pane shows the existing localized `ui.craft.inventory_full` line (already translated in all 14 locales — no locale changes needed). Client-only change; the server check stays authoritative.

## Verification

- `dotnet test -c Release --filter Category!=Slow`: 1913 server + 244 client tests green.
- Local Unity batch build of the Windows player: compiles clean, build completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)