### PR TITLE
fix(client): stop rerouting ground places into a parked ship's bounding box

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -105,6 +105,19 @@ Per-item detail lives in the dated work log below. **Since 2026-07 versions are 
 
 ---
 
+### ★ Blocks can be placed on the ground beside a parked ship again (#1023, 2026-08-14, branch fix/ship-box-place-redirect)
+LAN playtest: "sand and dirt can't be placed" — the materials were innocent. The client rerouted ANY
+place whose target cell fell inside a landed ship's bounding box to a structure edit, even when the
+player aimed at the ground: the box test (`LandedShipBoundsAt`, `dy 0..Height` inclusive over the full
+Width×Length rectangle) also covers the ground-level air ring around the hull. Beside another pilot's
+ship the server answered `none_here` ("No such structure here."), beside your own `no_anchor` — or,
+hull-adjacent, the block silently became part of the ship. Since you spawn next to your ship, freshly
+mined dirt/sand was the typical victim. `PlayerController` now reroutes only when the aim ray actually
+hit that ship (`boundsShip == aimedShip`); aiming at a world block always sends a world place, and the
+server keeps guarding the real interior (`ShipInteriorContains`). Cabin furnishing and roof building
+still target ship cells, so they keep working. Client-only, no protocol change. Likely the same root
+cause as the "painted block won't place" LAN report.
+
 ### ★ Crafting menu says "no room for the result" up front instead of a missable toast (#1010, 2026-08-14, branch fix/craft-ui-inventory-full)
 LAN playtest: a player had unlocked the paint-tool blueprint and owned every ingredient, yet the craft
 kept failing — the backpack was full (24/24 slots), the inputs only shrink existing stacks without

--- a/client/Assets/BlocksBeyondTheStars/Scripts/PlayerController.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/PlayerController.cs
@@ -2848,9 +2848,14 @@ namespace BlocksBeyondTheStars.Client
                 if (def != null && !string.IsNullOrEmpty(def.PlacesBlock))
                 {
                     // Placing INSIDE a parked ship furnishes the cabin: route to a structure edit (the
-                    // block becomes part of the ship and persists with it), not a world place.
+                    // block becomes part of the ship and persists with it), not a world place. Only when the
+                    // aim ray hit THAT ship, though — the bounding box also covers the ground-level air ring
+                    // around the hull, and rerouting a place that targets a world block (the ground beside a
+                    // parked ship) made any block "unplaceable" there: a foreign ship answers none_here, the
+                    // own hull no_anchor (#1023). Aiming at the ground → world place; the server still guards
+                    // the real interior authoritatively.
                     var boundsShip = Game.LandedShipBoundsAt(placeCell.x, placeCell.y, placeCell.z, out var lp);
-                    if (boundsShip != null)
+                    if (boundsShip != null && boundsShip == aimedShip)
                     {
                         Game.Network.SendStructureEdit(boundsShip.StructureId, lp.X, lp.Y, lp.Z, mine: false, item);
                         TriggerSwing();


### PR DESCRIPTION
## Summary

LAN playtest 2026-08-14: "sand and dirt cannot be placed". The materials were innocent — **any** block placement failed when the target cell fell inside a landed ship's bounding box, because the client silently rerouted the place into a structure edit even when the player was aiming at the ground.

- `LandedShipBoundsAt` tests the full `Width × Length` box with `dy 0..Height` inclusive, which also covers the **ground-level air ring around the hull**.
- Beside another pilot's ship the server rejected with `@srv.structure.none_here` ("No such structure here."), beside your own ship with `@srv.structure.no_anchor` — or, hull-adjacent, the block silently became part of the ship structure.
- Players spawn next to their ship, so freshly mined dirt/sand was the typical victim. Likely the same root cause as the "painted block won't place" LAN report.

## Fix

`PlayerController` only reroutes to a structure edit when the aim ray actually hit that ship (`boundsShip == aimedShip`). Aiming at a world block always sends a normal world place; the server stays authoritative for the real interior (`ShipInteriorContains`). Cabin furnishing and roof building keep working — there the aim target *is* a ship cell.

Client-only, no protocol change.

## Verification

- `dotnet test -c Release` (fast tier): **1914 server + 244 client tests green**
- Local Unity build (`scripts/build-client.ps1`): **clean**, fresh `BlocksBeyondTheStars.Client.dll`, no generated files to commit

Closes #1023

🤖 Generated with [Claude Code](https://claude.com/claude-code)