### PR TITLE
fix(ships): wooden door built into a self-built ship stays hand-operated

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -105,6 +105,18 @@ Per-item detail lives in the dated work log below. **Since 2026-07 versions are 
 
 ---
 
+### ★ Wooden door on a self-built ship swings by hand again (#1021, 2026-08-14, branch fix/ship-door-kind)
+LAN playtest: "the wooden door can't be opened." A door block built into a self-built ship (#948) was
+collapsed into a position-only `DoorCells` entry, and `RegisterDoors` hard-coded every landed-ship door
+to the authored ships' auto-sliding **energy** hatch (item 35) — `HandleDoorInteract` only serves
+hand-operated kinds and the client's `NearestHinge` skips non-hinged kinds, so E did nothing and no
+"E: Door" hint showed. The structure now records the door KIND per doorway cell
+(`SpaceStructure.DoorKinds`, carried through `LandedShip.Doors`): self-built ships register the door
+the player actually placed (wood/hinge swing on E; slide/energy keep proximity auto-open + the forced
+rear-hatch axis), authored ships keep their all-energy doors unchanged. Ground-placed doors were always
+fine (`PlaceableDoorTests`); new regression test `WoodenDoor_OnASelfBuiltShip_StaysHandOperated`.
+Server-only, no protocol change (`NetDoor.Kind` already carried the string).
+
 ### ★ VEGA introduces the menu and the Codex on first boot (#1015, 2026-08-14, branch feat/vega-codex-craft-hints)
 New players were never told two fundamental things: that the Tab menu exists (only mentioned in passing
 by onboarding stages 2–3) and that the Codex — the in-game wiki with 24 guide articles — exists at all

--- a/src/BlocksBeyondTheStars.GameServer/GameServer.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServer.cs
@@ -4035,13 +4035,7 @@ public sealed partial class GameServer
         // A door isn't a voxel block — it fills the (air) cell as a server door entity (Task 5 Stage 3c).
         if (IsDoorBlock(blockDef.Key))
         {
-            PlaceDoor(session, pos, blockDef.Key switch
-            {
-                "door_slide" => "slide",
-                "door_wood" => "wood", // cheap early-game hinge door, swings by hand like the metal one
-                "door_energy" => "energy", // walk-through air curtain — the door that seals a base room (#793)
-                _ => "hinge",
-            });
+            PlaceDoor(session, pos, DoorKindForBlock(blockDef.Key));
             SendInventory(session);
             return;
         }

--- a/src/BlocksBeyondTheStars.GameServer/GameServerCustomShips.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerCustomShips.cs
@@ -159,9 +159,12 @@ public sealed partial class GameServer
 
         foreach (var (pos, block) in cells)
         {
-            if (IsDoorBlockId(block))
+            if (_content.BlockById(block) is { } doorDef && IsDoorBlock(doorDef.Key))
             {
-                s.DoorCells.Add(pos); // a server-authoritative slide door fills the opening
+                // A server-authoritative door fills the opening — and it keeps the KIND of the door block
+                // the player built in, so a wooden/hinge door still swings by hand with E (#1021).
+                s.DoorCells.Add(pos);
+                s.DoorKinds[pos] = DoorKindForBlock(doorDef.Key);
                 continue;
             }
 
@@ -656,7 +659,7 @@ public sealed partial class GameServer
     private string? AirtightProblem(ShipState ship)
     {
         var s = BuildCustomShipStructure("validate:" + ship.ShipType, string.Empty, ship, commissioned: false);
-        var doorCells = new HashSet<Vector3i>(s.DoorCells);
+        var doorCells = new HashSet<Vector3i>(s.DoorCells); // any kind seals for validation (the panel fills the opening)
 
         bool Seals(Vector3i c)
         {

--- a/src/BlocksBeyondTheStars.GameServer/GameServerDoors.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerDoors.cs
@@ -69,6 +69,17 @@ public sealed partial class GameServer
     private static bool IsDoorBlock(string blockKey)
         => blockKey is "door_hinge" or "door_slide" or "door_wood" or "door_energy";
 
+    /// <summary>Door kind for a placeable door BLOCK key — the inverse of <see cref="DoorItemFor"/>. Used
+    /// wherever a player places a door block (world cell or self-built ship), so the door entity keeps the
+    /// behaviour of the block that was placed (#1021).</summary>
+    private static string DoorKindForBlock(string blockKey) => blockKey switch
+    {
+        "door_slide" => "slide",
+        "door_wood" => "wood",   // cheap early-game hinge door, swings by hand like the metal one
+        "door_energy" => "energy", // walk-through air curtain — the door that seals a base room (#793)
+        _ => "hinge",
+    };
+
     /// <summary>The item a door of this kind hands back when it is picked up again.</summary>
     private static string DoorItemFor(string kind) => kind switch
     {
@@ -118,20 +129,22 @@ public sealed partial class GameServer
                 continue;
             }
 
-            foreach (var pos in rec.Doors)
+            foreach (var (kind, pos) in rec.Doors)
             {
-                // The ship's doors are energy doors (item 35): a slide door with a passable blue energy field
-                // shown in the opening while open. Auto-open like a slide door (handled above). The hatch is the
-                // wide gap in the ship's rear (-Z) wall, which runs along X → force that door across X so it
-                // sits parallel to the opening, not lengthwise in the cabin (B41a; a ±1 jamb probe at the
-                // centre of a wide gap is ambiguous). Only the rear-wall hatch gets the forced axis: interior
-                // doors of a multi-room layout (hammerhead) can face ±X, and their narrower openings make the
-                // jamb probe unambiguous — let it decide.
+                // An authored ship's doors are all energy doors (item 35): a slide door with a passable blue
+                // energy field shown in the opening while open, auto-open like a slide door (handled above).
+                // A SELF-BUILT ship's doors keep the kind of the door block the player placed, so a wooden or
+                // metal hinge door still swings by hand with E (#1021). The hatch is the wide gap in the
+                // ship's rear (-Z) wall, which runs along X → force that door across X so it sits parallel to
+                // the opening, not lengthwise in the cabin (B41a; a ±1 jamb probe at the centre of a wide gap
+                // is ambiguous). Only the rear-wall hatch gets the forced axis: interior doors of a
+                // multi-room layout (hammerhead) can face ±X, and their narrower openings make the jamb probe
+                // unambiguous — let it decide.
                 var ship = rec;
                 var local = ship.ToLocal(new Vector3i(
                     (int)System.Math.Floor(pos.X), (int)System.Math.Floor(pos.Y), (int)System.Math.Floor(pos.Z)),
                     _world.Circumference);
-                _doors.Add(MakeDoor("energy", pos, ShipHatchOpenRange, forceAxisX: local.Z == 0 ? true : (bool?)null,
+                _doors.Add(MakeDoor(kind, pos, ShipHatchOpenRange, forceAxisX: local.Z == 0 ? true : (bool?)null,
                     solid: (x, y, z) => !ship.Structure.Get(ship.ToLocal(new Vector3i(x, y, z), _world.Circumference)).IsAir));
             }
         }

--- a/src/BlocksBeyondTheStars.GameServer/GameServerShipStructure.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerShipStructure.cs
@@ -97,8 +97,11 @@ public sealed partial class GameServer
         rec.Doors.Clear();
         foreach (var cell in s.DoorCells)
         {
-            rec.Doors.Add(new Vector3f(
-                rec.Origin.X + cell.X + 0.5f, rec.Origin.Y + cell.Y, rec.Origin.Z + cell.Z + 0.5f));
+            // No recorded kind (authored ships) → energy door, the sealing auto-door every authored ship
+            // uses (item 35). Self-built ships record the placed door block's kind per cell (#1021).
+            rec.Doors.Add((
+                s.DoorKinds.TryGetValue(cell, out var kind) ? kind : "energy",
+                new Vector3f(rec.Origin.X + cell.X + 0.5f, rec.Origin.Y + cell.Y, rec.Origin.Z + cell.Z + 0.5f)));
         }
 
         rec.HealTank = s.MedbayCell is { } mb

--- a/src/BlocksBeyondTheStars.GameServer/GameServerSpaceStructure.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerSpaceStructure.cs
@@ -64,6 +64,11 @@ public sealed class SpaceStructure
     /// <summary>Doorway base cells (sci-fi slide doors fill these openings) in structure-local coords.</summary>
     public List<Vector3i> DoorCells { get; } = new();
 
+    /// <summary>Door kind per doorway cell ("slide"/"hinge"/"wood"/"energy"). Authored ships leave this
+    /// empty — their doors all register as energy doors (item 35). A self-built ship records the kind of
+    /// the door block the player actually placed, so a wooden/hinge door stays hand-operated (#1021).</summary>
+    public Dictionary<Vector3i, string> DoorKinds { get; } = new();
+
     /// <summary>The medbay heal-tank cell (respawn point), if the design carries one.</summary>
     public Vector3i? MedbayCell { get; set; }
 

--- a/src/BlocksBeyondTheStars.GameServer/WorldManager.cs
+++ b/src/BlocksBeyondTheStars.GameServer/WorldManager.cs
@@ -266,7 +266,7 @@ internal sealed class LandedShip
     public SpaceStructure Structure { get; set; } = new();
     public Vector3f HealTank { get; set; }            // medbay respawn point (world coords)
     public List<(string Type, Vector3f Pos)> Stations { get; } = new(); // world coords
-    public List<Vector3f> Doors { get; } = new();     // doorway base centres (world coords)
+    public List<(string Kind, Vector3f Pos)> Doors { get; } = new(); // door kind + doorway base centre (world coords)
 
     /// <summary>Maps a world cell into the structure-local grid (longitude wrap-aware on X).</summary>
     public Vector3i ToLocal(Vector3i world, int circumference)

--- a/tests/BlocksBeyondTheStars.Tests/CustomShipTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/CustomShipTests.cs
@@ -233,6 +233,38 @@ public sealed class CustomShipTests : IDisposable
         }
     }
 
+    // ---------------- Door kinds (#1021) ----------------
+
+    /// <summary>A wooden door built into a self-built ship must stay a hand-operated wooden door. It used
+    /// to register as an auto-sliding energy door like the authored ships' hatches — E did nothing and no
+    /// door hint showed, so "the wooden door can't be opened" (#1021).</summary>
+    [Fact]
+    public void WoodenDoor_OnASelfBuiltShip_StaysHandOperated()
+    {
+        var server = Started(out var repo);
+        using (repo)
+        {
+            var pilot = server.AddLocalPlayer("Pilot");
+            LayKeel(server, pilot);
+
+            // A doorway next to the keel: floor row, jambs left + right, the wooden door in between.
+            const string yard = "shipyard:Pilot";
+            Edit(server, yard, 1, 0, 0, "iron_wall");
+            Edit(server, yard, 2, 0, 0, "iron_wall");
+            Edit(server, yard, 0, 1, 0, "iron_wall");
+            Edit(server, yard, 2, 1, 0, "iron_wall");
+            Edit(server, yard, 1, 1, 0, "door_wood");
+
+            // The registered door is a WOODEN door, not the authored ships' auto-sliding energy hatch …
+            var wood = server.DoorSnapshots.Single(d => d.Kind == "wood");
+            Assert.False(wood.Open);
+
+            // … so pressing E at it swings it open, exactly like a wooden door placed on the ground.
+            server.InteractDoorForTest(pilot, wood.Id);
+            Assert.True(server.DoorSnapshots.Single(d => d.Id == wood.Id).Open);
+        }
+    }
+
     // ---------------- Commissioning ----------------
 
     [Fact]


### PR DESCRIPTION
## Summary

LAN playtest report: **a wooden door can't be opened.** A ground-placed wooden door works (covered by `PlaceableDoorTests`), but one built into a **self-built ship** (#948) did not react to E and showed no "E: Door" hint.

Root cause: `BuildCustomShipStructure` collapsed every door block into a position-only `DoorCells` entry, and `RegisterDoors` hard-coded every landed-ship door to `MakeDoor("energy", ...)` — the authored ships' auto-sliding hatch (item 35). `HandleDoorInteract` only serves hand-operated kinds and the client's `NearestHinge` skips non-hinged kinds, so the player's E press was dropped on both ends.

## Changes

- `SpaceStructure.DoorKinds` — door kind per doorway cell. Authored ships leave it empty (→ energy, unchanged); self-built ships record the kind of the door block the player actually placed.
- `LandedShip.Doors` now carries `(Kind, Pos)`; `DeriveLandedAnchors` resolves the kind with an `"energy"` fallback.
- `RegisterDoors` registers landed-ship doors with their real kind: wood/hinge swing by hand on E, slide/energy keep the proximity auto-open and the forced rear-hatch axis (B41a).
- New shared `DoorKindForBlock` helper; the world door-place path in `HandlePlace` reuses it (was an inline switch).
- Regression test: `WoodenDoor_OnASelfBuiltShip_StaysHandOperated`.

Server-only, no protocol change (`NetDoor.Kind` already carried the kind string; the client renders `wood` doors since #611).

## Test plan

- [x] `dotnet test -c Release --filter "Category!=Slow"` — 1915/1915 passed locally
- [x] New regression test builds a doorway with `door_wood` on a construction site, asserts the registered kind is `wood` and that E toggles it open
- [ ] Playtest: build a wooden door into a self-built ship, open/close it with E (landed + ship interior)

closes #1021

🤖 Generated with [Claude Code](https://claude.com/claude-code)