### PR TITLE
fix(multiplayer): respawn at your own ship and keep pad occupancy live

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ the richer, screenshot-laden versions live there. `(#123)` references the pull r
 
 ## [Unreleased]
 
+### Fixed
+
+- **Dying near another player could respawn you inside *their* ship.** Deaths dealt by the world's AI
+  (creatures, guardian machines, bandits, a destroyed speeder) — and the void-rescue teleport — resolved
+  the respawn target through whichever player the server had served last, dropping the victim at the
+  other player's heal tank (and it could even re-home that ship). Every death and rescue path now pins
+  the dying player's own ship first. (#1020)
+- **Another player's landing pad never showed as occupied on your world map.** The pad list was sent
+  only once, on your own arrival: anyone who landed *after* you kept showing as a free, anonymous pad
+  forever. Claiming or releasing a pad (landing, joining, leaving, observer mode) now republishes the
+  pad list to everyone on the body. (#1020)
+
 ## [2026.8.14] — 2026-08-14
 
 The shipshape release. After the last two versions turned the game into something you play with other

--- a/TODO.md
+++ b/TODO.md
@@ -7958,6 +7958,31 @@ still rejected, and `/give` to a spaced name landing in *that* player's inventor
 
 ---
 
+## ✅ Done (2026-08-14): dying no longer respawns you in another player's ship; pad occupancy live for everyone (#1020)
+
+From the 3-player LAN playtest: the host died and woke up in a joiner's ship, and two of the three
+players never saw the third player's landing pad as occupied on their world maps.
+
+**Respawn:** the AI damage ticks (creatures, guardian machines, bandits, destroyed speeders) call
+`RespawnPlayer` without pinning the per-player ship cursor, which still pointed at whoever the server
+served last — `RecoverToShip` then read (and even re-homed) *that* player's ship and dropped the victim
+at their heal tank. Same class as #997, which fixed it for `CreateNewPlayer` only. Fix: pin the cursor
+at the top of `RespawnPlayer` **and** `RecoverToShip` (before the first `_ship` read), and make
+`SafeSpawnPoint` resolve the ship by its `playerId` argument (`LandedFor(playerId)`) instead of the
+cursor — the void-rescue tick used it unpinned and teleported rescued players into foreign hulls too.
+
+**Pads:** `LandingPadList` was a world-entry snapshot, sent only to the arriving player. New
+`BroadcastLandingPads()` republishes it (per session — `Mine` is receiver-relative) on every occupancy
+change: landing/relocate, join, disconnect, observer on/off. Players up in space are skipped (their pad
+chooser owns the client's single pad-list slot) except the lander themselves. Server-only, existing
+message, no protocol bump — effective via the host's bundled server even for older clients.
+
+Three new `LanPlaytestRegressionTests`; `KillPlayerForTest` mirrors the unpinned AI-tick call. Follow-up
+noted in #1020: the client keeps one global pad-list slot and the world map doesn't gate on its body id,
+so a chooser reply for a padless body wipes the map's markers until re-entry.
+
+---
+
 ## ✅ Done (2026-08-13): landing back on the same planet puts you back in your ship (#971)
 
 Found in a singleplayer playtest of the released v2026.8.12 build: launch from the starter planet, land

--- a/src/BlocksBeyondTheStars.GameServer/GameServer.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServer.cs
@@ -820,7 +820,7 @@ public sealed partial class GameServer
         SendBeacons(session);
         SendBeams(session); // placed beam blocks (teleporter pads) on this body
         SendBases(session); // player-founded bases on this body (Grundstein markers)
-        SendLandingPads(session);
+        BroadcastLandingPads(session); // the arrival claimed a pad — everyone's map must show it (#1020)
         SendContainers(session);
         SendStarMap(session);
         SyncAppearance(session); // faces + body paintings both ways — appearance is per-world state (#982)
@@ -1417,6 +1417,11 @@ public sealed partial class GameServer
     /// <summary>Test helper kept explicit so tests can drive one authoritative server tick.</summary>
     public void TickForTest(double deltaSeconds) => Tick(deltaSeconds);
 
+    /// <summary>Test entrypoint mirroring the AI damage ticks (creatures/bandits/machines/speeders): a direct
+    /// <see cref="RespawnPlayer"/> call, deliberately WITHOUT serving the victim first — those ticks run with
+    /// the ship cursor on whoever was served last, which is exactly the #1020 death-in-a-foreign-ship setup.</summary>
+    public void KillPlayerForTest(PlayerSession session, string reason) => RespawnPlayer(session, reason);
+
     /// <summary>Saves everything durably NOW, outside the autosave cadence — the same guarded path the
     /// periodic autosave takes. The browser singleplayer host calls this when the tab loses focus
     /// (visibility change): a WebGL page gets no reliable shutdown callback, so waiting out the autosave
@@ -1736,6 +1741,12 @@ public sealed partial class GameServer
     /// </summary>
     private void RespawnPlayer(PlayerSession session, string reason)
     {
+        // Deaths dealt by AI ticks (creatures, guardians, bandits, speeder crashes) arrive here with the
+        // ship cursor still on whoever the server served last — everything downstream (_ship/_shipPlaced/
+        // _healTank) would resolve to THAT player's ship, respawning the victim inside someone else's hull
+        // (#1020, same class as #997). Pin the cursor to the dying player before any of it is read.
+        SetCurrent(session);
+
         var p = session.State;
         bool dropSalvage = !Rules.KeepInventoryOnDeath &&
                            Rules.DeathPenalty is DeathPenalty.Normal or DeathPenalty.Hard;
@@ -1895,8 +1906,10 @@ public sealed partial class GameServer
     private void RecoverToShip(PlayerSession session, string reason, bool salvaged)
     {
         var p = session.State;
-        // The cursor is already on this session (set by the per-player tick / Serve), so _ship is this
-        // player's ship — recover to the world it's parked on.
+        // Pin the ship cursor BEFORE the first _ship read: this runs from death paths where the cursor may
+        // still point at another player (#1020) — reading (or re-homing, below) _ship then targets the
+        // wrong player's ship and recovers the victim to the world THAT ship is parked on.
+        SetCurrent(session);
         string shipHome = !string.IsNullOrEmpty(_ship?.CurrentLocationId) ? _ship.CurrentLocationId : _meta.ActiveLocationId;
 
         // Finale rule (P6): a death inside the Guardian system must not respawn the clone in the boss arena —
@@ -2396,6 +2409,7 @@ public sealed partial class GameServer
             RemoveLandedShip(session); // the parked ship object leaves with its owner (ship-as-object)
             RemoveConstructionSite(session); // the half-built hull despawns too — it lives on in the fleet save
             BroadcastToWorld(new PlayerLeft { PlayerId = session.State.PlayerId }); // remove their avatar in-world
+            BroadcastLandingPads(); // the leaver's pad is free again — everyone's map must show it (#1020)
             if (!string.IsNullOrEmpty(loc) && loc != _meta.ActiveLocationId && !OccupiedLocations().Contains(loc))
             {
                 // Move the cursor off the world we're about to drop, back to the (always-resident) default
@@ -2960,7 +2974,7 @@ public sealed partial class GameServer
         SendBases(session); // player-founded bases on the join world (Grundstein markers)
         SendAllianceList(session); // the player's alliance roster (shared station/base access + Funk tab)
         SendStoryStateOnJoin(session); // story meter + per-player beat catch-up (P0)
-        SendLandingPads(session);
+        BroadcastLandingPads(session); // the join claimed a pad — everyone's map must show it (#1020)
         SendContainers(session);
         SendExistingPresences(session); // show already-online players to the newcomer
         SyncAppearance(session);        // custom faces + body paintings, BOTH ways (#982)

--- a/src/BlocksBeyondTheStars.GameServer/GameServerObserver.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerObserver.cs
@@ -92,6 +92,7 @@ public sealed partial class GameServer
 
         session.AssignedPadIndex = -1;        // release the landing pad: pads are communal and finite
         BroadcastToWorld(new PlayerLeft { PlayerId = p.PlayerId }); // clients drop the avatar they can see
+        BroadcastLandingPads(); // the released pad is free again — everyone's map must show it (#1020)
         // Pets and deployed speeders despawn on the next reconcile tick — CompanionOwnersHere/ReconcileSpeeders
         // stop counting a spectating session as present.
 
@@ -125,6 +126,8 @@ public sealed partial class GameServer
                 ClaimPadOrReject(session, session.CurrentLocationId, -1); // take a pad again (any free one)
                 PlaceLandedShip();
             }
+
+            BroadcastLandingPads(session); // the re-claimed pad is taken again — everyone's map must show it (#1020)
         }
 
         // Re-announce: presence resumes on the next tick by itself, but the face is out-of-band and would

--- a/src/BlocksBeyondTheStars.GameServer/GameServerSpace.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerSpace.cs
@@ -550,7 +550,7 @@ public sealed partial class GameServer
         Send(session, new RespawnNotice { X = spawn.X, Y = spawn.Y, Z = spawn.Z, Reason = "@srv.land.touchdown" });
         SendPlayerState(session);
         SendLandedShips(session); // the landing world's parked ship objects (incl. the player's own)
-        SendLandingPads(session);
+        BroadcastLandingPads(session); // the touchdown claimed a pad — everyone's map must show it (#1020)
         SyncAppearance(session); // faces + body paintings both ways — the launch dropped them (#982)
         // Parity with the cross-body travel path (#957): without these the HUD compass ship blip and the
         // world-map marker kept pointing at the pad of the PREVIOUS landing.
@@ -577,6 +577,25 @@ public sealed partial class GameServer
 
         // This is the active body, so its day fraction is live (drives the world-map terminator client-side).
         Send(session, new LandingPadList { BodyId = _world.LocationId, Pads = pads, TimeOfDay = (float)_dayFraction });
+    }
+
+    /// <summary>Re-sends the active body's pad list to everyone on it. The list is otherwise a world-entry
+    /// snapshot: a pad claimed or released AFTER a bystander arrived stayed free/anonymous on their world
+    /// map forever (#1020). Occupancy (<see cref="NetLandingPad.Mine"/>) is receiver-relative, so this must
+    /// send per session rather than broadcast one message. Players up in space are skipped — their pad
+    /// chooser owns the client's single pad-list slot and a fresh list arrives with their touchdown —
+    /// except <paramref name="always"/>, the player whose arrival triggered the update.</summary>
+    private void BroadcastLandingPads(PlayerSession? always = null)
+    {
+        foreach (var s in JoinedInActiveWorld())
+        {
+            if (s != always && InSpace(s.State.PlayerId))
+            {
+                continue;
+            }
+
+            SendLandingPads(s);
+        }
     }
 
     /// <summary>The day fraction the player will arrive at when landing on <paramref name="bodyId"/>: the live time

--- a/src/BlocksBeyondTheStars.GameServer/GameServerSpawnSafety.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerSpawnSafety.cs
@@ -158,13 +158,16 @@ public sealed partial class GameServer
     /// <summary>How far up we look for standing room before giving up and using the ship/landing pad.</summary>
     private const int EntombedProbeHeight = 256;
 
-    /// <summary>A safe place to stand in the active world: the ship's heal-tank if a ship is parked, else
-    /// the landing-zone surface.</summary>
+    /// <summary>A safe place to stand in the active world: the player's OWN ship's heal-tank if their ship
+    /// is parked here, else the landing-zone surface. Resolved by <paramref name="playerId"/>, NOT the ship
+    /// cursor — the void-rescue tick runs with the cursor on whoever was served last, and the cursor's heal
+    /// tank teleported the rescued player into someone else's hull (#1020).</summary>
     private Vector3f SafeSpawnPoint(string playerId)
     {
-        if (_shipPlaced)
+        var ownShip = _worlds.Active.LandedFor(playerId);
+        if (ownShip.Placed)
         {
-            return _healTank;
+            return ownShip.HealTank;
         }
 
         var pad = FindSessionByPlayerId(playerId) is { } s ? PlayerPad(s)

--- a/tests/BlocksBeyondTheStars.Tests/LanPlaytestRegressionTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/LanPlaytestRegressionTests.cs
@@ -11,7 +11,10 @@ using BlocksBeyondTheStars.Networking.Transport;
 using BlocksBeyondTheStars.Persistence;
 using BlocksBeyondTheStars.Shared.Configuration;
 using BlocksBeyondTheStars.Shared.Content;
+using BlocksBeyondTheStars.Shared.Geometry;
+using BlocksBeyondTheStars.Shared.Primitives;
 using BlocksBeyondTheStars.Shared.State;
+using BlocksBeyondTheStars.Shared.World;
 using Xunit;
 using SvGameServer = BlocksBeyondTheStars.GameServer.GameServer;
 
@@ -456,6 +459,124 @@ public sealed class LanPlaytestRegressionTests : IDisposable
             System.Math.Abs(newbie.State.RespawnPoint.X - host.State.RespawnPoint.X) > 8
             || System.Math.Abs(newbie.State.RespawnPoint.Z - host.State.RespawnPoint.Z) > 8,
             "the new player's respawn anchor must not be the host's heal tank");
+    }
+
+    // ---------------- #1020: dying to an AI tick respawned you inside ANOTHER player's ship ----------------
+
+    [Fact]
+    public void DyingToAnAiTick_RecoversToYourOwnShipsWorld_NotTheLastServedOnes()
+    {
+        // The AI damage ticks (creatures/bandits/machines/speeders) call RespawnPlayer with the ship cursor
+        // still on whoever the server served last. RecoverToShip read THAT player's ship to pick the
+        // recovery world (and could even re-home that ship there) — the host died and came back at the
+        // OTHER player's ship instead of his own.
+        var transport = new RecordingTransport();
+        var server = NewServer("death_cursor", transport);
+        var host = server.AddLocalPlayer("Host");
+        var mary = server.AddLocalPlayer("Mary");
+        server.SetInstantTravelForTest(true);
+
+        // Park the two ships on two DIFFERENT galaxy bodies (real travels, so both ship records carry a
+        // proper body id — the fresh start world still runs under its legacy planet-type key).
+        var planets = server.Galaxy.AllBodies().Where(b =>
+                b.Kind == CelestialKind.Planet
+                && !string.IsNullOrEmpty(b.PlanetType)
+                && _content.GetPlanet(b.PlanetType!) is not null
+                && b.Id != host.CurrentLocationId)
+            .Take(2).ToArray();
+        var (hostBody, maryBody) = (planets[0], planets[1]);
+
+        server.RequestLandingPadsForTest(host, host.CurrentLocationId); // serves the host → server.Ship is his
+        server.Ship.Modules.Add("jump_generator"); // the destinations may sit in another system (as in TravelTests)
+        Assert.True(server.QuickTravelForTest("Host", hostBody.Id));
+
+        server.EnterSpace("Host"); // die away from the surface → the RecoverToShip (world-transition) path
+
+        server.RequestLandingPadsForTest(mary, mary.CurrentLocationId); // serves Mary → server.Ship is hers
+        server.Ship.Modules.Add("jump_generator");
+        Assert.True(server.QuickTravelForTest("Mary", maryBody.Id)); // the travel serves her → cursor on Mary
+
+        server.KillPlayerForTest(host, "@srv.death.wildlife");
+
+        // The host must recover to HIS ship's world and heal tank — not to the body Mary's ship parks on.
+        Assert.Equal(hostBody.Id, host.CurrentLocationId);
+        Assert.True(server.HasShip, "the victim's own ship must be re-parked for the respawn");
+        Assert.Equal(server.HealTank.X, host.State.Position.X);
+        Assert.Equal(server.HealTank.Z, host.State.Position.Z);
+        Assert.Equal(maryBody.Id, mary.CurrentLocationId); // and Mary was not dragged anywhere either
+    }
+
+    [Fact]
+    public void VoidRescue_RecoversToYourOwnShip_NotTheLastServedOnes()
+    {
+        // SafeSpawnPoint took a playerId and ignored it in the ship branch (_shipPlaced/_healTank = the
+        // cursor): the void-rescue tick, which never pins the cursor, teleported a falling player into
+        // whichever ship the server touched last.
+        var transport = new RecordingTransport();
+        var server = NewServer("void_cursor", transport);
+        var host = server.AddLocalPlayer("Host");
+        var mary = server.AddLocalPlayer("Mary");
+        var hostAnchor = host.State.RespawnPoint;
+        var maryAnchor = mary.State.RespawnPoint;
+
+        server.RequestLandingPadsForTest(mary, mary.CurrentLocationId); // serves Mary → the ship cursor points at her
+
+        // Carve a deep air shaft below the host and drop him in (the world has a bedrock floor, so the
+        // void has to be made, not found) — the same setup SpawnSafetyTests uses.
+        int bx = (int)System.Math.Floor(host.State.Position.X), bz = (int)System.Math.Floor(host.State.Position.Z);
+        int top = (int)host.State.Position.Y;
+        for (int y = top; y > top - 160; y--)
+        {
+            server.World.SetBlock(new Vector3i(bx, y, bz), BlockId.Air);
+        }
+
+        host.State.Position = new Vector3f(bx + 0.5f, top - 50, bz + 0.5f);
+        Assert.True(server.IsInVoidForTest(host.State.Position), "the host must start in the void for the rescue to fire");
+
+        server.RunVoidRescueForTest();
+
+        Assert.InRange(host.State.Position.X, hostAnchor.X - 8, hostAnchor.X + 8);
+        Assert.InRange(host.State.Position.Z, hostAnchor.Z - 8, hostAnchor.Z + 8);
+        Assert.True(
+            System.Math.Abs(host.State.Position.X - maryAnchor.X) > 8
+            || System.Math.Abs(host.State.Position.Z - maryAnchor.Z) > 8,
+            "the rescued player must not be teleported into the other player's ship");
+    }
+
+    // ---------------- #1020: a pad claimed after your arrival never showed as occupied ----------------
+
+    [Fact]
+    public void ALandingClaimingAPad_RepublishesOccupancyToPlayersAlreadyOnTheBody()
+    {
+        // LandingPadList was a world-entry snapshot: whoever was already on the body kept seeing a later
+        // lander's pad as free/anonymous forever ("we couldn't see her landing pad").
+        var transport = new RecordingTransport();
+        var server = NewServer("pad_republish", transport);
+        var host = server.AddLocalPlayer("Host");
+        var justus = server.AddLocalPlayer("Justus");
+        var mary = server.AddLocalPlayer("Mary");
+
+        server.EnterSpace("Mary");
+        transport.Sent.Clear();
+        server.LandOnCurrentBodyForTest(mary, 3); // an explicit free pad pick, like the chooser sends
+
+        foreach (var bystander in new[] { host, justus })
+        {
+            var list = transport.Sent
+                .Where(x => x.Conn == bystander.ConnectionId)
+                .Select(x => x.Msg).OfType<LandingPadList>().LastOrDefault();
+            Assert.NotNull(list);
+            var pad = list!.Pads.Single(p => p.Index == 3);
+            Assert.True(pad.Occupied, "the freshly claimed pad must be published as occupied");
+            Assert.Equal("Mary", pad.Occupant);
+        }
+
+        // The lander's own list marks the pad as hers (receiver-relative Mine, #977).
+        var maryList = transport.Sent
+            .Where(x => x.Conn == mary.ConnectionId)
+            .Select(x => x.Msg).OfType<LandingPadList>().LastOrDefault();
+        Assert.NotNull(maryList);
+        Assert.True(maryList!.Pads.Single(p => p.Index == 3).Mine);
     }
 
     public void Dispose()


### PR DESCRIPTION
closes #1020

Two findings from the 3-player LAN session on 2026-08-14: the host died and respawned inside a joiner's ship, and two of the three players never saw the third player's landing pad as occupied.

## Death respawn: pin the ship cursor to the dying player

The respawn target resolves through the global ship cursor (`_ship` / `_shipPlaced` / `_healTank`). The AI damage ticks (creatures, guardian machines, bandits, destroyed speeders) call `RespawnPlayer` without pinning it, so it still pointed at whoever the server served last — same class as #997, which fixed it for `CreateNewPlayer` only.

- `RespawnPlayer` now pins the cursor first.
- `RecoverToShip` pins **before** its first `_ship` read — it used to read (and even re-home) the stale cursor's ship at the top and only pin afterwards, recovering the victim to the world the *other* player's ship was parked on.
- `SafeSpawnPoint(playerId)` now resolves the ship via `LandedFor(playerId)` instead of the cursor. Its callers (`TickVoidRescue`, `EnsureSafeSpawn`) run unpinned; the void rescue teleported players into foreign hulls (and `EnsureSafeSpawn` could *persist* a foreign heal tank as the respawn anchor).

## Landing pads: republish occupancy on every change

`LandingPadList` was a world-entry snapshot, only ever unicast to the arriving player — a pad claimed or released after a bystander arrived stayed free/anonymous on their world map forever. New `BroadcastLandingPads()` re-sends the active body's list to everyone on it (per session — `NetLandingPad.Mine` is receiver-relative) on: landing/relocate, cross-body travel arrival, join, disconnect, and observer on/off. Players up in space are skipped (their pad chooser owns the client's single pad-list slot), except the player whose own arrival triggered the update.

Server-only, existing message, no protocol bump — effective through the host's bundled server even for older clients.

## Tests

Three new `LanPlaytestRegressionTests` (all three verified to fail with the fix hunks reverted):

- `DyingToAnAiTick_RecoversToYourOwnShipsWorld_NotTheLastServedOnes` — two ships on two bodies, cursor poisoned on the other player, unpinned kill (`KillPlayerForTest` mirrors the AI-tick call).
- `VoidRescue_RecoversToYourOwnShip_NotTheLastServedOnes` — carved void shaft, cursor poisoned, rescue must use the victim's own heal tank.
- `ALandingClaimingAPad_RepublishesOccupancyToPlayersAlreadyOnTheBody` — bystanders receive the updated pad list with the lander's name; the lander's own list marks the pad `Mine`.

Follow-up noted in #1020 (not fixed here): the client keeps one global slot for any `LandingPadList` and the world map doesn't gate on its body id, so a chooser reply for a padless body wipes the surface map's markers until re-entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
