### PR TITLE
feat(worldgen): split shallow ore veins across two noise scales

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7971,6 +7971,32 @@ is **pre-approved** (keys in `tools/ai-assets/.env`, run via `uv`).
 
 ---
 
+## ✅ Done (2026-08-14): shallow ore veins split across two noise scales — the ore lottery is over (#1024)
+
+Player report (LAN playtest): *"copper is too rare — and the deposits are gigantic, but which ore you
+find is pure luck."* Measurement (a sim replicating `SelectOre` + the #472 CDF calibration 1:1) proved
+the *shape* wrong, not the amount: copper was 1.9–3.1 % of all rock, but 93–96 % of it sat in deposits
+of ≥ 64 blocks (largest ~5,000), so the first *any* ore was visible after a median 0–9 m of tunnelling
+while the first *copper* took a median ~90 m — and 14–25 % of 256 m tunnels never met any. Root cause:
+a quantile threshold over ONE smooth 9-block-scale field necessarily concentrates a vein's whole kept
+fraction into few huge blobs around rare field maxima; deposit count/size was not a knob at all.
+
+Fix in `SelectOre` (#1024): shallow starter veins (`minDepth ≤ 8`) now spend **half their budget on the
+coarse 9-block field** (mother-lode strikes stay worth prospecting for) and **half on a new fine
+4.5-block sprinkle field** (own seed offset + own per-world CDF in the calibration), so small veins turn
+up regularly wherever a player digs. Deep rarities keep the single coarse field — a rare strike should
+be a find. Both ore CDFs now sample 16,384 field points (up from 4,096): the thresholds sit at 98.5+ %
+quantiles where the smaller sample drifted a vein's kept fraction by up to ±25 % between worlds.
+
+Measured after the split (same sim): median tunnel distance to first copper 25–41 m (p90 91–169 m),
+"no copper in 256 m" tunnels 2–4 % (was 14–25 %), 16³ deep-rock pockets without copper ≤ 1 % (was
+22–29 %) — total per-ore fractions unchanged within calibration accuracy. New regression test
+`ShallowOres_TurnUpInNearlyEveryPocket_NotOnlyInRareGiantStrikes` (two seeds; verified to FAIL on the
+old distribution). No protocol change (chunks are server-streamed); like every worldgen field change,
+ore shifts inside *unmodified* terrain of existing saves.
+
+---
+
 ## ✅ Done (2026-08-13): admin commands accept player names with spaces — and any capitalisation (#980)
 
 Reported from a hosted world: teleporting to the player `mincraft Fan` was impossible. `/tpp mincraft Fan`

--- a/docs/developer/WORLD_GENERATION.md
+++ b/docs/developer/WORLD_GENERATION.md
@@ -215,7 +215,12 @@ above it so digging out the bottom is impossible). The server's vertical build b
 **Y −2100** (#580), so even the deepest foundation is reachable — "dig to the bedrock" works on every
 world. Ore veins (3D noise × rarity × per-world richness) and caves (3D noise, if `CaveThreshold > 0`)
 are carved into the crust; ore density ramps up to **+60 % over the first ~600 blocks down** (#580),
-so the descent pays.
+so the descent pays. Shallow starter veins (`minDepth ≤ 8`: iron/copper/silicate class) spend their
+budget on **two field scales** (#1024): half on the coarse 9-block field (big "mother lode" strikes
+worth prospecting for) and half on a fine 4.5-block sprinkle field (small veins that turn up
+regularly while digging) — one smooth coarse field alone concentrated a vein's whole budget into few
+giant deposits, making *which* ore a player found a lottery. Deep rarities stay single-field: a rare
+strike should be a find.
 
 ---
 

--- a/src/BlocksBeyondTheStars.WorldGeneration/WorldGenerator.cs
+++ b/src/BlocksBeyondTheStars.WorldGeneration/WorldGenerator.cs
@@ -2546,6 +2546,7 @@ public sealed class WorldGenerator
                                               // ordinary surface into the middle entries.
         public double CaveThreshold;          // quantile-calibrated (0 = caves disabled)
         public double[] OreCdf = System.Array.Empty<double>();  // sorted ore-field samples (empirical CDF)
+        public double[] OreFineCdf = System.Array.Empty<double>(); // ditto for the fine sprinkle field (#1024)
         public int LavaTableDepth = int.MaxValue; // cave cells deeper than this fill with lava (#472/#477 L-A)
         public double BaseTemperature;        // planet base + per-world variation (°C) — worldgen-static part
         public double LapsePerBlock;          // °C lost per block above the reference altitude (#476)
@@ -2652,7 +2653,11 @@ public sealed class WorldGenerator
 
         // 4) Ore field CDF (#472): SelectOre turns each vein's rarity into a quantile of this, so `rarity`
         //    finally IS the kept fraction (the multiplier bumps never fixed this because the knob was broken).
-        c.OreCdf = FieldSamplesSorted(seed + 100, 9.0, 9.0, 9.0);
+        //    The fine sprinkle field (#1024) gets its own CDF: in theory both fields share one distribution,
+        //    but the thresholds sit in the far tail where the 4096-sample quantile is noisy — measuring each
+        //    field keeps the kept fraction exact for both.
+        c.OreCdf = FieldSamplesSorted(seed + 100, 9.0, 9.0, 9.0, samples: 16384);
+        c.OreFineCdf = FieldSamplesSorted(seed + OreFineFieldSalt, OreFineScale, OreFineScale, OreFineScale, samples: 16384);
 
         // 5) Deep lava table (#472/#477 L-A): carved cave cells below this depth fill with molten rock — the
         //    danger half to the now-reachable deep ore bands. Kept below the cave-fauna scan (surface−49).
@@ -2702,10 +2707,14 @@ public sealed class WorldGenerator
     }
 
     /// <summary>Sorted samples of a ValueT field over this world's domain — its empirical CDF. Thresholds
-    /// derived from this stay meaningful no matter how many interpolation axes the torus sampler stacks.</summary>
-    private double[] FieldSamplesSorted(long fieldSeed, double scaleX, double scaleY, double scaleZ)
+    /// derived from this stay meaningful no matter how many interpolation axes the torus sampler stacks.
+    /// Ore thresholds sit at 98.5–99.5+ % quantiles where a 4096-sample estimate drifts a vein's kept
+    /// fraction by ±25 % between worlds — those callers pass a larger <paramref name="samples"/> (#1024);
+    /// the cave carve fraction (2–22 %) is fine at the default.</summary>
+    private double[] FieldSamplesSorted(long fieldSeed, double scaleX, double scaleY, double scaleZ,
+        int samples = 4096)
     {
-        const int N = 4096;
+        int N = samples;
         var vals = new double[N];
         int period = LatPeriod;
         for (int i = 0; i < N; i++)
@@ -4553,6 +4562,11 @@ public sealed class WorldGenerator
         return 1 + (int)System.Math.Round(n * (baseDepth - 1));
     }
 
+    // Two-scale veins (#1024): the sprinkle field's block scale and its seed offset. The offset keeps the
+    // fine fields (salt + i*31) clear of the coarse fields (100 + i*31) and every other worldgen salt.
+    private const double OreFineScale = 4.5;
+    private const long OreFineFieldSalt = 61000;
+
     private BlockId SelectOre(PlanetType planet, WorldCalibration calib, long seed, int x, int y, int z,
         int depth, BlockId fallback, double richness)
     {
@@ -4586,9 +4600,33 @@ public sealed class WorldGenerator
                 continue;
             }
 
-            double threshold = calib.OreCdf[(int)((1.0 - frac) * (calib.OreCdf.Length - 1))];
-            double n = ValueT(seed + 100 + i * 31, x, y, z, 9.0, 9.0, 9.0);
-            if (n > threshold)
+            bool hit;
+            if (ore.MinDepth <= 8)
+            {
+                // Two-scale split (#1024): a quantile over ONE smooth 9-block field concentrates a vein's
+                // whole budget into few huge deposits (measured: >90 % of copper sat in ≥64-block blobs and
+                // a straight tunnel needed a median ~90 m to meet the first one — "which ore you find is a
+                // lottery"). Shallow starter veins therefore spend half their budget on the coarse field
+                // (big strikes stay worth prospecting for) and half on a fine 4.5-block field whose small
+                // veins turn up regularly while digging. The union stays ≈ frac (overlap is frac²/4).
+                double half = frac * 0.5;
+                double coarseThr = calib.OreCdf[(int)((1.0 - half) * (calib.OreCdf.Length - 1))];
+                hit = ValueT(seed + 100 + i * 31, x, y, z, 9.0, 9.0, 9.0) > coarseThr;
+                if (!hit)
+                {
+                    double fineThr = calib.OreFineCdf[(int)((1.0 - half) * (calib.OreFineCdf.Length - 1))];
+                    hit = ValueT(seed + OreFineFieldSalt + i * 31, x, y, z, OreFineScale, OreFineScale, OreFineScale) > fineThr;
+                }
+            }
+            else
+            {
+                // Deep rarities keep the single coarse field: a rare strike SHOULD be a find, and their
+                // budgets are too thin to split without dissolving into single-block specks.
+                double threshold = calib.OreCdf[(int)((1.0 - frac) * (calib.OreCdf.Length - 1))];
+                hit = ValueT(seed + 100 + i * 31, x, y, z, 9.0, 9.0, 9.0) > threshold;
+            }
+
+            if (hit)
             {
                 var oreBlock = _content.GetBlock(ore.Block);
                 if (oreBlock is not null)

--- a/tests/BlocksBeyondTheStars.Tests/WorldGenerationTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/WorldGenerationTests.cs
@@ -444,6 +444,54 @@ public class WorldGenerationTests
         }
     }
 
+    [Theory]
+    [InlineData(77)]
+    [InlineData(4242)]
+    public void ShallowOres_TurnUpInNearlyEveryPocket_NotOnlyInRareGiantStrikes(long seed)
+    {
+        // #1024: a quantile over ONE smooth 9-block field concentrated a starter vein's whole budget into
+        // few giant deposits — copper was ~2 % of all rock yet a straight tunnel needed a median ~90 m to
+        // meet any ("which ore you find is a lottery"). The two-scale split spends half of every shallow
+        // vein's budget on a fine sprinkle field, so modest amounts turn up wherever a player digs.
+        // Yardstick: 16³ pockets ≈ the rock a short mining gallery sweeps. Before the split 22–29 % of
+        // deep-interior pockets held no copper at all (measured); after it ≤ 1 %. The 95 % gate below
+        // leaves room for cave-riddled pockets without ever passing the old distribution.
+        var content = Content();
+        var planet = content.GetPlanet("rocky")!;
+        var gen = new WorldGenerator(seed, content);
+        ushort copper = content.GetBlock("copper_ore")!.NumericId.Value;
+
+        int pockets = 0, withCopper = 0;
+        for (int cx = 0; cx < 3; cx++)
+            for (int cz = 0; cz < 3; cz++)
+            {
+                // cy = 0 → Y 0..31, well below the rocky surface: every shallow vein is depth-eligible.
+                var chunk = gen.Generate(planet, new ChunkCoord(cx, 0, cz));
+                for (int ox = 0; ox < WorldConstants.ChunkSize; ox += 16)
+                    for (int oy = 0; oy < WorldConstants.ChunkSize; oy += 16)
+                        for (int oz = 0; oz < WorldConstants.ChunkSize; oz += 16)
+                        {
+                            bool has = false;
+                            for (int x = ox; x < ox + 16 && !has; x++)
+                                for (int y = oy; y < oy + 16 && !has; y++)
+                                    for (int z = oz; z < oz + 16 && !has; z++)
+                                    {
+                                        has = chunk.Get(x, y, z).Value == copper;
+                                    }
+
+                            pockets++;
+                            if (has)
+                            {
+                                withCopper++;
+                            }
+                        }
+            }
+
+        Assert.True(withCopper >= (int)(pockets * 0.95),
+            $"copper missing in {pockets - withCopper} of {pockets} 16³ deep-rock pockets — " +
+            "the fine sprinkle half of the two-scale vein split (#1024) is not reaching the world");
+    }
+
     private static int CountBlock(WorldGenerator gen, BlocksBeyondTheStars.Shared.Definitions.PlanetType planet, ushort block,
         int cyLo = 3, int cyHi = 5)
     {


### PR DESCRIPTION
Closes #1024

## What

`SelectOre` spent each vein's whole budget on one smooth 9-block-scale noise field. A quantile threshold over a smooth coarse field necessarily concentrates the kept fraction into few giant blobs — which made *which* ore a player finds a lottery (LAN playtest: "copper is too rare, deposits are gigantic").

Shallow starter veins (`minDepth <= 8`: iron/copper/silicate class) now split their budget 50/50:

- **half on the existing coarse 9-block field** — the big mother-lode strikes stay worth prospecting for,
- **half on a new fine 4.5-block sprinkle field** (own seed offset `seed + 61000 + i*31`, own per-world CDF) — small veins turn up regularly wherever a player digs.

Deep rarities (diamond, uranium, …) keep the single coarse field: a rare strike should be a find, and their budgets are too thin to split.

Both ore CDFs now sample 16,384 field points (was 4,096) — the thresholds sit at 98.5+ % quantiles where the smaller sample drifted a vein's kept fraction by up to ±25 % between worlds. The cave CDF is untouched (carve fractions live at mild quantiles); caves are byte-identical.

## Measured (sim replicating `SelectOre` + calibration 1:1; rocky, 3 seeds, 256×61×256, depth 4–64)

| Metric | before | after |
|---|---|---|
| median tunnel distance to first copper (depth 30) | 39–91 m | 25–41 m |
| tunnels finding NO copper in 256 m | 14–25 % | 2–4 % |
| 16³ deep-rock pockets without copper | 22–29 % | ≤ 1 % |
| copper deposits in volume (count / mean size) | ~700 / ~110–155 | ~3,000–3,800 / ~24–34 |
| share of copper in ≥64-block deposits | 93–96 % | 55–68 % |
| per-ore total fraction | unchanged within calibration accuracy | |

## Tests

- New `ShallowOres_TurnUpInNearlyEveryPocket_NotOnlyInRareGiantStrikes` (two seeds) — **verified to fail against the old distribution** and passes on the new one. Statistical gate (95 %), no golden hashes (trig-derived floats differ across libm).
- Full non-Slow suite: **1916 passed** locally in the worktree.

## Compatibility

- No wire-format change — multiplayer chunks are server-streamed, so no protocol bump.
- Like every worldgen field change: ore positions shift inside **unmodified** terrain of existing saves (baseline regenerates from seed; player deltas persist).
- Perf: one extra field evaluation per shallow vein per rock cell (short-circuited when the coarse field hits); the 2×16k CDF sampling happens once per world and is cached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)