### PR TITLE
fix(server): re-stream terrain a partner kept loaded + harden /tpp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ the richer, screenshot-laden versions live there. `(#123)` references the pull r
 
 ### Fixed
 
+- **"I only see space": returning to an area another player kept loaded showed void terrain.** The
+  client frees far-away terrain to keep memory bounded, but the server only forgot what it had sent a
+  player when the area was far from *everyone*. With a partner standing there, coming back — by
+  teleport, beam or on foot — streamed nothing: ship and animals rendered over a starfield. The server
+  now also forgets per player, by that player's own distance, so a return always re-streams the ground.
+  `/tpp` additionally refreshes your aboard-ship state and refuses targets that are in space or on
+  another planet instead of copying their coordinates into the wrong scene. (#1030)
+
 - **Dying near another player could respawn you inside *their* ship.** Deaths dealt by the world's AI
   (creatures, guardian machines, bandits, a destroyed speeder) — and the void-rescue teleport — resolved
   the respawn target through whichever player the server had served last, dropping the victim at the

--- a/TODO.md
+++ b/TODO.md
@@ -118,6 +118,22 @@ server keeps guarding the real interior (`ShipInteriorContains`). Cabin furnishi
 still target ship cells, so they keep working. Client-only, no protocol change. Likely the same root
 cause as the "painted block won't place" LAN report.
 
+### ★ Returning to an area a partner kept loaded no longer shows void terrain (#1030, 2026-08-15, branch fix/tpp-void-terrain)
+F1 report from tonight's LAN session: after `/tpp` to a player 1.7 km away, "I only see space" — the
+target's ship and the animals rendered, the terrain did not, while the server's bump snapshot showed
+solid forest all around. Multiplayer-only bookkeeping gap: since #966 the client unloads chunks
+farther than ~384 blocks (block data included), but the server only forgot a session's `SentChunks`
+via the sweep's far-from-EVERY-player eviction. With a partner camping in an area its chunks stayed
+cached — and stayed "already sent" for the returning player, so `StreamChunks` skipped them forever
+and missing chunks render as air. The sweep now ALSO prunes each session's sent-set by that session's
+OWN anchor (view radius + 4, seam-aware on both wrap axes, capped safely below the client's 24-chunk
+unload distance); anything pruned while the client still holds it merely re-streams idempotently on
+return. `/tpp` itself hardened for parity with `/tp`: it now refreshes the aboard state after the
+snap and refuses targets in a space instance or on another body (new `srv.tpp.not_here` key, EN+DE)
+instead of copying coordinates across scenes. Server-only fix — a host update suffices, no protocol
+bump. Regression tests: two-player sweep round-trip (red before the fix), cross-body reject, aboard
+refresh.
+
 ### ★ VEGA hints and story pages stay until the player continues (#1011, 2026-08-14, branch fix/vega-lines-persist)
 Every line in VEGA's speech panel — advisor hints, story/memory beats, onboarding, prologue pages —
 was auto-dismissed 25 s after it finished typing (`AutoAdvanceSeconds` in `VegaPanel`), so slow

--- a/data/locales/de.json
+++ b/data/locales/de.json
@@ -3106,6 +3106,7 @@
   "srv.tp.to_ship": "Zurück zu deinem Schiff teleportiert.",
   "srv.tp.unknown_kind": "Unbekanntes Ziel '{name}'. Mögliche Ziele mit /tp auflisten.",
   "srv.tp.your_ship": "dein Schiff",
+  "srv.tpp.not_here": "{name} ist gerade nicht auf diesem Planeten — /tpp erreicht nur Spieler auf demselben Planeten.",
   "srv.trade.busy": "Gerade kann kein Handel gestartet werden.",
   "srv.trade.cancelled": "Handel abgebrochen.",
   "srv.trade.complete": "Handel abgeschlossen.",

--- a/data/locales/en.json
+++ b/data/locales/en.json
@@ -3106,6 +3106,7 @@
   "srv.tp.to_ship": "Teleported back to your ship.",
   "srv.tp.unknown_kind": "Unknown target '{name}'. List what is here with /tp.",
   "srv.tp.your_ship": "your ship",
+  "srv.tpp.not_here": "{name} is not on this planet right now — /tpp only reaches players on the same planet.",
   "srv.trade.busy": "Can't start a trade right now.",
   "srv.trade.cancelled": "Trade cancelled.",
   "srv.trade.complete": "Trade complete.",

--- a/src/BlocksBeyondTheStars.GameServer/GameServer.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServer.cs
@@ -2179,8 +2179,10 @@ public sealed partial class GameServer
     /// <summary>Evicts cached chunks in the active world that fall outside the keep-range of every joined player,
     /// bounding server memory on long exploration (the cache otherwise only ever grew). The keep radius sits a
     /// few chunks beyond the streaming radius so a chunk the player can currently see is never dropped; chunks
-    /// regenerate on demand (with persisted edits re-applied) if the player returns, and the client keeps its own
-    /// copy regardless (it never unloads), so eviction is invisible. Honours <see cref="ServerConfig.MaxLoadedChunksPerPlayer"/>
+    /// regenerate on demand (with persisted edits re-applied) if the player returns. The client unloads its own
+    /// far chunks too (~384 blocks, #966), so each session's sent-set is also pruned by that session's OWN
+    /// distance below — the cache eviction alone only forgets chunks far from EVERY player, which left a
+    /// returning player's sent-set stale wherever another player kept the area alive (#1030). Honours <see cref="ServerConfig.MaxLoadedChunksPerPlayer"/>
     /// in spirit by keeping the resident set proportional to the view, not the distance travelled.</summary>
     private void SweepFarChunks()
     {
@@ -2216,6 +2218,42 @@ public sealed partial class GameServer
                 }
             }
         }
+
+        // The eviction above only forgets chunks that are far from EVERY player — but the client unloads by its
+        // own distance alone (RepositionChunks, ~384 blocks = 24 chunks). So while another player camped in an
+        // area, its chunks stayed cached AND stayed in a departed player's sent-set even though that player's
+        // client had long discarded them; on return, StreamChunks skipped them as "already sent" and the
+        // returner stood in void terrain the server actually had ("/tpp … I only see space", #1030). Prune each
+        // sent-set by ITS OWN session's anchor too. The prune radius must stay below the client's 24-chunk
+        // unload distance (or a client-unloaded chunk could survive in the sent-set); a chunk pruned while the
+        // client still holds it merely re-streams when it re-enters the view, which is idempotent.
+        foreach (var session in JoinedInActiveWorld())
+        {
+            var anchor = WorldConstants.WorldToChunk(session.State.Position.ToBlock());
+            int pruneRadius = System.Math.Min(EffectiveViewRadius(session) + 4, 20);
+            int pruneSq = pruneRadius * pruneRadius;
+            int circumference = _world.Circumference;
+            session.SentChunks.RemoveWhere(c => WrappedChunkDistanceSquared(c, anchor, circumference) > pruneSq);
+        }
+    }
+
+    /// <summary>Squared chunk-grid distance measured the short way round BOTH seams (X wraps at the chunk
+    /// circumference, Z at the latitude chunk band; Y is linear). The sent-set prune must not read a chunk just
+    /// across a seam as "far", or a player standing near a seam would re-stream half their view every sweep.</summary>
+    private static int WrappedChunkDistanceSquared(ChunkCoord a, ChunkCoord b, int circumference)
+    {
+        int dx = WrapChunkDelta(a.X - b.X, WorldConstants.ChunksAroundOf(circumference));
+        int dy = a.Y - b.Y;
+        int dz = WrapChunkDelta(a.Z - b.Z, WorldConstants.LatitudePeriodFor(circumference) / WorldConstants.ChunkSize);
+        return dx * dx + dy * dy + dz * dz;
+    }
+
+    /// <summary>Shortest signed delta on a wrapping chunk axis with the given period (chunk-unit twin of
+    /// <see cref="WorldConstants.WrapDeltaX(int,int)"/>, whose parameter is a BLOCK circumference).</summary>
+    private static int WrapChunkDelta(int delta, int period)
+    {
+        int m = ((delta % period) + period) % period;
+        return m > period / 2 ? m - period : m;
     }
 
     /// <summary>Fills a chunk message's sparse colour-modifier + shape arrays from the chunk's dyed/glowing/
@@ -4791,10 +4829,28 @@ public sealed partial class GameServer
                         return;
                     }
 
+                    // A position is only meaningful inside its own scene: while flying a space instance the
+                    // snap channel would fight the flight scene (same guard as /tp), and a target who is in
+                    // space or on another body has coordinates that mean nothing on the admin's body — copying
+                    // them raw dropped the admin at a spot picked from the wrong scene (#1030).
+                    if (InSpace(p.PlayerId))
+                    {
+                        Reject(session, "admin", "@srv.tp.no_surface_targets");
+                        return;
+                    }
+
+                    if (InSpace(target.State.PlayerId)
+                        || !string.Equals(target.CurrentLocationId, session.CurrentLocationId, System.StringComparison.Ordinal))
+                    {
+                        Reject(session, "admin", "@srv.tpp.not_here:" + target.State.Name);
+                        return;
+                    }
+
                     p.Position = target.State.Position;
                     // Same snap-channel rule as teleport_to_location (#414 M7).
                     Send(session, new RespawnNotice { X = p.Position.X, Y = p.Position.Y, Z = p.Position.Z, Reason = "@srv.tp.to:" + target.State.Name });
                     SendPlayerState(session);
+                    UpdateAboard(session); // jumping onto/off a ship must flip the aboard state now, not on the next move (parity with /tp)
                     CheatLog(p, $"teleported to player {target.State.Name}");
                     break;
                 }

--- a/tests/BlocksBeyondTheStars.Tests/AdminCheatTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/AdminCheatTests.cs
@@ -184,6 +184,52 @@ public sealed class AdminCheatTests : IDisposable
         Assert.Equal(123f, snap.Z);
     }
 
+    /// <summary>A target on another body has coordinates from a different scene — copying them raw dropped
+    /// the admin at a spot that means nothing on their own body (#1030), so the jump is refused instead.</summary>
+    [Fact]
+    public void Teleport_ToPlayer_RejectsTargetOnAnotherBody()
+    {
+        var rules = new GameRules { AdminCheats = true, AllowCheatsInSurvival = true };
+        var (server, client) = Start(rules, "tpbody");
+        var before = server.Sessions[1].State.Position;
+
+        var target = server.AddLocalPlayer("Target");
+        target.State.Position = new Shared.Geometry.Vector3f(321, 70, 123);
+        target.CurrentLocationId = "elsewhere"; // parked on a different body than the admin
+
+        ActionRejected? rejected = null;
+        client.PayloadReceived += pl => { if (NetCodec.Decode(pl) is ActionRejected r) rejected = r; };
+
+        client.Send(NetCodec.Encode(new AdminCommandIntent { Command = "teleport_to_player", TargetPlayer = "Target" }),
+            DeliveryMode.ReliableOrdered);
+        server.Tick(0.1);
+        client.Poll();
+
+        Assert.NotNull(rejected);
+        Assert.Equal(before, server.Sessions[1].State.Position);
+    }
+
+    /// <summary>/tpp used to skip the aboard-state refresh /tp performs after its snap, so an admin jumping
+    /// OFF their ship kept AboardShip=true until their next step — wrong O2 semantics meanwhile (#1030).</summary>
+    [Fact]
+    public void Teleport_ToPlayer_RefreshesAboardState()
+    {
+        var rules = new GameRules { AdminCheats = true, AllowCheatsInSurvival = true };
+        var (server, client) = Start(rules, "tpaboard");
+        var admin = server.Sessions[1];
+        Assert.True(admin.State.AboardShip); // spawns at the heal tank, aboard the starter ship
+
+        var target = server.AddLocalPlayer("Target");
+        target.State.Position = new Shared.Geometry.Vector3f(321, 70, 123); // on open ground, off the ship
+
+        client.Send(NetCodec.Encode(new AdminCommandIntent { Command = "teleport_to_player", TargetPlayer = "Target" }),
+            DeliveryMode.ReliableOrdered);
+        server.Tick(0.1);
+
+        Assert.Equal(target.State.Position, admin.State.Position);
+        Assert.False(admin.State.AboardShip); // refreshed by the snap, not deferred to the next move
+    }
+
     /// <summary>An empty or unknown target still has to be refused — the tolerant match must not fall
     /// back to "some session" (or to the admin's own).</summary>
     [Theory]

--- a/tests/BlocksBeyondTheStars.Tests/ChunkStreamingTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/ChunkStreamingTests.cs
@@ -132,6 +132,67 @@ public sealed class ChunkStreamingTests : IDisposable
         Assert.True(server.World.IsChunkLoaded(nearChunk), "the player's own region must stay resident through the sweep");
     }
 
+    /// <summary>The multiplayer half of the sweep (#1030): the cache eviction only forgets chunks that are far
+    /// from EVERY player, so chunks a camping partner kept alive stayed in a departed player's sent-set even
+    /// though that player's client had long unloaded them (RepositionChunks drops everything past ~384 blocks).
+    /// On return — /tpp, a beam, or simply walking back — StreamChunks skipped them as "already sent" and the
+    /// returner stood in void terrain the server actually had ("I only see space"). The sweep must therefore
+    /// also prune every session's sent-set by that session's OWN distance.</summary>
+    [Fact]
+    [Trait("Category", "Slow")]
+    public void Sweep_ForgetsADepartedPlayersSentChunks_EvenWhenAPartnerKeepsThemCached()
+    {
+        using var repo = new SqliteWorldRepository(new SaveGamePaths(_root, "sweep_mp"));
+        var st = new LoopbackServerTransport(new LoopbackLink());
+        var config = new ServerConfig
+        {
+            WorldName = "sweep_mp",
+            Seed = 1,
+            AutoSaveIntervalMinutes = 9999,
+            PlaceStarterShip = false,
+            ViewDistanceChunks = 2,
+        };
+        var server = new SvGameServer(config, _content, st, repo);
+        server.Start();
+
+        var camper = server.AddLocalPlayer("Camper");
+        var traveler = server.AddLocalPlayer("Traveler");
+        traveler.State.Position = camper.State.Position; // side by side, sharing one home region
+        var home = WorldConstants.WorldToChunk(camper.State.Position.ToBlock());
+
+        for (int i = 0; i < 20; i++)
+        {
+            server.TickForTest(0.1); // stream the shared home region to BOTH sessions
+        }
+
+        Assert.Contains(home, traveler.SentChunks); // sanity: the home chunk reached the traveler
+
+        // The traveler leaves — far past the streaming radius AND the client's ~24-chunk unload distance,
+        // placed high above the terrain so neither the entombed- nor the void-rescue relocates the anchor.
+        var homePos = camper.State.Position;
+        traveler.State.Position = new Vector3f(homePos.X, homePos.Y + 120f, homePos.Z + 640f);
+
+        for (int i = 0; i < 15; i++)
+        {
+            server.TickForTest(1.0); // run past the 10 s sweep interval
+        }
+
+        // The camper keeps the region alive, so the cache must keep it — which is exactly why the old
+        // "forget only what was evicted" bookkeeping never forgot it for the traveler.
+        Assert.True(server.World.IsChunkLoaded(home), "the camper's region must stay cached through the sweep");
+        Assert.Contains(home, camper.SentChunks); // the camper still sees it — no over-pruning
+        Assert.DoesNotContain(home, traveler.SentChunks); // the traveler's client unloaded it — forget it here too
+
+        // And the return trip re-streams it through the normal path (the visible half of the bug).
+        traveler.State.Position = homePos;
+        for (int i = 0; i < 20; i++)
+        {
+            server.TickForTest(0.1);
+        }
+
+        Assert.Contains(home, traveler.SentChunks);
+    }
+
     [Fact]
     [Trait("Category", "Slow")]
     public void ClientViewDistance_ExtendsStreamingRadius_BeyondHostDefault()


### PR DESCRIPTION
## Summary

Fixes tonight's F1 report (world `mämämämä_höhö`, v2026.8.14): after `/tpp` to a player ~1.7 km away, the admin saw **only starfield** — the target's ship and creatures rendered, terrain didn't, while the server's bump snapshot showed solid forest all around.

### Root cause (multiplayer-only)

Since #966 the **client** unloads chunks farther than ~384 blocks (block data included) and relies on the server forgetting them too. But the **server** only forgot a session's `SentChunks` via the sweep's *far-from-EVERY-player* eviction. With a partner camping in an area, its chunks stayed cached — and stayed "already sent" for the returning player, so `StreamChunks` skipped the whole region forever and missing chunks render as air. Return by `/tpp`, beam, or walking back — same void.

### Fix

- `SweepFarChunks` now **also prunes each session's sent-set by that session's OWN anchor** (view radius + 4 chunks, seam-aware on both wrap axes, capped safely below the client's 24-chunk unload distance). A chunk pruned while the client still holds it merely re-streams idempotently when it re-enters the view.
- `/tpp` hardening for parity with `/tp`: refreshes the aboard state after the snap (stale `AboardShip` = wrong O2 semantics), and refuses targets in a space instance or on another body instead of copying coordinates across scenes (new `srv.tpp.not_here` key, EN + DE; other locales fall back per key).

Server-only — a host update suffices, no protocol bump.

## Tests

- `Sweep_ForgetsADepartedPlayersSentChunks_EvenWhenAPartnerKeepsThemCached` — two players, camper keeps the region cached, departed traveler's sent-set must be pruned and the return trip must re-stream. **Verified red before the fix, green after.**
- `Teleport_ToPlayer_RejectsTargetOnAnotherBody` and `Teleport_ToPlayer_RefreshesAboardState`.
- Full suite green locally: 1921 server + 244 client, 0 failures.

closes #1030

🤖 Generated with [Claude Code](https://claude.com/claude-code)
