### PR TITLE
fix(client): show the player's hand when an empty hotbar slot is selected

### DIFF
--- a/client/Assets/BlocksBeyondTheStars/Scripts/GameBootstrap.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/GameBootstrap.cs
@@ -1499,6 +1499,9 @@ namespace BlocksBeyondTheStars.Client
                     ? (Atlas.Texture, Atlas.TileUv(b.NumericId.Value))
                     : null;
 
+            // The empty-slot hand (#1033) wears a glove in the player's suit arm colour.
+            HeldItem.HandTintResolver = () => Settings?.ArmColor;
+
             if (Loopback != null)
             {
                 // In-process singleplayer: the server lives in THIS process (BrowserLocalServer) — the

--- a/client/Assets/BlocksBeyondTheStars/Scripts/HeldItem.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/HeldItem.cs
@@ -14,18 +14,31 @@ namespace BlocksBeyondTheStars.Client
     /// </summary>
     public static class HeldItem
     {
-        public enum Kind { None, Block, Drill, Gun, Blade, Scanner, Tool, Gadget }
+        public enum Kind { None, Block, Drill, Gun, Blade, Scanner, Tool, Gadget, Hand }
 
         /// <summary>Resolves a block key to its atlas texture + tile UV rect, so a held block shows its REAL
         /// in-world texture instead of a flat map colour. Wired by GameBootstrap once the atlas exists; null
         /// (or a null result) falls back to the tinted cube.</summary>
         public static System.Func<string, (Texture2D Tex, Rect Uv)?> BlockTileResolver;
 
+        /// <summary>Resolves the local player's suit arm colour so the empty-slot hand matches the
+        /// avatar's glove. Wired by GameBootstrap; null falls back to the default suit blue.</summary>
+        public static System.Func<Color?> HandTintResolver;
+
+        /// <summary>Default glove colour when no resolver is wired (= <c>ClientSettings.ArmColor</c> default).</summary>
+        private static readonly Color DefaultGlove = new Color(0.20f, 0.45f, 0.80f);
+
         /// <summary>Maps the selected inventory item to a held-item kind + tint (+ the block key for
         /// <see cref="Kind.Block"/>, so the held cube can carry the block's real atlas tile).</summary>
         public static (Kind kind, Color tint, string blockKey) For(GameContent content, string itemKey)
         {
-            if (string.IsNullOrEmpty(itemKey) || content == null)
+            if (string.IsNullOrEmpty(itemKey))
+            {
+                // Empty hotbar slot: show the bare (gloved) hand instead of nothing (#1033).
+                return (Kind.Hand, HandTintResolver?.Invoke() ?? DefaultGlove, null);
+            }
+
+            if (content == null)
             {
                 return (Kind.None, Color.white, null);
             }
@@ -141,6 +154,16 @@ namespace BlocksBeyondTheStars.Client
                     Cube(holder.transform, new Vector3(0f, 0f, 0.18f), new Vector3(0.08f, 0.08f, 0.12f), dark);     // barrel
                     Cube(holder.transform, new Vector3(0f, 0f, 0.27f), new Vector3(0.10f, 0.10f, 0.05f), tint);     // emitter glow
                     Cube(holder.transform, new Vector3(0f, -0.12f, -0.04f), new Vector3(0.07f, 0.16f, 0.09f), dark); // grip
+                    break;
+
+                case Kind.Hand:
+                    // Empty slot (#1033): a gloved fist on the suit-coloured forearm — thumb on the inner
+                    // side of a right hand, cuff a darker shade for definition.
+                    var cuff = new Color(tint.r * 0.7f, tint.g * 0.7f, tint.b * 0.7f);
+                    Cube(holder.transform, new Vector3(0.02f, -0.06f, -0.16f), new Vector3(0.11f, 0.11f, 0.30f), tint); // forearm
+                    Cube(holder.transform, new Vector3(0f, -0.02f, -0.02f), new Vector3(0.12f, 0.12f, 0.07f), cuff);    // cuff
+                    Cube(holder.transform, new Vector3(0f, 0f, 0.07f), new Vector3(0.13f, 0.12f, 0.14f), tint);         // fist
+                    Cube(holder.transform, new Vector3(-0.075f, 0.01f, 0.05f), new Vector3(0.05f, 0.06f, 0.08f), tint); // thumb
                     break;
 
                 default: // Tool

--- a/client/Assets/BlocksBeyondTheStars/Scripts/PlayerAvatar.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/PlayerAvatar.cs
@@ -420,9 +420,9 @@ namespace BlocksBeyondTheStars.Client
                 _held = null;
             }
 
-            if (kind == HeldItem.Kind.None)
+            if (kind == HeldItem.Kind.None || kind == HeldItem.Kind.Hand)
             {
-                return;
+                return; // Hand (#1033) is first-person only — the avatar already has its own hand mesh.
             }
 
             _held = HeldItem.Build(_handR, kind, tint, blockKey);

--- a/client/Assets/Tests/EditMode/HeldItemEditModeTests.cs
+++ b/client/Assets/Tests/EditMode/HeldItemEditModeTests.cs
@@ -1,0 +1,48 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using BlocksBeyondTheStars.Client;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace BlocksBeyondTheStars.Client.Tests.EditMode
+{
+    /// <summary>
+    /// Pins the empty-hotbar-slot hand from issue #1033: selecting an empty slot must resolve to
+    /// <see cref="HeldItem.Kind.Hand"/> (so the first-person viewmodel shows the gloved hand instead
+    /// of nothing), tinted with the player's suit arm colour when the resolver is wired.
+    /// </summary>
+    public sealed class HeldItemEditModeTests
+    {
+        [TearDown]
+        public void TearDown() => HeldItem.HandTintResolver = null;
+
+        [Test]
+        public void EmptySlotResolvesToHand()
+        {
+            Assert.That(HeldItem.For(null, null).kind, Is.EqualTo(HeldItem.Kind.Hand));
+            Assert.That(HeldItem.For(null, "").kind, Is.EqualTo(HeldItem.Kind.Hand));
+        }
+
+        [Test]
+        public void HandUsesResolvedArmColour()
+        {
+            var arm = new Color(0.9f, 0.1f, 0.2f);
+            HeldItem.HandTintResolver = () => arm;
+            Assert.That(HeldItem.For(null, "").tint, Is.EqualTo(arm));
+        }
+
+        [Test]
+        public void HandFallsBackToDefaultGloveWithoutResolver()
+        {
+            HeldItem.HandTintResolver = null;
+            Assert.That(HeldItem.For(null, "").tint, Is.EqualTo(new Color(0.20f, 0.45f, 0.80f)));
+        }
+
+        [Test]
+        public void NonEmptyKeyWithoutContentStaysNone()
+        {
+            Assert.That(HeldItem.For(null, "iron_drill").kind, Is.EqualTo(HeldItem.Kind.None));
+        }
+    }
+}

--- a/client/Assets/Tests/EditMode/HeldItemEditModeTests.cs.meta
+++ b/client/Assets/Tests/EditMode/HeldItemEditModeTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 53a6250e370945038647f0d5a4d421bc


### PR DESCRIPTION
Closes #1033

## Problem

Selecting an empty hotbar slot showed nothing at all in first person: `HeldItem.For` returned `Kind.None`, `HeldItem.Build` built nothing, and `Viewmodel.ApplyVisible` deactivated the holder — no hand, no bob/sway, no feedback that the slot switch happened.

## Fix

- **New `HeldItem.Kind.Hand`**: a gloved fist + forearm built from the same procedural cubes as every other held item (thumb on the inner side of a right hand, darker cuff for definition).
- **`HeldItem.For`** resolves an empty item key to `Kind.Hand` instead of `Kind.None`. A non-empty key with no content/definition still resolves to `None` (raw materials unchanged, per the issue's scope).
- **`HeldItem.HandTintResolver`** (same pattern as `BlockTileResolver`, wired in `GameBootstrap`) tints the glove with the player's suit `ArmColor`, falling back to the default suit blue — so the first-person hand matches the third-person avatar's glove.
- **`PlayerAvatar.SetHeldItem`** treats `Hand` like `None`: the avatar already has a real hand mesh, so third person and remote players are unchanged.
- **No `Viewmodel` change needed**: the `_kind != Kind.None` visibility gate lets `Hand` through, and the existing generic jab swing doubles as the punch. EVA gets the hand too via the viewmodel's self-refresh.

## Tests / verification

- 4 new EditMode tests (`HeldItemEditModeTests`) pin: empty key → `Kind.Hand`, resolver tint, default-glove fallback, unknown key without content stays `None`.
- Local verification: UnityEdit suite 28/28 passed; full local Unity client build (`scripts/build-client.ps1`) succeeded with a fresh `BlocksBeyondTheStars.Client.dll`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)