### PR TITLE
fix(client): ingredient source tag no longer clips at the detail pane's right edge (#1057)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -8123,6 +8123,20 @@ input sanitising and the persistence roundtrip.
 
 ---
 
+## ✅ Done (2026-08-15): the ingredient source tag ("craftable" / "raw resource") no longer clips at the detail pane's edge (#1057)
+
+Playtest find on v2026.8.15: the right-aligned source tag that #1016/#1022 added to every ingredient row
+in the Crafting / Tech / Ship detail pane read `craftabl|e` — its last glyph was cut off. Cause: the tag was
+placed at `x 20 + w 620 = 640` inside a detail scroll viewport that is only **636 px** wide and clipped by a
+`RectMask2D`, with the 8-px auto-hide inline scrollbar overlaying the viewport's right edge on top of that.
+Left-anchored rows share the same geometry but never showed it (their text ends long before the edge).
+Fix: the tag's rect now ends at 616 (20 px inside the viewport, clear of the scrollbar). Client-only, no
+protocol/content change. New `CraftDetailLayoutTests` (client suite) parse `CraftingTechShipUI.cs` /
+`UiKit.cs` and assert every right-anchored `AddText(_detail, …)` ends inside `viewport − scrollbar`, plus a
+pinned check on the #1057 row itself.
+
+---
+
 ## ✅ Done (2026-08-14): shallow ore veins split across two noise scales — the ore lottery is over (#1024)
 
 Player report (LAN playtest): *"copper is too rare — and the deposits are gigantic, but which ore you

--- a/client/Assets/BlocksBeyondTheStars/Scripts/CraftingTechShipUI.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/CraftingTechShipUI.cs
@@ -3332,7 +3332,10 @@ namespace BlocksBeyondTheStars.Client
             bool craftable = Game.Content.CraftDepth(inp.Item) > 0;
             UiKit.AddText(_detail, 20, y, 620, size + 8, $"{(ok ? "✓" : "✗")} {ItemName(inp.Item)}  {have}/{inp.Count}", size,
                 ok ? UiKit.Ok : new Color(1f, 0.5f, 0.5f), TextAnchor.UpperLeft);
-            UiKit.AddText(_detail, 20, y, 620, size + 8, L(craftable ? "ui.craft.src_craftable" : "ui.craft.src_raw"),
+            // Right-anchored, so its right edge must clear the detail viewport (636 wide, RectMask2D) AND the
+            // 8-px inline scrollbar that overlays the viewport's right edge — x = 20 + 620 = 640 lost the last
+            // glyph ("craftabl|e", #1057). 20 + 596 = 616 leaves 20 px, well clear of both.
+            UiKit.AddText(_detail, 20, y, 596, size + 8, L(craftable ? "ui.craft.src_craftable" : "ui.craft.src_raw"),
                 size - 4, UiKit.CyanDim, TextAnchor.UpperRight);
             y += size + 10f;
             if (!craftable || ok)

--- a/tests/BlocksBeyondTheStars.Client.Tests/CraftDetailLayoutTests.cs
+++ b/tests/BlocksBeyondTheStars.Client.Tests/CraftDetailLayoutTests.cs
@@ -1,0 +1,108 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using System.Globalization;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace BlocksBeyondTheStars.Client.Tests;
+
+/// <summary>
+/// The Crafting / Tech / Ship detail pane is a fixed-width scroll view: its content is clipped by a
+/// <c>RectMask2D</c> at the viewport width, and an auto-hide inline scrollbar overlays the viewport's
+/// right-most pixels. Left-anchored rows tolerate a little overshoot (their text ends long before the
+/// edge), but a RIGHT-anchored text whose rect ends past the viewport loses its last glyphs — #1057:
+/// the ingredient source tag ("craftable" / "raw resource") rendered as "craftabl|e".
+/// <para>
+/// This guard is parsed out of <c>CraftingTechShipUI.cs</c> / <c>UiKit.cs</c> rather than mirroring
+/// copied numbers: every right-anchored <c>AddText(_detail, …)</c> is checked against the viewport
+/// width and scrollbar width the source actually declares, so a new tag or a resized pane is covered
+/// automatically. (The Unity files cannot be compiled into this suite — they need UnityEngine.)
+/// </para>
+/// </summary>
+public sealed class CraftDetailLayoutTests
+{
+    private static string Read(string file)
+    {
+        string path = Path.Combine(
+            ClientTestPaths.RepoRoot(),
+            "client", "Assets", "BlocksBeyondTheStars", "Scripts", file);
+        Assert.True(File.Exists(path), $"{file} not found at {path} — did the client scripts move?");
+        return File.ReadAllText(path);
+    }
+
+    private static float Constant(string source, string pattern, string what)
+    {
+        var m = Regex.Match(source, pattern, RegexOptions.CultureInvariant, TimeSpan.FromSeconds(2));
+        Assert.True(m.Success, $"Could not read {what} — this guard needs updating.");
+        return float.Parse(m.Groups[1].Value, CultureInfo.InvariantCulture);
+    }
+
+    /// <summary>Viewport width of the detail scroll (<c>_detail = MakeScroll(root, x, y, W, h)</c>).</summary>
+    private static float DetailViewportWidth(string ui) =>
+        Constant(ui, @"_detail = MakeScroll\(root,\s*[0-9.]+f?,\s*[0-9.]+f?,\s*([0-9.]+)f?,", "the detail viewport width");
+
+    /// <summary>Default width of <c>UiKit.AddInlineScrollbar</c>, which anchors to the viewport's right edge.</summary>
+    private static float ScrollbarWidth(string uiKit) =>
+        Constant(uiKit, @"AddInlineScrollbar\(ScrollRect scroll, float width = ([0-9.]+)f\)", "the inline scrollbar width");
+
+    [Fact]
+    public void RightAnchoredDetailTexts_EndInsideViewportAndClearOfScrollbar()
+    {
+        string ui = Read("CraftingTechShipUI.cs");
+        float viewport = DetailViewportWidth(ui);
+        float scrollbar = ScrollbarWidth(Read("UiKit.cs"));
+        float limit = viewport - scrollbar;
+
+        // Every AddText on the detail content with literal x / w and a right-side anchor. The call may
+        // wrap over several lines, so scan up to the closing ');' for the anchor.
+        var calls = Regex.Matches(
+            ui,
+            @"UiKit\.AddText\(_detail,\s*(?<x>[0-9.]+)f?,\s*[^,]+,\s*(?<w>[0-9.]+)f?,(?<rest>[^;]*?)\);",
+            RegexOptions.CultureInvariant | RegexOptions.Singleline,
+            TimeSpan.FromSeconds(5));
+        Assert.NotEmpty(calls);
+
+        var rightAnchored = calls
+            .Where(m => Regex.IsMatch(
+                m.Groups["rest"].Value,
+                @"TextAnchor\.(Upper|Middle|Lower)Right",
+                RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture,
+                TimeSpan.FromSeconds(2)))
+            .ToList();
+        Assert.NotEmpty(rightAnchored); // the ingredient source tag (#1016) is one — if it vanished, revisit this guard
+
+        var overshoot = rightAnchored
+            .Select(m => (
+                X: float.Parse(m.Groups["x"].Value, CultureInfo.InvariantCulture),
+                W: float.Parse(m.Groups["w"].Value, CultureInfo.InvariantCulture),
+                Line: ui.Take(m.Index).Count(c => c == '\n') + 1))
+            .Where(t => t.X + t.W > limit)
+            .ToList();
+
+        Assert.True(
+            overshoot.Count == 0,
+            $"Right-anchored detail text ends past the visible edge (viewport {viewport} − scrollbar {scrollbar} = {limit}): "
+            + string.Join(", ", overshoot.Select(t => $"line {t.Line}: x {t.X} + w {t.W} = {t.X + t.W}"))
+            + " — the last glyphs get masked (#1057).");
+    }
+
+    [Fact]
+    public void IngredientSourceTag_IsRightAnchoredInsideTheViewport()
+    {
+        // Pin the specific row from #1057 so a future refactor that drops the anchor (or moves the tag
+        // to a wider rect) trips here with a pointed message rather than only through the generic sweep.
+        string ui = Read("CraftingTechShipUI.cs");
+        var m = Regex.Match(
+            ui,
+            @"UiKit\.AddText\(_detail,\s*(?<x>[0-9.]+)f?,\s*y,\s*(?<w>[0-9.]+)f?,\s*size \+ 8,\s*L\(craftable \? ""ui\.craft\.src_craftable"" : ""ui\.craft\.src_raw""\),\s*size - 4,\s*UiKit\.CyanDim,\s*TextAnchor\.UpperRight\);",
+            RegexOptions.CultureInvariant | RegexOptions.Singleline,
+            TimeSpan.FromSeconds(5));
+        Assert.True(m.Success, "The ingredient source tag row in IngredientRow was not found — did it move or lose its right anchor?");
+
+        float right = float.Parse(m.Groups["x"].Value, CultureInfo.InvariantCulture)
+                    + float.Parse(m.Groups["w"].Value, CultureInfo.InvariantCulture);
+        float limit = DetailViewportWidth(ui) - ScrollbarWidth(Read("UiKit.cs"));
+        Assert.True(right <= limit, $"Source tag right edge {right} exceeds the visible limit {limit} (#1057).");
+    }
+}


### PR DESCRIPTION
## Summary

Closes #1057.

The right-aligned ingredient source tag ("craftable" / "raw resource", DE "herstellbar" / "Rohstoff") added by #1016/#1022 was clipped at the right edge of the Crafting / Tech / Ship detail pane — it read `craftabl|e` in the 2026.8.15 playtest.

**Root cause:** `IngredientRow` placed the tag at `x 20 + w 620 = 640` inside the `_detail` scroll content, but the detail viewport is only **636 px** wide (`MakeScroll(root, 1232, 162, 636, 796)`, clipped by `RectMask2D`) and the 8-px auto-hide inline scrollbar overlays the viewport's right edge on top of that. Left-anchored rows share the same numbers and never showed it — only the right-anchored tag exposes the overshoot.

**Fix:** the tag rect now ends at 616 (20 px inside the viewport, clear of the scrollbar). One numeric change; client-only, no protocol/content change.

## Tests

- New `CraftDetailLayoutTests` (client suite, source-guard pattern like `WorldOptionsLayoutTests`): parses `CraftingTechShipUI.cs` / `UiKit.cs` and asserts every right-anchored `AddText(_detail, …)` ends inside `viewport − scrollbar` (a new tag or resized pane is covered automatically), plus a pinned check on the #1057 row itself.
- `BlocksBeyondTheStars.Client.Tests`: 253/253 green locally; clean rebuild with `-warnaserror` 0 warnings / 0 errors; `dotnet format --verify-no-changes` clean.
- No local Unity build: the change is a single width literal in an already-compiling `AddText` call (no new symbols, no synced/generated files), so it cannot introduce a Unity-only compile failure.

## Docs

- TODO.md work-log entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
