### PR TITLE
fix(worldhost): world detail page reads attributed saves again; sections degrade independently (#1063)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -105,6 +105,18 @@ Per-item detail lives in the dated work log below. **Since 2026-07 versions are 
 
 ---
 
+### ★ Admin portal: world detail page reads attributed saves again (#1063, 2026-08-15, branch fix/1063-inspector-max-aggregate)
+Every world with a save file showed `Could not read the world save: SQLite Error 1: 'misuse of aggregate
+function MAX()'` and three empty cards ("No player records…"). `WorldInspector.ReadHotspots` put
+`MAX(e.owner_id)` inside the WHERE of a correlated sub-select — illegal in SQLite, fails at prepare time —
+and that branch runs for any save carrying the #490 attribution columns, i.e. everything since #491
+(2026-07-26). The "last editor" now comes from SQLite's bare-column rule (`e.owner_id` of the row holding
+`MAX(edited_unix)` — the genuinely most recent editor, not the highest player id). `Read()` also degrades
+per section: a failing query reports on its own card (`PlayersProblem`/`BuildsProblem`/`HotspotsProblem`)
+instead of blanking players and structures with a false "no player records". New `WorldInspectorTests`
+write a real save through `SqliteWorldRepository` (attributed, legacy schema, sabotaged table, missing
+file). WorldHost-only — needs a world-host image rebuild + pin bump to reach the fleet.
+
 ### ★ Factories look like factories: textured machines with visible moving parts (#1050–#1053, 2026-08-15, branch feat/factory-look)
 A found factory read as "a room with two big grey boxes". Three independent causes stacked up: (1)
 `machine_block`, `factory_pipe` and `factory_terminal` had no bundled tile and no palette entry, so the

--- a/src/BlocksBeyondTheStars.WorldHost/WorldHostAdminPages.cs
+++ b/src/BlocksBeyondTheStars.WorldHost/WorldHostAdminPages.cs
@@ -75,7 +75,11 @@ public static class WorldHostAdminPages
 
         // ---- Players ----
         sb.Append("<div class='card'><h2>Players</h2>");
-        if (insight.Players.Count == 0)
+        if (insight.PlayersProblem is { } playersProblem)
+        {
+            sb.Append($"<p class='beta'>{E(playersProblem)}</p>");
+        }
+        else if (insight.Players.Count == 0)
         {
             sb.Append("<p class='hint'>No player records in this save.</p>");
         }
@@ -96,7 +100,11 @@ public static class WorldHostAdminPages
 
         // ---- Named structures ----
         sb.Append("<div class='card'><h2>Structures</h2>");
-        if (insight.Builds.Count == 0)
+        if (insight.BuildsProblem is { } buildsProblem)
+        {
+            sb.Append($"<p class='beta'>{E(buildsProblem)}</p>");
+        }
+        else if (insight.Builds.Count == 0)
         {
             sb.Append("<p class='hint'>No bases, beacons, beam pads or stations have been placed.</p>");
         }
@@ -121,7 +129,11 @@ public static class WorldHostAdminPages
         sb.Append("<p class='hint'>Clusters of changed blocks — this is how you find a house someone built " +
                   "without placing a base core, or a hillside that was dug away. \"Last editor\" is empty for " +
                   "cells changed before edit attribution shipped; it cannot be reconstructed.</p>");
-        if (insight.Hotspots.Count == 0)
+        if (insight.HotspotsProblem is { } hotspotsProblem)
+        {
+            sb.Append($"<p class='beta'>{E(hotspotsProblem)}</p>");
+        }
+        else if (insight.Hotspots.Count == 0)
         {
             sb.Append("<p class='hint'>No building activity of note yet.</p>");
         }

--- a/src/BlocksBeyondTheStars.WorldHost/WorldInspector.cs
+++ b/src/BlocksBeyondTheStars.WorldHost/WorldInspector.cs
@@ -17,13 +17,18 @@ public sealed record InspectedBuild(string Kind, string Name, string Owner, stri
 /// cells edited before attribution existed (issue #490 cannot be back-filled).</summary>
 public sealed record InspectedHotspot(string Body, int X, int Z, int Edits, string LastEditor, DateTime? LastEditUtc);
 
-/// <summary>Everything the world-detail page shows, plus how stale it might be.</summary>
+/// <summary>Everything the world-detail page shows, plus how stale it might be.
+/// <see cref="Problem"/> is set only when the save could not be opened at all; a section that fails on its own
+/// (schema drift, a bad row) reports through its <c>*Problem</c> field so the other cards stay useful (#1063).</summary>
 public sealed record WorldInsight(
     IReadOnlyList<InspectedPlayer> Players,
     IReadOnlyList<InspectedBuild> Builds,
     IReadOnlyList<InspectedHotspot> Hotspots,
     DateTime? SaveModifiedUtc,
-    string? Problem);
+    string? Problem,
+    string? PlayersProblem = null,
+    string? BuildsProblem = null,
+    string? HotspotsProblem = null);
 
 /// <summary>
 /// Reads a world save directly for the operator's world-detail page.
@@ -89,12 +94,20 @@ public static class WorldInspector
             using var con = new SqliteConnection(builder.ToString());
             con.Open();
 
+            // Each section fails on its own: one broken query must not blank the others and make the page
+            // claim "no player records" for a world full of players (issue #1063 — that is exactly what the
+            // hotspot query did for every attributed save).
+            var (players, playersProblem) = Section<IReadOnlyList<InspectedPlayer>>("players", () => ReadPlayers(con));
+            var (builds, buildsProblem) = Section<IReadOnlyList<InspectedBuild>>("structures", () => ReadBuilds(con));
+            var (hotspots, hotspotsProblem) = Section<IReadOnlyList<InspectedHotspot>>("build hotspots", () => ReadHotspots(con));
+
             return new WorldInsight(
-                ReadPlayers(con),
-                ReadBuilds(con),
-                ReadHotspots(con),
+                players ?? Array.Empty<InspectedPlayer>(),
+                builds ?? Array.Empty<InspectedBuild>(),
+                hotspots ?? Array.Empty<InspectedHotspot>(),
                 File.GetLastWriteTimeUtc(path),
-                null);
+                null,
+                playersProblem, buildsProblem, hotspotsProblem);
         }
         catch (Exception e)
         {
@@ -103,6 +116,19 @@ public static class WorldInspector
             return new WorldInsight(
                 Array.Empty<InspectedPlayer>(), Array.Empty<InspectedBuild>(), Array.Empty<InspectedHotspot>(),
                 null, "Could not read the world save: " + e.Message);
+        }
+    }
+
+    private static (T? Value, string? Problem) Section<T>(string what, Func<T> read)
+        where T : class
+    {
+        try
+        {
+            return (read(), null);
+        }
+        catch (Exception e) when (e is SqliteException or InvalidOperationException or InvalidCastException)
+        {
+            return (null, $"Could not read {what} from the world save: {e.Message}");
         }
     }
 
@@ -210,9 +236,14 @@ public static class WorldInspector
         const string bucketX = "CAST(FLOOR(CAST(x AS REAL) / $bucket) AS INTEGER)";
         const string bucketZ = "CAST(FLOOR(CAST(z AS REAL) / $bucket) AS INTEGER)";
 
+        // "Last editor" leans on SQLite's bare-column rule: in an aggregate query with exactly one MIN()/MAX(),
+        // bare columns (here e.owner_id inside the correlated sub-select) come from the row that holds the
+        // maximum — so the name belongs to the most recent edit in the bucket. COUNT(*) does not disturb the
+        // rule (only MIN/MAX count). Do NOT write MAX(e.owner_id) inside the sub-select: an aggregate in a
+        // sub-query's WHERE is "misuse of aggregate function" and took the whole page down (issue #1063).
         cmd.CommandText = attributed
             ? $@"SELECT planet, {bucketX} AS bx, {bucketZ} AS bz, COUNT(*) AS n,
-                        COALESCE((SELECT r.name FROM player_ref r WHERE r.id = MAX(e.owner_id)), ''),
+                        COALESCE((SELECT r.name FROM player_ref r WHERE r.id = e.owner_id), ''),
                         MAX(e.edited_unix)
                  FROM block_edit e GROUP BY planet, bx, bz
                  HAVING n >= $min ORDER BY n DESC LIMIT $limit;"

--- a/tests/BlocksBeyondTheStars.Tests/WorldInspectorTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/WorldInspectorTests.cs
@@ -1,0 +1,176 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using System;
+using System.IO;
+using System.Linq;
+using BlocksBeyondTheStars.Persistence;
+using BlocksBeyondTheStars.Shared.Geometry;
+using BlocksBeyondTheStars.Shared.State;
+using BlocksBeyondTheStars.WorldHost;
+using Microsoft.Data.Sqlite;
+using Xunit;
+
+namespace BlocksBeyondTheStars.Tests;
+
+/// <summary>
+/// The operator's world-detail page reads a real save through <see cref="WorldInspector"/> (issue #1063).
+///
+/// These tests write the save with the game's own <see cref="SqliteWorldRepository"/> so the schema is the one
+/// production produces — the bug they pin down (an aggregate inside a correlated sub-select) only fires on the
+/// attributed schema every save has had since #490, and no test exercised that path before.
+/// </summary>
+public sealed class WorldInspectorTests : IDisposable
+{
+    private const string WorldId = "577a035779b4";
+    private const string Planet = "sys0-p1";
+
+    private readonly string _root;
+    private readonly WorldHostConfig _config;
+
+    public WorldInspectorTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "bbts_inspector_" + Guid.NewGuid().ToString("N"));
+        _config = new WorldHostConfig { WorldsDir = _root };
+    }
+
+    [Fact]
+    public void AttributedSave_ReportsHotspotWithMostRecentEditor_AndNoProblem()
+    {
+        // Two builders in one 32-block bucket. "bob" gets the higher player_ref id (registered second) but
+        // "a17" made the most recent edit — "last editor" has to be a17, not the highest id.
+        using (var repo = OpenRepository())
+        {
+            for (int i = 0; i < 20; i++)
+            {
+                repo.SetBlock(Planet, new Vector3i(i, 64, 3), 5, owner: "a17");
+            }
+
+            for (int i = 0; i < 10; i++)
+            {
+                repo.SetBlock(Planet, new Vector3i(i, 65, 3), 5, owner: "bob");
+            }
+
+            repo.SavePlayer(new PlayerState { PlayerId = "a17", Name = "a17", CurrentLocationId = Planet });
+            repo.Flush();
+        }
+
+        // Stamp the timestamps explicitly: SetBlock uses wall-clock seconds, and thirty edits in one test tick
+        // would all tie. bob's are older, a17's newest edit is the maximum in the bucket.
+        StampEdits(owner: "bob", unix: 1_000);
+        StampEdits(owner: "a17", unix: 2_000);
+
+        var insight = WorldInspector.Read(_config, WorldId);
+
+        Assert.Null(insight.Problem);
+        Assert.Null(insight.HotspotsProblem);
+        Assert.Null(insight.PlayersProblem);
+        Assert.Null(insight.BuildsProblem);
+
+        var hotspot = Assert.Single(insight.Hotspots);
+        Assert.Equal(Planet, hotspot.Body);
+        Assert.Equal(30, hotspot.Edits);
+        Assert.Equal("a17", hotspot.LastEditor);
+        Assert.Equal(DateTimeOffset.FromUnixTimeSeconds(2_000).UtcDateTime, hotspot.LastEditUtc);
+
+        var player = Assert.Single(insight.Players);
+        Assert.Equal("a17", player.Name);
+    }
+
+    [Fact]
+    public void LegacySaveWithoutAttribution_StillListsHotspots()
+    {
+        using (var repo = OpenRepository())
+        {
+            for (int i = 0; i < 30; i++)
+            {
+                repo.SetBlock(Planet, new Vector3i(i, 64, 3), 5, owner: "a17");
+            }
+
+            repo.Flush();
+        }
+
+        // Rebuild block_edit without the #490 columns, as a save from an older build would have it.
+        Execute(
+            "CREATE TABLE legacy AS SELECT planet, x, y, z, block, tint, glow, shape FROM block_edit;" +
+            "DROP TABLE block_edit; ALTER TABLE legacy RENAME TO block_edit;");
+
+        var insight = WorldInspector.Read(_config, WorldId);
+
+        Assert.Null(insight.Problem);
+        Assert.Null(insight.HotspotsProblem);
+        var hotspot = Assert.Single(insight.Hotspots);
+        Assert.Equal(30, hotspot.Edits);
+        Assert.Equal(string.Empty, hotspot.LastEditor);
+        Assert.Null(hotspot.LastEditUtc);
+    }
+
+    [Fact]
+    public void BrokenSection_DoesNotBlankTheOtherCards()
+    {
+        using (var repo = OpenRepository())
+        {
+            repo.SavePlayer(new PlayerState { PlayerId = "a17", Name = "a17", CurrentLocationId = Planet });
+            repo.Flush();
+        }
+
+        // Sabotage only the hotspot source: the players card must survive with its rows and the failure has
+        // to be reported on the hotspot card, not as a page-wide "could not read the world save".
+        Execute("DROP TABLE block_edit; CREATE TABLE block_edit (planet TEXT NOT NULL);");
+
+        var insight = WorldInspector.Read(_config, WorldId);
+
+        Assert.Null(insight.Problem);
+        Assert.NotNull(insight.HotspotsProblem);
+        Assert.Contains("build hotspots", insight.HotspotsProblem, StringComparison.Ordinal);
+        Assert.Equal("a17", Assert.Single(insight.Players).Name);
+    }
+
+    [Fact]
+    public void MissingSave_IsAnEmptyStateNotAnError()
+    {
+        var insight = WorldInspector.Read(_config, WorldId);
+
+        Assert.NotNull(insight.Problem);
+        Assert.Contains("never been started", insight.Problem, StringComparison.Ordinal);
+        Assert.Empty(insight.Players);
+    }
+
+    private SqliteWorldRepository OpenRepository()
+    {
+        var repo = new SqliteWorldRepository(new SaveGamePaths(SavePaths.HostSavesDir(_config, WorldId), WorldId));
+        repo.Initialize();
+        return repo;
+    }
+
+    private void StampEdits(string owner, long unix)
+        => Execute("UPDATE block_edit SET edited_unix = " + unix +
+                   " WHERE owner_id = (SELECT id FROM player_ref WHERE name = '" + owner + "');");
+
+    private void Execute(string sql)
+    {
+        using var con = new SqliteConnection("Data Source=" + SavePaths.WorldDbPath(_config, WorldId));
+        con.Open();
+        using var cmd = con.CreateCommand();
+        cmd.CommandText = sql;
+        cmd.ExecuteNonQuery();
+    }
+
+    public void Dispose()
+    {
+        SqliteConnection.ClearAllPools();
+        try
+        {
+            if (Directory.Exists(_root))
+            {
+                Directory.Delete(_root, recursive: true);
+            }
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #1063

The fleet admin's world detail page failed for every world with a save file:

> Could not read the world save: SQLite Error 1: 'misuse of aggregate function MAX()'.

followed by three empty cards ("No player records in this save" …) — even for worlds full of players.

**Root cause:** `WorldInspector.ReadHotspots` had `MAX(e.owner_id)` inside the `WHERE` of a correlated sub-select. SQLite rejects that at prepare time, and the branch runs for any save carrying the #490 attribution columns — i.e. every save since #491 (2026-07-26). No test covered `WorldInspector`.

## Changes

- **Query**: "Last editor" now uses SQLite's bare-column rule — with exactly one `MAX()`, bare columns come from the row holding the max, so `e.owner_id` belongs to the most recent edit in the bucket. That is also semantically right: the old `MAX(owner_id)` would have shown the *highest player id*, not the last editor.
- **Per-section degradation**: `WorldInsight` gains `PlayersProblem` / `BuildsProblem` / `HotspotsProblem`; a failing section reports on its own card instead of blanking players and structures with a false "no player records". Page-wide `Problem` is reserved for "cannot open the save at all".
- **Tests**: new `WorldInspectorTests` write a real save through `SqliteWorldRepository` — attributed (two builders, most recent one has the *lower* id → must win), legacy schema without `owner_id`, sabotaged `block_edit` (players card survives), missing file. Mutation-checked: restoring the old query fails the attributed test with the exact production message.
- TODO.md entry.

## Follow-up (not in this PR)

WorldHost-only change — the world-host image needs a rebuild and the pin (`sha-4b4895e`) a bump before the portal picks it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
