### PR TITLE
fix(audit): loud content fallbacks, last hard-coded server lines, five latent client fixes (#427, #428)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -137,6 +137,26 @@ a `--list-tests --filter Category=Slow` listing. Follow-ups (not in this PR): th
 Slow tests (`Reap_SkipsAWorld…` 29 s → 918 s, `Gateway_DropsAConnection…` 275 s → 896 s on a loaded
 runner) and, only if the gate grows again, building the Docker image up front and retagging after it.
 
+### ★ Audit leftovers: loud content fallbacks, the last hard-coded server lines, and five latent client fixes (#427, #428, 2026-08-16, branch fix/audit-427-428)
+Two static-audit issues from July closed out. **Server (#427):** an unknown block id in an authored
+`data/ship_layouts/*.json` cell used to become hull silently (`?? iron_wall`) — `GameContent.Validate`
+now fails the load for it (the editor's special ids hatch/door_*/glass/light*/engine and station markers
+stay legal; `ShipLayoutCell.IsElementId`), and the stamp path warns once per layout+id should anything
+bypass the loader; a board-mission template whose item vanished from content logs a warning before
+collapsing onto template 0. The last 10 hard-coded English server lines (paint rejects, `/paintwipe` +
+`/shapewipe` usage/results) moved behind `@srv.*` keys in all 14 locales (en/de by hand, 12 via
+`translate_locale.py`) — S20 itself had already been done wholesale by #822. **Client (#428):** placed-lamp
+light now crosses the world wrap seams — `ClientWorld.LightSourcesNear` measures with `WrapDeltaX/Z` and
+hands the mesher sources re-expressed in the chunk's own frame, so the flood fill (raw keys + canonicalized
+lookups) carries colour across X = 0 / circumference and the latitude seam like skylight and AO
+(`LightSourcesWrapTests`); the two `localized == key` guards (`Localizer.Get` returns `"[key]"`, so they never
+fired) use `Localizer.Has` — no more raw `[ui.portal.err_x]` / `[ui.notice.reason_x]`, and the Codex VEGA log
+skips untranslated future hints properly; a corrupt `wiki/articles.json` now logs a warning instead of
+wiping the wiki silently; the BuildScript always-include safety net lists all 21 runtime `Shader.Find`
+shaders (+ the `Unlit/Transparent` / `Sprites/Default` fallbacks) and the retired VolumetricFog GUID is
+gone from GraphicsSettings; the Built-in-RP subshader of BlockAtlas got the URP pass's bark branch (mode 4)
+so `wood_log` no longer falls into the player-dye recolour if URP ever falls back.
+
 ### ★ VEGA context tips: "it's dark and your suit lamp is off", rare ore, places, asteroids — throttled and repeatable (#1077–#1082, 2026-08-16, branch feat/vega-context-tips)
 VEGA's advisor hints fired exactly once per save with no cooldown and no notion of pacing — fine for
 teaching moments, useless for situational advice. New `GameServerShipAiContext.cs` adds a **throttled tip

--- a/client/Assets/BlocksBeyondTheStars/Editor/BuildScript.cs
+++ b/client/Assets/BlocksBeyondTheStars/Editor/BuildScript.cs
@@ -32,21 +32,38 @@ namespace BlocksBeyondTheStars.Client.EditorTools
         private const string SceneDir = "Assets/Scenes";
         private const string ScenePath = SceneDir + "/Launcher.unity";
 
-        /// <summary>Shaders the client loads at runtime via Shader.Find — must be force-included or the build strips them.</summary>
+        /// <summary>Shaders the client loads at runtime via Shader.Find — must be force-included or the build strips them.
+        /// Keep this the FULL set of <c>Shader.Find("BlocksBeyondTheStars/…")</c> names in Scripts/ (plus the built-in
+        /// fallbacks those call sites use): GraphicsSettings.asset normally already lists them, but this pass is the
+        /// safety net when that asset regresses (merge conflict, Unity rewrite) — a missing entry strips silently and
+        /// the build succeeds with no glass submesh / starfield / visor (#428). Check with
+        /// <c>grep -rhoE 'Shader\.Find\("[^"]+"\)' client/Assets/BlocksBeyondTheStars/Scripts | sort -u</c>.</summary>
         private static readonly string[] RuntimeShaders =
         {
-            "BlocksBeyondTheStars/VertexColorOpaque",
-            "BlocksBeyondTheStars/BlockAtlas",
-            "BlocksBeyondTheStars/LitColor",
-            "BlocksBeyondTheStars/SunGlow",
-            "BlocksBeyondTheStars/SunRays",
-            "BlocksBeyondTheStars/Nebula",
             "BlocksBeyondTheStars/Atmosphere",
+            "BlocksBeyondTheStars/Aurora",
+            "BlocksBeyondTheStars/BlockAtlas",
+            "BlocksBeyondTheStars/BlockAtlasTransparent",
+            "BlocksBeyondTheStars/Cloud",
+            "BlocksBeyondTheStars/HeatHaze",
+            "BlocksBeyondTheStars/LitColor",
+            "BlocksBeyondTheStars/Nebula",
             "BlocksBeyondTheStars/Particle",
             "BlocksBeyondTheStars/ParticleAlpha",
-            "BlocksBeyondTheStars/Aurora",
-            "BlocksBeyondTheStars/Cloud",
+            "BlocksBeyondTheStars/PlanetRing",
+            "BlocksBeyondTheStars/ScatterLit",
+            "BlocksBeyondTheStars/SkyBodyPhase",
+            "BlocksBeyondTheStars/Starfield",
+            "BlocksBeyondTheStars/SunGlow",
+            "BlocksBeyondTheStars/SunRays",
+            "BlocksBeyondTheStars/Thermal",
+            "BlocksBeyondTheStars/ThermalMarker",
+            "BlocksBeyondTheStars/VertexColorOpaque",
+            "BlocksBeyondTheStars/Visor",
+            "BlocksBeyondTheStars/VisorGlass",
             "Unlit/Color",
+            "Unlit/Transparent", // `?? Shader.Find("Unlit/Transparent")` fallbacks (glow/field quads)
+            "Sprites/Default",   // MenuBackground particle fallback
         };
 
         [MenuItem("BlocksBeyondTheStars/Build Windows Player")]

--- a/client/Assets/BlocksBeyondTheStars/Scripts/ChunkMesher.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/ChunkMesher.cs
@@ -1551,6 +1551,9 @@ namespace BlocksBeyondTheStars.Client
             sources.Clear();
             if (lights != null)
             {
+                // The sources arrive already re-expressed in THIS chunk's raw frame (ClientWorld.LightSourcesNear
+                // measures across the wrap seams, #428), so a plain box test and raw-integer flood keys are
+                // correct here: worldBlock() canonicalizes every lookup, so the flood crosses the seam.
                 int loX = origin.X - LightRadius, hiX = origin.X + n + LightRadius;
                 int loY = origin.Y - LightRadius, hiY = origin.Y + n + LightRadius;
                 int loZ = origin.Z - LightRadius, hiZ = origin.Z + n + LightRadius;

--- a/client/Assets/BlocksBeyondTheStars/Scripts/CraftingTechShipUI.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/CraftingTechShipUI.cs
@@ -2507,13 +2507,12 @@ namespace BlocksBeyondTheStars.Client
             {
                 foreach (var key in Game.VegaLogKeys)
                 {
-                    string text = L(key);
-                    if (text == key)
+                    if (Game?.Localizer == null || !Game.Localizer.Has(key))
                     {
-                        continue; // a future server hint this client has no translation for — no raw ids
+                        continue; // a future server hint this client has no translation for — no raw "[key]" (#428)
                     }
 
-                    y = StoryEntry(y, text);
+                    y = StoryEntry(y, L(key));
                     anyTip = true;
                 }
             }

--- a/client/Assets/BlocksBeyondTheStars/Scripts/UiMainMenu.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/UiMainMenu.cs
@@ -378,9 +378,10 @@ namespace BlocksBeyondTheStars.Client
                     return error;
                 }
 
+                // Localizer.Get returns "[key]" on a miss (never the bare key), so ask Has() — comparing
+                // against the key could never match and leaked the raw "[ui.portal.err_x]" (#428).
                 string key = "ui.portal.err_" + code;
-                string localized = shell.L(key);
-                return localized == key ? error : localized;
+                return shell.Localizer != null && shell.Localizer.Has(key) ? shell.L(key) : error;
             }
 
             bool SignedIn() => !string.IsNullOrEmpty(shell.Settings.PortalSessionToken);
@@ -614,8 +615,7 @@ namespace BlocksBeyondTheStars.Client
                 if (!string.IsNullOrEmpty(code))
                 {
                     string key = "ui.notice.reason_" + code;
-                    string localized = shell.L(key);
-                    translated = localized == key ? code : localized;
+                    translated = shell.Localizer != null && shell.Localizer.Has(key) ? shell.L(key) : code;
                 }
 
                 if (string.IsNullOrWhiteSpace(reason))

--- a/client/Assets/BlocksBeyondTheStars/Scripts/WikiUI.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/WikiUI.cs
@@ -392,8 +392,10 @@ namespace BlocksBeyondTheStars.Client
                     _articles = Array.Empty<Article>();
                 }
             }
-            catch
+            catch (Exception e)
             {
+                // A corrupt articles.json used to remove every hand-written article without a trace (#428).
+                Debug.LogWarning($"[WikiUI] failed to load wiki/articles.json: {e.Message}");
                 _articles = Array.Empty<Article>();
             }
         }

--- a/client/Assets/BlocksBeyondTheStars/Shaders/BlockAtlas.shader
+++ b/client/Assets/BlocksBeyondTheStars/Shaders/BlockAtlas.shader
@@ -431,6 +431,16 @@ Shader "BlocksBeyondTheStars/BlockAtlas"
                 {
                     // Molten lava surface (mode 5): untinted; the animated crust modulates the glow below.
                 }
+                // Bark (mode 4): mirrors the URP pass (#428) — without this branch a wood_log face fell
+                // through to the player-dye recolour. Per-world dark bark hue in TEXCOORD2.yzw; black = natural.
+                else if (i.skyl.y > 3.5)
+                {
+                    if (dot(i.leaf.yzw, float3(1, 1, 1)) > 0.01)
+                    {
+                        float lum = dot(albedo, float3(0.299, 0.587, 0.114));
+                        albedo = lerp(albedo, lum * i.leaf.yzw * 1.4, 0.72);
+                    }
+                }
                 // Player dye (mode 3): a luminance-based recolour applied everywhere (independent of the
                 // flora-tint global), so dyed building blocks read vividly on any world and in caves.
                 else if (i.skyl.y > 2.5)

--- a/client/ProjectSettings/GraphicsSettings.asset
+++ b/client/ProjectSettings/GraphicsSettings.asset
@@ -47,7 +47,6 @@ GraphicsSettings:
   - {fileID: 4800000, guid: ab1b150a16b496c49a252b47ed7a0bca, type: 3}
   - {fileID: 4800000, guid: 1cc174ca4ed4ce545b1e4714f2fac56c, type: 3}
   - {fileID: 4800000, guid: e9afc87e9e7ce6c409b1d15168b5f765, type: 3}
-  - {fileID: 4800000, guid: 7e376c0e4d7f48f4f92f816116a3cd63, type: 3}
   - {fileID: 4800000, guid: d6f579bfd8be4ed45a09648c28eee8db, type: 3}
   - {fileID: 4800000, guid: 76a15af7b5bfeac4c829fa8c28d94b2f, type: 3}
   - {fileID: 4800000, guid: fda0a4c83ff73c547b203fc88e23d23e, type: 3}
@@ -57,6 +56,7 @@ GraphicsSettings:
   - {fileID: 4800000, guid: 9d2f4b6a8c0e41d2a3b5c7d9e1f0a2b4, type: 3}
   - {fileID: 4800000, guid: 3a7f21c8b95d4e1287c6d0f4a5b6e719, type: 3}
   - {fileID: 4800000, guid: 4b8e32d9ca6e5f2398d7e1a5b6c7f82a, type: 3}
+  - {fileID: 10750, guid: 0000000000000000f000000000000000, type: 0}
   m_PreloadedShaders: []
   m_PreloadShadersBatchTimeLimit: -1
   m_SpritesDefaultMaterial: {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}

--- a/data/locales/de.json
+++ b/data/locales/de.json
@@ -3281,5 +3281,14 @@
   "ui.pause.resume": "Weiterspielen",
   "ui.pause.title": "Pause",
   "ui.pause.waiting_for": "Pausiert {0}/{1} – warten auf: {2}",
-  "ui.pause.world_held": "Welt angehalten – alle sind im Pausenmenü."
+  "ui.pause.world_held": "Welt angehalten – alle sind im Pausenmenü.",
+  "srv.admin.paint_none": "Keine Bemalungen für '{name}' gefunden.",
+  "srv.admin.paint_wiped": "{name} Bemalung(en) gelöscht.",
+  "srv.admin.shapes_none": "Keine eigenen Formen für '{name}' gefunden.",
+  "srv.admin.shapes_wiped": "{name} eigene Form(en) gelöscht.",
+  "srv.admin.usage_paintwipe": "Verwendung: /paintwipe Spieler  oder  /paintwipe #designId",
+  "srv.admin.usage_shapewipe": "Verwendung: /shapewipe Spieler  oder  /shapewipe #shapeId",
+  "srv.paint.out_of_reach": "Dieser Block ist außer Reichweite — geh näher heran.",
+  "srv.paint.protected": "Dieser Bereich ist geschützt — hier kann nichts bemalt werden.",
+  "srv.paint.solid_only": "Nur massive Blöcke lassen sich bemalen."
 }

--- a/data/locales/en.json
+++ b/data/locales/en.json
@@ -3281,5 +3281,14 @@
   "ui.pause.resume": "Resume",
   "ui.pause.title": "Paused",
   "ui.pause.waiting_for": "Paused {0}/{1} — waiting for: {2}",
-  "ui.pause.world_held": "World held — everyone is in the pause menu."
+  "ui.pause.world_held": "World held — everyone is in the pause menu.",
+  "srv.admin.paint_none": "No paint designs found for '{name}'.",
+  "srv.admin.paint_wiped": "Wiped {name} paint design(s).",
+  "srv.admin.shapes_none": "No custom forms found for '{name}'.",
+  "srv.admin.shapes_wiped": "Wiped {name} custom form(s).",
+  "srv.admin.usage_paintwipe": "Usage: /paintwipe Player  or  /paintwipe #designId",
+  "srv.admin.usage_shapewipe": "Usage: /shapewipe Player  or  /shapewipe #shapeId",
+  "srv.paint.out_of_reach": "That block is out of reach — move closer.",
+  "srv.paint.protected": "This area is protected — it cannot be painted.",
+  "srv.paint.solid_only": "Only solid blocks can be painted."
 }

--- a/data/locales/es.json
+++ b/data/locales/es.json
@@ -3281,5 +3281,14 @@
   "ui.pause.resume": "Continuar",
   "ui.pause.title": "Pausado",
   "ui.pause.waiting_for": "Pausado {0}/{1}: esperando a {2}",
-  "ui.pause.world_held": "Mundo detenido: todos están en el menú de pausa."
+  "ui.pause.world_held": "Mundo detenido: todos están en el menú de pausa.",
+  "srv.admin.paint_none": "No se encontraron diseños de pintura para '{name}'.",
+  "srv.admin.paint_wiped": "Se borró(n) {name} diseño(s) de pintura.",
+  "srv.admin.shapes_none": "No se encontraron formas personalizadas para '{name}'.",
+  "srv.admin.shapes_wiped": "Se borró(n) {name} forma(s) personalizada(s).",
+  "srv.admin.usage_paintwipe": "Uso: /paintwipe Jugador  o  /paintwipe #designId",
+  "srv.admin.usage_shapewipe": "Uso: /shapewipe Jugador  o  /shapewipe #shapeId",
+  "srv.paint.out_of_reach": "Ese bloque está fuera de alcance — acércate.",
+  "srv.paint.protected": "Esta área está protegida — no se puede pintar.",
+  "srv.paint.solid_only": "Solo se pueden pintar bloques sólidos."
 }

--- a/data/locales/fr.json
+++ b/data/locales/fr.json
@@ -3281,5 +3281,14 @@
   "ui.pause.resume": "Reprendre",
   "ui.pause.title": "En pause",
   "ui.pause.waiting_for": "En pause {0}/{1} — en attente de : {2}",
-  "ui.pause.world_held": "Monde suspendu — tout le monde est dans le menu pause."
+  "ui.pause.world_held": "Monde suspendu — tout le monde est dans le menu pause.",
+  "srv.admin.paint_none": "Aucun motif de peinture trouvé pour '{name}'.",
+  "srv.admin.paint_wiped": "Motif(s) de peinture {name} effacé(s).",
+  "srv.admin.shapes_none": "Aucune forme personnalisée trouvée pour '{name}'.",
+  "srv.admin.shapes_wiped": "Forme(s) personnalisée(s) {name} effacée(s).",
+  "srv.admin.usage_paintwipe": "Utilisation : /paintwipe Joueur  ou  /paintwipe #designId",
+  "srv.admin.usage_shapewipe": "Utilisation : /shapewipe Joueur  ou  /shapewipe #shapeId",
+  "srv.paint.out_of_reach": "Ce bloc est hors de portée — approche-toi.",
+  "srv.paint.protected": "Cette zone est protégée — elle ne peut pas être peinte.",
+  "srv.paint.solid_only": "Seuls les blocs pleins peuvent être peints."
 }

--- a/data/locales/it.json
+++ b/data/locales/it.json
@@ -3281,5 +3281,14 @@
   "ui.pause.resume": "Riprendi",
   "ui.pause.title": "In pausa",
   "ui.pause.waiting_for": "In pausa {0}/{1} — in attesa di: {2}",
-  "ui.pause.world_held": "Mondo fermo — sono tutti nel menu di pausa."
+  "ui.pause.world_held": "Mondo fermo — sono tutti nel menu di pausa.",
+  "srv.admin.paint_none": "Nessun motivo di vernice trovato per '{name}'.",
+  "srv.admin.paint_wiped": "Cancellato/i {name} motivo/i di vernice.",
+  "srv.admin.shapes_none": "Nessuna forma personalizzata trovata per '{name}'.",
+  "srv.admin.shapes_wiped": "Cancellata/e {name} forma/e personalizzata/e.",
+  "srv.admin.usage_paintwipe": "Uso: /paintwipe Giocatore  o  /paintwipe #designId",
+  "srv.admin.usage_shapewipe": "Uso: /shapewipe Giocatore  o  /shapewipe #shapeId",
+  "srv.paint.out_of_reach": "Quel blocco è fuori portata — avvicinati.",
+  "srv.paint.protected": "Questa area è protetta — non può essere pitturata.",
+  "srv.paint.solid_only": "Possono essere pitturati solo blocchi solidi."
 }

--- a/data/locales/ja.json
+++ b/data/locales/ja.json
@@ -3281,5 +3281,14 @@
   "ui.pause.resume": "再開",
   "ui.pause.title": "一時停止中",
   "ui.pause.waiting_for": "一時停止 {0}/{1} — 待機中: {2}",
-  "ui.pause.world_held": "ワールド停止中 — 全員が一時停止メニューにいます。"
+  "ui.pause.world_held": "ワールド停止中 — 全員が一時停止メニューにいます。",
+  "srv.admin.paint_none": "「{name}」のペイントデザインは見つかりませんでした。",
+  "srv.admin.paint_wiped": "{name} のペイントデザインを削除しました。",
+  "srv.admin.shapes_none": "「{name}」のカスタム形状は見つかりませんでした。",
+  "srv.admin.shapes_wiped": "{name} のカスタム形状を削除しました。",
+  "srv.admin.usage_paintwipe": "使い方: /paintwipe プレイヤー  または  /paintwipe #designId",
+  "srv.admin.usage_shapewipe": "使い方: /shapewipe プレイヤー  または  /shapewipe #shapeId",
+  "srv.paint.out_of_reach": "そのブロックには届きません — もっと近づいてください。",
+  "srv.paint.protected": "このエリアは保護されています — ペイントできません。",
+  "srv.paint.solid_only": "塗装できるのはソリッドブロックのみです。"
 }

--- a/data/locales/ko.json
+++ b/data/locales/ko.json
@@ -3281,5 +3281,14 @@
   "ui.pause.resume": "계속",
   "ui.pause.title": "일시 중지",
   "ui.pause.waiting_for": "일시 중지 {0}/{1} — 대기 중: {2}",
-  "ui.pause.world_held": "월드 정지 — 모두가 일시 중지 메뉴에 있습니다."
+  "ui.pause.world_held": "월드 정지 — 모두가 일시 중지 메뉴에 있습니다.",
+  "srv.admin.paint_none": "'{name}'에 대한 페인트 디자인을 찾을 수 없습니다.",
+  "srv.admin.paint_wiped": "{name} 페인트 디자인을 삭제했습니다.",
+  "srv.admin.shapes_none": "'{name}'에 대한 사용자 정의 형태를 찾을 수 없습니다.",
+  "srv.admin.shapes_wiped": "{name} 사용자 정의 형태를 삭제했습니다.",
+  "srv.admin.usage_paintwipe": "사용법: /paintwipe 플레이어  또는  /paintwipe #designId",
+  "srv.admin.usage_shapewipe": "사용법: /shapewipe 플레이어  또는  /shapewipe #shapeId",
+  "srv.paint.out_of_reach": "그 블록은 닿을 수 없는 거리예요 — 더 가까이 이동하세요.",
+  "srv.paint.protected": "이 지역은 보호되어 있어요 — 페인트할 수 없습니다.",
+  "srv.paint.solid_only": "페인트할 수 있는 것은 단단한 블록뿐이에요."
 }

--- a/data/locales/nl.json
+++ b/data/locales/nl.json
@@ -3281,5 +3281,14 @@
   "ui.pause.resume": "Doorgaan",
   "ui.pause.title": "Gepauzeerd",
   "ui.pause.waiting_for": "Gepauzeerd {0}/{1} — wachten op: {2}",
-  "ui.pause.world_held": "Wereld stilgezet — iedereen zit in het pauzemenu."
+  "ui.pause.world_held": "Wereld stilgezet — iedereen zit in het pauzemenu.",
+  "srv.admin.paint_none": "Geen verfdesigns gevonden voor '{name}'.",
+  "srv.admin.paint_wiped": "Verwijderde {name} verfdesign(s).",
+  "srv.admin.shapes_none": "Geen aangepaste vormen gevonden voor '{name}'.",
+  "srv.admin.shapes_wiped": "Verwijderde {name} aangepaste vorm(en).",
+  "srv.admin.usage_paintwipe": "Gebruik: /paintwipe Speler  of  /paintwipe #designId",
+  "srv.admin.usage_shapewipe": "Gebruik: /shapewipe Speler  of  /shapewipe #shapeId",
+  "srv.paint.out_of_reach": "Dat blok is buiten bereik — ga dichterbij.",
+  "srv.paint.protected": "Dit gebied is beschermd — het kan niet geverfd worden.",
+  "srv.paint.solid_only": "Alleen massieve blokken kunnen geverfd worden."
 }

--- a/data/locales/pl.json
+++ b/data/locales/pl.json
@@ -3281,5 +3281,14 @@
   "ui.pause.resume": "Wznów",
   "ui.pause.title": "Pauza",
   "ui.pause.waiting_for": "Pauza {0}/{1} — czekamy na: {2}",
-  "ui.pause.world_held": "Świat zatrzymany — wszyscy są w menu pauzy."
+  "ui.pause.world_held": "Świat zatrzymany — wszyscy są w menu pauzy.",
+  "srv.admin.paint_none": "Nie znaleziono wzorów malowania dla '{name}'.",
+  "srv.admin.paint_wiped": "Usunięto {name} wzór(y) malowania.",
+  "srv.admin.shapes_none": "Nie znaleziono niestandardowych form dla '{name}'.",
+  "srv.admin.shapes_wiped": "Usunięto {name} niestandardową formę/formy.",
+  "srv.admin.usage_paintwipe": "Użycie: /paintwipe Gracz  lub  /paintwipe #designId",
+  "srv.admin.usage_shapewipe": "Użycie: /shapewipe Gracz  lub  /shapewipe #shapeId",
+  "srv.paint.out_of_reach": "Ten blok jest poza zasięgiem — podejdź bliżej.",
+  "srv.paint.protected": "Ten obszar jest chroniony — nie można go pomalować.",
+  "srv.paint.solid_only": "Malować można tylko bloki pełne."
 }

--- a/data/locales/pt.json
+++ b/data/locales/pt.json
@@ -3281,5 +3281,14 @@
   "ui.pause.resume": "Continuar",
   "ui.pause.title": "Pausado",
   "ui.pause.waiting_for": "Pausado {0}/{1} — à espera de: {2}",
-  "ui.pause.world_held": "Mundo parado — todos estão no menu de pausa."
+  "ui.pause.world_held": "Mundo parado — todos estão no menu de pausa.",
+  "srv.admin.paint_none": "Nenhum desenho de pintura encontrado para '{name}'.",
+  "srv.admin.paint_wiped": "Desenho(s) de pintura {name} apagado(s).",
+  "srv.admin.shapes_none": "Nenhuma forma personalizada encontrada para '{name}'.",
+  "srv.admin.shapes_wiped": "Forma(s) personalizada(s) {name} apagada(s).",
+  "srv.admin.usage_paintwipe": "Uso: /paintwipe Jogador  ou  /paintwipe #designId",
+  "srv.admin.usage_shapewipe": "Uso: /shapewipe Jogador  ou  /shapewipe #shapeId",
+  "srv.paint.out_of_reach": "Esse bloco está fora de alcance — aproxime-se.",
+  "srv.paint.protected": "Esta área é protegida — não pode ser pintada.",
+  "srv.paint.solid_only": "Apenas blocos sólidos podem ser pintados."
 }

--- a/data/locales/ru.json
+++ b/data/locales/ru.json
@@ -3281,5 +3281,14 @@
   "ui.pause.resume": "Продолжить",
   "ui.pause.title": "Пауза",
   "ui.pause.waiting_for": "Пауза {0}/{1} — ждём: {2}",
-  "ui.pause.world_held": "Мир остановлен — все в меню паузы."
+  "ui.pause.world_held": "Мир остановлен — все в меню паузы.",
+  "srv.admin.paint_none": "Для «{name}» не найдено раскрасок.",
+  "srv.admin.paint_wiped": "Удалено {name} раскраски(й).",
+  "srv.admin.shapes_none": "Для «{name}» не найдено пользовательских форм.",
+  "srv.admin.shapes_wiped": "Удалено {name} пользовательской формы(й).",
+  "srv.admin.usage_paintwipe": "Использование: /paintwipe Игрок  или  /paintwipe #designId",
+  "srv.admin.usage_shapewipe": "Использование: /shapewipe Игрок  или  /shapewipe #shapeId",
+  "srv.paint.out_of_reach": "Этот блок вне досягаемости — подойдите ближе.",
+  "srv.paint.protected": "Эта область защищена — её нельзя раскрашивать.",
+  "srv.paint.solid_only": "Можно раскрашивать только твёрдые блоки."
 }

--- a/data/locales/tr.json
+++ b/data/locales/tr.json
@@ -3281,5 +3281,14 @@
   "ui.pause.resume": "Devam et",
   "ui.pause.title": "Duraklatıldı",
   "ui.pause.waiting_for": "Duraklatıldı {0}/{1} — bekleniyor: {2}",
-  "ui.pause.world_held": "Dünya durduruldu — herkes duraklatma menüsünde."
+  "ui.pause.world_held": "Dünya durduruldu — herkes duraklatma menüsünde.",
+  "srv.admin.paint_none": "'{name}' için boya deseni bulunamadı.",
+  "srv.admin.paint_wiped": "{name} boya deseni(leri) temizlendi.",
+  "srv.admin.shapes_none": "'{name}' için özel form bulunamadı.",
+  "srv.admin.shapes_wiped": "{name} özel form(ları) temizlendi.",
+  "srv.admin.usage_paintwipe": "Kullanım: /paintwipe Player  veya  /paintwipe #designId",
+  "srv.admin.usage_shapewipe": "Kullanım: /shapewipe Player  veya  /shapewipe #shapeId",
+  "srv.paint.out_of_reach": "O blok erişim dışında — biraz daha yaklaş.",
+  "srv.paint.protected": "Bu alan korumalı — burası boyanamaz.",
+  "srv.paint.solid_only": "Sadece katı bloklar boyanabilir."
 }

--- a/data/locales/uk.json
+++ b/data/locales/uk.json
@@ -3281,5 +3281,14 @@
   "ui.pause.resume": "Продовжити",
   "ui.pause.title": "Пауза",
   "ui.pause.waiting_for": "Пауза {0}/{1} — чекаємо на: {2}",
-  "ui.pause.world_held": "Світ зупинено — усі в меню паузи."
+  "ui.pause.world_held": "Світ зупинено — усі в меню паузи.",
+  "srv.admin.paint_none": "Дизайнів фарбування для '{name}' не знайдено.",
+  "srv.admin.paint_wiped": "Видалено {name} дизайн(и) фарбування.",
+  "srv.admin.shapes_none": "Користувацьких форм для '{name}' не знайдено.",
+  "srv.admin.shapes_wiped": "Видалено {name} користувацьку(і) форму(и).",
+  "srv.admin.usage_paintwipe": "Використання: /paintwipe Player  або  /paintwipe #designId",
+  "srv.admin.usage_shapewipe": "Використання: /shapewipe Player  або  /shapewipe #shapeId",
+  "srv.paint.out_of_reach": "Цей блок за межами досяжності — підійди ближче.",
+  "srv.paint.protected": "Ця зона захищена — її не можна фарбувати.",
+  "srv.paint.solid_only": "Фарбувати можна тільки суцільні блоки."
 }

--- a/data/locales/zh.json
+++ b/data/locales/zh.json
@@ -3281,5 +3281,14 @@
   "ui.pause.resume": "继续",
   "ui.pause.title": "已暂停",
   "ui.pause.waiting_for": "已暂停 {0}/{1} — 等待：{2}",
-  "ui.pause.world_held": "世界已停止 — 所有人都在暂停菜单中。"
+  "ui.pause.world_held": "世界已停止 — 所有人都在暂停菜单中。",
+  "srv.admin.paint_none": "未找到 '{name}' 的油漆设计。",
+  "srv.admin.paint_wiped": "已清除 {name} 的油漆设计。",
+  "srv.admin.shapes_none": "未找到 '{name}' 的自定义形状。",
+  "srv.admin.shapes_wiped": "已清除 {name} 的自定义形状。",
+  "srv.admin.usage_paintwipe": "用法：/paintwipe 玩家 或 /paintwipe #designId",
+  "srv.admin.usage_shapewipe": "用法：/shapewipe 玩家 或 /shapewipe #shapeId",
+  "srv.paint.out_of_reach": "该方块够不着 — 请靠近一点。",
+  "srv.paint.protected": "此区域受保护 — 无法涂色。",
+  "srv.paint.solid_only": "只有实体方块可以被涂色。"
 }

--- a/src/BlocksBeyondTheStars.Client.Core/ClientWorld.cs
+++ b/src/BlocksBeyondTheStars.Client.Core/ClientWorld.cs
@@ -189,7 +189,12 @@ namespace BlocksBeyondTheStars.Client
         }
 
         /// <summary>Light sources within <paramref name="radius"/> blocks of a chunk's box — handed to the
-        /// mesher so a placed lamp's colour floods across chunk seams, not just its own chunk.</summary>
+        /// mesher so a placed lamp's colour floods across chunk seams, not just its own chunk.
+        /// Round worlds (#428): the sources are stored canonically, but the distance is measured the short way
+        /// round BOTH wrap seams and every hit is re-expressed in the chunk's own (un-wrapped) frame — so a
+        /// lamp at X = circumference − 2 reaches the chunk at X = 0 as X = −2, and the mesher's flood fill
+        /// (which keys cells in that raw frame and canonicalizes block lookups) carries light across the seam
+        /// like skylight and AO already do.</summary>
         public List<(Vector3i Pos, int Rgb)> LightSourcesNear(ChunkCoord coord, int radius)
         {
             var result = new List<(Vector3i, int)>();
@@ -201,18 +206,24 @@ namespace BlocksBeyondTheStars.Client
             coord = WorldConstants.CanonicalChunk(coord, _circumference);
             var origin = WorldConstants.ChunkOrigin(coord);
             int nsz = WorldConstants.ChunkSize;
-            int loX = origin.X - radius, hiX = origin.X + nsz + radius;
-            int loY = origin.Y - radius, hiY = origin.Y + nsz + radius;
-            int loZ = origin.Z - radius, hiZ = origin.Z + nsz + radius;
+            int lo = -radius, hi = nsz + radius;
             foreach (var kv in _lightSources)
             {
                 var p = kv.Key;
-                if (p.X < loX || p.X > hiX || p.Y < loY || p.Y > hiY || p.Z < loZ || p.Z > hiZ)
+                int dy = p.Y - origin.Y;
+                if (dy < lo || dy > hi)
                 {
                     continue;
                 }
 
-                result.Add((p, kv.Value));
+                int dx = WorldConstants.WrapDeltaX(p.X - origin.X, _circumference);
+                int dz = WorldConstants.WrapDeltaZ(p.Z - origin.Z, _circumference);
+                if (dx < lo || dx > hi || dz < lo || dz > hi)
+                {
+                    continue;
+                }
+
+                result.Add((new Vector3i(origin.X + dx, p.Y, origin.Z + dz), kv.Value));
             }
 
             return result;

--- a/src/BlocksBeyondTheStars.GameServer/GameServerCustomShapes.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerCustomShapes.cs
@@ -281,7 +281,7 @@ public sealed partial class GameServer
         string target = (arg ?? string.Empty).Trim();
         if (target.Length == 0)
         {
-            Reject(session, "admin", "Usage: /shapewipe Player  or  /shapewipe #shapeId");
+            Reject(session, "admin", "@srv.admin.usage_shapewipe");
             return;
         }
 
@@ -305,7 +305,7 @@ public sealed partial class GameServer
 
         if (toWipe.Count == 0)
         {
-            Send(session, new ServerMessage { Text = $"No custom forms found for '{target}'." });
+            Send(session, new ServerMessage { Text = "@srv.admin.shapes_none:" + target });
             return;
         }
 
@@ -325,7 +325,7 @@ public sealed partial class GameServer
             }
         }
 
-        Send(session, new ServerMessage { Text = $"Wiped {toWipe.Count} custom form(s)." });
+        Send(session, new ServerMessage { Text = "@srv.admin.shapes_wiped:" + toWipe.Count });
         CheatLog(session.State, $"wiped {toWipe.Count} custom form(s) ({target})");
     }
 }

--- a/src/BlocksBeyondTheStars.GameServer/GameServerMissions.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerMissions.cs
@@ -461,6 +461,9 @@ public sealed partial class GameServer
 
     private const int BoardWindow = 3;
 
+    // #427: mission templates already reported as referencing a missing item.
+    private readonly HashSet<string> _warnedMissionTemplates = new(StringComparer.Ordinal);
+
     private static readonly (string Need, int Target, string Reward, int RewardN)[] GiverMissionTemplates =
     {
         ("iron_ore", 10, "iron_plate", 3),
@@ -481,9 +484,16 @@ public sealed partial class GameServer
     {
         var rng = new System.Random(unchecked((int)WorldGenerator.StableHash($"{boardKey}:mission:{slot}")));
         var tpl = GiverMissionTemplates[rng.Next(GiverMissionTemplates.Length)];
-        // Fall back to the first template if a content item is missing.
+        // Fall back to the first template if a content item is missing — and say so (#427): the templates are
+        // code, not validated content, so a renamed item would otherwise silently collapse every board onto
+        // template 0. Warned once per template, not per coined mission.
         if (_content.GetItem(tpl.Need) is null || _content.GetItem(tpl.Reward) is null)
         {
+            if (_warnedMissionTemplates.Add(tpl.Need + ">" + tpl.Reward))
+            {
+                _log.Warn($"Board mission template '{tpl.Need}' → '{tpl.Reward}' references an unknown item; falling back to template 0 ('{GiverMissionTemplates[0].Need}').");
+            }
+
             tpl = GiverMissionTemplates[0];
         }
 

--- a/src/BlocksBeyondTheStars.GameServer/GameServerPaint.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerPaint.cs
@@ -97,14 +97,14 @@ public sealed partial class GameServer
         var pos = new Vector3i(intent.X, intent.Y, intent.Z);
         if (!WithinReach(session.State, pos))
         {
-            Reject(session, "paint", "Out of reach.");
+            Reject(session, "paint", "@srv.paint.out_of_reach");
             return;
         }
 
         var current = _world.GetBlock(pos);
         if (current.Value == BlockId.AirValue || _world.Definition(current) is not { Solid: true })
         {
-            Reject(session, "paint", "Only solid blocks can be painted.");
+            Reject(session, "paint", "@srv.paint.solid_only");
             return;
         }
 
@@ -113,7 +113,7 @@ public sealed partial class GameServer
         if (IsFactoryProtected(pos, session.State.PlayerId, session.State.IsAdmin)
             || IsBaseProtected(pos, session.State.PlayerId, session.State.IsAdmin))
         {
-            Reject(session, "paint", "This area is protected.");
+            Reject(session, "paint", "@srv.paint.protected");
             return;
         }
 
@@ -379,7 +379,7 @@ public sealed partial class GameServer
         string target = (arg ?? string.Empty).Trim();
         if (target.Length == 0)
         {
-            Reject(session, "admin", "Usage: /paintwipe Player  or  /paintwipe #designId");
+            Reject(session, "admin", "@srv.admin.usage_paintwipe");
             return;
         }
 
@@ -403,7 +403,7 @@ public sealed partial class GameServer
 
         if (toWipe.Count == 0)
         {
-            Send(session, new ServerMessage { Text = $"No paint designs found for '{target}'." });
+            Send(session, new ServerMessage { Text = "@srv.admin.paint_none:" + target });
             return;
         }
 
@@ -423,7 +423,7 @@ public sealed partial class GameServer
             }
         }
 
-        Send(session, new ServerMessage { Text = $"Wiped {toWipe.Count} paint design(s)." });
+        Send(session, new ServerMessage { Text = "@srv.admin.paint_wiped:" + toWipe.Count });
         CheatLog(session.State, $"wiped {toWipe.Count} paint design(s) ({target})");
     }
 }

--- a/src/BlocksBeyondTheStars.GameServer/GameServerSpaceStructure.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerSpaceStructure.cs
@@ -147,6 +147,9 @@ public sealed partial class GameServer
         => BuildShipStructureFrom(structureId, string.Empty,
             _content.GetShip(shipTypeKey) ?? _content.GetShip("starter"), persistEdits: false);
 
+    // #427: layout ids already warned about (one line per layout+id, not one per cell per rebuild).
+    private readonly HashSet<string> _warnedLayoutIds = new(StringComparer.Ordinal);
+
     private SpaceStructure BuildShipStructureFrom(string structureId, string ownerId, ShipDefinition? design, bool persistEdits)
     {
         var s = new SpaceStructure { Id = structureId, Kind = "ship", OwnerId = ownerId };
@@ -205,7 +208,15 @@ public sealed partial class GameServer
 
                 // Any block key (iron_wall, carbon cargo, …) renders as that block; unknown ids fall back to hull.
                 // Authored dye/glow/shape ride along (the ship editor can tint + shape + orient any block).
-                s.Set(p, _content.GetBlock(cell.Id)?.NumericId ?? wall, cell.Tint, cell.Glow, cell.Shape);
+                // #427: content validation rejects unknown ids at load, so this fallback should never fire —
+                // if it does (a layout that bypassed the loader), say so once instead of stamping hull silently.
+                var cellBlock = _content.GetBlock(cell.Id);
+                if (cellBlock == null && _warnedLayoutIds.Add($"{layout.Key}:{cell.Id}"))
+                {
+                    _log.Warn($"Ship layout '{layout.Key}' cell ({cell.X},{cell.Y},{cell.Z}) has unknown block id '{cell.Id}' — stamping hull instead.");
+                }
+
+                s.Set(p, cellBlock?.NumericId ?? wall, cell.Tint, cell.Glow, cell.Shape);
             }
 
             // Guarantee a flush, solid floor across the footprint (fills layout gaps) so the player never

--- a/src/BlocksBeyondTheStars.Shared/Content/GameContent.cs
+++ b/src/BlocksBeyondTheStars.Shared/Content/GameContent.cs
@@ -686,6 +686,24 @@ public sealed class GameContent
             }
         }
 
+        // #427: authored voxel ship layouts. The server used to turn an unknown cell id silently into hull
+        // (`?? iron_wall`), so a data typo would ship invisibly — surface it at load like every other reference.
+        foreach (var layout in _shipLayouts.Values)
+        {
+            foreach (var cell in layout.Cells)
+            {
+                if (cell.Kind == "station")
+                {
+                    continue; // station types map to marker blocks server-side (unknown → hull marker, by design)
+                }
+
+                if (string.IsNullOrEmpty(cell.Id) || (!ShipLayoutCell.IsElementId(cell.Id) && !_blocks.ContainsKey(cell.Id)))
+                {
+                    problems.Add($"Ship layout '{layout.Key}' cell ({cell.X},{cell.Y},{cell.Z}) references unknown block or element '{cell.Id}'.");
+                }
+            }
+        }
+
         if (problems.Count > 0)
         {
             throw new ContentValidationException(problems);

--- a/src/BlocksBeyondTheStars.Shared/Definitions/ShipLayout.cs
+++ b/src/BlocksBeyondTheStars.Shared/Definitions/ShipLayout.cs
@@ -26,6 +26,18 @@ public sealed class ShipLayout
 /// <summary>One placed cell: position + what it is (a block, a station marker, or a special element).</summary>
 public sealed class ShipLayoutCell
 {
+    /// <summary>The non-block ids a layout cell may carry (kind "block"/"element"): the ship editor's special
+    /// palette entries the server stamps as something other than a plain content block. Anything else must be a
+    /// real block key — <c>GameContent.Validate</c> fails the load on an unknown id (#427) instead of the server
+    /// silently stamping hull there.</summary>
+    private static readonly HashSet<string> ElementIds = new(System.StringComparer.Ordinal)
+    {
+        "hatch", "door_slide", "door_hinge", "door_energy", "glass", "light", "headlight", "light_red", "light_green", "engine",
+    };
+
+    /// <summary>True for a special (non-block) palette id — see <see cref="ElementIds"/>.</summary>
+    public static bool IsElementId(string? id) => !string.IsNullOrEmpty(id) && ElementIds.Contains(id!);
+
     public int X { get; set; }
     public int Y { get; set; }
     public int Z { get; set; }

--- a/tests/BlocksBeyondTheStars.Client.Tests/LightSourcesWrapTests.cs
+++ b/tests/BlocksBeyondTheStars.Client.Tests/LightSourcesWrapTests.cs
@@ -1,0 +1,82 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using System.Linq;
+using BlocksBeyondTheStars.Shared.Geometry;
+using BlocksBeyondTheStars.Shared.World;
+using Xunit;
+
+namespace BlocksBeyondTheStars.Client.Tests;
+
+/// <summary>
+/// #428 (N10): placed-lamp light must not stop dead at the world wrap seams. Sources are stored canonically;
+/// <see cref="ClientWorld.LightSourcesNear"/> has to measure the short way round the X (circumference) and Z
+/// (latitude) seams and hand the mesher positions in the queried chunk's own un-wrapped frame.
+/// </summary>
+public sealed class LightSourcesWrapTests
+{
+    private const int Circ = 512; // small round world: X wraps at 512, Z period = 256 (±128)
+
+    private static ClientWorld World(params ChunkCoord[] chunks)
+    {
+        var w = new ClientWorld();
+        w.SetCircumference(Circ);
+        foreach (var c in chunks)
+        {
+            w.StoreChunk(c, new ushort[WorldConstants.ChunkSize * WorldConstants.ChunkSize * WorldConstants.ChunkSize]);
+        }
+
+        return w;
+    }
+
+    [Fact]
+    public void LampJustWestOfTheSeam_ReachesTheChunkAtXZero_InItsRawFrame()
+    {
+        // The last chunk column (X = 496..511) and the first (X = 0..15) touch across the seam.
+        var w = World(new ChunkCoord(0, 0, 0), new ChunkCoord(Circ / 16 - 1, 0, 0));
+        Assert.True(w.ApplyBlockChange(Circ - 2, 4, 3, block: 1, tint: 0, glow: 0xFF8800, out _));
+
+        var near = w.LightSourcesNear(new ChunkCoord(0, 0, 0), 9);
+
+        var hit = Assert.Single(near);
+        Assert.Equal(new Vector3i(-2, 4, 3), hit.Pos); // re-expressed: 510 → −2 relative to origin X = 0
+        Assert.Equal(0xFF8800, hit.Rgb);
+    }
+
+    [Fact]
+    public void LampJustEastOfTheSeam_ReachesTheLastChunk_AsPastTheCircumference()
+    {
+        var w = World(new ChunkCoord(0, 0, 0), new ChunkCoord(Circ / 16 - 1, 0, 0));
+        Assert.True(w.ApplyBlockChange(2, 4, 3, block: 1, tint: 0, glow: 0x00FF00, out _));
+
+        var near = w.LightSourcesNear(new ChunkCoord(Circ / 16 - 1, 0, 0), 9);
+
+        var hit = Assert.Single(near);
+        Assert.Equal(new Vector3i(Circ + 2, 4, 3), hit.Pos); // origin 496: 2 → 514 (raw frame of that chunk)
+    }
+
+    [Fact]
+    public void LampAcrossTheLatitudeSeam_IsFound()
+    {
+        // Latitude period 256 → canonical Z ∈ [−128, 128); Z = −128 (first row) and Z = 127 (last row) touch.
+        int lastZChunk = 127 / 16;   // chunk Z 7 (112..127)
+        int firstZChunk = -128 / 16; // chunk Z −8 (−128..−113)
+        var w = World(new ChunkCoord(0, 0, firstZChunk), new ChunkCoord(0, 0, lastZChunk));
+        Assert.True(w.ApplyBlockChange(5, 4, 126, block: 1, tint: 0, glow: 0x0000FF, out _));
+
+        var near = w.LightSourcesNear(new ChunkCoord(0, 0, firstZChunk), 9);
+
+        var hit = Assert.Single(near);
+        Assert.Equal(new Vector3i(5, 4, -130), hit.Pos); // 126 → −130 (2 south of the −128 origin, the short way)
+    }
+
+    [Fact]
+    public void LampFarAway_IsStillFiltered()
+    {
+        var w = World(new ChunkCoord(0, 0, 0), new ChunkCoord(10, 0, 0));
+        Assert.True(w.ApplyBlockChange(165, 4, 3, block: 1, tint: 0, glow: 0xFFFFFF, out _));
+
+        Assert.Empty(w.LightSourcesNear(new ChunkCoord(0, 0, 0), 9));
+        Assert.Single(w.LightSourcesNear(new ChunkCoord(10, 0, 0), 9));
+    }
+}

--- a/tests/BlocksBeyondTheStars.Tests/ContentTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/ContentTests.cs
@@ -188,6 +188,35 @@ public class ContentTests
         Assert.Contains(ex.Problems, p => p.Contains("nonexistent_item"));
     }
 
+    /// <summary>#427: an unknown block id in an authored ship layout used to become hull silently at stamp
+    /// time; the validator now fails the load, while the editor's special palette ids (hatch, doors, lights,
+    /// engine, glass) and station markers stay legal.</summary>
+    [Fact]
+    public void Validation_DetectsUnknownShipLayoutCell()
+    {
+        static GameContent Build(params ShipLayoutCell[] cells) => new(
+            blocks: new[] { new BlockDefinition { Key = "iron_wall" } },
+            items: Array.Empty<ItemDefinition>(),
+            recipes: Array.Empty<RecipeDefinition>(),
+            blueprints: Array.Empty<BlueprintDefinition>(),
+            shipModules: Array.Empty<ShipModuleDefinition>(),
+            locales: new Dictionary<GameLocale, Dictionary<string, string>>(),
+            shipLayouts: new[] { new ShipLayout { Key = "ship_test", Width = 3, Height = 3, Length = 3, Cells = cells.ToList() } });
+
+        // Legal: a real block, every element id and a station marker.
+        Build(
+            new ShipLayoutCell { Id = "iron_wall" },
+            new ShipLayoutCell { Id = "hatch" },
+            new ShipLayoutCell { Id = "door_slide", Kind = "element" },
+            new ShipLayoutCell { Id = "light_red" },
+            new ShipLayoutCell { Id = "engine" },
+            new ShipLayoutCell { Id = "cockpit", Kind = "station" }).Validate();
+
+        var ex = Assert.Throws<ContentValidationException>(() =>
+            Build(new ShipLayoutCell { X = 1, Y = 2, Z = 0, Id = "iron_wal" }).Validate());
+        Assert.Contains(ex.Problems, p => p.Contains("ship_test") && p.Contains("iron_wal") && p.Contains("(1,2,0)"));
+    }
+
     /// <summary>The browser client parses locale files it fetched over HTTP with this entry point, before
     /// its content cache exists, so the splash/intro screens can localize (#831). It must read a real
     /// shipped locale file exactly like the filesystem path does.</summary>


### PR DESCRIPTION
Closes #427
Closes #428

Closes out the two static-audit issues from July. Every remaining checkbox is addressed; the one item already done elsewhere (S20, the ~182 hard-coded server messages → `@srv.*` keys) landed wholesale in #822 — this PR converts the 10 leftovers.

## Server (#427)
- **S19a** — `GameContent.Validate` now fails the load when an authored `data/ship_layouts/*.json` cell references an unknown block/element id (the ship editor's special ids `hatch`/`door_*`/`glass`/`light*`/`engine` stay legal via `ShipLayoutCell.IsElementId`; station markers are skipped). The stamp path in `GameServerSpaceStructure` additionally `_log.Warn`s once per layout+id should a layout ever bypass the loader — instead of silently stamping `iron_wall`. Test: `ContentTests.Validation_DetectsUnknownShipLayoutCell`.
- **S19b** — a board-mission template whose item is missing from content logs a warning (once per template) before collapsing onto template 0.
- **S20 leftovers** — 3 player-facing paint rejects (`Out of reach.`, `Only solid blocks…`, `This area is protected.`) + 7 admin lines (`/paintwipe`, `/shapewipe` usage/results) moved behind `@srv.paint.*` / `@srv.admin.*` keys in all 14 locales (en/de by hand, 12 machine via `translate_locale.py`; `locale_report.py --check` clean).

## Client (#428)
- **N10** — `ClientWorld.LightSourcesNear` measures across BOTH wrap seams (`WrapDeltaX/Z`) and hands the mesher sources re-expressed in the chunk's own un-wrapped frame; the flood fill keeps raw keys + canonicalized lookups, so placed-lamp light now crosses X = 0/circumference and the latitude seam like skylight/AO. New `LightSourcesWrapTests` (4).
- **N11** — the `localized == key` guards (`Localizer.Get` returns `"[key]"`, so they could never fire) use `Localizer.Has`: portal error codes, ban-notice reason codes, Codex VEGA log.
- **N12** — `WikiUI` logs a `Debug.LogWarning` when `wiki/articles.json` fails to load.
- **N15** — `BuildScript.RuntimeShaders` lists all 21 runtime `Shader.Find` shaders (+ the `Unlit/Transparent` / `Sprites/Default` fallbacks the call sites use); the retired VolumetricFog GUID is gone from `GraphicsSettings.asset` (the local Unity build re-added `Unlit/Transparent` to the always-included list — committed).
- **N16** — the Built-in-RP subshader of `BlockAtlas` mirrors the URP pass's bark branch (mode 4), so `wood_log` no longer falls into the player-dye recolour on a URP fallback.

## Verification
- `dotnet test` fast tier: **1961 server + 254 client passing** (Release, `-warnaserror` build clean); `dotnet format --verify-no-changes` clean.
- Local Unity batch build (`scripts/build-client.ps1`) succeeded — 0 compiler errors, `BlockAtlas` compiles on both subshaders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
