### PR TITLE
fix(codex): Guide + Items chapters render again — chunk chapters below uGUI's 65 000-vertex limit (#1097)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ the richer, screenshot-laden versions live there. `(#123)` references the pull r
 
 ## [Unreleased]
 
+### 🐛 Codex: Guide and Items chapters render again (#1097)
+
+- Codex → **Guide** ("Anleitung") and **Items** showed an empty pane. One uGUI `Text` held the whole chapter,
+  and past ~16 250 characters uGUI refuses to build the mesh (`Mesh can not have more than 65000 vertices`)
+  — nothing at all was drawn. German crossed that line on 2026-08-08, English with the 2026.8.17 articles;
+  the Items chapter (195 items with descriptions) was over it in both languages.
+- Chapters are now rendered as a column of Texts split at paragraph boundaries (`UiTextChunks`, ≤ 10 000
+  characters each, unit-tested against the real `articles.json` in EN and DE). Scrolling covers the whole
+  chapter as before; the articles and descriptions may keep growing.
+
 ## [2026.8.17] — 2026-08-16
 
 The wayfinder release. Two things players kept asking — *why is this tab greyed out?* and *what

--- a/TODO.md
+++ b/TODO.md
@@ -105,6 +105,16 @@ Per-item detail lives in the dated work log below. **Since 2026-07 versions are 
 
 ---
 
+### ★ Codex Guide + Items chapters render again — one uGUI Text hit the 65 000-vertex limit (#1097, 2026-08-16, branch fix/codex-guide-blank-1097)
+Codex → Guide ("Anleitung") and Items showed a completely empty pane. `WikiUI.RenderChapter` put the whole
+chapter into ONE `UnityEngine.UI.Text`; uGUI builds 4 vertices per glyph and `VertexHelper.FillMesh` throws
+`Mesh can not have more than 65000 vertices` at ~16 250 characters, inside the Graphic rebuild — so the
+Text silently gets no mesh. The Guide (25 articles) crossed that line in German on 2026-08-08 (#852) and in
+English on 2026-08-16 (#1083); Items (195 names + descriptions, ~20 k chars) was over it in both languages,
+Blocks (~15 k DE) sat at the edge. New pure `UiTextChunks.Split` (Client.Core; paragraph → line → tag-safe
+hard cut, lossless) and `RenderChapter` stacks one Text per ≤ 10 000-char chunk. `UiTextChunksTests` cover
+the boundaries and run the real `articles.json` in EN + DE through the WikiUI pipeline. Client-only.
+
 ### ★ Admin portal: world detail page reads attributed saves again (#1063, 2026-08-15, branch fix/1063-inspector-max-aggregate)
 Every world with a save file showed `Could not read the world save: SQLite Error 1: 'misuse of aggregate
 function MAX()'` and three empty cards ("No player records…"). `WorldInspector.ReadHotspots` put

--- a/client/Assets/BlocksBeyondTheStars/Scripts/WikiUI.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/WikiUI.cs
@@ -171,18 +171,29 @@ namespace BlocksBeyondTheStars.Client
             return content;
         }
 
-        /// <summary>Renders the current chapter as a single wrapped rich-text block and sizes the scroll content
-        /// to it (one block keeps the layout robust; per-entry rows can come with the in-editor polish pass).</summary>
+        /// <summary>Renders the current chapter as a column of wrapped rich-text blocks and sizes the scroll
+        /// content to their sum. The chapter text is split into chunks of at most
+        /// <see cref="UiTextChunks.DefaultMaxChars"/> characters (paragraph boundaries first): a single uGUI Text
+        /// past ~16 250 characters trips VertexHelper's 65 000-vertex ArgumentException inside the Graphic rebuild
+        /// and renders NOTHING — which is exactly how the Guide and Items chapters went blank once the articles
+        /// and item descriptions grew (#1097). Each chunk keeps its trailing newlines, so the paragraph gap
+        /// between two chunks survives the split (preferredHeight counts them).</summary>
         private void RenderChapter(Transform content, float textW)
         {
             string body = BuildChapterText(_chapter);
-            var t = UiKit.AddText(content, Pad, Pad, textW, 100f, body, 18, UiKit.TextCol, TextAnchor.UpperLeft);
-            t.horizontalOverflow = HorizontalWrapMode.Wrap;
-            t.verticalOverflow = VerticalWrapMode.Overflow;
+            float y = Pad;
+            foreach (string chunk in UiTextChunks.Split(body))
+            {
+                var t = UiKit.AddText(content, Pad, y, textW, 100f, chunk, 18, UiKit.TextCol, TextAnchor.UpperLeft);
+                t.horizontalOverflow = HorizontalWrapMode.Wrap;
+                t.verticalOverflow = VerticalWrapMode.Overflow;
 
-            float textH = t.preferredHeight; // wrapped height for the current rect width
-            ((RectTransform)t.transform).sizeDelta = new Vector2(textW, textH + 10f);
-            ((RectTransform)content).sizeDelta = new Vector2(0f, Mathf.Max(RegionH, textH + 2f * Pad));
+                float textH = t.preferredHeight; // wrapped height for the current rect width
+                ((RectTransform)t.transform).sizeDelta = new Vector2(textW, textH + 10f);
+                y += textH;
+            }
+
+            ((RectTransform)content).sizeDelta = new Vector2(0f, Mathf.Max(RegionH, y + Pad));
         }
 
         private string BuildChapterText(string chapter) => chapter switch

--- a/docs/developer/MINIGAMES_AND_WIKI.md
+++ b/docs/developer/MINIGAMES_AND_WIKI.md
@@ -67,6 +67,11 @@ Menu "Codex"/"DataQubes" button
   (icon/title/desc + cube seed → game). On WebGL this comes from the cached StreamingAssets data folder.
 - `WikiUI.cs` + `WikiMarkup` (`Client.Core`) — load `StreamingAssets/data/wiki/articles.json` and render the
   articles natively (discovery-gated Systems & Worlds chapters from the player's visited set).
+  A chapter is rendered as a **column of uGUI Texts**, split by `UiTextChunks.Split` (`Client.Core`) at
+  paragraph boundaries into chunks of ≤ 10 000 characters: one uGUI `Text` past ~16 250 characters trips
+  `VertexHelper`'s 65 000-vertex `ArgumentException` and draws **nothing** — the Guide and Items chapters
+  went blank that way once the content grew (#1097). Articles and descriptions may grow freely; a new
+  data-fed Text elsewhere must chunk the same way (or render per-entry rows like What's New).
 - `DataCubeView.cs` — renders the glowing cube (texture `Resources/props/data_cube`, point light, pulse),
   proximity hum (`data_cube_hum`), and the E label. `PlayerController` E-interact sends the download +
   plays `data_cube_download`.

--- a/src/BlocksBeyondTheStars.Client.Core/UiTextChunks.cs
+++ b/src/BlocksBeyondTheStars.Client.Core/UiTextChunks.cs
@@ -1,0 +1,108 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+
+using System;
+using System.Collections.Generic;
+
+namespace BlocksBeyondTheStars.Client
+{
+    /// <summary>
+    /// Splits a long (rich-)text block into pieces that a single uGUI <c>Text</c> can render.
+    ///
+    /// uGUI builds four vertices per character and <c>VertexHelper.FillMesh</c> throws
+    /// <c>ArgumentException("Mesh can not have more than 65000 vertices")</c> once one Text holds
+    /// roughly 16 250 characters. The exception fires inside the Graphic rebuild, so the Text silently
+    /// gets NO mesh at all — the Codex Guide and Items chapters rendered as an empty pane once the
+    /// articles / item descriptions grew past that size (#1097). Any UI that feeds data-driven text of
+    /// unbounded length into a uGUI Text must go through this splitter (or render per-entry rows).
+    ///
+    /// Pure string processing — no UnityEngine — so it lives in Client.Core and is unit-tested headless.
+    /// </summary>
+    public static class UiTextChunks
+    {
+        /// <summary>Characters at which one uGUI Text stops rendering (65 000 vertices / 4 per glyph). Every
+        /// character — including spaces and newlines — produces a quad; rich-text tags do not, so counting raw
+        /// characters against this limit is conservative.</summary>
+        public const int UguiGlyphLimit = 65000 / 4;
+
+        /// <summary>Default per-chunk budget: comfortably under <see cref="UguiGlyphLimit"/> so wrapped or
+        /// slightly mis-counted text still has headroom.</summary>
+        public const int DefaultMaxChars = 10_000;
+
+        /// <summary>
+        /// Splits <paramref name="text"/> into chunks of at most <paramref name="maxChars"/> characters.
+        /// Boundaries are chosen, in order of preference, at a paragraph break (<c>\n\n</c>), a line break
+        /// (<c>\n</c>), or — for a single unbroken run longer than the budget — a hard cut that never lands
+        /// inside a <c>&lt;tag&gt;</c> or between a surrogate pair. The split is lossless: the separator stays
+        /// at the END of the preceding chunk, so concatenating the chunks reproduces the input exactly (a
+        /// renderer stacking the chunks keeps the paragraph gap by leaving the trailing newlines in place).
+        /// Empty/null input yields an empty list.
+        /// </summary>
+        public static IReadOnlyList<string> Split(string? text, int maxChars = DefaultMaxChars)
+        {
+            var chunks = new List<string>();
+            if (string.IsNullOrEmpty(text))
+            {
+                return chunks;
+            }
+
+            if (maxChars < 1)
+            {
+                throw new ArgumentOutOfRangeException(nameof(maxChars), maxChars, "chunk budget must be at least one character");
+            }
+
+            string s = text!;
+            int start = 0;
+            while (s.Length - start > maxChars)
+            {
+                int cut = FindCut(s, start, maxChars);
+                chunks.Add(s.Substring(start, cut - start));
+                start = cut;
+            }
+
+            chunks.Add(s.Substring(start));
+            return chunks;
+        }
+
+        /// <summary>Absolute index just past the end of the next chunk (exclusive), given that at least
+        /// <paramref name="maxChars"/> + 1 characters remain from <paramref name="start"/>.</summary>
+        private static int FindCut(string s, int start, int maxChars)
+        {
+            int last = start + maxChars - 1; // last index that may still belong to this chunk
+
+            // 1. Paragraph break: the "\n\n" must fit entirely inside the window, and leave a non-empty chunk.
+            int para = s.LastIndexOf("\n\n", last, last - start + 1, StringComparison.Ordinal);
+            if (para > start)
+            {
+                return para + 2;
+            }
+
+            // 2. Line break.
+            int line = s.LastIndexOf('\n', last, last - start + 1);
+            if (line > start)
+            {
+                return line + 1;
+            }
+
+            // 3. Hard cut at the budget — but not inside "<...>" and not between a surrogate pair.
+            int cut = start + maxChars;
+            int lt = s.LastIndexOf('<', cut - 1, cut - start);
+            if (lt > start)
+            {
+                int gt = s.IndexOf('>', lt);
+                if (gt < 0 || gt >= cut)
+                {
+                    cut = lt; // the tag straddles the cut → end the chunk before it
+                }
+            }
+
+            if (cut > start + 1 && char.IsHighSurrogate(s[cut - 1]))
+            {
+                cut--;
+            }
+
+            return cut;
+        }
+    }
+}

--- a/tests/BlocksBeyondTheStars.Client.Tests/UiTextChunksTests.cs
+++ b/tests/BlocksBeyondTheStars.Client.Tests/UiTextChunksTests.cs
@@ -1,0 +1,144 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using BlocksBeyondTheStars.Client;
+using Xunit;
+
+namespace BlocksBeyondTheStars.Client.Tests;
+
+/// <summary>
+/// Headless tests for the uGUI text splitter behind the Codex chapters (#1097). One uGUI Text stops
+/// rendering (VertexHelper's 65 000-vertex ArgumentException) at ~16 250 characters, which made the Guide
+/// and Items chapters render EMPTY once the articles / descriptions grew — so every chunk must stay under
+/// the budget, the split must be lossless, and it must never cut a rich-text tag in half.
+/// </summary>
+public sealed class UiTextChunksTests
+{
+    [Fact]
+    public void Empty_YieldsNoChunks()
+    {
+        Assert.Empty(UiTextChunks.Split(null));
+        Assert.Empty(UiTextChunks.Split(string.Empty));
+    }
+
+    [Fact]
+    public void ShortText_IsOneChunk_Unchanged()
+    {
+        var chunks = UiTextChunks.Split("<b>Title</b>\n\nbody\n", 100);
+        Assert.Single(chunks);
+        Assert.Equal("<b>Title</b>\n\nbody\n", chunks[0]);
+    }
+
+    [Fact]
+    public void PrefersParagraphBreak_KeepsSeparatorOnPrecedingChunk()
+    {
+        // 6 + 2 + 6 + 2 + 6 = 22 chars; budget 15 → the cut lands on the paragraph break, not mid-word.
+        var chunks = UiTextChunks.Split("aaaaaa\n\nbbbbbb\n\ncccccc", 15);
+        Assert.Equal(new[] { "aaaaaa\n\n", "bbbbbb\n\ncccccc" }, chunks);
+    }
+
+    [Fact]
+    public void FallsBackToLineBreak_WhenNoParagraphFits()
+    {
+        var chunks = UiTextChunks.Split("aaaaaa\nbbbbbb\ncccccc", 15);
+        Assert.Equal(new[] { "aaaaaa\nbbbbbb\n", "cccccc" }, chunks);
+    }
+
+    [Fact]
+    public void HardCut_ForUnbrokenRun_NeverExceedsBudget()
+    {
+        string run = new string('x', 35);
+        var chunks = UiTextChunks.Split(run, 10);
+        Assert.Equal(4, chunks.Count);
+        Assert.All(chunks, c => Assert.InRange(c.Length, 1, 10));
+        Assert.Equal(run, string.Concat(chunks));
+    }
+
+    [Fact]
+    public void HardCut_DoesNotLandInsideATag()
+    {
+        // Budget 12 would cut "xxxxxxxx<col|or=#fff>y" inside the tag; the chunk ends before '<' instead.
+        var chunks = UiTextChunks.Split("xxxxxxxx<color=#fff>y</color>", 12);
+        Assert.Equal("xxxxxxxx", chunks[0]);
+        Assert.All(chunks, c => Assert.DoesNotMatch("^[^<]*>", c)); // no chunk starts with the tail of a tag
+        Assert.Equal("xxxxxxxx<color=#fff>y</color>", string.Concat(chunks));
+    }
+
+    [Fact]
+    public void HardCut_DoesNotSplitSurrogatePairs()
+    {
+        string s = "abcd" + "\U0001F680" + "efgh"; // 🚀 is two UTF-16 code units at index 4..5
+        var chunks = UiTextChunks.Split(s, 5);
+        Assert.Equal("abcd", chunks[0]);
+        Assert.Equal(s, string.Concat(chunks));
+        Assert.All(chunks, c => Assert.False(char.IsHighSurrogate(c[c.Length - 1]), "chunk ends on a lone high surrogate"));
+    }
+
+    [Fact]
+    public void Split_IsLossless()
+    {
+        var sb = new StringBuilder();
+        for (int i = 0; i < 400; i++)
+        {
+            sb.Append("<b>Head ").Append(i).Append("</b>\n• line one\n• line two\n\n");
+        }
+
+        string text = sb.ToString();
+        var chunks = UiTextChunks.Split(text, 1000);
+        Assert.True(chunks.Count > 5);
+        Assert.All(chunks, c => Assert.InRange(c.Length, 1, 1000));
+        Assert.Equal(text, string.Concat(chunks));
+    }
+
+    [Fact]
+    public void ZeroBudget_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => UiTextChunks.Split("abc", 0));
+    }
+
+    /// <summary>The regression itself: the whole Guide chapter, rendered the way WikiUI renders it (every
+    /// article's title + WikiMarkup body concatenated), is OVER the uGUI limit for both mandatory languages —
+    /// and split with the default budget every chunk is safely under it, without losing a character.</summary>
+    [Theory]
+    [InlineData("en")]
+    [InlineData("de")]
+    public void RealGuideChapter_ExceedsOneText_ButEveryChunkFits(string lang)
+    {
+        string path = Path.Combine(ClientTestPaths.DataDir(), "wiki", "articles.json");
+        using var doc = JsonDocument.Parse(File.ReadAllText(path));
+
+        var sb = new StringBuilder();
+        foreach (var article in doc.RootElement.EnumerateArray())
+        {
+            sb.Append("<b><size=24>").Append(Loc(article.GetProperty("title"), lang)).Append("</size></b>\n\n");
+            sb.Append(WikiMarkup.ToUnityRichText(Loc(article.GetProperty("body"), lang))).Append("\n\n\n");
+        }
+
+        string guide = sb.ToString();
+        int visible = Regex.Replace(guide, "<[^>]+>", string.Empty, RegexOptions.None, TimeSpan.FromSeconds(1)).Length;
+        var chunks = UiTextChunks.Split(guide);
+
+        // At the time of the fix both languages were over the limit (EN ~17 k, DE ~19 k visible characters);
+        // should the articles ever shrink below one Text's budget again, one chunk is the right answer.
+        Assert.True(
+            chunks.Count >= (visible > UiTextChunks.DefaultMaxChars ? 2 : 1),
+            $"the {lang} Guide ({visible} visible chars) must be split into more than one Text");
+        Assert.All(chunks, c => Assert.InRange(c.Length, 1, UiTextChunks.DefaultMaxChars));
+        Assert.Equal(guide, string.Concat(chunks));
+
+        // Every chunk starts at an article/paragraph boundary — never mid-sentence — for the real content.
+        for (int i = 1; i < chunks.Count; i++)
+        {
+            Assert.EndsWith("\n", chunks[i - 1]);
+        }
+    }
+
+    private static string Loc(JsonElement loc, string lang)
+        => loc.TryGetProperty(lang, out var v) && v.GetString() is { Length: > 0 } s
+            ? s
+            : loc.GetProperty("en").GetString() ?? string.Empty;
+}


### PR DESCRIPTION
## Summary

Codex → **Guide** ("Anleitung") and **Items** showed a completely empty content pane.

`WikiUI.RenderChapter` rendered a whole chapter as **one** uGUI `Text`. uGUI builds 4 vertices per glyph and `VertexHelper.FillMesh` throws `Mesh can not have more than 65000 vertices` at ~16 250 characters — inside the Graphic rebuild, so the Text silently gets no mesh and nothing is drawn. The Guide crossed that line in German on 2026-08-08 (#852) and in English on 2026-08-16 (#1083); Items (195 names + descriptions, ~20 k chars) was over it in both languages; Blocks (~15 k DE) sat right at the edge.

## Changes

- **`UiTextChunks.Split`** (new, `Client.Core`, pure): splits a rich-text block into ≤ 10 000-char chunks at paragraph → line → tag-safe/surrogate-safe hard-cut boundaries; lossless (concat == input, separator stays on the preceding chunk).
- **`WikiUI.RenderChapter`** stacks one Text per chunk and sizes the scroll content to the sum (trailing newlines stay in the chunk so the paragraph gap survives).
- **`UiTextChunksTests`** (11 tests): boundaries, budget, tag/surrogate safety, losslessness, and the real `data/wiki/articles.json` in EN + DE run through the WikiUI pipeline (≥ 2 chunks, each ≤ budget, lossless, splits on line boundaries only).
- Docs: `MINIGAMES_AND_WIKI.md` (the limit + the rule), CHANGELOG Unreleased, TODO.md.

Client-only; no protocol/data change.

## Test plan

- [x] `dotnet test` Client.Tests (new + WikiMarkup tests green, `--warnaserror` clean)
- [x] local Unity build compiles (local build succeeded, 0 compile errors)
- [ ] playtest: Codex → Guide / Items show text in EN + DE, whole chapter scrollable, no `65000 vertices` in Player.log

Closes #1097

🤖 Generated with [Claude Code](https://claude.com/claude-code)

