### PR TITLE
perf(client): SRP Batcher — URP shaders declare their material properties in UnityPerMaterial (#573)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -105,6 +105,34 @@ Per-item detail lives in the dated work log below. **Since 2026-07 versions are 
 
 ---
 
+### ★ SRP Batcher: the URP shaders declare their material properties where the batcher can see them (#573, 2026-08-17, branch perf/573-srp-batcher-cbuffers)
+The SRP Batcher has been enabled in the URP asset all along, but almost none of our own shaders qualified for
+it: a shader is only batched when **every per-material property sits in one `CBUFFER_START(UnityPerMaterial)`
+block, with the same layout in every pass** of the SubShader — and ours declared them bare, which silently
+costs one SetPass call per material. Eleven URP SubShaders now declare them properly: `LitColor` (the real
+prize — avatars, held items, doors, ship previews, station/structure models are many distinct materials on one
+shader), `BlockAtlas` + `BlockAtlasTransparent`, `SkyBodyPhase` (one material per planet/moon), `Atmosphere`,
+`Aurora`, `Nebula`, `SunRays`, `PlanetRing`, `Particle`, `ParticleAlpha`. `LitColor` and `BlockAtlas` repeat the
+identical block in their ShadowCaster pass, because a layout that differs between passes disqualifies the whole
+shader. **The `_Sc_*` / `_HeatAmp` / `_ThermalAmt` globals stay OUTSIDE the cbuffer on purpose** — they are
+per-frame `Shader.SetGlobal*` values (sun, sky, fog, headlamp), and inside `UnityPerMaterial` the batcher would
+serve each material's own stale copy of them instead. Deliberately unchanged, all verified compatible or out of
+scope: `ScatterLit`, `VertexColorOpaque`, `HeatHaze`, `Thermal` (no material properties at all — nothing to
+wrap), `Visor` (a render-graph blit; the batcher only ever sees `DrawRenderers`), `VisorGlass` (Built-in-RP
+overlay quad, no URP SubShader), and `Cloud`/`Starfield`/`SunGlow`/`ThermalMarker` (already correct).
+No visual change is intended — this moves declarations, not maths. New `ShaderSrpBatcherEditModeTests` keeps it
+that way: the shaders compile, Unity itself reports every URP SubShader as batcher-compatible (through the same
+internal API the Material Inspector's "SRP Batcher: compatible" line uses, with `VisorGlass` explicitly waived),
+and a source-level check fails any future property declared outside the cbuffer. Frame-time effect not measured
+yet — the win is fewer SetPass calls, best seen in the Frame Debugger. Ask 2 of #573 (the WebGL startup
+`ERROR: Shader` lines) is untouched and now tracked on its own as #1099.
+
+One thing the work turned up for anyone reaching for the same check: Unity's own compatibility API
+(`ShaderUtil.GetSRPBatcherCompatibilityCode`, what the Shader Inspector's "SRP Batcher" line shows) can only
+answer for a SubShader that has actually been compiled. In a headless `-nographics` batch run every URP
+SubShader — URP's own `Lit` included — answers `Not initialized ()`, so that check skips itself there and the
+source-level one carries CI.
+
 ### ★ Codex Guide + Items chapters render again — one uGUI Text hit the 65 000-vertex limit (#1097, 2026-08-16, branch fix/codex-guide-blank-1097)
 Codex → Guide ("Anleitung") and Items showed a completely empty pane. `WikiUI.RenderChapter` put the whole
 chapter into ONE `UnityEngine.UI.Text`; uGUI builds 4 vertices per glyph and `VertexHelper.FillMesh` throws

--- a/client/Assets/BlocksBeyondTheStars/Shaders/Atmosphere.shader
+++ b/client/Assets/BlocksBeyondTheStars/Shaders/Atmosphere.shader
@@ -27,7 +27,11 @@ Shader "BlocksBeyondTheStars/Atmosphere"
             #pragma fragment frag
             #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
 
-            float _Brightness;
+            // SRP Batcher (#573): per-MATERIAL properties in UnityPerMaterial; the _Sc_* globals below stay out.
+            CBUFFER_START(UnityPerMaterial)
+                float _Brightness;
+            CBUFFER_END
+
             float4 _Sc_SunDir; // world-space direction TO the sun
             float4 _Sc_Sky;    // current sky colour
             float4 _Sc_Light;  // sun colour × day brightness (a>0.5 = set)

--- a/client/Assets/BlocksBeyondTheStars/Shaders/Aurora.shader
+++ b/client/Assets/BlocksBeyondTheStars/Shaders/Aurora.shader
@@ -25,7 +25,10 @@ Shader "BlocksBeyondTheStars/Aurora"
             #pragma fragment frag
             #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
 
-            float4 _Color;
+            // SRP Batcher (#573): per-MATERIAL properties in UnityPerMaterial.
+            CBUFFER_START(UnityPerMaterial)
+                float4 _Color;
+            CBUFFER_END
 
             struct Attributes { float4 positionOS : POSITION; float2 uv : TEXCOORD0; };
             struct Varyings { float4 positionCS : SV_POSITION; float2 uv : TEXCOORD0; };

--- a/client/Assets/BlocksBeyondTheStars/Shaders/BlockAtlas.shader
+++ b/client/Assets/BlocksBeyondTheStars/Shaders/BlockAtlas.shader
@@ -55,7 +55,14 @@ Shader "BlocksBeyondTheStars/BlockAtlas"
             float4 _Sc_LampColor;
             float  _Sc_Indoor;
             float4 _Sc_FloraTint;
-            float  _LeafCutoff;
+
+            // SRP Batcher (#573): the per-MATERIAL properties (the Properties block above) live here and
+            // nowhere else, with the same layout in every pass — the ShadowCaster below repeats it. The _Sc_*
+            // globals above stay outside on purpose: they are per-frame values (Shader.SetGlobal*), and the
+            // batcher would otherwise serve each material's own stale copy of them.
+            CBUFFER_START(UnityPerMaterial)
+                float _LeafCutoff;
+            CBUFFER_END
 
             struct Attributes
             {
@@ -309,8 +316,13 @@ Shader "BlocksBeyondTheStars/BlockAtlas"
             #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Shadows.hlsl"
 
             TEXTURE2D(_MainTex); SAMPLER(sampler_MainTex);
-            float _LeafCutoff;
-            float3 _LightDirection; // set by URP while rendering the shadow map
+
+            // Must match the forward pass's UnityPerMaterial layout exactly (SRP Batcher requirement).
+            CBUFFER_START(UnityPerMaterial)
+                float _LeafCutoff;
+            CBUFFER_END
+
+            float3 _LightDirection; // set by URP while rendering the shadow map (a global, not a material property)
 
             struct SAttr { float4 positionOS : POSITION; float3 normal : NORMAL; float2 uv : TEXCOORD0; };
             struct SVary { float4 positionCS : SV_POSITION; float2 uv : TEXCOORD0; };

--- a/client/Assets/BlocksBeyondTheStars/Shaders/BlockAtlasTransparent.shader
+++ b/client/Assets/BlocksBeyondTheStars/Shaders/BlockAtlasTransparent.shader
@@ -46,7 +46,12 @@ Shader "BlocksBeyondTheStars/BlockAtlasTransparent"
             float4 _Sc_SunDir;
             float4 _Sc_Sky;   // sky colour (set by Sky.cs) — water SSR sky fallback
             float _Sc_ScreenFx; // 1 when the depth+opaque textures exist (Medium+); 0 on Low → water uses the simple look
-            float _BaseAlpha;
+
+            // SRP Batcher (#573): per-MATERIAL properties only. The _Sc_* globals above stay outside — they are
+            // set once per frame via Shader.SetGlobal*, not per material.
+            CBUFFER_START(UnityPerMaterial)
+                float _BaseAlpha;
+            CBUFFER_END
 
             struct Attributes
             {

--- a/client/Assets/BlocksBeyondTheStars/Shaders/LitColor.shader
+++ b/client/Assets/BlocksBeyondTheStars/Shaders/LitColor.shader
@@ -41,10 +41,19 @@ Shader "BlocksBeyondTheStars/LitColor"
             #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Lighting.hlsl"
 
             TEXTURE2D(_MainTex); SAMPLER(sampler_MainTex);
-            float4 _MainTex_ST;
-            float4 _Color;
-            float _Floor;
-            float _Fill;
+
+            // SRP Batcher (#573): every per-MATERIAL property (i.e. everything in the Properties block above)
+            // must sit in this one cbuffer, and its layout must be IDENTICAL in every pass of this SubShader —
+            // the ShadowCaster below repeats it verbatim. Texture/sampler handles stay outside, and so do the
+            // _Sc_* globals: those are one value for the whole frame (Shader.SetGlobal*), not per material, and
+            // moving them in here would make the batcher feed each material's stale copy instead.
+            CBUFFER_START(UnityPerMaterial)
+                float4 _MainTex_ST;
+                float4 _Color;
+                float _Floor;
+                float _Fill;
+            CBUFFER_END
+
             float4 _Sc_LampPos;
             float4 _Sc_LampDir;
             float4 _Sc_LampColor;
@@ -101,7 +110,16 @@ Shader "BlocksBeyondTheStars/LitColor"
             #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
             #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Shadows.hlsl"
 
-            float3 _LightDirection;
+            // Same UnityPerMaterial layout as the forward pass — the SRP Batcher only accepts a shader whose
+            // passes agree on it, so this repeats the block even though the shadow pass reads none of it.
+            CBUFFER_START(UnityPerMaterial)
+                float4 _MainTex_ST;
+                float4 _Color;
+                float _Floor;
+                float _Fill;
+            CBUFFER_END
+
+            float3 _LightDirection; // set by URP while rendering the shadow map (a global, not a material property)
 
             struct SAttr { float4 positionOS : POSITION; float3 normal : NORMAL; };
             struct SVary { float4 positionCS : SV_POSITION; };

--- a/client/Assets/BlocksBeyondTheStars/Shaders/Nebula.shader
+++ b/client/Assets/BlocksBeyondTheStars/Shaders/Nebula.shader
@@ -26,7 +26,10 @@ Shader "BlocksBeyondTheStars/Nebula"
             #pragma fragment frag
             #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
 
-            float _Brightness;
+            // SRP Batcher (#573): per-MATERIAL properties in UnityPerMaterial.
+            CBUFFER_START(UnityPerMaterial)
+                float _Brightness;
+            CBUFFER_END
 
             struct Attributes { float4 positionOS : POSITION; float4 color : COLOR; };
             struct Varyings { float4 positionCS : SV_POSITION; float3 dir : TEXCOORD0; float4 color : COLOR; };

--- a/client/Assets/BlocksBeyondTheStars/Shaders/Particle.shader
+++ b/client/Assets/BlocksBeyondTheStars/Shaders/Particle.shader
@@ -26,7 +26,11 @@ Shader "BlocksBeyondTheStars/Particle"
             #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
 
             TEXTURE2D(_MainTex); SAMPLER(sampler_MainTex);
-            float4 _MainTex_ST;
+
+            // SRP Batcher (#573): per-MATERIAL properties in UnityPerMaterial (texture handles stay outside).
+            CBUFFER_START(UnityPerMaterial)
+                float4 _MainTex_ST;
+            CBUFFER_END
 
             struct Attributes { float4 positionOS : POSITION; float2 uv : TEXCOORD0; float4 color : COLOR; };
             struct Varyings { float4 positionCS : SV_POSITION; float2 uv : TEXCOORD0; float4 color : COLOR; };

--- a/client/Assets/BlocksBeyondTheStars/Shaders/ParticleAlpha.shader
+++ b/client/Assets/BlocksBeyondTheStars/Shaders/ParticleAlpha.shader
@@ -25,7 +25,11 @@ Shader "BlocksBeyondTheStars/ParticleAlpha"
             #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
 
             TEXTURE2D(_MainTex); SAMPLER(sampler_MainTex);
-            float4 _MainTex_ST;
+
+            // SRP Batcher (#573): per-MATERIAL properties in UnityPerMaterial (texture handles stay outside).
+            CBUFFER_START(UnityPerMaterial)
+                float4 _MainTex_ST;
+            CBUFFER_END
 
             struct Attributes { float4 positionOS : POSITION; float2 uv : TEXCOORD0; float4 color : COLOR; };
             struct Varyings { float4 positionCS : SV_POSITION; float2 uv : TEXCOORD0; float4 color : COLOR; };

--- a/client/Assets/BlocksBeyondTheStars/Shaders/PlanetRing.shader
+++ b/client/Assets/BlocksBeyondTheStars/Shaders/PlanetRing.shader
@@ -27,8 +27,12 @@ Shader "BlocksBeyondTheStars/PlanetRing"
             #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
 
             TEXTURE2D(_MainTex); SAMPLER(sampler_MainTex);
-            float4 _MainTex_ST;
-            half4 _Color;
+
+            // SRP Batcher (#573): per-MATERIAL properties in UnityPerMaterial (texture handles stay outside).
+            CBUFFER_START(UnityPerMaterial)
+                float4 _MainTex_ST;
+                half4 _Color;
+            CBUFFER_END
 
             struct Attributes { float4 positionOS : POSITION; float2 uv : TEXCOORD0; };
             struct Varyings { float4 positionCS : SV_POSITION; float2 uv : TEXCOORD0; };

--- a/client/Assets/BlocksBeyondTheStars/Shaders/SkyBodyPhase.shader
+++ b/client/Assets/BlocksBeyondTheStars/Shaders/SkyBodyPhase.shader
@@ -40,13 +40,20 @@ Shader "BlocksBeyondTheStars/SkyBodyPhase"
             #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
 
             TEXTURE2D(_MainTex); SAMPLER(sampler_MainTex);
-            float4 _MainTex_ST;
-            float4 _Color;
-            float4 _PhaseSunDir;
-            float _Earthshine;
-            float _TermSoft;
-            float _LimbDark;
-            float _DayLight;
+
+            // SRP Batcher (#573): per-MATERIAL properties in UnityPerMaterial. Sky bodies are the textbook case —
+            // every planet/moon is its own material with its own phase direction, so the batcher can only keep
+            // them in one SetPass if the properties live here.
+            CBUFFER_START(UnityPerMaterial)
+                float4 _MainTex_ST;
+                float4 _Color;
+                float4 _PhaseSunDir;
+                float _Earthshine;
+                float _TermSoft;
+                float _LimbDark;
+                float _DayLight;
+            CBUFFER_END
+
             float4 _Sc_Sky; // global: current sky colour (linear, set by Sky.cs) — daytime atmosphere wash
 
             struct Attributes { float4 positionOS : POSITION; float3 normal : NORMAL; float2 uv : TEXCOORD0; };

--- a/client/Assets/BlocksBeyondTheStars/Shaders/SunRays.shader
+++ b/client/Assets/BlocksBeyondTheStars/Shaders/SunRays.shader
@@ -29,8 +29,12 @@ Shader "BlocksBeyondTheStars/SunRays"
             #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
 
             TEXTURE2D(_MainTex); SAMPLER(sampler_MainTex);
-            float4 _MainTex_ST;
-            float4 _Color;
+
+            // SRP Batcher (#573): per-MATERIAL properties in UnityPerMaterial (texture handles stay outside).
+            CBUFFER_START(UnityPerMaterial)
+                float4 _MainTex_ST;
+                float4 _Color;
+            CBUFFER_END
 
             struct Attributes { float4 positionOS : POSITION; float2 uv : TEXCOORD0; };
             struct Varyings { float4 positionCS : SV_POSITION; float2 uv : TEXCOORD0; };

--- a/client/Assets/Tests/EditMode/ShaderSrpBatcherEditModeTests.cs
+++ b/client/Assets/Tests/EditMode/ShaderSrpBatcherEditModeTests.cs
@@ -1,0 +1,320 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEditor.Rendering;
+using UnityEngine;
+using UnityEngine.Rendering;
+
+namespace BlocksBeyondTheStars.Client.Tests.EditMode
+{
+    /// <summary>
+    /// Guards the SRP Batcher contract for the project's own shaders (#573). The batcher can only keep many
+    /// distinct materials in one SetPass call when a shader declares every per-MATERIAL property inside a single
+    /// <c>CBUFFER_START(UnityPerMaterial)</c> block, with the same layout in every pass of the SubShader; a
+    /// single property left bare silently drops that shader back to one SetPass per material. Because "silently"
+    /// is the operative word — nothing at runtime complains — the rule is checked here instead.
+    ///
+    /// Three angles: the shaders still compile, Unity's own checker reports the URP SubShader as compatible, and
+    /// the cbuffer discipline is readable straight from the source. The middle one asks the internal API behind
+    /// the Shader Inspector's "SRP Batcher: compatible" line — authoritative, but it can only answer for a
+    /// SubShader that has actually been compiled, so in a headless batch run it says "Not initialized" for every
+    /// URP SubShader and the test skips itself (see the canary below). The source-level check has no such
+    /// dependency and is what keeps CI honest; run this suite from the Editor's Test Runner for the real verdict.
+    /// </summary>
+    public sealed class ShaderSrpBatcherEditModeTests
+    {
+        private const string ShaderFolder = "Assets/BlocksBeyondTheStars/Shaders";
+
+        /// <summary>
+        /// Shaders that cannot be batcher-compatible, with the reason. Kept explicit so adding one is a
+        /// decision someone writes down, not an omission.
+        /// </summary>
+        private static readonly Dictionary<string, string> ExpectedIncompatible = new Dictionary<string, string>
+        {
+            // Built-in-RP CG only (no URP SubShader): a single full-screen additive overlay quad drawn once per
+            // menu frame, so there is nothing to batch and no reason to port it. See VisorGlass.shader.
+            ["VisorGlass"] = "no URP SubShader — Built-in RP CG overlay, one draw",
+        };
+
+        private static IEnumerable<Shader> AllProjectShaders()
+        {
+            foreach (string guid in AssetDatabase.FindAssets("t:Shader", new[] { ShaderFolder }))
+            {
+                string path = AssetDatabase.GUIDToAssetPath(guid);
+                var shader = AssetDatabase.LoadAssetAtPath<Shader>(path);
+                if (shader != null)
+                {
+                    yield return shader;
+                }
+            }
+        }
+
+        /// <summary>Index of the SubShader tagged for URP, or -1 when the shader has none.</summary>
+        private static int UrpSubShaderIndex(Shader shader)
+        {
+            var tag = new ShaderTagId("RenderPipeline");
+            for (int i = 0; i < shader.subshaderCount; i++)
+            {
+                if (shader.FindSubshaderTagValue(i, tag).name == "UniversalPipeline")
+                {
+                    return i;
+                }
+            }
+
+            return -1;
+        }
+
+        [Test]
+        public void ProjectShaders_CompileWithoutErrors()
+        {
+            var broken = new List<string>();
+            foreach (var shader in AllProjectShaders())
+            {
+                if (!ShaderUtil.ShaderHasError(shader))
+                {
+                    continue;
+                }
+
+                string messages = string.Join("; ", ShaderUtil.GetShaderMessages(shader)
+                    .Where(m => m.severity == ShaderCompilerMessageSeverity.Error)
+                    .Select(m => $"{m.file}:{m.line} {m.message}"));
+                broken.Add($"{shader.name}: {messages}");
+            }
+
+            Assert.That(broken, Is.Empty, "Shaders failed to compile:\n" + string.Join("\n", broken));
+        }
+
+        [Test]
+        public void UrpSubShaders_AreSrpBatcherCompatible()
+        {
+            // UnityEditor.ShaderUtil.GetSRPBatcherCompatibilityCode(Shader, int) — internal, and the only way to
+            // read what the Shader Inspector shows. 0 = compatible, everything else is a reason code.
+            var method = typeof(ShaderUtil).GetMethod(
+                "GetSRPBatcherCompatibilityCode",
+                BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic,
+                binder: null,
+                types: new[] { typeof(Shader), typeof(int) },
+                modifiers: null);
+            if (method == null)
+            {
+                Assert.Ignore("UnityEditor.ShaderUtil.GetSRPBatcherCompatibilityCode(Shader, int) is gone — this "
+                    + "Unity version needs a new probe. The source-level cbuffer test still guards the rule.");
+            }
+
+            // Canary: URP's own Lit shader is batcher-compatible by construction. When the probe calls even that
+            // one incompatible, it is not reading real data — a URP SubShader that was never compiled in this
+            // session answers "Not initialized ()", which is what a batch run (`scripts/run-tests.ps1
+            // -Suites UnityEdit`, `-nographics`) gets for every one of them. Failing the build on that would be
+            // pure noise, so the run is skipped and the source-level test below — which needs no graphics device
+            // — keeps guarding the rule. Run this suite from the Editor's Test Runner window for the real verdict.
+            var canary = Shader.Find("Universal Render Pipeline/Lit");
+            int canaryIndex = canary == null ? -1 : UrpSubShaderIndex(canary);
+            int canaryCode = canaryIndex < 0 ? 0 : (int)method.Invoke(null, new object[] { canary, canaryIndex });
+            if (canaryCode != 0)
+            {
+                Assert.Ignore("SRP Batcher compatibility is unreadable in this session — URP's own Lit shader "
+                    + $"reports '{SrpBatcherIssue(canary, canaryIndex, canaryCode)}'. Expected in a batch run; "
+                    + "use the Editor's Test Runner window (or the Shader Inspector) for the real verdict.");
+            }
+
+            var failures = new List<string>();
+            var unexpectedlyFine = new List<string>();
+            foreach (var shader in AllProjectShaders())
+            {
+                string name = Path.GetFileNameWithoutExtension(AssetDatabase.GetAssetPath(shader));
+                bool waived = ExpectedIncompatible.ContainsKey(name);
+                int subShader = UrpSubShaderIndex(shader);
+                if (subShader < 0)
+                {
+                    if (!waived)
+                    {
+                        failures.Add($"{name}: no URP SubShader (add one, or waive it in ExpectedIncompatible)");
+                    }
+
+                    continue;
+                }
+
+                int code = (int)method.Invoke(null, new object[] { shader, subShader });
+                if (code != 0 && !waived)
+                {
+                    failures.Add($"{name}: SRP Batcher incompatible ({SrpBatcherIssue(shader, subShader, code)}) — "
+                        + "declare every property from the Properties block inside CBUFFER_START(UnityPerMaterial), "
+                        + "identically in every pass");
+                }
+                else if (code == 0 && waived)
+                {
+                    unexpectedlyFine.Add(name);
+                }
+            }
+
+            Assert.That(failures, Is.Empty, "SRP Batcher regressions:\n" + string.Join("\n", failures));
+            Assert.That(unexpectedlyFine, Is.Empty,
+                "These shaders are batcher-compatible now — drop them from ExpectedIncompatible: "
+                + string.Join(", ", unexpectedlyFine));
+        }
+
+        /// <summary>
+        /// The human-readable reason behind a non-zero compatibility code — the same sentence the Material
+        /// Inspector prints, e.g. "Material property is found in another cbuffer than UnityPerMaterial (_Color)".
+        /// Falls back to the bare code when the (internal, signature-unstable) accessor isn't there.
+        /// </summary>
+        private static string SrpBatcherIssue(Shader shader, int subShaderIndex, int code)
+        {
+            foreach (var candidate in typeof(ShaderUtil).GetMethods(BindingFlags.Static | BindingFlags.Public
+                | BindingFlags.NonPublic))
+            {
+                if (!candidate.Name.Contains("SRPBatcher") || candidate.ReturnType != typeof(string))
+                {
+                    continue;
+                }
+
+                var parameters = candidate.GetParameters();
+                object[] args = parameters.Length == 2 ? new object[] { shader, subShaderIndex }
+                    : parameters.Length == 3 ? new object[] { shader, subShaderIndex, code }
+                    : null;
+                if (args == null)
+                {
+                    continue;
+                }
+
+                try
+                {
+                    string reason = (string)candidate.Invoke(null, args);
+                    if (!string.IsNullOrEmpty(reason))
+                    {
+                        return reason;
+                    }
+                }
+                catch (TargetInvocationException)
+                {
+                    // Wrong overload for this Unity version — fall through to the next candidate.
+                }
+            }
+
+            return "code " + code;
+        }
+
+        [Test]
+        public void UrpPasses_DeclareMaterialPropertiesInsideUnityPerMaterial()
+        {
+            var failures = new List<string>();
+            foreach (string guid in AssetDatabase.FindAssets("t:Shader", new[] { ShaderFolder }))
+            {
+                string path = AssetDatabase.GUIDToAssetPath(guid);
+                string name = Path.GetFileNameWithoutExtension(path);
+                string source = File.ReadAllText(path); // asset paths are relative to the project folder = CWD
+
+                string urp = UrpSubShaderSource(source);
+                if (urp == null)
+                {
+                    continue; // Built-in-RP-only shader (waived above) — the batcher never sees it.
+                }
+
+                var cbufferTextRanges = CbufferTextRanges(urp);
+                foreach (string property in MaterialPropertyNames(source))
+                {
+                    // A texture property contributes _Name_ST / _Name_TexelSize / _Name_HDR constants; the
+                    // TEXTURE2D/SAMPLER handles themselves must stay OUT of the cbuffer, so they aren't matched.
+                    var declaration = new Regex(
+                        @"^[ \t]*(?:float|half|fixed|int|uint|bool)[1-4]?(?:x[1-4])?[ \t]+"
+                        + Regex.Escape(property) + @"(?:_ST|_TexelSize|_HDR)?[ \t]*;",
+                        RegexOptions.Multiline);
+                    foreach (Match match in declaration.Matches(urp))
+                    {
+                        if (!cbufferTextRanges.Any(r => match.Index >= r.Start && match.Index < r.End))
+                        {
+                            failures.Add($"{name}: '{match.Value.Trim()}' is a material property declared outside "
+                                + "CBUFFER_START(UnityPerMaterial) — the SRP Batcher skips the whole shader for it");
+                        }
+                    }
+                }
+            }
+
+            Assert.That(failures, Is.Empty, "Material properties outside UnityPerMaterial:\n"
+                + string.Join("\n", failures));
+        }
+
+        /// <summary>Property names from the shader's top-level <c>Properties { ... }</c> block.</summary>
+        private static IEnumerable<string> MaterialPropertyNames(string source)
+        {
+            var block = Regex.Match(source, @"^\s*Properties\s*\{", RegexOptions.Multiline);
+            if (!block.Success)
+            {
+                yield break; // e.g. VertexColorOpaque: vertex colours only, no material properties at all
+            }
+
+            string body = BracedBody(source, block.Index + block.Length - 1);
+            foreach (Match property in Regex.Matches(body, @"^[ \t]*(_\w+)\s*\(", RegexOptions.Multiline))
+            {
+                yield return property.Groups[1].Value;
+            }
+        }
+
+        /// <summary>The source of the SubShader tagged "UniversalPipeline", or null if there is none.</summary>
+        private static string UrpSubShaderSource(string source)
+        {
+            foreach (Match subShader in Regex.Matches(source, @"^\s*SubShader\s*\{", RegexOptions.Multiline))
+            {
+                string body = BracedBody(source, subShader.Index + subShader.Length - 1);
+                if (Regex.IsMatch(body, "\"RenderPipeline\"\\s*=\\s*\"UniversalPipeline\""))
+                {
+                    return body;
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>Text between the brace at <paramref name="openBrace"/> and its match.</summary>
+        private static string BracedBody(string source, int openBrace)
+        {
+            int depth = 0;
+            for (int i = openBrace; i < source.Length; i++)
+            {
+                if (source[i] == '{')
+                {
+                    depth++;
+                }
+                else if (source[i] == '}' && --depth == 0)
+                {
+                    return source.Substring(openBrace + 1, i - openBrace - 1);
+                }
+            }
+
+            throw new InvalidOperationException("Unbalanced braces in shader source at index " + openBrace);
+        }
+
+        private readonly struct TextRange
+        {
+            public TextRange(int start, int end)
+            {
+                Start = start;
+                End = end;
+            }
+
+            public int Start { get; }
+
+            public int End { get; }
+        }
+
+        private static List<TextRange> CbufferTextRanges(string source)
+        {
+            var ranges = new List<TextRange>();
+            foreach (Match start in Regex.Matches(source, @"CBUFFER_START\s*\(\s*UnityPerMaterial\s*\)"))
+            {
+                int end = source.IndexOf("CBUFFER_END", start.Index, StringComparison.Ordinal);
+                ranges.Add(new TextRange(start.Index, end < 0 ? source.Length : end));
+            }
+
+            return ranges;
+        }
+    }
+}

--- a/client/Assets/Tests/EditMode/ShaderSrpBatcherEditModeTests.cs.meta
+++ b/client/Assets/Tests/EditMode/ShaderSrpBatcherEditModeTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c4df5ab1eafd5504ab0e0d05777b71f2

--- a/docs/developer/CLIENT_TESTING.md
+++ b/docs/developer/CLIENT_TESTING.md
@@ -14,7 +14,7 @@ not a mock — at three tiers, fastest first.
 | Tier | Suite | What runs | Needs Unity? | Needs server exe? |
 |---|---|---|---|---|
 | 1 | `ClientCore` | Real `NetworkClient` ↔ real in-process `GameServer` over a `LoopbackLink` | no | no |
-| 1.5 | `UnityEdit` | Unity EditMode unit tests (ClientWorld, BlockTextureAtlas) | yes (Editor) | no |
+| 1.5 | `UnityEdit` | Unity EditMode unit tests (ClientWorld, mesh packing, shader/asset rules) | yes (Editor) | no |
 | 2 | `UnityPlay` | Real `NetworkClient` ↔ the **published** server exe over loopback UDP | yes (Editor) | yes |
 | — | `Dotnet` | The existing .NET server/shared xUnit suite | no | no |
 
@@ -60,6 +60,15 @@ These are the bulk of the value and run in `dotnet test`. All test classes carry
 `client/Assets/Tests/EditMode/`. Headless in-Editor unit tests for **Unity-runtime-safe** logic — `ClientWorld`
 round-trips run inside the Editor/Mono. (Code that calls `Object.Destroy` cannot run here — `Destroy` is illegal
 in edit mode — so the atlas test lives in PlayMode below.)
+
+This tier is also where **asset-level** rules are checked, because they need the `AssetDatabase`:
+`ShaderSrpBatcherEditModeTests` asserts that the project's shaders compile and that every per-material property
+is declared inside `CBUFFER_START(UnityPerMaterial)`, which is what makes a shader SRP-Batcher-compatible
+(#573). ⚠️ One caveat worth knowing before adding more graphics assertions: the runner passes `-nographics`, and
+Unity's own compatibility API can only answer for a SubShader it has actually **compiled** — headless it reports
+`Not initialized ()` for every URP SubShader, URP's own `Lit` included. That test therefore canaries on `Lit`
+and skips itself rather than fail on a blind probe; the source-level check next to it needs no graphics device
+and is the one that holds in CI. Run the suite from the Editor's Test Runner window for the real verdict.
 
 ## Tier 2 — Unity PlayMode (`UnityPlay`)
 


### PR DESCRIPTION
Closes #573 (ask 1). Ask 2 — the WebGL startup `ERROR: Shader` lines — is untouched here and split out
into #1099 so it stays tracked.

## The problem

The SRP Batcher is enabled in the URP asset, but a shader only qualifies for it when **every per-material
property sits in one `CBUFFER_START(UnityPerMaterial)` block, with the same layout in every pass** of the
SubShader. Ours declared them bare, which costs one SetPass call per material and says nothing at runtime.

Unity's own checker spells the rule out, and this PR's diagnostic runs caught it saying so on our untouched
Built-in-RP SubShaders:

> `Material property is found in another cbuffer than "UnityPerMaterial" (_Floor)`

## What changed

Eleven URP SubShaders now declare their properties in `UnityPerMaterial`:

| Shader | Why it matters |
| --- | --- |
| `LitColor` | the real prize — avatars, held items, doors, ship previews, station/structure models are many distinct materials on one shader |
| `SkyBodyPhase` | one material per planet/moon, each with its own phase direction |
| `BlockAtlas`, `BlockAtlasTransparent` | terrain shares one material, so the win is small, but the rule is the rule |
| `Atmosphere`, `Aurora`, `Nebula`, `SunRays`, `PlanetRing` | sky/effect materials |
| `Particle`, `ParticleAlpha` | consistency; particle geometry is not batched by the SRP Batcher anyway |

`LitColor` and `BlockAtlas` repeat the identical block in their **ShadowCaster** pass — a layout that differs
between passes disqualifies the whole shader.

**The `_Sc_*` / `_HeatAmp` / `_ThermalAmt` globals stay outside the cbuffer on purpose.** They are per-frame
`Shader.SetGlobal*` values (sun, sky, fog, headlamp, heat/thermal amount); inside `UnityPerMaterial` the
batcher would serve each material's own stale copy of them instead. Same for the `TEXTURE2D`/`SAMPLER` handles
and URP's `_LightDirection`.

### Deliberately unchanged

| Shader | Reason |
| --- | --- |
| `ScatterLit`, `VertexColorOpaque`, `HeatHaze`, `Thermal` | no material properties at all — nothing to wrap, already compliant |
| `Visor` | a render-graph blit; the SRP Batcher only ever sees `DrawRenderers` |
| `VisorGlass` | Built-in-RP CG overlay quad, no URP SubShader — one draw per menu frame, nothing to batch (waived explicitly in the test) |
| `Cloud`, `Starfield`, `SunGlow`, `ThermalMarker` | already correct |

So the issue's "15 of 18" is really **11 worth fixing**: four of the listed shaders have no material
properties to begin with, and two are full-screen/overlay passes the batcher never touches.

No visual change is intended — this moves declarations, not maths.

## Regression guard

New `ShaderSrpBatcherEditModeTests` (3 tests):

1. every project shader still compiles;
2. Unity's own compatibility verdict for each URP SubShader, with `VisorGlass` explicitly waived;
3. a source-level check that fails any material property declared outside `UnityPerMaterial`.

Worth knowing for anyone reaching for check 2: `ShaderUtil.GetSRPBatcherCompatibilityCode` can only answer for
a SubShader that has actually been **compiled**. In a headless `-nographics` batch run every URP SubShader —
URP's own `Lit` included — answers `Not initialized ()`. The test therefore canaries on `Lit` and skips itself
rather than fail the build on a blind probe; check 3 needs no graphics device and is what holds the line in
CI. Run the suite from the Editor's Test Runner window (or eyeball the Shader Inspector) for the real verdict.

## Verification

- Unity EditMode suite in a worktree: **35 tests, 34 passed, 0 failed, 1 skipped** (the probe above).
- Local Unity Windows player build: green — the shaders compile for a real player target.
- No .NET code touched.
- Frame-time effect **not measured**; the win is fewer SetPass calls, best seen in the Frame Debugger.
  Worth a PerfProbe A/B later, but the acceptance criterion for this issue was the cbuffer discipline.
