### PR TITLE
Fix/corrupted player join rejection

### DIFF
--- a/data/locales/de.json
+++ b/data/locales/de.json
@@ -3138,6 +3138,7 @@
   "srv.join.failed": "Der Beitritt ist auf dem Server fehlgeschlagen. Bitte versuch es noch einmal.",
   "srv.join.token_required": "Dieser Server verlangt ein gültiges Join-Token. Bitte über das Weltenportal beitreten.",
   "srv.join.welcome": "Willkommen! Diese Welt ist Teil eines Familien-Projekts — sei nett zu anderen. Keine Hetze, kein Mobbing, kein Rassismus (führt zum Bann). Beta: Welten können verloren gehen — lade im Portal Sicherungen herunter!",
+  "srv.join.data_corrupted": "Deine Spielerdaten auf diesem Server sind beschädigt und konnten nicht geladen werden. Bitte melde dich beim Server-Admin.",
   "srv.land.full": "Alle Landezonen sind belegt.",
   "srv.land.no_pad": "Diesen Landeplatz gibt es nicht.",
   "srv.land.pad_taken": "Dieser Landeplatz ist schon belegt.",

--- a/data/locales/en.json
+++ b/data/locales/en.json
@@ -3138,6 +3138,7 @@
   "srv.join.failed": "Joining failed on the server. Please try again.",
   "srv.join.token_required": "This server requires a valid join token. Please join through the worlds portal.",
   "srv.join.welcome": "Welcome! This world is part of a family project — be kind to others. No hate, bullying or racism (leads to a ban). Beta: worlds can be lost — download backups on the portal!",
+  "srv.join.data_corrupted": "Your player data on this server is damaged and could not be loaded. Please contact the server admin.",
   "srv.land.full": "All landing zones are taken.",
   "srv.land.no_pad": "That landing pad doesn't exist.",
   "srv.land.pad_taken": "That landing pad is already taken.",

--- a/src/BlocksBeyondTheStars.GameServer/GameServer.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServer.cs
@@ -3313,7 +3313,6 @@ public sealed partial class GameServer
         var (joinBody, joinBodyType) = RestoreJoinBody(state);
         LoadWorld(joinBodyType, joinBody);
 
-        // ... rest of setup
         var session = new PlayerSession(connectionId, state)
         {
             Joined = true,

--- a/src/BlocksBeyondTheStars.GameServer/GameServer.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServer.cs
@@ -2919,7 +2919,22 @@ public sealed partial class GameServer
         // `marcel` ≠ `Marcel` mismatch would grant nothing with no error anywhere.
         bool fleetAdmin = IsFleetAdminName(name);
 
-        var state = _repo.LoadPlayer(name) ?? CreateNewPlayer(name);
+        PlayerState state;
+        try
+        {
+            state = _repo.LoadPlayer(name) ?? CreateNewPlayer(name);
+        }
+        catch (InvalidDataException ex)
+        {
+            _log.Error($"Failed to load player '{name}' (connection {connectionId}): persisted data is corrupted. " +
+                       $"The database record was kept untouched for manual recovery. Error: {ex.Message} -> {ex.InnerException?.Message}\n{ex.StackTrace}");
+
+            SendTo(connectionId, new JoinRejected
+            {
+                Reason = "@srv.join.data_corrupted"
+            });
+            return;
+        }
         string tokenHash = HashNameToken(join.Token);
 
         // Reconnect eviction (#964). A client that dies without closing its socket cleanly — PC crash, hard
@@ -3275,7 +3290,17 @@ public sealed partial class GameServer
     /// </summary>
     public PlayerSession AddLocalPlayer(string name, string locale = "en")
     {
-        var state = _repo.LoadPlayer(name) ?? CreateNewPlayer(name);
+        PlayerState state;
+        try
+        {
+            state = _repo.LoadPlayer(name) ?? CreateNewPlayer(name);
+        }
+        catch (InvalidDataException ex)
+        {
+            _log.Error($"Failed to load local player '{name}': save data is corrupted. " +
+                       $"Kept data untouched for manual recovery. Error: {ex.Message} -> {ex.InnerException?.Message}");
+            throw; // Preserve the contract: surface the corruption to UI/caller without overwriting
+        }
 
         if (state.Role != PlayerRole.WorldAdmin && _config.AdminPlayers.Contains(name))
         {
@@ -3288,6 +3313,7 @@ public sealed partial class GameServer
         var (joinBody, joinBodyType) = RestoreJoinBody(state);
         LoadWorld(joinBodyType, joinBody);
 
+        // ... rest of setup
         var session = new PlayerSession(connectionId, state)
         {
             Joined = true,


### PR DESCRIPTION
PR: Reject joins for corrupted player data

Summary

Catch InvalidDataException when loading players during local player creation and network joins.
Log corrupted persisted player data without modifying the stored record.
Return JoinRejected with @srv.join.data_corrupted when a network player's save data is corrupted instead of allowing the join to fail into a timeout.

Testing

Existing persistence corruption tests pass.
Verified the GameServer changes build successfully.