### PR TITLE
Fix/persistence init corruption

### DIFF
--- a/src/BlocksBeyondTheStars.GameServer/GameServer.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServer.cs
@@ -224,7 +224,17 @@ public sealed partial class GameServer
 
     public void Start()
     {
-        _repo.Initialize();
+        try
+        {
+            _repo.Initialize();
+        }
+        catch (InvalidDataException ex)
+        {
+            _log.Error($"Failed to initialize persistence: database is corrupted. " +
+                       $"The database was left untouched. Error: {ex.Message}");
+
+            throw;
+        }
         // Record the current block-id palette and remap any save written under a different block set BEFORE
         // world load. Block ids are assigned by key sort order, so adding a block shifts them; without this a
         // content update would silently decode every stored edit to the wrong block.

--- a/src/BlocksBeyondTheStars.Persistence/PostgreSqlWorldRepository.cs
+++ b/src/BlocksBeyondTheStars.Persistence/PostgreSqlWorldRepository.cs
@@ -48,7 +48,9 @@ public sealed class PostgreSqlWorldRepository : IWorldRepository
 
     public void Initialize()
     {
-        _paths.EnsureDirectories();
+        try
+        {
+            _paths.EnsureDirectories();
 
         _connection = new NpgsqlConnection(_connectionString);
         _connection.Open();
@@ -138,6 +140,13 @@ public sealed class PostgreSqlWorldRepository : IWorldRepository
         TryExecute("ALTER TABLE paint_design ADD COLUMN IF NOT EXISTS owner_name TEXT NOT NULL DEFAULT '';");
         // Per-container stash filter (#1032): '' = no filter, which is what every pre-existing crate keeps.
         TryExecute("ALTER TABLE container ADD COLUMN IF NOT EXISTS filter TEXT NOT NULL DEFAULT '';");
+        }
+        catch (PostgresException ex) when (ex.SqlState is "42601" or "42P01" or "42P07")
+        {
+            throw new InvalidDataException(
+                $"PostgreSQL database is corrupted or incompatible: {_paths.WorldDirectory}",
+                ex);
+        }
     }
 
     // --- Block-id palette (content-shift migration) ---

--- a/src/BlocksBeyondTheStars.Persistence/PostgreSqlWorldRepository.cs
+++ b/src/BlocksBeyondTheStars.Persistence/PostgreSqlWorldRepository.cs
@@ -141,7 +141,9 @@ public sealed class PostgreSqlWorldRepository : IWorldRepository
             // Per-container stash filter (#1032): '' = no filter, which is what every pre-existing crate keeps.
             TryExecute("ALTER TABLE container ADD COLUMN IF NOT EXISTS filter TEXT NOT NULL DEFAULT '';");
         }
-        catch (PostgresException ex) when (ex.SqlState is "42601" or "42P01" or "42P07")
+        // 42P01/42P07 = the stored schema no longer matches what Initialize expects (undefined/duplicate
+        // relation). Deliberately NOT 42601 (syntax_error) — that is a bug in our SQL, not a broken save.
+        catch (PostgresException ex) when (ex.SqlState is "42P01" or "42P07")
         {
             throw new InvalidDataException(
                 $"PostgreSQL database is corrupted or incompatible: {_paths.WorldDirectory}",

--- a/src/BlocksBeyondTheStars.Persistence/PostgreSqlWorldRepository.cs
+++ b/src/BlocksBeyondTheStars.Persistence/PostgreSqlWorldRepository.cs
@@ -52,13 +52,13 @@ public sealed class PostgreSqlWorldRepository : IWorldRepository
         {
             _paths.EnsureDirectories();
 
-        _connection = new NpgsqlConnection(_connectionString);
-        _connection.Open();
+            _connection = new NpgsqlConnection(_connectionString);
+            _connection.Open();
 
-        Execute($"CREATE SCHEMA IF NOT EXISTS {QuoteIdentifier(_schemaName)};");
-        Execute($"SET search_path TO {QuoteIdentifier(_schemaName)};");
+            Execute($"CREATE SCHEMA IF NOT EXISTS {QuoteIdentifier(_schemaName)};");
+            Execute($"SET search_path TO {QuoteIdentifier(_schemaName)};");
 
-        Execute(@"
+            Execute(@"
             CREATE TABLE IF NOT EXISTS world_meta (id INTEGER PRIMARY KEY CHECK (id = 0), json TEXT NOT NULL);
             CREATE TABLE IF NOT EXISTS block_edit (
                 planet TEXT NOT NULL, x INTEGER NOT NULL, y INTEGER NOT NULL, z INTEGER NOT NULL,
@@ -119,27 +119,27 @@ public sealed class PostgreSqlWorldRepository : IWorldRepository
             CREATE TABLE IF NOT EXISTS custom_shape (
                 id INTEGER PRIMARY KEY, owner TEXT NOT NULL, owner_name TEXT NOT NULL,
                 name TEXT NOT NULL, voxels TEXT NOT NULL);");
-        // (Landing pads are deterministic + live-occupancy now — no per-player landing_zone table; item 38.)
+            // (Landing pads are deterministic + live-occupancy now — no per-player landing_zone table; item 38.)
 
-        // Migrate older saves to carry per-voxel colour modifiers (dyed blocks / coloured lights). The
-        // columns are added if absent; on a fresh DB they already exist from the CREATE above, so the
-        // ALTERs throw "duplicate column" and are harmlessly ignored.
-        TryExecute("ALTER TABLE block_edit ADD COLUMN IF NOT EXISTS tint INTEGER NOT NULL DEFAULT 0;");
-        TryExecute("ALTER TABLE block_edit ADD COLUMN IF NOT EXISTS glow INTEGER NOT NULL DEFAULT 0;");
-        // Migrate older saves to carry the per-voxel shape descriptor (non-cube building forms). Same pattern:
-        // harmlessly ignored on a fresh DB where the CREATE already added the column.
-        TryExecute("ALTER TABLE block_edit ADD COLUMN IF NOT EXISTS shape INTEGER NOT NULL DEFAULT 0;");
-        // Block attribution (issue #490) — mirrors the SQLite side: interned owner + edit time, 0 = unknown for
-        // every row written before this shipped (no back-fill is possible).
-        TryExecute("ALTER TABLE block_edit ADD COLUMN IF NOT EXISTS owner_id INTEGER NOT NULL DEFAULT 0;");
-        TryExecute("ALTER TABLE block_edit ADD COLUMN IF NOT EXISTS edited_unix BIGINT NOT NULL DEFAULT 0;");
-        // Player-designed forms (#843) share the report table with paint — every pre-existing row is a paint
-        // report, which is exactly what the column default says.
-        TryExecute("ALTER TABLE paint_report ADD COLUMN IF NOT EXISTS kind TEXT NOT NULL DEFAULT 'paint';");
-        // Attribution for copied designs (#846): pre-existing designs simply have no designer name on record.
-        TryExecute("ALTER TABLE paint_design ADD COLUMN IF NOT EXISTS owner_name TEXT NOT NULL DEFAULT '';");
-        // Per-container stash filter (#1032): '' = no filter, which is what every pre-existing crate keeps.
-        TryExecute("ALTER TABLE container ADD COLUMN IF NOT EXISTS filter TEXT NOT NULL DEFAULT '';");
+            // Migrate older saves to carry per-voxel colour modifiers (dyed blocks / coloured lights). The
+            // columns are added if absent; on a fresh DB they already exist from the CREATE above, so the
+            // ALTERs throw "duplicate column" and are harmlessly ignored.
+            TryExecute("ALTER TABLE block_edit ADD COLUMN IF NOT EXISTS tint INTEGER NOT NULL DEFAULT 0;");
+            TryExecute("ALTER TABLE block_edit ADD COLUMN IF NOT EXISTS glow INTEGER NOT NULL DEFAULT 0;");
+            // Migrate older saves to carry the per-voxel shape descriptor (non-cube building forms). Same pattern:
+            // harmlessly ignored on a fresh DB where the CREATE already added the column.
+            TryExecute("ALTER TABLE block_edit ADD COLUMN IF NOT EXISTS shape INTEGER NOT NULL DEFAULT 0;");
+            // Block attribution (issue #490) — mirrors the SQLite side: interned owner + edit time, 0 = unknown for
+            // every row written before this shipped (no back-fill is possible).
+            TryExecute("ALTER TABLE block_edit ADD COLUMN IF NOT EXISTS owner_id INTEGER NOT NULL DEFAULT 0;");
+            TryExecute("ALTER TABLE block_edit ADD COLUMN IF NOT EXISTS edited_unix BIGINT NOT NULL DEFAULT 0;");
+            // Player-designed forms (#843) share the report table with paint — every pre-existing row is a paint
+            // report, which is exactly what the column default says.
+            TryExecute("ALTER TABLE paint_report ADD COLUMN IF NOT EXISTS kind TEXT NOT NULL DEFAULT 'paint';");
+            // Attribution for copied designs (#846): pre-existing designs simply have no designer name on record.
+            TryExecute("ALTER TABLE paint_design ADD COLUMN IF NOT EXISTS owner_name TEXT NOT NULL DEFAULT '';");
+            // Per-container stash filter (#1032): '' = no filter, which is what every pre-existing crate keeps.
+            TryExecute("ALTER TABLE container ADD COLUMN IF NOT EXISTS filter TEXT NOT NULL DEFAULT '';");
         }
         catch (PostgresException ex) when (ex.SqlState is "42601" or "42P01" or "42P07")
         {

--- a/src/BlocksBeyondTheStars.Persistence/SqliteWorldRepository.cs
+++ b/src/BlocksBeyondTheStars.Persistence/SqliteWorldRepository.cs
@@ -158,7 +158,6 @@ public sealed class SqliteWorldRepository : IWorldRepository
         }
     }
 
-
     // --- Block-id palette (content-shift migration) ---
 
     public void EnsureBlockPalette(IReadOnlyDictionary<ushort, string> currentPalette)

--- a/src/BlocksBeyondTheStars.Persistence/SqliteWorldRepository.cs
+++ b/src/BlocksBeyondTheStars.Persistence/SqliteWorldRepository.cs
@@ -44,23 +44,26 @@ public sealed class SqliteWorldRepository : IWorldRepository
 
     public void Initialize()
     {
-        _paths.EnsureDirectories();
-
-        var connectionString = new SqliteConnectionStringBuilder
+        try
         {
-            DataSource = _paths.DatabaseFile,
-            Mode = SqliteOpenMode.ReadWriteCreate,
-            Cache = SqliteCacheMode.Private,
-        }.ToString();
 
-        _connection = new SqliteConnection(connectionString);
-        _connection.Open();
+            _paths.EnsureDirectories();
 
-        Execute("PRAGMA journal_mode=WAL;");
-        Execute("PRAGMA synchronous=NORMAL;");
-        Execute("PRAGMA foreign_keys=ON;");
+            var connectionString = new SqliteConnectionStringBuilder
+            {
+                DataSource = _paths.DatabaseFile,
+                Mode = SqliteOpenMode.ReadWriteCreate,
+                Cache = SqliteCacheMode.Private,
+            }.ToString();
 
-        Execute(@"
+            _connection = new SqliteConnection(connectionString);
+            _connection.Open();
+
+            Execute("PRAGMA journal_mode=WAL;");
+            Execute("PRAGMA synchronous=NORMAL;");
+            Execute("PRAGMA foreign_keys=ON;");
+
+            Execute(@"
             CREATE TABLE IF NOT EXISTS world_meta (id INTEGER PRIMARY KEY CHECK (id = 0), json TEXT NOT NULL);
             CREATE TABLE IF NOT EXISTS block_edit (
                 planet TEXT NOT NULL, x INTEGER NOT NULL, y INTEGER NOT NULL, z INTEGER NOT NULL,
@@ -121,32 +124,40 @@ public sealed class SqliteWorldRepository : IWorldRepository
             CREATE TABLE IF NOT EXISTS custom_shape (
                 id INTEGER PRIMARY KEY, owner TEXT NOT NULL, owner_name TEXT NOT NULL,
                 name TEXT NOT NULL, voxels TEXT NOT NULL);");
-        // (Landing pads are deterministic + live-occupancy now — no per-player landing_zone table; item 38.)
+            // (Landing pads are deterministic + live-occupancy now — no per-player landing_zone table; item 38.)
 
-        // Migrate older saves to carry per-voxel colour modifiers (dyed blocks / coloured lights). The
-        // columns are added if absent; on a fresh DB they already exist from the CREATE above, so the
-        // ALTERs throw "duplicate column" and are harmlessly ignored.
-        TryExecute("ALTER TABLE block_edit ADD COLUMN tint INTEGER NOT NULL DEFAULT 0;");
-        TryExecute("ALTER TABLE block_edit ADD COLUMN glow INTEGER NOT NULL DEFAULT 0;");
-        // Migrate older saves to carry the per-voxel shape descriptor (non-cube building forms). Same pattern:
-        // harmlessly ignored on a fresh DB where the CREATE already added the column.
-        TryExecute("ALTER TABLE block_edit ADD COLUMN shape INTEGER NOT NULL DEFAULT 0;");
+            // Migrate older saves to carry per-voxel colour modifiers (dyed blocks / coloured lights). The
+            // columns are added if absent; on a fresh DB they already exist from the CREATE above, so the
+            // ALTERs throw "duplicate column" and are harmlessly ignored.
+            TryExecute("ALTER TABLE block_edit ADD COLUMN tint INTEGER NOT NULL DEFAULT 0;");
+            TryExecute("ALTER TABLE block_edit ADD COLUMN glow INTEGER NOT NULL DEFAULT 0;");
+            // Migrate older saves to carry the per-voxel shape descriptor (non-cube building forms). Same pattern:
+            // harmlessly ignored on a fresh DB where the CREATE already added the column.
+            TryExecute("ALTER TABLE block_edit ADD COLUMN shape INTEGER NOT NULL DEFAULT 0;");
 
-        // Block attribution (issue #490): who last changed a cell, and when. The owner is an interned integer
-        // rather than the player name — measured at +13.5 % on this table versus +24 % for the name as TEXT,
-        // and this is the one table that grows with play. 0 = unknown, which is what every pre-existing row
-        // keeps: there is no way to back-fill who built what before this shipped.
-        TryExecute("ALTER TABLE block_edit ADD COLUMN owner_id INTEGER NOT NULL DEFAULT 0;");
-        TryExecute("ALTER TABLE block_edit ADD COLUMN edited_unix INTEGER NOT NULL DEFAULT 0;");
+            // Block attribution (issue #490): who last changed a cell, and when. The owner is an interned integer
+            // rather than the player name — measured at +13.5 % on this table versus +24 % for the name as TEXT,
+            // and this is the one table that grows with play. 0 = unknown, which is what every pre-existing row
+            // keeps: there is no way to back-fill who built what before this shipped.
+            TryExecute("ALTER TABLE block_edit ADD COLUMN owner_id INTEGER NOT NULL DEFAULT 0;");
+            TryExecute("ALTER TABLE block_edit ADD COLUMN edited_unix INTEGER NOT NULL DEFAULT 0;");
 
-        // Player-designed forms (#843) share the report table with paint. Rows written before this shipped
-        // are all paint reports, which is exactly what the column default says.
-        TryExecute("ALTER TABLE paint_report ADD COLUMN kind TEXT NOT NULL DEFAULT 'paint';");
-        // Attribution for copied designs (#846): pre-existing designs simply have no designer name on record.
-        TryExecute("ALTER TABLE paint_design ADD COLUMN owner_name TEXT NOT NULL DEFAULT '';");
-        // Per-container stash filter (#1032): '' = no filter, which is what every pre-existing crate keeps.
-        TryExecute("ALTER TABLE container ADD COLUMN filter TEXT NOT NULL DEFAULT '';");
+            // Player-designed forms (#843) share the report table with paint. Rows written before this shipped
+            // are all paint reports, which is exactly what the column default says.
+            TryExecute("ALTER TABLE paint_report ADD COLUMN kind TEXT NOT NULL DEFAULT 'paint';");
+            // Attribution for copied designs (#846): pre-existing designs simply have no designer name on record.
+            TryExecute("ALTER TABLE paint_design ADD COLUMN owner_name TEXT NOT NULL DEFAULT '';");
+            // Per-container stash filter (#1032): '' = no filter, which is what every pre-existing crate keeps.
+            TryExecute("ALTER TABLE container ADD COLUMN filter TEXT NOT NULL DEFAULT '';");
+        }
+        catch (SqliteException ex) when (ex.SqliteErrorCode is 11 or 26)
+        {
+            throw new InvalidDataException(
+                $"SQLite database is corrupted: {_paths.DatabaseFile}",
+                ex);
+        }
     }
+
 
     // --- Block-id palette (content-shift migration) ---
 

--- a/tests/BlocksBeyondTheStars.Tests/PersistenceTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/PersistenceTests.cs
@@ -389,52 +389,6 @@ public sealed class PersistenceTests : IDisposable
         }
     }
 
-    [Theory]
-    [InlineData(0, true)]
-    [InlineData(50, false)]
-    public void Initialize_WithFlippedDatabaseByte_ReportsBehavior(
-        int offset,
-        bool shouldThrow)
-    {
-        string dbPath;
-
-        using (var repo = NewSqliteRepo())
-        {
-            repo.SaveMetadata(new WorldMetadata
-            {
-                WorldName = "Alpha",
-                Seed = 42,
-            });
-
-            dbPath = Path.Combine(_root, "world_001", "world.db");
-        }
-
-        byte[] bytes = File.ReadAllBytes(dbPath);
-        Assert.InRange(offset, 0, bytes.Length - 1);
-
-        bytes[offset] ^= 0xFF;
-        File.WriteAllBytes(dbPath, bytes);
-
-        var before = File.ReadAllBytes(dbPath);
-
-        Exception? exception;
-
-        using (var reopened = new SqliteWorldRepository(
-            new SaveGamePaths(_root, "world_001")))
-        {
-            exception = Record.Exception(() => reopened.Initialize());
-        }
-
-        var after = File.ReadAllBytes(dbPath);
-
-        Assert.Equal(before, after);
-        Assert.Equal(shouldThrow, exception is not null);
-        if (shouldThrow)
-        {
-            Assert.IsType<InvalidDataException>(exception);
-        }
-    }
-
     public void Dispose()
     {
         try

--- a/tests/BlocksBeyondTheStars.Tests/PersistenceTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/PersistenceTests.cs
@@ -322,7 +322,7 @@ public sealed class PersistenceTests : IDisposable
         using (var reopened = new SqliteWorldRepository(
             new SaveGamePaths(_root, "world_001")))
         {
-            Assert.ThrowsAny<Exception>(() => reopened.Initialize());
+            Assert.Throws<InvalidDataException>(() => reopened.Initialize());
         }
 
         var after = File.ReadAllBytes(dbPath);
@@ -429,6 +429,10 @@ public sealed class PersistenceTests : IDisposable
 
         Assert.Equal(before, after);
         Assert.Equal(shouldThrow, exception is not null);
+        if (shouldThrow)
+        {
+            Assert.IsType<InvalidDataException>(exception);
+        }
     }
 
     public void Dispose()


### PR DESCRIPTION
PR description

Handle corrupted persistence initialization

Translate database initialization failures caused by corrupted/incompatible SQLite and PostgreSQL persistence into InvalidDataException instead of exposing provider-specific exceptions.

SQLite corruption errors are translated while preserving the original exception as the inner exception.
PostgreSQL initialization errors are handled consistently.
Existing GameServer handling surfaces corrupted saves without overwriting them.
Existing persistence tests verify corrupted SQLite databases remain untouched.

This keeps the persistence failure contract consistent while preserving the original database for recovery.