### PR TITLE
fix(webgl): wait for the browser to decode a streamed track before playing it (#1167 follow-up)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -130,6 +130,15 @@ Docs: MUSIC_TRACKS.md, SOUND_DESIGN.md, NOTICES.md. **Gotchas:** keep the music 
 emits `game_ready` only once — verify on glitch.fun that late track loads don't re-show the overlay.
 **Follow-ups (not in this PR):** SFX import quality (119 clips at 100 %), native `Content-Encoding: br`
 instead of Unity's JS decompressor (needs a glitch-only test deploy first).
+**Glitch test deploy 2026-08-22 (`glitch-only.yml`, `2026.8.18-music1`, auto-activated):** `.data.unityweb`
+193.0 → **25.3 MB**, wasm 9.9 MB, music served as `audio/mpeg` on demand, data manifest unchanged. Found and
+fixed in the follow-up PR: in the browser `DownloadHandlerAudioClip.audioClip` is handed back **before the MP3
+is decoded** (`length == 0`, `loadState` still `Unloaded` — it only flips to `Loaded` later, so it is no
+"loading" signal for web-request clips); the re-roll check read length 0 as "track over" and immediately
+downloaded a second menu track. `LoadTrack` now waits for `clip.length > 0` (60 s cap; desktop clips are
+complete at once, no wait there), and the re-roll/prefetch check ignores length-0 clips. Measured in
+Chromium: decode 0.3 s, exactly one track fetch per context. Check script (Playwright, uv): loads the CDN
+or a local `http.server` copy of the build, logs `[Music]` console lines + per-file bytes.
 
 ### ★ Audit round 2 — radio calls to full spec, aboard-ship lamp light, and the last farms closed (#1158–#1162, 2026-08-21, branch feat/epic-1101-audit-round2)
 Round two of the epic-#1101 audit follow-ups, per the scope decisions of 2026-08-21. **#1158 radio calls to

--- a/client/Assets/BlocksBeyondTheStars/Scripts/ClientMusic.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/ClientMusic.cs
@@ -61,6 +61,7 @@ namespace BlocksBeyondTheStars.Client
         private const float CrossfadeRate = 0.4f;   // volume units / s → ~2.5 s for a full fade
         private const float RerollLead = 3.0f;       // re-roll this many seconds before a track ends
         private const float PrefetchLead = 45f;      // start fetching the re-roll candidate this early (browser bandwidth)
+        private const float DecodeTimeoutSeconds = 60f; // browser-side MP3 decode must finish within this, else the track is skipped
         private const float UnderwaterCutoff = 680f;  // Hz — music muffles while the head is submerged
         private const float OpenCutoff = 22000f;
 
@@ -150,7 +151,8 @@ namespace BlocksBeyondTheStars.Client
                 _mode = mode;
                 SwitchTo(want, mode, game, reroll: false);
             }
-            else if (mode == MusicMode.Tracks && !_activeLoops && _active.clip != null && _active.isPlaying)
+            else if (mode == MusicMode.Tracks && !_activeLoops && _active.clip != null && _active.isPlaying
+                     && _active.clip.length > 0f) // length 0 = still decoding (browser), not "over"
             {
                 float remaining = _active.clip.length - _active.time;
                 if (remaining <= RerollLead && _rerolledFrom != _activeName)
@@ -614,6 +616,34 @@ namespace BlocksBeyondTheStars.Client
                 {
                     Debug.LogWarning($"[Music] Track '{name}' could not be loaded from '{url}': {request.error}");
                 }
+            }
+
+            // The browser decodes the MP3 asynchronously: right after the download the clip has length 0
+            // (and its loadState is not meaningful for web-request clips there — it stays Unloaded). Seen on
+            // glitch.fun: the director mistook "length 0" for "track over" and re-rolled straight into a
+            // second download. Hand the clip out only once it is really usable (length known); desktop /
+            // Editor clips are complete immediately, so this never waits there.
+            if (clip != null && clip.length <= 0f)
+            {
+                var before = clip.loadState;
+                float started = Time.realtimeSinceStartup;
+                while (clip != null && clip.length <= 0f && clip.loadState != AudioDataLoadState.Failed
+                       && Time.realtimeSinceStartup - started < DecodeTimeoutSeconds)
+                {
+                    yield return null;
+                }
+
+                if (clip != null && clip.length > 0f)
+                {
+                    Debug.Log($"[Music] Track '{name}' decoded after {Time.realtimeSinceStartup - started:0.0} s (loadState {before} → {clip.loadState}).");
+                }
+            }
+
+            if (clip != null && clip.length <= 0f)
+            {
+                Debug.LogWarning($"[Music] Track '{name}' did not finish decoding ({clip.loadState}); skipping it.");
+                Destroy(clip);
+                clip = null;
             }
 
             if (clip != null)


### PR DESCRIPTION
Follow-up to #1168 (issue #1167), found on the first glitch.fun test deploy (`2026.8.18-music1`).

## Problem

In the browser `DownloadHandlerAudioClip.audioClip` comes back **before the MP3 is decoded**: the clip reports `length == 0` (its `loadState` is `Unloaded` at that point and only later flips to `Loaded` — it is not a usable "still loading" signal for web-request clips). `ClientMusic` handed that clip out immediately, and the re-roll check in `Update` read `length 0 − time ≥ … ≤ RerollLead` as "track over" → it re-rolled straight into a **second menu-track download** one second after the first (`[Music] Loaded track 'music_main_menu' (0 s)` → `music_main_menu_2`). Desktop was unaffected (clips are complete immediately).

## Fix

- `LoadTrack` now waits until the clip is really usable — **`clip.length > 0`** (or `loadState == Failed` / a 60 s cap) — before caching it and handing it to the fade. Measured in Chromium: `decoded after 0.3 s (loadState Unloaded → Loaded)`, then `Loaded track 'music_main_menu_2' (162 s)`; exactly **one** track download in the menu, no re-roll.
- The re-roll / prefetch check ignores clips with `length <= 0` (belt and braces).
- A clip that never decodes is dropped from its pool like a missing file.

## Verification

- Local WebGL build served over HTTP + headless Chromium (Playwright): one `.mp3` fetched after the menu appears, length logged correctly, no second fetch within 75 s.
- Windows build: 0 warnings; desktop smoke `[Music] Loaded track 'music_main_menu' (150 s)` unchanged (no wait on desktop).
- No .NET code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
