### PR TITLE
fix(research): toast says "Enough knowledge for:" + early knowledge ladder stretched 4–24 (#1184)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ the richer, screenshot-laden versions live there. `(#123)` references the pull r
 
 ## [Unreleased]
 
+### 🔬 The research toast says what it means — and the early knowledge ladder is no longer flat (#1184)
+
+- **"Enough knowledge for: X"** replaces "New research available!" on the HUD toast (all 14 languages). The
+  toast fires when a knowledge gain crosses a still-locked blueprint's threshold — prerequisites and research
+  materials may still be missing, and the old wording read as "blueprint unlocked" (a fresh multiplayer
+  session showed it burst after a few scans and two landings, although nothing had been researched).
+- **26 blueprints that cost 2–10 knowledge now cost 4–24**, same relative order, spread so no knowledge
+  value carries more than two root blueprints (`paint_tool` 4 … `oxygen_generator` 24). The ≥ 30 band from
+  #862 is unchanged, every prerequisite chain still climbs. Banked knowledge and unlocked blueprints in
+  existing saves are kept. Data + locales only.
+
 ### 🌐 Browser singleplayer survives a glitch.fun release — and can be started over (#1177, #1178, #1179, #1181)
 
 - **"New world…" in the browser menu.** The one-world browser singleplayer could never be reset — the menu

--- a/TODO.md
+++ b/TODO.md
@@ -8879,6 +8879,24 @@ is **pre-approved** (keys in `tools/ai-assets/.env`, run via `uv`).
 
 ---
 
+## ✅ Done (2026-08-22): research toast reworded + early knowledge ladder stretched (#1184)
+
+Multiplayer playtest 2026-08-22: after a few scans and two landings the HUD announced "New research
+available!" for blueprint after blueprint — read as "several blueprints unlocked" although nothing had been
+researched. Two causes, two data/locale-only fixes (no client code, no Unity build):
+
+- **Toast wording** — the #763 toast is threshold-only by design (prerequisites + materials ignored, so deeper
+  nodes get advertised), but the head line promised more. `ui.tech.research_available` is now "Enough
+  knowledge for:" (DE "Genug Wissen für:") in all 14 locales; the blueprint name stays on line two.
+- **Early ladder** — #767/#862 stretched the mid/late tiers but left `<= 10` alone, so 26 blueprints sat at
+  2–10 while ~10–15 knowledge arrives in the first minutes (block scan 1, creature 3, hostile 5, second-body
+  landing 5). Those 26 now cost 4–24 in the same relative order, at most two root blueprints per value
+  (`paint_tool` 4, `machete`/`shape_tool` 5, `oxygen_tank_1` 6 … `hull_plating` 23, `oxygen_generator` 24);
+  the ≥ 30 band is untouched and `BlueprintGraph_PrereqsResolve_NoCycles_CostsClimbAlongChains` still holds.
+
+Existing saves keep banked knowledge and unlocked blueprints. Actual unlocking was never automatic
+(`HandleUnlock` checks cockpit, prerequisites, materials, knowledge). Open: playtest the new first hour.
+
 ## ✅ Done (2026-08-22): README "Features at a Glance" + Status rewritten to match v2026.8.18
 
 A gap analysis of README.md and the website against the shipped game found 14 systems missing from

--- a/data/blueprints.json
+++ b/data/blueprints.json
@@ -1,17 +1,17 @@
 [
   {
     "key": "oxygen_tank_1", "nameKey": "blueprint.oxygen_tank_1.name", "descriptionKey": "blueprint.oxygen_tank_1.desc",
-    "category": "Suit", "prerequisites": [], "knowledgeCost": 3,
+    "category": "Suit", "prerequisites": [], "knowledgeCost": 6,
     "unlockCost": [ { "item": "data_fragment", "count": 1 }, { "item": "iron_plate", "count": 5 } ]
   },
   {
     "key": "titanium_drill", "nameKey": "blueprint.titanium_drill.name", "descriptionKey": "blueprint.titanium_drill.desc",
-    "category": "Tools", "prerequisites": [], "knowledgeCost": 6,
+    "category": "Tools", "prerequisites": [], "knowledgeCost": 15,
     "unlockCost": [ { "item": "data_fragment", "count": 2 }, { "item": "iron_plate", "count": 10 } ]
   },
   {
     "key": "field_medkit", "nameKey": "blueprint.field_medkit.name", "descriptionKey": "blueprint.field_medkit.desc",
-    "category": "Tools", "prerequisites": [], "knowledgeCost": 5,
+    "category": "Tools", "prerequisites": [], "knowledgeCost": 12,
     "unlockCost": [ { "item": "data_fragment", "count": 2 }, { "item": "iron_plate", "count": 6 } ]
   },
   {
@@ -31,7 +31,7 @@
   },
   {
     "key": "terrain_scanner", "nameKey": "blueprint.terrain_scanner.name", "descriptionKey": "blueprint.terrain_scanner.desc",
-    "category": "Tools", "prerequisites": [], "knowledgeCost": 8,
+    "category": "Tools", "prerequisites": [], "knowledgeCost": 20,
     "unlockCost": [ { "item": "data_fragment", "count": 3 }, { "item": "titanium_plate", "count": 3 } ]
   },
   {
@@ -41,7 +41,7 @@
   },
   {
     "key": "radio_beacon", "nameKey": "blueprint.radio_beacon.name", "descriptionKey": "blueprint.radio_beacon.desc",
-    "category": "Tools", "prerequisites": [], "knowledgeCost": 6,
+    "category": "Tools", "prerequisites": [], "knowledgeCost": 16,
     "unlockCost": [ { "item": "data_fragment", "count": 2 }, { "item": "iron_plate", "count": 5 }, { "item": "cable", "count": 2 } ]
   },
   {
@@ -56,22 +56,22 @@
   },
   {
     "key": "camera", "nameKey": "blueprint.camera.name", "descriptionKey": "blueprint.camera.desc",
-    "category": "Tools", "prerequisites": [], "knowledgeCost": 4,
+    "category": "Tools", "prerequisites": [], "knowledgeCost": 9,
     "unlockCost": [ { "item": "data_fragment", "count": 1 }, { "item": "iron_plate", "count": 3 }, { "item": "glass", "count": 1 } ]
   },
   {
     "key": "binoculars", "nameKey": "blueprint.binoculars.name", "descriptionKey": "blueprint.binoculars.desc",
-    "category": "Tools", "prerequisites": [], "knowledgeCost": 3,
+    "category": "Tools", "prerequisites": [], "knowledgeCost": 7,
     "unlockCost": [ { "item": "data_fragment", "count": 1 }, { "item": "iron_plate", "count": 4 }, { "item": "glass", "count": 2 } ]
   },
   {
     "key": "paint_tool", "nameKey": "blueprint.paint_tool.name", "descriptionKey": "blueprint.paint_tool.desc",
-    "category": "Tools", "prerequisites": [], "knowledgeCost": 2,
+    "category": "Tools", "prerequisites": [], "knowledgeCost": 4,
     "unlockCost": [ { "item": "berries", "count": 4 }, { "item": "iron_plate", "count": 1 } ]
   },
   {
     "key": "shape_tool", "nameKey": "blueprint.shape_tool.name", "descriptionKey": "blueprint.shape_tool.desc",
-    "category": "Tools", "prerequisites": [], "knowledgeCost": 2,
+    "category": "Tools", "prerequisites": [], "knowledgeCost": 5,
     "unlockCost": [ { "item": "crystal", "count": 1 }, { "item": "iron_plate", "count": 1 } ]
   },
   {
@@ -81,7 +81,7 @@
   },
   {
     "key": "cargo_expansion_1", "nameKey": "blueprint.cargo_expansion_1.name", "descriptionKey": "blueprint.cargo_expansion_1.desc",
-    "category": "ShipExpansion", "prerequisites": [], "knowledgeCost": 6,
+    "category": "ShipExpansion", "prerequisites": [], "knowledgeCost": 17,
     "unlockCost": [ { "item": "data_fragment", "count": 1 }, { "item": "iron_ingot", "count": 20 }, { "item": "cable", "count": 5 } ]
   },
   {
@@ -111,12 +111,12 @@
   },
   {
     "key": "oxygen_generator", "nameKey": "blueprint.oxygen_generator.name", "descriptionKey": "blueprint.oxygen_generator.desc",
-    "category": "ShipExpansion", "prerequisites": [], "knowledgeCost": 10,
+    "category": "ShipExpansion", "prerequisites": [], "knowledgeCost": 24,
     "unlockCost": [ { "item": "data_fragment", "count": 2 }, { "item": "ice", "count": 20 }, { "item": "cable", "count": 5 } ]
   },
   {
     "key": "docking_module", "nameKey": "blueprint.docking_module.name", "descriptionKey": "blueprint.docking_module.desc",
-    "category": "ShipExpansion", "prerequisites": [], "knowledgeCost": 8,
+    "category": "ShipExpansion", "prerequisites": [], "knowledgeCost": 18,
     "unlockCost": [ { "item": "data_fragment", "count": 2 }, { "item": "iron_plate", "count": 10 } ]
   },
   {
@@ -131,7 +131,7 @@
   },
   {
     "key": "hull_plating", "nameKey": "blueprint.hull_plating.name", "descriptionKey": "blueprint.hull_plating.desc",
-    "category": "ShipDefense", "prerequisites": [], "knowledgeCost": 10,
+    "category": "ShipDefense", "prerequisites": [], "knowledgeCost": 23,
     "unlockCost": [ { "item": "data_fragment", "count": 2 }, { "item": "titanium_plate", "count": 10 } ]
   },
   {
@@ -226,22 +226,22 @@
   },
   {
     "key": "armor_chest", "nameKey": "blueprint.armor_chest.name", "descriptionKey": "blueprint.armor_chest.desc",
-    "category": "Suit", "prerequisites": [], "knowledgeCost": 8,
+    "category": "Suit", "prerequisites": [], "knowledgeCost": 18,
     "unlockCost": [ { "item": "data_fragment", "count": 1 }, { "item": "iron_plate", "count": 12 } ]
   },
   {
     "key": "armor_legs", "nameKey": "blueprint.armor_legs.name", "descriptionKey": "blueprint.armor_legs.desc",
-    "category": "Suit", "prerequisites": [], "knowledgeCost": 6,
+    "category": "Suit", "prerequisites": [], "knowledgeCost": 13,
     "unlockCost": [ { "item": "data_fragment", "count": 1 }, { "item": "iron_plate", "count": 9 } ]
   },
   {
     "key": "helmet", "nameKey": "blueprint.helmet.name", "descriptionKey": "blueprint.helmet.desc",
-    "category": "Suit", "prerequisites": [], "knowledgeCost": 6,
+    "category": "Suit", "prerequisites": [], "knowledgeCost": 14,
     "unlockCost": [ { "item": "data_fragment", "count": 1 }, { "item": "iron_plate", "count": 8 }, { "item": "glass", "count": 3 } ]
   },
   {
     "key": "oxygen_tank_2", "nameKey": "blueprint.oxygen_tank_2.name", "descriptionKey": "blueprint.oxygen_tank_2.desc",
-    "category": "Suit", "prerequisites": [ "oxygen_tank_1" ], "knowledgeCost": 10,
+    "category": "Suit", "prerequisites": [ "oxygen_tank_1" ], "knowledgeCost": 21,
     "unlockCost": [ { "item": "data_fragment", "count": 2 }, { "item": "iron_plate", "count": 10 }, { "item": "glass", "count": 4 } ]
   },
   {
@@ -251,12 +251,12 @@
   },
   {
     "key": "suit_lamp", "nameKey": "blueprint.suit_lamp.name", "descriptionKey": "blueprint.suit_lamp.desc",
-    "category": "Suit", "prerequisites": [], "knowledgeCost": 4,
+    "category": "Suit", "prerequisites": [], "knowledgeCost": 7,
     "unlockCost": [ { "item": "iron_plate", "count": 4 }, { "item": "glass", "count": 2 } ]
   },
   {
     "key": "suit_liner_1", "nameKey": "blueprint.suit_liner_1.name", "descriptionKey": "blueprint.suit_liner_1.desc",
-    "category": "Suit", "prerequisites": [], "knowledgeCost": 6,
+    "category": "Suit", "prerequisites": [], "knowledgeCost": 14,
     "unlockCost": [ { "item": "data_fragment", "count": 1 }, { "item": "polymer", "count": 2 } ]
   },
   {
@@ -271,7 +271,7 @@
   },
   {
     "key": "comm_radio", "nameKey": "blueprint.comm_radio.name", "descriptionKey": "blueprint.comm_radio.desc",
-    "category": "Production", "prerequisites": [], "knowledgeCost": 4,
+    "category": "Production", "prerequisites": [], "knowledgeCost": 10,
     "unlockCost": [ { "item": "copper_wire", "count": 4 }, { "item": "data_fragment", "count": 1 } ]
   },
   {
@@ -301,12 +301,12 @@
   },
   {
     "key": "machete", "nameKey": "blueprint.machete.name", "descriptionKey": "blueprint.machete.desc",
-    "category": "Weapon", "prerequisites": [], "knowledgeCost": 3,
+    "category": "Weapon", "prerequisites": [], "knowledgeCost": 5,
     "unlockCost": [ { "item": "iron_plate", "count": 3 } ]
   },
   {
     "key": "vibro_knife", "nameKey": "blueprint.vibro_knife.name", "descriptionKey": "blueprint.vibro_knife.desc",
-    "category": "Weapon", "prerequisites": [ "machete" ], "knowledgeCost": 8,
+    "category": "Weapon", "prerequisites": [ "machete" ], "knowledgeCost": 19,
     "unlockCost": [ { "item": "data_fragment", "count": 1 }, { "item": "iron_plate", "count": 6 }, { "item": "cable", "count": 3 } ]
   },
   {
@@ -316,7 +316,7 @@
   },
   {
     "key": "gauss_pistol", "nameKey": "blueprint.gauss_pistol.name", "descriptionKey": "blueprint.gauss_pistol.desc",
-    "category": "Weapon", "prerequisites": [], "knowledgeCost": 4,
+    "category": "Weapon", "prerequisites": [], "knowledgeCost": 8,
     "unlockCost": [ { "item": "data_fragment", "count": 1 }, { "item": "iron_plate", "count": 6 } ]
   },
   {
@@ -346,17 +346,17 @@
   },
   {
     "key": "station_mission_board", "nameKey": "blueprint.station_mission_board.name", "descriptionKey": "blueprint.station_mission_board.desc",
-    "category": "Station", "prerequisites": [], "knowledgeCost": 8,
+    "category": "Station", "prerequisites": [], "knowledgeCost": 20,
     "unlockCost": [ { "item": "data_fragment", "count": 2 }, { "item": "circuit_board", "count": 1 }, { "item": "glass", "count": 3 } ]
   },
   {
     "key": "station_container", "nameKey": "blueprint.station_container.name", "descriptionKey": "blueprint.station_container.desc",
-    "category": "Station", "prerequisites": [], "knowledgeCost": 5,
+    "category": "Station", "prerequisites": [], "knowledgeCost": 11,
     "unlockCost": [ { "item": "data_fragment", "count": 1 }, { "item": "iron_plate", "count": 6 } ]
   },
   {
     "key": "door_energy", "nameKey": "blueprint.door_energy.name", "descriptionKey": "blueprint.door_energy.desc",
-    "category": "Production", "prerequisites": [], "knowledgeCost": 10,
+    "category": "Production", "prerequisites": [], "knowledgeCost": 22,
     "unlockCost": [ { "item": "data_fragment", "count": 2 }, { "item": "metal_panel", "count": 4 }, { "item": "crystal", "count": 1 } ]
   }
 ]

--- a/data/locales/de.json
+++ b/data/locales/de.json
@@ -950,7 +950,7 @@
   "ui.tech.progress": "{done} von {total} erforscht",
   "ui.tech.next": "Als Nächstes möglich: {name}",
   "ui.tech.next_none": "Gerade nichts freischaltbar — scanne, erkunde und sammle Forschungsmaterial.",
-  "ui.tech.research_available": "Neue Forschung verfügbar!",
+  "ui.tech.research_available": "Genug Wissen für:",
   "ui.tech.tier": "Stufe",
   "ui.tech.cat_production": "Produktion",
   "ui.tech.cat_ship": "Schiff",

--- a/data/locales/en.json
+++ b/data/locales/en.json
@@ -950,7 +950,7 @@
   "ui.tech.progress": "Researched {done} of {total}",
   "ui.tech.next": "Next affordable: {name}",
   "ui.tech.next_none": "Nothing affordable right now — scan, explore and gather research materials.",
-  "ui.tech.research_available": "New research available!",
+  "ui.tech.research_available": "Enough knowledge for:",
   "ui.tech.tier": "Tier",
   "ui.tech.cat_production": "Production",
   "ui.tech.cat_ship": "Ship",

--- a/data/locales/es.json
+++ b/data/locales/es.json
@@ -950,7 +950,7 @@
   "ui.tech.progress": "Investigado {done} de {total}",
   "ui.tech.next": "Siguiente asequible: {name}",
   "ui.tech.next_none": "Nada asequible ahora — escanea, explora y reúne materiales de investigación.",
-  "ui.tech.research_available": "¡Nueva investigación disponible!",
+  "ui.tech.research_available": "Conocimiento suficiente para:",
   "ui.tech.tier": "Nivel",
   "ui.tech.cat_production": "Producción",
   "ui.tech.cat_ship": "Nave",

--- a/data/locales/fr.json
+++ b/data/locales/fr.json
@@ -950,7 +950,7 @@
   "ui.tech.progress": "Recherché {done} sur {total}",
   "ui.tech.next": "Prochain abordable : {name}",
   "ui.tech.next_none": "Rien d'abordable pour l'instant — scanne, explore et collecte des matériaux de recherche.",
-  "ui.tech.research_available": "Nouvelle recherche disponible !",
+  "ui.tech.research_available": "Assez de savoir pour :",
   "ui.tech.tier": "Niveau",
   "ui.tech.cat_production": "Production",
   "ui.tech.cat_ship": "Vaisseau",

--- a/data/locales/it.json
+++ b/data/locales/it.json
@@ -950,7 +950,7 @@
   "ui.tech.progress": "Ricercati {done} su {total}",
   "ui.tech.next": "Prossimo accessibile: {name}",
   "ui.tech.next_none": "Niente accessibile ora — scansiona, esplora e raccogli materiali per la ricerca.",
-  "ui.tech.research_available": "Nuove ricerche disponibili!",
+  "ui.tech.research_available": "Conoscenza sufficiente per:",
   "ui.tech.tier": "Livello",
   "ui.tech.cat_production": "Produzione",
   "ui.tech.cat_ship": "Nave",

--- a/data/locales/ja.json
+++ b/data/locales/ja.json
@@ -950,7 +950,7 @@
   "ui.tech.progress": "研究済み {done} / {total}",
   "ui.tech.next": "次に買えるの: {name}",
   "ui.tech.next_none": "今は買えるものがありません — スキャン、探索、研究素材を集めましょう。",
-  "ui.tech.research_available": "新しい研究が利用可能！",
+  "ui.tech.research_available": "研究に必要な知識が揃いました：",
   "ui.tech.tier": "階層",
   "ui.tech.cat_production": "生産",
   "ui.tech.cat_ship": "船",

--- a/data/locales/ko.json
+++ b/data/locales/ko.json
@@ -950,7 +950,7 @@
   "ui.tech.progress": "연구 완료 {done}/{total}",
   "ui.tech.next": "다음으로 살 수 있는: {name}",
   "ui.tech.next_none": "지금은 구매할 수 있는 것이 없습니다 — 스캔하고 탐험하며 연구 재료를 모으세요.",
-  "ui.tech.research_available": "새 연구 가능!",
+  "ui.tech.research_available": "연구할 지식이 충분합니다:",
   "ui.tech.tier": "등급",
   "ui.tech.cat_production": "생산",
   "ui.tech.cat_ship": "우주선",

--- a/data/locales/nl.json
+++ b/data/locales/nl.json
@@ -950,7 +950,7 @@
   "ui.tech.progress": "Onderzocht {done} van {total}",
   "ui.tech.next": "Volgende betaalbaar: {name}",
   "ui.tech.next_none": "Niets betaalbaars nu — scan, ontdek en verzamel onderzoeksstoffen.",
-  "ui.tech.research_available": "Nieuw onderzoek beschikbaar!",
+  "ui.tech.research_available": "Genoeg kennis voor:",
   "ui.tech.tier": "Niveau",
   "ui.tech.cat_production": "Productie",
   "ui.tech.cat_ship": "Schip",

--- a/data/locales/pl.json
+++ b/data/locales/pl.json
@@ -950,7 +950,7 @@
   "ui.tech.progress": "Zbadano {done} z {total}",
   "ui.tech.next": "Następne do zdobycia: {name}",
   "ui.tech.next_none": "Nic teraz w zasięgu — skanuj, eksploruj i zbieraj materiały badawcze.",
-  "ui.tech.research_available": "Nowe badania dostępne!",
+  "ui.tech.research_available": "Wystarczająco wiedzy na:",
   "ui.tech.tier": "Poziom",
   "ui.tech.cat_production": "Produkcja",
   "ui.tech.cat_ship": "Statek",

--- a/data/locales/pt.json
+++ b/data/locales/pt.json
@@ -950,7 +950,7 @@
   "ui.tech.progress": "Pesquisado {done} de {total}",
   "ui.tech.next": "Próximo acessível: {name}",
   "ui.tech.next_none": "Nada acessível agora — escaneie, explore e colete materiais de pesquisa.",
-  "ui.tech.research_available": "Nova pesquisa disponível!",
+  "ui.tech.research_available": "Conhecimento suficiente para:",
   "ui.tech.tier": "Nível",
   "ui.tech.cat_production": "Produção",
   "ui.tech.cat_ship": "Nave",

--- a/data/locales/ru.json
+++ b/data/locales/ru.json
@@ -950,7 +950,7 @@
   "ui.tech.progress": "Исследовано {done} из {total}",
   "ui.tech.next": "Следующее по доступной цене: {name}",
   "ui.tech.next_none": "Сейчас ничего недоступного — сканируй, исследуй и собирай материалы для исследований.",
-  "ui.tech.research_available": "Доступны новые исследования!",
+  "ui.tech.research_available": "Достаточно знаний для:",
   "ui.tech.tier": "Уровень",
   "ui.tech.cat_production": "Производство",
   "ui.tech.cat_ship": "Корабль",

--- a/data/locales/tr.json
+++ b/data/locales/tr.json
@@ -950,7 +950,7 @@
   "ui.tech.progress": "Araştırıldı {done} / {total}",
   "ui.tech.next": "Sıradaki uygun: {name}",
   "ui.tech.next_none": "Şu an uygun bir şey yok — tarama yap, keşfet ve araştırma malzemeleri topla.",
-  "ui.tech.research_available": "Yeni araştırma hazır!",
+  "ui.tech.research_available": "Şunun için yeterli bilgi:",
   "ui.tech.tier": "Seviye",
   "ui.tech.cat_production": "Üretim",
   "ui.tech.cat_ship": "Gemi",

--- a/data/locales/uk.json
+++ b/data/locales/uk.json
@@ -950,7 +950,7 @@
   "ui.tech.progress": "Досліджено {done} з {total}",
   "ui.tech.next": "Наступне доступне: {name}",
   "ui.tech.next_none": "Поки нічого недоступного — скануй, досліджуй і збирай матеріали для досліджень.",
-  "ui.tech.research_available": "Нове дослідження доступне!",
+  "ui.tech.research_available": "Достатньо знань для:",
   "ui.tech.tier": "Рівень",
   "ui.tech.cat_production": "Виробництво",
   "ui.tech.cat_ship": "Корабель",

--- a/data/locales/zh.json
+++ b/data/locales/zh.json
@@ -950,7 +950,7 @@
   "ui.tech.progress": "已研究 {done} / {total}",
   "ui.tech.next": "下一个可负担：{name}",
   "ui.tech.next_none": "目前没有可负担的——扫描、探索并收集研究材料。",
-  "ui.tech.research_available": "有新的研究可用！",
+  "ui.tech.research_available": "知识已足够研究：",
   "ui.tech.tier": "等级",
   "ui.tech.cat_production": "生产",
   "ui.tech.cat_ship": "飞船",


### PR DESCRIPTION
closes #1184

## What

Fresh multiplayer session: after a few scans and two landings the HUD announced "New research available!" for blueprint after blueprint — it read as "several blueprints unlocked", although nothing had been researched (unlocking still goes through `HandleUnlock`: cockpit + prerequisites + materials + knowledge).

Two data/locale-only fixes, no client code, no Unity build:

- **Toast wording** — `ui.tech.research_available` is now **"Enough knowledge for:"** (DE "Genug Wissen für:") in all 14 locales. The #763 toast is threshold-only by design (prerequisites/materials ignored so deeper nodes get advertised); the head line now says exactly that much and no more. The blueprint name stays on line two.
- **Early knowledge ladder** — #767/#862 stretched the mid/late tiers but left `<= 10` untouched, so 26 blueprints sat at 2–10 knowledge while ~10–15 knowledge arrives in the first minutes (block scan 1, creature 3, hostile 5, first landing on a second body 5). Those 26 now cost **4–24**, same relative order, at most two root blueprints per value:

  | cost | blueprints |
  |---|---|
  | 4 | paint_tool |
  | 5 | machete, shape_tool |
  | 6 | oxygen_tank_1 |
  | 7 | binoculars, suit_lamp |
  | 8 | gauss_pistol |
  | 9 | camera |
  | 10 | comm_radio |
  | 11 | station_container |
  | 12 | field_medkit |
  | 13 | armor_legs |
  | 14 | helmet, suit_liner_1 |
  | 15 | titanium_drill |
  | 16 | radio_beacon |
  | 17 | cargo_expansion_1 |
  | 18 | armor_chest, docking_module |
  | 19 | vibro_knife |
  | 20 | station_mission_board, terrain_scanner |
  | 21 | oxygen_tank_2 |
  | 22 | door_energy |
  | 23 | hull_plating |
  | 24 | oxygen_generator |

  The ≥ 30 band (#862) is unchanged; every prerequisite chain still climbs (`BlueprintGraph_PrereqsResolve_NoCycles_CostsClimbAlongChains`). Existing saves keep banked knowledge and unlocked blueprints.

- CHANGELOG (Unreleased) + TODO.md entry.

## Verification

- Script check: 26 blueprints < 30, no chain inversions, no free blueprints, all 14 locale files parse.
- `dotnet test BlocksBeyondTheStars.sln -c Release --filter Category!=Slow` — see PR checks / comment below.

## Open

- Playtest the new first hour (does it still feel rewarding?).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
