### PR TITLE
feat(content): warn about unreadable user templates instead of skipping them silently

### DIFF
--- a/src/BlocksBeyondTheStars.GameServer/Program.cs
+++ b/src/BlocksBeyondTheStars.GameServer/Program.cs
@@ -48,7 +48,7 @@ if (appliedOverrides.Count > 0)
 GameContent content;
 try
 {
-    content = ContentLoader.LoadFromDirectory(dataDir, userContentDir);
+    content = ContentLoader.LoadFromDirectory(dataDir, userContentDir, logger.Warn);
     logger.Info($"Loaded content: {content.Blocks.Count} blocks, {content.Items.Count} items, {content.Recipes.Count} recipes, {content.Planets.Count} planets.");
     if (userContentDir != null && Directory.Exists(userContentDir))
     {

--- a/src/BlocksBeyondTheStars.Shared/Content/ContentLoader.cs
+++ b/src/BlocksBeyondTheStars.Shared/Content/ContentLoader.cs
@@ -33,7 +33,7 @@ public static class ContentLoader
     /// there by the in-game editor (<c>station_templates/*.json</c>, <c>settlement_templates/*.json</c>,
     /// one <see cref="StructureTemplate"/> per file) are merged into the pools — so a structure built
     /// in-game appears in the next new world without a Python merge or rebuild.</summary>
-    public static GameContent LoadFromDirectory(string dataDir, string? userContentDir = null)
+    public static GameContent LoadFromDirectory(string dataDir, string? userContentDir = null, Action<string>? warn = null)
     {
         if (!Directory.Exists(dataDir))
         {
@@ -78,8 +78,8 @@ public static class ContentLoader
         // the shipped pools so in-game builds are picked up at world creation without a rebuild.
         if (!string.IsNullOrEmpty(userContentDir) && Directory.Exists(userContentDir))
         {
-            stationTemplates.AddRange(LoadUserTemplates(Path.Combine(userContentDir!, "station_templates"), "station"));
-            settlementTemplates.AddRange(LoadUserTemplates(Path.Combine(userContentDir!, "settlement_templates"), "settlement"));
+            stationTemplates.AddRange(LoadUserTemplates(Path.Combine(userContentDir!, "station_templates"), "station", warn));
+            settlementTemplates.AddRange(LoadUserTemplates(Path.Combine(userContentDir!, "settlement_templates"), "settlement", warn));
         }
 
         content.SetStructureTemplates(stationTemplates, settlementTemplates);
@@ -125,7 +125,7 @@ public static class ContentLoader
 
     /// <summary>Loads every <see cref="StructureTemplate"/> from a user-content sub-folder (one per file,
     /// key defaulting to the file name). Malformed files are skipped so one bad export can't break load.</summary>
-    private static List<StructureTemplate> LoadUserTemplates(string dir, string kind)
+    private static List<StructureTemplate> LoadUserTemplates(string dir, string kind, Action<string>? warn = null)
     {
         var result = new List<StructureTemplate>();
         if (!Directory.Exists(dir))
@@ -155,9 +155,9 @@ public static class ContentLoader
 
                 result.Add(t);
             }
-            catch (JsonException)
+            catch (JsonException ex)
             {
-                // Ignore an unreadable export; the rest of the folder still loads.
+                warn?.Invoke($"Skipping unreadable user template '{file}': {ex.Message}");
             }
         }
 

--- a/tests/BlocksBeyondTheStars.Tests/StructureTemplateTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/StructureTemplateTests.cs
@@ -303,6 +303,39 @@ public sealed class StructureTemplateTests
     }
 
     [Fact]
+    public void UserContentFolder_WarnsAboutUnreadableTemplate_AndStillLoadsTheRest()
+    {
+        // #1048: a malformed editor export used to be skipped silently. The loader still skips it (one bad
+        // file must not break the load), but reports it through the optional warn callback — by file name,
+        // so the player can find and fix it — while the good file in the same folder loads as before.
+        var root = Path.Combine(Path.GetTempPath(), "bbts_usercontent_" + Guid.NewGuid().ToString("N"));
+        var stationDir = Path.Combine(root, "station_templates");
+        Directory.CreateDirectory(stationDir);
+        File.WriteAllText(Path.Combine(stationDir, "good_base.json"),
+            "{ \"name\": \"Good\", \"tier\": \"medium\", \"width\": 1, \"height\": 1, \"length\": 1, " +
+            "\"cells\": [ { \"x\": 0, \"y\": 0, \"z\": 0, \"kind\": \"block\", \"id\": \"iron_wall\" } ] }");
+        File.WriteAllText(Path.Combine(stationDir, "broken_export.json"), "{ \"name\": \"Broken\", \"cells\": [ {");
+
+        try
+        {
+            var warnings = new List<string>();
+            var content = ContentLoader.LoadFromDirectory(TestPaths.DataDir(), root, warnings.Add);
+
+            Assert.Single(content.StationTemplates, t => t.Key == "good_base");
+            Assert.DoesNotContain(content.StationTemplates, t => t.Key == "broken_export");
+            var warning = Assert.Single(warnings);
+            Assert.Contains("broken_export.json", warning);
+
+            // Without a callback the contract is unchanged: the bad file is skipped, nothing throws.
+            Assert.Single(ContentLoader.LoadFromDirectory(TestPaths.DataDir(), root).StationTemplates, t => t.Key == "good_base");
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
     public void WorldDescription_DefaultsKeepTemplatesOccasional()
     {
         var desc = new WorldDescription();


### PR DESCRIPTION
User Template Loader: Added an optional Action<string>? warn callback to ContentLoader.LoadFromDirectory / LoadUserTemplates so malformed JSON templates emit a warning with the affected filename rather than silently swallowing JsonException.

Server Wiring: Wired logger.Warn to the warning callback in GameServer.Program.