### PR TITLE
feat(content): validate atlas bounds, item max stack, empty keys and planet surface blocks (#1048)

### DIFF
--- a/src/BlocksBeyondTheStars.Shared/Content/GameContent.cs
+++ b/src/BlocksBeyondTheStars.Shared/Content/GameContent.cs
@@ -407,6 +407,7 @@ public sealed class GameContent
                 continue; // explicit JSON opt-in stays
             }
 
+
             bool categorySeals = block.Category is "terrain" or "building" or "ore" or "machine" or "light";
             block.Airtight = categorySeals && block.Key != "air" && !AirtightExceptions.Contains(block.Key);
         }
@@ -626,6 +627,15 @@ public sealed class GameContent
 
         foreach (var block in _blocks.Values)
         {
+            if (string.IsNullOrWhiteSpace(block.Key))
+            {
+                problems.Add("Block definition has an empty or whitespace key.");
+            }
+            if (block.NumericId.Value >= 256)
+            {
+                problems.Add($"Block '{block.Key}' has numeric ID {block.NumericId.Value} exceeding the 256-tile atlas limit.");
+            }
+
             foreach (var drop in block.Drops)
             {
                 RequireItem($"Block '{block.Key}' drop", drop.Item);
@@ -638,6 +648,17 @@ public sealed class GameContent
             {
                 problems.Add($"Item '{item.Key}' places unknown block '{item.PlacesBlock}'.");
             }
+
+            if (string.IsNullOrWhiteSpace(item.Key))
+            {
+                problems.Add("Item definition has an empty or whitespace key.");
+            }
+
+            if (item.MaxStack < 1)
+            {
+                problems.Add($"Item '{item.Key}' has invalid MaxStack {item.MaxStack}; must be >= 1.");
+            }
+
         }
 
         foreach (var recipe in _recipes.Values)
@@ -679,6 +700,11 @@ public sealed class GameContent
 
         foreach (var bp in _blueprints.Values)
         {
+            if (string.IsNullOrWhiteSpace(bp.Key))
+            {
+                problems.Add("Blueprint definition has an empty or whitespace key.");
+            }
+
             foreach (var pre in bp.Prerequisites)
             {
                 RequireBlueprint($"Blueprint '{bp.Key}' prerequisite", pre);
@@ -726,6 +752,10 @@ public sealed class GameContent
 
         foreach (var planet in _planets.Values)
         {
+            if (string.IsNullOrWhiteSpace(planet.SurfaceBlock) || planet.SurfaceBlock == "air")
+            {
+                problems.Add($"Planet '{planet.Key}' surface block cannot be empty or air.");
+            }
             RequireBlock($"Planet '{planet.Key}' surface", planet.SurfaceBlock);
             RequireBlock($"Planet '{planet.Key}' sub-surface", planet.SubSurfaceBlock);
             RequireBlock($"Planet '{planet.Key}' deep", planet.DeepBlock);

--- a/tests/BlocksBeyondTheStars.Tests/ContentTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/ContentTests.cs
@@ -278,4 +278,51 @@ public class ContentTests
     {
         Assert.Empty(ContentLoader.ParseLocaleTable("{}"));
     }
+
+    [Fact]
+    public void Validation_RejectsInvalidItemMaxStack()
+    {
+        var ex = Assert.Throws<ContentValidationException>(() => new GameContent(
+            blocks: Array.Empty<BlockDefinition>(),
+            items: new[] { new ItemDefinition { Key = "broken_crate", MaxStack = 0 } },
+            recipes: Array.Empty<RecipeDefinition>(),
+            blueprints: Array.Empty<BlueprintDefinition>(),
+            shipModules: Array.Empty<ShipModuleDefinition>(),
+            locales: new Dictionary<GameLocale, Dictionary<string, string>>()).Validate());
+
+        Assert.Contains(ex.Problems, p => p.Contains("broken_crate") && p.Contains("MaxStack"));
+    }
+
+    [Fact]
+    public void Validation_RejectsPlanetWithAirOrEmptySurfaceBlock()
+    {
+        var ex = Assert.Throws<ContentValidationException>(() => new GameContent(
+            blocks: new[] { new BlockDefinition { Key = "air" }, new BlockDefinition { Key = "stone" } },
+            items: Array.Empty<ItemDefinition>(),
+            recipes: Array.Empty<RecipeDefinition>(),
+            blueprints: Array.Empty<BlueprintDefinition>(),
+            shipModules: Array.Empty<ShipModuleDefinition>(),
+            locales: new Dictionary<GameLocale, Dictionary<string, string>>(),
+            planets: new[] { new PlanetType { Key = "void_world", SurfaceBlock = "air" } }).Validate());
+
+        Assert.Contains(ex.Problems, p => p.Contains("void_world") && p.Contains("surface block"));
+    }
+
+    [Fact]
+    public void Validation_RejectsBlockCountExceedingAtlasLimit()
+    {
+        var blocks = Enumerable.Range(1, 260)
+            .Select(i => new BlockDefinition { Key = $"block_{i}" })
+            .ToList();
+
+        var ex = Assert.Throws<ContentValidationException>(() => new GameContent(
+            blocks: blocks,
+            items: Array.Empty<ItemDefinition>(),
+            recipes: Array.Empty<RecipeDefinition>(),
+            blueprints: Array.Empty<BlueprintDefinition>(),
+            shipModules: Array.Empty<ShipModuleDefinition>(),
+            locales: new Dictionary<GameLocale, Dictionary<string, string>>()).Validate());
+
+        Assert.Contains(ex.Problems, p => p.Contains("256") || p.Contains("atlas"));
+    }
 }


### PR DESCRIPTION
### Summary
Extends `GameContent.Validate()` with the remaining Starter-4 rules from #1048 (hard load errors, same pattern as #1188):

* non-empty / non-whitespace definition keys (`Block`, `Item`, `Blueprint`);
* `Item.MaxStack >= 1`;
* `Block.NumericId < 256` — the client's `BlockTextureAtlas` is a 16×16 tile grid and silently renders any higher id as an untextured grey tile;
* a planet's `SurfaceBlock` must be set and must not be `air`.

All shipped content already complies (`ShippedContent_LoadsAndValidates`). Three new `ContentTests` pin the rules (invalid `MaxStack`, air surface block, block count beyond the atlas).

closes #1048
