### PR TITLE
feat(endgame): Remnant Protocol — defeating the Guardian no longer empties the galaxy (#1206)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -139,6 +139,25 @@ empty-state line); `TechStatus` gained a distinct **"Knowledge missing"** before
 appends `Knowledge have/need`. Tabs are fixed 150 px + `FitLabel`, so the bar needed no change. USER_MANUAL updated.
 Out of scope (noted in the issue): the `blueprint_tool` item ("Bauplan-Werkzeug") keeps its name.
 
+### ★ Remnant Protocol — the ending no longer empties the galaxy (#1206, 2026-08-22, branch feat/1206-remnant-protocol)
+Third slice of the feature-deepening package (epic #1197). `MarkGuardianDefeated` set a one-way flag that
+`PlanetEnemiesActive` (GameServerEnemies.cs), the ambient space spawn (GameServerSpaceCombat.cs) and
+`BanditShipsAllowed` (GameServerBanditShips.cs) all read as "off forever" — after the finale no machine, no
+UFO and **no bandit ship** ever spawned again, so the saved galaxy was emptier than the threatened one and the
+station raider bounty could never be offered again (`ShipBountyOffered` keys on it). **Now the flag is a
+factor:** `RemnantEra` halves the planet cap (`PlanetEnemyCap` = max(1, cap/2)), doubles the spawn cadence
+(`RemnantPaceFactor` on both the initial fill and the #740 refill roll), and spawns scan-drones only (the
+hunter robots are gone — lore: drones were the explore units; `PlanetDrones=false` keeps its meaning and then
+leaves a few walkers); the win still clears the live machines (the dramatic beat). Space: the finale gauntlet
+stays down for good, ambient waves + UFOs survive only where space is dangerous by nature —
+`RemnantSpaceHostile` = pirate haven OR (`FrontierDanger` && frontier tier ≥ 2). Bandit ships: new
+`BanditShipsAllowedIn(systemId)` (rules + pirate space + post-win only `SystemArchetype.PirateHaven`) used by
+the ambush roll, the warp-in, VEGA's sector warning and `ShipBountyOffered`. Family/peaceful rules
+(PlanetEnemies Off) stay at zero. Tests: `GameServerStoryCombatTests` pacify test rewritten to the remnant
+shape (1 drone at Normal+solo), new `RemnantProtocolTests` (two players → 2 drones from a cap of 4; Off stays
+empty; family presets; bandit havens keep raiders, other pirate space loses them). Docs: USER_MANUAL § Story,
+STORY_IMPLEMENTATION §6. Follow-up: #1213 relay "survey orders" chains build on these remnants.
+
 ### ★ Chat content filter + every village keeps its mission board (#1207, #1199, 2026-08-22, branch feat/1199-1207-board-fallback-chat-filter)
 First two slices of the feature-deepening package (epic #1197; analysis 2026-08-22). **#1199 (fix-first):**
 `SettlementGenerator.cs` rolled the 18 % village plot-skip for every plot > 0 — including **plot 1, the

--- a/docs/developer/STORY_IMPLEMENTATION.md
+++ b/docs/developer/STORY_IMPLEMENTATION.md
@@ -62,9 +62,14 @@ never the count — toggled by `GameRules.MachineWreckCoupling`.
 5. **Stage 4 — argument duel:** data-driven from the pack's `coreArguments`; a correct contradiction
    advances, a wrong pick re-presents the node (the duel can stall but never be lost). Clearing the last node
    calls `MarkGuardianDefeated`.
-6. **Pacification:** the one-way `guardianDefeated` flag gates the pack's planet + space machine spawns off
-   and despawns live machines (it does **not** touch the admin threat sliders). A death in the boss system
-   respawns the clone on the world it launched from (no death-loop).
+6. **Pacification → Remnant Protocol (#1206):** the one-way `guardianDefeated` flag despawns the live planet
+   machines at the moment of the win (the dramatic beat) and then acts as a *factor*, not a switch: the planet
+   cap halves (floor one, `PlanetEnemyCap`), refills run at twice the interval (`RemnantPaceFactor`), only
+   scan-drones spawn (`RemnantEra`); the finale gauntlet stays down; ambient space waves survive only in
+   pirate havens and the frontier-danger tier (`RemnantSpaceHostile`); bandit ships keep only pirate havens
+   (`BanditShipsAllowedIn`), so the raider bounty stays offerable. It does **not** touch the admin threat
+   sliders; PlanetEnemies *Off* still means zero. A death in the boss system respawns the clone on the world
+   it launched from (no death-loop).
 
 ## Networking (NetCodec tags)
 

--- a/docs/user/USER_MANUAL.md
+++ b/docs/user/USER_MANUAL.md
@@ -745,6 +745,11 @@ separate unlock; admins can still disable it through server world rules.
   the credits roll, and an epilogue that opens the door to what comes after. It's skippable (**Esc**),
   plays once on the next join for anyone who was offline at the time, and the Story tab keeps a
   **"Watch the ending again"** button once you've earned it.
+- **After the ending the galaxy is calmer, not empty.** The Guardian's machines don't vanish for good: the
+  hunter robots are gone and only a thinned-out remnant of scan-drones keeps roaming (half as many, spawning
+  half as often), space stays hostile only where it is dangerous by nature — **pirate havens** and the
+  opt-in *Frontier danger* tier — and raiders keep their havens, so the station **raider bounty** can still
+  be earned. Worlds with planet enemies *Off* (the family presets) stay peaceful as before.
 
 ### Scanning & knowledge
 - With a scanner selected, **left-click** a creature or block to scan it. Scans award **knowledge points**

--- a/src/BlocksBeyondTheStars.GameServer/GameServerBanditShips.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerBanditShips.cs
@@ -31,12 +31,21 @@ public sealed partial class GameServer
     private const double BanditAmbushDelayMax = 90.0;
 
     /// <summary>Whether bandit ships may operate at all: bandits on, survival, space combat live, ship
-    /// weapons usable against NPCs, and the galaxy not yet pacified. Every leg of this keeps the player
-    /// ABLE to fight back — the hard lesson from the unkillable-UFO bug.</summary>
+    /// weapons usable against NPCs. Every leg of this keeps the player ABLE to fight back — the hard lesson
+    /// from the unkillable-UFO bug. The Guardian's defeat no longer switches raiders off galaxy-wide
+    /// (that also killed the raider bounty for good, #1206) — see <see cref="BanditShipsAllowedIn"/>.</summary>
     private bool BanditShipsAllowed => BanditsActive
         && Rules.SpaceCombat is SpaceCombatMode.PvE or SpaceCombatMode.Both
-        && Rules.ShipWeapons is not (ShipWeaponMode.Off or ShipWeaponMode.MiningOnly)
-        && !_storyState.GuardianDefeated;
+        && Rules.ShipWeapons is not (ShipWeaponMode.Off or ShipWeaponMode.MiningOnly);
+
+    /// <summary>Whether bandit ships may operate in the given star system: the rules above AND the system
+    /// rolls as pirate space — AND, once the galaxy is pacified (Remnant Protocol, #1206), only a genuine
+    /// pirate haven still harbours raiders, so the post-game keeps one place where the raider bounty can
+    /// be earned without the whole galaxy staying hostile.</summary>
+    private bool BanditShipsAllowedIn(string systemId)
+        => BanditShipsAllowed
+           && BanditSystem(systemId)
+           && (!_storyState.GuardianDefeated || SystemArchetypeOf(systemId) == SystemArchetype.PirateHaven);
 
     /// <summary>Deterministic "pirate space" flag per star system (trader-traffic pattern): roughly a
     /// quarter of all systems, always the same ones for a given save. With system variance (#547) the
@@ -76,7 +85,7 @@ public sealed partial class GameServer
         {
             instance.BanditRolled = true;
             instance.BanditAmbushAt = 0;
-            if (BanditShipsAllowed && BanditSystem(SystemIdOfInstance(instance)))
+            if (BanditShipsAllowedIn(SystemIdOfInstance(instance)))
             {
                 double chance = Rules.Bandits switch
                 {
@@ -106,7 +115,7 @@ public sealed partial class GameServer
         if (instance.BanditAmbushAt > 0 && _uptime >= instance.BanditAmbushAt && instance.BanditShipId.Length == 0)
         {
             instance.BanditAmbushAt = 0;
-            if (BanditShipsAllowed)
+            if (BanditShipsAllowedIn(SystemIdOfInstance(instance)))
             {
                 SpawnBanditShip(instance);
             }
@@ -371,7 +380,7 @@ public sealed partial class GameServer
     /// with a short per-entry sector warning. Never fires where bandit ships can't spawn anyway.</summary>
     private void ShipAiBanditSectorWarning(PlayerSession session, SpaceInstance instance)
     {
-        if (!BanditShipsAllowed || !BanditSystem(SystemIdOfInstance(instance)))
+        if (!BanditShipsAllowedIn(SystemIdOfInstance(instance)))
         {
             return;
         }
@@ -414,6 +423,10 @@ public sealed partial class GameServer
 
     /// <summary>Test/util: whether a system id rolls as pirate space for this save.</summary>
     public bool BanditSystemForTest(string systemId) => BanditSystem(systemId);
+
+    public bool BanditShipsAllowedInForTest(string systemId) => BanditShipsAllowedIn(systemId);
+
+    public SystemArchetype SystemArchetypeForTest(string systemId) => SystemArchetypeOf(systemId);
 
     /// <summary>Test/util: force-spawn the bandit ship ambush in the player's current instance.</summary>
     public void SpawnBanditShipForTest(string playerId)

--- a/src/BlocksBeyondTheStars.GameServer/GameServerBountyMissions.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerBountyMissions.cs
@@ -125,9 +125,8 @@ public sealed partial class GameServer
     /// story) AND the station's system must roll as pirate space AND the world's Danger option must not
     /// have disabled ambushes — otherwise the quest could never be completed.</summary>
     private bool ShipBountyOffered(string stationId)
-        => BanditShipsAllowed
-           && _meta.Description.Danger.DangerFactor() > 0
-           && BanditSystem(_galaxy.FindBody(stationId)?.SystemId ?? string.Empty);
+        => _meta.Description.Danger.DangerFactor() > 0
+           && BanditShipsAllowedIn(_galaxy.FindBody(stationId)?.SystemId ?? string.Empty);
 
     /// <summary>Adds the raider bounty to a station board's offers when the system qualifies.</summary>
     private void EnsureStationBounty(string idPrefix, string stationId, HashSet<string> currentBoardIds)

--- a/src/BlocksBeyondTheStars.GameServer/GameServerEnemies.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerEnemies.cs
@@ -54,11 +54,31 @@ public sealed partial class GameServer
     /// <summary>Hostile creatures currently active on the surface.</summary>
     public IReadOnlyList<CombatEntity> PlanetEnemies => _planetEnemies;
 
-    /// <summary>Whether hostile planet enemies may exist given the active rules. Once the Guardian core is
-    /// destroyed (P6 pacification) no machine spawns anywhere — the galaxy is at peace.</summary>
+    /// <summary>Whether hostile planet enemies may exist given the active rules. The Guardian's defeat no
+    /// longer switches them off (#1206): see <see cref="RemnantEra"/>.</summary>
     private bool PlanetEnemiesActive => Rules.PlanetEnemies != AlienActivity.Off
-        && Rules.GameMode == GameMode.Survival
-        && !_storyState.GuardianDefeated;
+        && Rules.GameMode == GameMode.Survival;
+
+    /// <summary>"Remnant Protocol" (#1206): once the Guardian core is shut down the galaxy is calmer, not
+    /// empty. Before, <c>GuardianDefeated</c> switched every planet machine, space wave and bandit ship off
+    /// for good — the post-game world was emptier than the one the player had just saved, and the raider
+    /// bounty could never be offered again. Now the flag is a <em>factor</em>: the planet cap halves (never
+    /// below one), refills come at twice the interval, and only the leftover scan-drones roam (the walking
+    /// hunter robots are gone — lore: the drones were the explore units); space waves keep only the places
+    /// that are dangerous by their own nature (pirate havens, the opt-in frontier-danger tier) and bandit
+    /// ships keep only their havens. Peaceful/family rules (PlanetEnemies Off) stay at zero as before.</summary>
+    private bool RemnantEra => _storyState.GuardianDefeated;
+
+    /// <summary>Post-win pacing multiplier for the planet-machine spawn cadence (#1206).</summary>
+    private double RemnantPaceFactor => RemnantEra ? 2.0 : 1.0;
+
+    /// <summary>The live planet-machine cap for the given number of surface targets: the activity rule times
+    /// the players, halved (floor one) once the galaxy is pacified (#1206).</summary>
+    private int PlanetEnemyCap(int targets)
+    {
+        int cap = ActivityCount(Rules.PlanetEnemies) * targets;
+        return RemnantEra ? System.Math.Max(1, cap / 2) : cap;
+    }
 
     private void TickEnemies(double dt)
     {
@@ -91,7 +111,7 @@ public sealed partial class GameServer
             return;
         }
 
-        int cap = ActivityCount(Rules.PlanetEnemies) * targets.Count;
+        int cap = PlanetEnemyCap(targets.Count);
         if (_planetEnemies.Count >= cap)
         {
             // At the cap the timer must not bank time (#740): it used to keep accumulating here, so the
@@ -106,7 +126,7 @@ public sealed partial class GameServer
 
             _enemySpawnTimer = 0;
         }
-        else if ((_enemySpawnTimer += dt) >= (_worlds.Active.EnemyCapSeen ? _worlds.Active.EnemyNextSpawnIn : EnemySpawnInterval))
+        else if ((_enemySpawnTimer += dt) >= (_worlds.Active.EnemyCapSeen ? _worlds.Active.EnemyNextSpawnIn : EnemySpawnInterval) * RemnantPaceFactor)
         {
             _enemySpawnTimer = 0;
             _worlds.Active.EnemyNextSpawnIn = RollEnemyRefillInterval();
@@ -122,7 +142,9 @@ public sealed partial class GameServer
             {
                 if (e.Kind == CombatEntityKind.ScanDrone) { droneCount++; }
             }
-            bool asDrone = Rules.PlanetDrones && droneCount * 5 < (_planetEnemies.Count + 1) * 2;
+            // Remnant era (#1206): only the scan-drones are left; the world option PlanetDrones=false keeps
+            // its meaning (then the few remnants are walkers — still fewer and slower than before the win).
+            bool asDrone = Rules.PlanetDrones && (RemnantEra || droneCount * 5 < (_planetEnemies.Count + 1) * 2);
             SpawnPlanetEnemyNear(targets[_planetEnemies.Count % targets.Count].State, asDrone);
             BroadcastPlanetEnemies();
         }

--- a/src/BlocksBeyondTheStars.GameServer/GameServerSpaceCombat.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerSpaceCombat.cs
@@ -663,16 +663,21 @@ public sealed partial class GameServer
         AddPersistedStations(instance); // item 20 S4: re-create player-built stations floating in this instance
         AddDerelictToInstance(instance); // #1129: "The Long Quiet" drifts in exactly one body's space
 
-        // Hostile NPC drones only when space combat is enabled and NPC enemies are switched on — and never
-        // once the Guardian core is destroyed (P6 pacification: the galaxy is at peace).
+        // Hostile NPC drones only when space combat is enabled and NPC enemies are switched on. Once the
+        // Guardian core is destroyed the finale gauntlet stays down for good, and the ambient waves survive
+        // only where space is dangerous by its own nature — pirate havens and the opt-in frontier-danger
+        // tier (Remnant Protocol, #1206) — so the post-game galaxy is calmer, not empty.
         bool combatEnabled = Rules.SpaceCombat is SpaceCombatMode.PvE or SpaceCombatMode.Both;
-        if (combatEnabled && !_storyState.GuardianDefeated)
+        if (combatEnabled)
         {
             // The finale system runs its own scripted ELITE gauntlet (P6 Stage 1) instead of the ambient
             // hostiles — the anchor body id (the "space:" prefix already stripped above) keys the check.
             if (IsGuardianSystemLocation(anchorId))
             {
-                SpawnGuardianGauntlet(instance);
+                if (!_storyState.GuardianDefeated)
+                {
+                    SpawnGuardianGauntlet(instance);
+                }
             }
             else
             {
@@ -687,7 +692,8 @@ public sealed partial class GameServer
                 // the fresh-start difficulty in pirate-space starts.
                 var archetype = SystemArchetypeOf(_galaxy?.FindBody(anchorId)?.SystemId);
                 int drones = ActivityCount(Rules.SpaceNpcEnemies);
-                if (archetype == SystemArchetype.Desolate)
+                bool remnantSpace = RemnantSpaceHostile(archetype, anchorId);
+                if (archetype == SystemArchetype.Desolate || !remnantSpace)
                 {
                     drones = 0;
                 }
@@ -730,7 +736,7 @@ public sealed partial class GameServer
                 }
 
                 if (Rules.AlienUfos != AlienActivity.Off && archetype != SystemArchetype.Desolate
-                    && wave.UfosKilled == 0)
+                    && remnantSpace && wave.UfosKilled == 0)
                 {
                     float uang = 2.42f + flight * 2.39996f; // roughly opposite the drone fan, rotating per flight
                     instance.Entities.Add(new CombatEntity
@@ -752,6 +758,14 @@ public sealed partial class GameServer
 
         return instance;
     }
+
+    /// <summary>Remnant Protocol (#1206): before the win every non-desolate system carries ambient hostiles;
+    /// after it only the places that are dangerous by their own nature keep them — a pirate haven, or the
+    /// full-frontier tier when the world's opt-in FrontierDanger rule is on.</summary>
+    private bool RemnantSpaceHostile(SystemArchetype archetype, string anchorBodyId)
+        => !_storyState.GuardianDefeated
+           || archetype == SystemArchetype.PirateHaven
+           || (Rules.FrontierDanger && FrontierTierForBody(anchorBodyId) >= 2);
 
     /// <summary>#741: session-scoped ambient-wave memory for one location — how many launches happened here
     /// (varies the wave layout per flight) and which ambient hostiles were destroyed (kept dead until the

--- a/src/BlocksBeyondTheStars.GameServer/GameServerStory.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerStory.cs
@@ -334,9 +334,11 @@ public sealed partial class GameServer
 
     // ---------------- Finale pacification (P6) ----------------
 
-    /// <summary>Finale win: the Guardian core is shut down — pacify the galaxy. One-way per-save: gates the
-    /// pack's planet + space machine spawns off (see <c>PlanetEnemiesActive</c> + the space spawn), despawns
-    /// live planet machines on the active world, persists, and broadcasts. The game continues afterwards.</summary>
+    /// <summary>Finale win: the Guardian core is shut down — pacify the galaxy. One-way per-save: despawns the
+    /// live planet machines on the active world (the dramatic beat), persists, and broadcasts. The game continues
+    /// afterwards under the Remnant Protocol (#1206, see <c>RemnantEra</c>): the flag no longer switches every
+    /// spawn off — the planet cap halves, refills slow down, only scan-drones remain, space waves keep only
+    /// pirate havens / the frontier-danger tier, bandit ships keep only their havens.</summary>
     private void MarkGuardianDefeated()
     {
         if (!StoryActive || _storyState.GuardianDefeated)

--- a/tests/BlocksBeyondTheStars.Tests/GameServerStoryCombatTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/GameServerStoryCombatTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
 using System.Linq;
+using BlocksBeyondTheStars.GameServer;
 using BlocksBeyondTheStars.Networking.Transport;
 using BlocksBeyondTheStars.Persistence;
 using BlocksBeyondTheStars.Shared.Configuration;
@@ -124,8 +125,12 @@ public sealed class GameServerStoryCombatTests : IDisposable
     }
 
     [Fact]
-    public void Defeating_the_guardian_pacifies_the_galaxy_so_no_more_planet_machines_spawn()
+    public void Defeating_the_guardian_leaves_only_remnant_drones_at_half_the_cap()
     {
+        // Remnant Protocol (#1206): the win used to switch every planet machine off for good — the saved
+        // galaxy was emptier than the threatened one. Now the live machines vanish at the moment of the win
+        // (the dramatic beat) and refill as a thinned-out remnant: half the cap (Normal + solo = 2 → 1),
+        // scan-drones only, at twice the interval.
         var server = Started("rocky", out var repo);
         using (repo)
         {
@@ -135,14 +140,16 @@ public sealed class GameServerStoryCombatTests : IDisposable
 
             server.MarkGuardianDefeatedForTest(); // win the finale → pacify the galaxy
             Assert.True(server.StorySnapshot.Defeated);
+            Assert.Empty(server.PlanetEnemies); // the live machines are gone at the moment of the win
 
-            for (int i = 0; i < 10; i++)
+            for (int i = 0; i < 20; i++)
             {
                 server.Tick(6.0);
                 p.State.Health = 100f;
             }
 
-            Assert.Empty(server.PlanetEnemies); // machines no longer spawn once the Guardian is down
+            Assert.Single(server.PlanetEnemies); // remnant cap = max(1, 2 / 2)
+            Assert.All(server.PlanetEnemies, e => Assert.Equal(CombatEntityKind.ScanDrone, e.Kind));
         }
     }
 

--- a/tests/BlocksBeyondTheStars.Tests/RemnantProtocolTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/RemnantProtocolTests.cs
@@ -1,0 +1,179 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using System;
+using BlocksBeyondTheStars.GameServer;
+using BlocksBeyondTheStars.Networking.Transport;
+using BlocksBeyondTheStars.Persistence;
+using BlocksBeyondTheStars.Shared.Configuration;
+using BlocksBeyondTheStars.Shared.Content;
+using BlocksBeyondTheStars.Shared.Geometry;
+using BlocksBeyondTheStars.WorldGeneration;
+using Xunit;
+using SvGameServer = BlocksBeyondTheStars.GameServer.GameServer;
+
+namespace BlocksBeyondTheStars.Tests;
+
+/// <summary>
+/// Remnant Protocol (#1206): defeating the Guardian no longer empties the galaxy. Planet machines refill as a
+/// thinned remnant (half cap, drones only, slower), peaceful/family rules still mean zero, and bandit ships keep
+/// only genuine pirate havens — so the raider bounty stays earnable after the ending.
+/// </summary>
+public sealed class RemnantProtocolTests : IDisposable
+{
+    private readonly string _root;
+    private readonly GameContent _content;
+
+    public RemnantProtocolTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "bbts_remnant_" + Guid.NewGuid().ToString("N"));
+        _content = ContentLoader.LoadFromDirectory(TestPaths.DataDir());
+    }
+
+    private SvGameServer Started(string name, Action<GameRules>? rules, out SqliteWorldRepository repo, long seed = 4242)
+    {
+        repo = new SqliteWorldRepository(new SaveGamePaths(_root, name));
+        var st = new LoopbackServerTransport(new LoopbackLink());
+        var config = new ServerConfig
+        {
+            WorldName = name,
+            Seed = seed,
+            StartPlanet = "rocky",
+            AutoSaveIntervalMinutes = 9999,
+            PlaceStarterShip = false,
+        };
+        rules?.Invoke(config.Rules);
+        var server = new SvGameServer(config, _content, st, repo);
+        server.Start();
+        return server;
+    }
+
+    private static void TickSurface(SvGameServer server, PlayerSession p, int ticks)
+    {
+        for (int i = 0; i < ticks; i++)
+        {
+            server.Tick(6.0);
+            p.State.Health = 100f;
+        }
+    }
+
+    [Fact]
+    public void AfterTheWin_TwoPlayersShareAHalvedCap_OfDronesOnly()
+    {
+        var server = Started("remnant_two", null, out var repo); // Survival + PlanetEnemies Normal (2 per player)
+        using (repo)
+        {
+            var a = server.AddLocalPlayer("Ada");
+            var b = server.AddLocalPlayer("Ben");
+            foreach (var p in new[] { a, b })
+            {
+                p.State.AboardShip = false;
+                p.State.Position = new Vector3f(0, 64, 0);
+            }
+
+            // Before the win the world fills to the full cap (2 × 2 players = 4).
+            for (int i = 0; i < 40 && server.PlanetEnemies.Count < 4; i++)
+            {
+                server.Tick(6.0);
+                a.State.Health = 100f;
+                b.State.Health = 100f;
+            }
+
+            Assert.Equal(4, server.PlanetEnemies.Count);
+
+            server.MarkGuardianDefeatedForTest();
+            Assert.Empty(server.PlanetEnemies);
+
+            for (int i = 0; i < 40; i++)
+            {
+                server.Tick(6.0);
+                a.State.Health = 100f;
+                b.State.Health = 100f;
+            }
+
+            Assert.Equal(2, server.PlanetEnemies.Count); // max(1, 4 / 2)
+            Assert.All(server.PlanetEnemies, e => Assert.Equal(CombatEntityKind.ScanDrone, e.Kind));
+        }
+    }
+
+    [Fact]
+    public void AfterTheWin_PeacefulRulesStillMeanNoMachines()
+    {
+        var server = Started("remnant_peaceful", r => r.PlanetEnemies = AlienActivity.Off, out var repo);
+        using (repo)
+        {
+            var p = server.AddLocalPlayer("Hero");
+            p.State.AboardShip = false;
+            p.State.Position = new Vector3f(0, 64, 0);
+
+            server.MarkGuardianDefeatedForTest();
+            TickSurface(server, p, 20);
+
+            Assert.Empty(server.PlanetEnemies);
+        }
+    }
+
+    [Fact]
+    public void FamilyPresets_KeepPlanetMachinesOff()
+    {
+        Assert.Equal(AlienActivity.Off, ServerPresets.Get("family")!.PlanetEnemies);
+        Assert.Equal(AlienActivity.Off, ServerPresets.Get("peaceful-creative")!.PlanetEnemies);
+    }
+
+    [Fact]
+    public void AfterTheWin_BanditShipsKeepOnlyPirateHavens()
+    {
+        // Scan a handful of start systems: before the win any pirate-space system harbours raiders, after it
+        // only a genuine PirateHaven does — and a haven keeps them, so the raider bounty stays earnable.
+        bool sawNonHavenPirateSpace = false, sawHaven = false;
+        for (long seed = 1; seed <= 40 && !(sawNonHavenPirateSpace && sawHaven); seed++)
+        {
+            var server = Started("remnant_bandit" + seed, r =>
+            {
+                r.PlanetEnemies = AlienActivity.Off;
+                r.Bandits = AlienActivity.Normal;
+                r.FreeSpaceFlight = true;
+                r.SpaceCombat = SpaceCombatMode.PvE;
+                r.ShipWeapons = ShipWeaponMode.NpcsOnly;
+            }, out var repo, seed);
+            using (repo)
+            {
+                var pilot = server.AddLocalPlayer("Pilot");
+                pilot.State.AboardShip = true;
+                server.Ship.CurrentLocationId = pilot.CurrentLocationId;
+                server.EnterSpace("Pilot");
+                string systemId = server.SpaceSystemIdForTest(pilot.State.PlayerId);
+                if (systemId.Length == 0 || !server.BanditSystemForTest(systemId))
+                {
+                    continue;
+                }
+
+                bool haven = server.SystemArchetypeForTest(systemId) == SystemArchetype.PirateHaven;
+                Assert.True(server.BanditShipsAllowedInForTest(systemId), "pirate space harbours raiders before the win");
+
+                server.MarkGuardianDefeatedForTest();
+                Assert.Equal(haven, server.BanditShipsAllowedInForTest(systemId));
+                sawHaven |= haven;
+                sawNonHavenPirateSpace |= !haven;
+            }
+        }
+
+        Assert.True(sawNonHavenPirateSpace, "expected at least one non-haven pirate-space start system in 40 seeds");
+    }
+
+    public void Dispose()
+    {
+        Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+        try
+        {
+            if (Directory.Exists(_root))
+            {
+                Directory.Delete(_root, recursive: true);
+            }
+        }
+        catch
+        {
+            // best-effort temp cleanup
+        }
+    }
+}


### PR DESCRIPTION
Third slice of the feature-deepening package (epic #1197) — server only, **no Unity client change**.

## Problem

`MarkGuardianDefeated` set a one-way flag that three spawners read as "off forever": `PlanetEnemiesActive` (`GameServerEnemies.cs`), the ambient space wave (`GameServerSpaceCombat.cs:669`) and `BanditShipsAllowed` (`GameServerBanditShips.cs`). After the finale no machine, no UFO and **no bandit ship** ever spawned again — the saved galaxy was emptier than the threatened one, and the station **raider bounty** could never be offered again (`ShipBountyOffered` keys on that gate).

## Fix — the flag becomes a factor ("Remnant Protocol")

- **Planet:** `RemnantEra` halves the cap (`PlanetEnemyCap` = max(1, cap/2)), doubles the spawn cadence (`RemnantPaceFactor` on the initial fill and the #740 refill roll) and spawns **scan-drones only** (the hunter robots are gone — lore: drones were the explore units; `PlanetDrones=false` keeps its meaning and then leaves a few walkers). The win still clears the live machines — the dramatic beat stays.
- **Space:** the finale gauntlet stays down for good; ambient drones + UFOs survive only where space is dangerous by nature — `RemnantSpaceHostile` = pirate haven **or** (`FrontierDanger` && frontier tier ≥ 2).
- **Bandit ships:** new `BanditShipsAllowedIn(systemId)` (rules + pirate space + post-win only `SystemArchetype.PirateHaven`), used by the ambush roll, the warp-in, VEGA's sector warning and `ShipBountyOffered` → the raider bounty stays earnable after the ending.
- Family/peaceful rules (`PlanetEnemies Off`) stay at zero; nothing new is persisted (everything derives from the existing flag).

## Tests
`GameServerStoryCombatTests` pacify test rewritten to the remnant shape (1 drone at Normal + solo); new `RemnantProtocolTests` (two players → 2 drones from a cap of 4, drones only; Off stays empty; family presets; bandit havens keep raiders while other pirate space loses them).

## Docs
USER_MANUAL § Story ("After the ending the galaxy is calmer, not empty"), STORY_IMPLEMENTATION §6, TODO.md. Follow-up in the package: #1213 relay "survey orders" chains build on these remnants.

closes #1206

🤖 Generated with [Claude Code](https://claude.com/claude-code)
