### PR TITLE
feat(content): every ore gets a second buyer — factory raw-ore tier, market barter, sinks + generalised economy test (#1200)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -179,6 +179,33 @@ finding kept as a comment: a **digit-heavy marker label** trips the name screen'
 (Crews) + new § Map markers & ping. Still open on-device: two-client crew flow, marker editor on pad/touch,
 ping in real co-op (rides the #1227 playtest).
 
+### ★ Ore economy — every ore gets a second buyer, and a test that keeps it so (#1200, 2026-08-24, branch feat/1200-economy)
+Twenty-sixth slice of the feature-deepening package (epic #1197); pure data + tests + docs, no client build.
+Eleven ores (aluminium, cobalt, diamond, lead, lithium, neodymium, platinum, tin, tungsten, uranium, zinc) fed
+nothing but their own smelt; `silver_ingot` and `uranium` were thin; the factory's ten recipes all duplicated
+workshop/refinery outputs; `MaterialEconomyTests` checked a hand-picked list of 13 metals.
+**Recipes (`data/recipes.json`, no new items, no locale keys):** a factory **raw-ore tier** — light alloy, bronze,
+brass, power cell, carbide, magnet, diamond, reactor fuel straight from ore (more ore per step, never a better
+per-ore yield than the refinery chain; rosters are seeded per world → new factories only, the manual says so);
+market `sell_uranium` (researchers),
+`buy_lead` (miners), `sell_silver` (traders); sinks silver_ingot → medbay_panel + light_white, bronze → workbench +
+ship_engine, brass_fitting → hydro_tray + factory_pipe + oxygen_extractor, sulfur → `meat_bait_cured` (hand),
+`power_cell_irradiated` (refinery, uranium's third consumer). ⚠ The issue's `market_buy_lead` is a SOURCE, not a
+sink, and `market_sell_uranium` alone leaves uranium at two uses — hence `factory_reactor_fuel` (uranium_ore +
+lead_ore; reactor fuel as an OUTPUT is fine, #1106 only forbids it as an input), `factory_diamond` and the
+irradiated cell; `market_sell_silver` / `market_sell_diamond` give silver and diamond their second station.
+⚠ **NOT done, deliberately:** the issue's transmuter resynth of tungsten/platinum/neodymium ore collides with the
+transmuter's I1 invariant (`MatterConverterTests.Transmuter_NeverOutputs_Tier3Materials`: endgame ores stay
+mining-exclusive, "breaks the mining economy"). The invariant wins until the maintainer says otherwise; the ores
+get their second consumer from the factory tier instead, so nothing else depended on the resynth recipes.
+**Test (`MaterialEconomyTests`, generalised, hard-fail):** every ore drop ≥ 2 consumers / ≥ 2 stations; every
+smeltable (output of a non-market/factory recipe whose inputs are all ore drops) ≥ 3 / ≥ 2; every station except
+hand/market ≥ 3 recipes — detoxifier/algae tank/campfire carry a documented ≥ 1 allowance until #1203's station
+packs land; every Material-category item consumed; the un-consumed Component set is an EXACT end-product whitelist
+(14 entries). The H2 list test stays as the historical anchor. Pre-refinery progression untouched (all sink
+edits use workshop-smelted metals). Docs: USER_MANUAL factory raw-ore tier + new-worlds note, transmuter resynth
+line, market themes.
+
 ### ★ Two more crops — grain + mushroom join the berry in the greenhouse (#1204, 2026-08-24, branch feat/1204-crops)
 Twenty-fifth slice of the feature-deepening package (epic #1197); started ahead of the blueprint re-parenting
 (#1202, community-assigned) on purpose — crops touch flora/server/client and the item/block regions, never

--- a/data/recipes.json
+++ b/data/recipes.json
@@ -73,6 +73,17 @@
   { "key": "factory_circuit_board",   "station": "factory", "inputs": [ { "item": "gold_ore", "count": 3 }, { "item": "silver_ore", "count": 3 }, { "item": "silicate", "count": 4 } ], "outputs": [ { "item": "circuit_board", "count": 1 } ] },
   { "key": "factory_polymer",         "station": "factory", "inputs": [ { "item": "carbon", "count": 3 }, { "item": "sulfur_ore", "count": 2 } ],                           "outputs": [ { "item": "polymer", "count": 1 } ] },
   { "key": "factory_titanium_plate",  "station": "factory", "inputs": [ { "item": "titanium_ore", "count": 3 } ],                                                          "outputs": [ { "item": "titanium_plate", "count": 1 } ] },
+  // #1200 raw-ore -> part tier: the factory skips the smelt stages of the alloy / component chains at the price of
+  // more ore per step (never a better per-ore yield than the refinery route). Gives the 11 single-use ores a
+  // second consumer at a second station. Rosters are seeded per world, so these show up in NEW factories.
+  { "key": "factory_light_alloy", "station": "factory", "inputs": [ { "item": "aluminium_ore", "count": 4 }, { "item": "titanium_ore", "count": 2 } ], "outputs": [ { "item": "light_alloy", "count": 2 } ] },
+  { "key": "factory_bronze", "station": "factory", "inputs": [ { "item": "tin_ore", "count": 2 }, { "item": "copper_ore", "count": 2 } ], "outputs": [ { "item": "bronze", "count": 3 } ] },
+  { "key": "factory_brass", "station": "factory", "inputs": [ { "item": "zinc_ore", "count": 2 }, { "item": "copper_ore", "count": 2 } ], "outputs": [ { "item": "brass", "count": 3 } ] },
+  { "key": "factory_power_cell", "station": "factory", "inputs": [ { "item": "lithium_ore", "count": 2 }, { "item": "cobalt_ore", "count": 2 }, { "item": "copper_ore", "count": 2 }, { "item": "silicate", "count": 2 } ], "outputs": [ { "item": "power_cell", "count": 1 } ] },
+  { "key": "factory_carbide", "station": "factory", "inputs": [ { "item": "tungsten_ore", "count": 3 }, { "item": "platinum_ore", "count": 3 }, { "item": "carbon", "count": 1 } ], "outputs": [ { "item": "carbide", "count": 1 } ] },
+  { "key": "factory_magnet", "station": "factory", "inputs": [ { "item": "neodymium_ore", "count": 3 }, { "item": "iron_ore", "count": 3 } ], "outputs": [ { "item": "magnet", "count": 4 } ] },
+  { "key": "factory_diamond", "station": "factory", "inputs": [ { "item": "diamond_ore", "count": 3 }, { "item": "carbon", "count": 1 } ], "outputs": [ { "item": "diamond", "count": 2 } ] },
+  { "key": "factory_reactor_fuel", "station": "factory", "inputs": [ { "item": "uranium_ore", "count": 6 }, { "item": "lead_ore", "count": 3 } ], "outputs": [ { "item": "reactor_fuel", "count": 1 } ] },
 
   { "key": "matter_forge", "station": "workshop", "requiredBlueprint": "matter_forge", "inputs": [ { "item": "metal_panel", "count": 6 }, { "item": "circuit_board", "count": 2 }, { "item": "glass", "count": 3 }, { "item": "energy_cell_1", "count": 3 } ], "outputs": [ { "item": "matter_forge", "count": 1 } ] },
 
@@ -97,11 +108,13 @@
 
   { "key": "forage_bait", "station": "hand", "inputs": [ { "item": "plant_fiber", "count": 2 }, { "item": "berries", "count": 1 } ], "outputs": [ { "item": "forage_bait", "count": 2 } ] },
   { "key": "meat_bait",   "station": "hand", "inputs": [ { "item": "creature_meat", "count": 1 } ], "outputs": [ { "item": "meat_bait", "count": 2 } ] },
+  // #1200: curing the meat with sulfur doubles the bait per cut — sulfur's first use outside the workshop chain.
+  { "key": "meat_bait_cured", "station": "hand", "inputs": [ { "item": "creature_meat", "count": 1 }, { "item": "sulfur", "count": 1 } ], "outputs": [ { "item": "meat_bait", "count": 4 } ] },
   { "key": "nectar_lure", "station": "hand", "inputs": [ { "item": "berries", "count": 2 }, { "item": "salt", "count": 1 } ], "outputs": [ { "item": "nectar_lure", "count": 2 } ] },
 
   { "key": "suit_teleporter", "station": "workshop", "requiredBlueprint": "suit_teleporter", "inputs": [ { "item": "titanium_plate", "count": 4 }, { "item": "cable", "count": 6 }, { "item": "energy_cell_1", "count": 3 }, { "item": "data_fragment", "count": 2 } ], "outputs": [ { "item": "suit_teleporter", "count": 1 } ] },
 
-  { "key": "oxygen_extractor", "station": "workshop", "requiredBlueprint": "oxygen_extractor", "inputs": [ { "item": "iron_plate", "count": 4 }, { "item": "cable", "count": 4 }, { "item": "glass", "count": 2 }, { "item": "energy_cell_1", "count": 2 } ], "outputs": [ { "item": "oxygen_extractor", "count": 1 } ] },
+  { "key": "oxygen_extractor", "station": "workshop", "requiredBlueprint": "oxygen_extractor", "inputs": [ { "item": "iron_plate", "count": 4 }, { "item": "cable", "count": 4 }, { "item": "glass", "count": 2 }, { "item": "energy_cell_1", "count": 2 }, { "item": "brass_fitting", "count": 1 } ], "outputs": [ { "item": "oxygen_extractor", "count": 1 } ] },
 
   { "key": "stealth_suit",     "station": "workshop", "requiredBlueprint": "stealth_suit",     "inputs": [ { "item": "titanium_plate", "count": 6 }, { "item": "cable", "count": 8 }, { "item": "energy_cell_1", "count": 3 }, { "item": "polymer", "count": 2 } ], "outputs": [ { "item": "stealth_suit", "count": 1 } ] },
   { "key": "jetpack",          "station": "workshop", "requiredBlueprint": "jetpack",          "inputs": [ { "item": "titanium_plate", "count": 6 }, { "item": "cable", "count": 6 }, { "item": "energy_cell_1", "count": 3 }, { "item": "light_alloy", "count": 2 }, { "item": "polymer", "count": 2 } ], "outputs": [ { "item": "jetpack", "count": 1 } ] },
@@ -127,15 +140,20 @@
   { "key": "market_copper_to_silicate","station": "market", "marketTheme": "traders", "inputs": [ { "item": "copper_ore", "count": 3 } ],    "outputs": [ { "item": "silicate", "count": 4 } ] },
   { "key": "market_sell_crystal",      "station": "market", "marketTheme": "traders", "inputs": [ { "item": "crystal", "count": 2 } ],       "outputs": [ { "item": "titanium_ore", "count": 1 }, { "item": "iron_ore", "count": 3 } ] },
   { "key": "market_sell_gold",         "station": "market", "marketTheme": "traders", "inputs": [ { "item": "gold_ingot", "count": 1 } ],   "outputs": [ { "item": "titanium_ore", "count": 6 } ] },
+  { "key": "market_sell_silver", "station": "market", "marketTheme": "traders", "inputs": [ { "item": "silver_ingot", "count": 2 } ], "outputs": [ { "item": "titanium_ore", "count": 5 } ] },
+  { "key": "market_sell_diamond", "station": "market", "marketTheme": "traders", "inputs": [ { "item": "diamond", "count": 1 } ], "outputs": [ { "item": "titanium_ore", "count": 8 } ] },
   // A rare SPS / Scout-and-Pioneer-Service access code, occasionally offered by travelling traders. Steep barter — claiming a structure is a major prize.
   { "key": "market_buy_access_code",   "station": "market", "marketTheme": "traders", "inputs": [ { "item": "gold_ingot", "count": 4 }, { "item": "crystal", "count": 4 }, { "item": "circuit_board", "count": 2 } ], "outputs": [ { "item": "access_code", "count": 1 } ] },
 
   { "key": "market_buy_iron",          "station": "market", "marketTheme": "miners", "inputs": [ { "item": "silicate", "count": 4 } ],      "outputs": [ { "item": "iron_ore", "count": 6 } ] },
   { "key": "market_buy_copper",        "station": "market", "marketTheme": "miners", "inputs": [ { "item": "silicate", "count": 3 } ],      "outputs": [ { "item": "copper_ore", "count": 4 } ] },
   { "key": "market_carbon_to_crystal", "station": "market", "marketTheme": "miners", "inputs": [ { "item": "carbon", "count": 8 } ],        "outputs": [ { "item": "crystal", "count": 1 } ] },
+  { "key": "market_buy_lead", "station": "market", "marketTheme": "miners", "inputs": [ { "item": "silicate", "count": 3 } ], "outputs": [ { "item": "lead_ore", "count": 4 } ] },
 
   { "key": "market_buy_data_fragment", "station": "market", "marketTheme": "researchers", "inputs": [ { "item": "titanium_ore", "count": 3 }, { "item": "crystal", "count": 1 } ], "outputs": [ { "item": "data_fragment", "count": 1 } ] },
   { "key": "market_data_to_circuit",   "station": "market", "marketTheme": "researchers", "inputs": [ { "item": "data_fragment", "count": 1 } ], "outputs": [ { "item": "circuit_board", "count": 2 } ] },
+  // #1200: researchers pay well for refined uranium — the one buyer for it outside the reactor.
+  { "key": "market_sell_uranium", "station": "market", "marketTheme": "researchers", "inputs": [ { "item": "uranium", "count": 1 } ], "outputs": [ { "item": "data_fragment", "count": 2 } ] },
 
   { "key": "market_sell_meat",         "station": "market", "marketTheme": "settlers", "inputs": [ { "item": "creature_meat", "count": 4 } ], "outputs": [ { "item": "iron_ore", "count": 3 } ] },
   { "key": "market_buy_food",          "station": "market", "marketTheme": "settlers", "inputs": [ { "item": "iron_ore", "count": 3 } ],      "outputs": [ { "item": "creature_meat", "count": 5 } ] },
@@ -172,7 +190,7 @@
   { "key": "bronze_block", "station": "workshop", "inputs": [ { "item": "bronze", "count": 2 } ], "outputs": [ { "item": "bronze_block", "count": 1 } ] },
   { "key": "brass_block",  "station": "workshop", "inputs": [ { "item": "brass", "count": 2 } ],  "outputs": [ { "item": "brass_block", "count": 1 } ] },
 
-  { "key": "workbench",   "station": "workshop", "inputs": [ { "item": "iron_plate", "count": 4 }, { "item": "steel", "count": 1 } ], "outputs": [ { "item": "workbench", "count": 1 } ] },
+  { "key": "workbench",   "station": "workshop", "inputs": [ { "item": "iron_plate", "count": 4 }, { "item": "steel", "count": 1 }, { "item": "bronze", "count": 1 } ], "outputs": [ { "item": "workbench", "count": 1 } ] },
   { "key": "forge",       "station": "workshop", "inputs": [ { "item": "stone", "count": 6 }, { "item": "iron_plate", "count": 4 } ],  "outputs": [ { "item": "forge", "count": 1 } ] },
   { "key": "steel_floor", "station": "workshop", "inputs": [ { "item": "steel", "count": 1 } ],                                      "outputs": [ { "item": "steel_floor", "count": 4 } ] },
   { "key": "metal_panel", "station": "workshop", "inputs": [ { "item": "iron_plate", "count": 2 } ],                                 "outputs": [ { "item": "metal_panel", "count": 4 } ] },
@@ -194,7 +212,7 @@
   { "key": "station_core", "station": "workshop", "inputs": [ { "item": "metal_panel", "count": 6 }, { "item": "circuit_board", "count": 2 }, { "item": "energy_cell_1", "count": 1 } ], "outputs": [ { "item": "station_core", "count": 1 } ] },
   { "key": "ship_core",   "station": "workshop", "requiredBlueprint": "ship_builder", "inputs": [ { "item": "metal_panel", "count": 8 }, { "item": "circuit_board", "count": 2 }, { "item": "energy_cell_1", "count": 2 } ], "outputs": [ { "item": "ship_core", "count": 1 } ] },
   { "key": "ship_helm",   "station": "workshop", "requiredBlueprint": "ship_builder", "inputs": [ { "item": "metal_panel", "count": 4 }, { "item": "circuit_board", "count": 2 }, { "item": "glass", "count": 2 } ], "outputs": [ { "item": "ship_helm", "count": 1 } ] },
-  { "key": "ship_engine", "station": "workshop", "requiredBlueprint": "ship_builder", "inputs": [ { "item": "metal_panel", "count": 4 }, { "item": "steel", "count": 2 }, { "item": "energy_cell_1", "count": 1 } ], "outputs": [ { "item": "ship_engine", "count": 1 } ] },
+  { "key": "ship_engine", "station": "workshop", "requiredBlueprint": "ship_builder", "inputs": [ { "item": "metal_panel", "count": 4 }, { "item": "steel", "count": 2 }, { "item": "energy_cell_1", "count": 1 }, { "item": "bronze", "count": 2 } ], "outputs": [ { "item": "ship_engine", "count": 1 } ] },
   { "key": "base_core",    "station": "workshop", "inputs": [ { "item": "stone", "count": 6 }, { "item": "iron_plate", "count": 2 } ], "outputs": [ { "item": "base_core", "count": 1 } ] },
   { "key": "station_vendor",    "station": "workshop", "requiredBlueprint": "station_vendor",        "inputs": [ { "item": "metal_panel", "count": 4 }, { "item": "circuit_board", "count": 2 }, { "item": "energy_cell_1", "count": 1 } ], "outputs": [ { "item": "station_vendor", "count": 1 } ] },
   { "key": "mission_board",     "station": "workshop", "requiredBlueprint": "station_mission_board", "inputs": [ { "item": "metal_panel", "count": 3 }, { "item": "circuit_board", "count": 1 }, { "item": "glass", "count": 2 } ],         "outputs": [ { "item": "mission_board", "count": 1 } ] },
@@ -209,7 +227,7 @@
   { "key": "seed_grain",   "station": "hand", "inputs": [ { "item": "grain", "count": 3 } ],       "outputs": [ { "item": "grain_seed", "count": 2 } ] },
   { "key": "seed_shroom",  "station": "hand", "inputs": [ { "item": "mushroom_cap", "count": 2 } ], "outputs": [ { "item": "shroom_seed", "count": 2 } ] },
   // The hydroponic tray the high-tech greenhouses grow crops in — the one host block that is not soil.
-  { "key": "hydro_tray",   "station": "workshop", "inputs": [ { "item": "metal_panel", "count": 1 }, { "item": "glass", "count": 1 }, { "item": "plant_fiber", "count": 2 } ], "outputs": [ { "item": "hydro_tray", "count": 2 } ] },
+  { "key": "hydro_tray",   "station": "workshop", "inputs": [ { "item": "metal_panel", "count": 1 }, { "item": "glass", "count": 1 }, { "item": "plant_fiber", "count": 2 }, { "item": "brass_fitting", "count": 1 } ], "outputs": [ { "item": "hydro_tray", "count": 2 } ] },
 
   { "key": "bronze_gear",   "station": "workshop", "inputs": [ { "item": "bronze", "count": 2 } ], "outputs": [ { "item": "bronze_gear", "count": 2 } ] },
   { "key": "brass_fitting", "station": "workshop", "inputs": [ { "item": "brass", "count": 2 } ],  "outputs": [ { "item": "brass_fitting", "count": 2 } ] },
@@ -279,18 +297,18 @@
   // starboard lenses, cobalt the cyan strip, brass the warm one); panels are plated metal_panel; the machine parts
   // are geared, piped and circuit-bound. The force field is a hard-light barrier — energy-door tech, platinum emitter.
   // Each also gives one of the H2 metals a job (#1107). data_cache stays loot-only.
-  { "key": "light_white", "station": "workshop", "inputs": [ { "item": "glass", "count": 2 }, { "item": "crystal", "count": 1 }, { "item": "aluminium_ingot", "count": 1 } ], "outputs": [ { "item": "light_white", "count": 4 } ] },
+  { "key": "light_white", "station": "workshop", "inputs": [ { "item": "glass", "count": 2 }, { "item": "crystal", "count": 1 }, { "item": "aluminium_ingot", "count": 1 }, { "item": "silver_ingot", "count": 1 } ], "outputs": [ { "item": "light_white", "count": 4 } ] },
   { "key": "light_red", "station": "workshop", "inputs": [ { "item": "glass", "count": 2 }, { "item": "crystal", "count": 1 }, { "item": "aluminium_ingot", "count": 1 }, { "item": "berries", "count": 2 } ], "outputs": [ { "item": "light_red", "count": 4 } ] },
   { "key": "light_green", "station": "workshop", "inputs": [ { "item": "glass", "count": 2 }, { "item": "crystal", "count": 1 }, { "item": "aluminium_ingot", "count": 1 }, { "item": "plant_fiber", "count": 2 } ], "outputs": [ { "item": "light_green", "count": 4 } ] },
   { "key": "strip_light_cyan", "station": "workshop", "inputs": [ { "item": "metal_panel", "count": 1 }, { "item": "glass", "count": 1 }, { "item": "crystal", "count": 1 }, { "item": "cobalt_ingot", "count": 1 } ], "outputs": [ { "item": "strip_light_cyan", "count": 4 } ] },
   { "key": "strip_light_warm", "station": "workshop", "inputs": [ { "item": "metal_panel", "count": 1 }, { "item": "glass", "count": 1 }, { "item": "crystal", "count": 1 }, { "item": "brass", "count": 1 } ], "outputs": [ { "item": "strip_light_warm", "count": 4 } ] },
-  { "key": "medbay_panel", "station": "workshop", "inputs": [ { "item": "metal_panel", "count": 2 }, { "item": "polymer", "count": 1 }, { "item": "tin_ingot", "count": 1 } ], "outputs": [ { "item": "medbay_panel", "count": 4 } ] },
+  { "key": "medbay_panel", "station": "workshop", "inputs": [ { "item": "metal_panel", "count": 2 }, { "item": "polymer", "count": 1 }, { "item": "tin_ingot", "count": 1 }, { "item": "silver_ingot", "count": 1 } ], "outputs": [ { "item": "medbay_panel", "count": 4 } ] },
   { "key": "lab_panel", "station": "workshop", "inputs": [ { "item": "metal_panel", "count": 2 }, { "item": "polymer", "count": 1 }, { "item": "nickel_ingot", "count": 1 } ], "outputs": [ { "item": "lab_panel", "count": 4 } ] },
   { "key": "cargo_floor", "station": "workshop", "inputs": [ { "item": "iron_plate", "count": 2 }, { "item": "zinc_ingot", "count": 1 } ], "outputs": [ { "item": "cargo_floor", "count": 4 } ] },
   { "key": "engine_panel", "station": "workshop", "inputs": [ { "item": "metal_panel", "count": 2 }, { "item": "tungsten_ingot", "count": 1 } ], "outputs": [ { "item": "engine_panel", "count": 4 } ] },
   { "key": "engine_nozzle", "station": "workshop", "inputs": [ { "item": "steel", "count": 2 }, { "item": "tungsten_ingot", "count": 1 }, { "item": "carbide", "count": 1 } ], "outputs": [ { "item": "engine_nozzle", "count": 2 } ] },
   { "key": "factory_terminal", "station": "workshop", "inputs": [ { "item": "metal_panel", "count": 3 }, { "item": "circuit_board", "count": 1 }, { "item": "glass", "count": 1 }, { "item": "cable", "count": 2 } ], "outputs": [ { "item": "factory_terminal", "count": 1 } ] },
-  { "key": "factory_pipe", "station": "workshop", "inputs": [ { "item": "iron_plate", "count": 1 }, { "item": "lead_ingot", "count": 1 } ], "outputs": [ { "item": "factory_pipe", "count": 4 } ] },
+  { "key": "factory_pipe", "station": "workshop", "inputs": [ { "item": "iron_plate", "count": 1 }, { "item": "lead_ingot", "count": 1 }, { "item": "brass_fitting", "count": 1 } ], "outputs": [ { "item": "factory_pipe", "count": 4 } ] },
   { "key": "machine_block", "station": "workshop", "inputs": [ { "item": "metal_panel", "count": 3 }, { "item": "bronze_gear", "count": 1 }, { "item": "magnet", "count": 1 }, { "item": "cable", "count": 2 } ], "outputs": [ { "item": "machine_block", "count": 2 } ] },
   { "key": "force_field", "station": "workshop", "requiredBlueprint": "door_energy", "inputs": [ { "item": "circuit_board", "count": 1 }, { "item": "crystal", "count": 2 }, { "item": "platinum_ingot", "count": 1 }, { "item": "energy_cell_1", "count": 1 } ], "outputs": [ { "item": "force_field", "count": 2 } ] },
 
@@ -304,6 +322,8 @@
   { "key": "refine_steel", "station": "refinery", "inputs": [ { "item": "iron_ingot", "count": 2 }, { "item": "nickel_ingot", "count": 1 }, { "item": "carbon", "count": 1 } ], "outputs": [ { "item": "steel", "count": 2 } ] },
   { "key": "carbide_cobalt", "station": "refinery", "inputs": [ { "item": "tungsten_ingot", "count": 1 }, { "item": "cobalt_ingot", "count": 1 }, { "item": "carbon", "count": 1 } ], "outputs": [ { "item": "carbide", "count": 1 } ] },
   { "key": "power_cell_refined", "station": "refinery", "inputs": [ { "item": "energy_cell_1", "count": 2 }, { "item": "lithium", "count": 1 }, { "item": "cobalt_ingot", "count": 1 } ], "outputs": [ { "item": "power_cell", "count": 2 } ] },
+  // #1200: an irradiated alternative — refined uranium instead of lithium + cobalt (uranium's third consumer).
+  { "key": "power_cell_irradiated", "station": "refinery", "inputs": [ { "item": "energy_cell_1", "count": 2 }, { "item": "uranium", "count": 1 } ], "outputs": [ { "item": "power_cell", "count": 2 } ] },
   { "key": "magnet_sintered", "station": "refinery", "inputs": [ { "item": "neodymium", "count": 1 }, { "item": "iron_ingot", "count": 2 } ], "outputs": [ { "item": "magnet", "count": 4 } ] },
   { "key": "energy_cell_lithium", "station": "workshop", "inputs": [ { "item": "cable", "count": 1 }, { "item": "carbon_composite", "count": 1 }, { "item": "lithium", "count": 1 } ], "outputs": [ { "item": "energy_cell_1", "count": 3 } ] },
   { "key": "torch_oil", "station": "hand", "inputs": [ { "item": "biofuel", "count": 1 }, { "item": "plant_fiber", "count": 1 } ], "outputs": [ { "item": "torch", "count": 6 } ] },

--- a/docs/user/USER_MANUAL.md
+++ b/docs/user/USER_MANUAL.md
@@ -430,6 +430,8 @@ separate unlock; admins can still disable it through server world rules.
   blueprint). Only the data cache stays loot-only.
 - The **transmuter** (the *matter forge* block or ship module, unlocked via Tech) compacts spare terrain
   (sand, dirt, stone, …) into *matter dust* and synthesises it back into ore — a sink for surplus digging.
+  With the **matter resynth** blueprint it also rebuilds titanium, silver and cobalt ore and lithium from dust
+  plus a power cell. The endgame ores (tungsten, platinum, neodymium, uranium, diamond) stay **mining-only**.
 - **Blueprints** gate advanced recipes — research them at your ship's **cockpit** (Blueprints tab; the helm counts
   while flying) with **knowledge points** (earned by scanning) plus
   research materials; some require prerequisite blueprints.
@@ -676,6 +678,10 @@ separate unlock; admins can still disable it through server world rules.
   more input per step, fewer refining stages. The catch: each factory only makes the **1–4 items on its
   own roster**, so a recipe the menu lists may say *"Use a factory terminal that makes this"* — you'll need
   a different factory. Factory crafts **cannot be disassembled** back into their inputs.
+- Besides the basic parts (plates, panels, cable, glass, steel, energy cells, circuit boards, polymer) factories
+  run a **raw-ore tier**: light alloy, bronze, brass, power cells, carbide, magnets, diamonds and even reactor
+  fuel straight from ore — every ore has a second buyer that way. A factory's roster is fixed when its world
+  is created, so these recipes turn up in **factories of new worlds**, not in halls you have already found.
 - **Operating a terminal is public** — you don't need to own a factory to craft there. But a spawned
   factory is **read-only** (you can't mine or rebuild it) until you **claim** it: stand at the terminal
   with an **SPS access code** (see below) and press **E**. Claiming spends one code, makes the factory
@@ -830,7 +836,9 @@ separate unlock; admins can still disable it through server world rules.
 - **Vendors / market:** press **E** next to a settlement or space-station **vendor** to open the **Market**
   (the gameplay menu's Crafting tab on the *Market* category). Barter recipes there trade your raw
   resources for goods. The market is also available **aboard your ship** (Tab → Crafting → Market), via the
-  ship's trade console — so you can trade without a vendor too.
+  ship's trade console — so you can trade without a vendor too. Vendors have **themes**: miners sell iron,
+  copper and lead ore for silicate, traders buy crystal, gold and silver, researchers buy refined uranium and
+  sell data fragments and circuit boards, settlers trade food.
 
 ### Story: finding the thread
 - After the tutorial the **objective chip** keeps a quiet story pointer ("a net fragment is on this

--- a/tests/BlocksBeyondTheStars.Tests/MaterialEconomyTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/MaterialEconomyTests.cs
@@ -81,6 +81,135 @@ public sealed class MaterialEconomyTests
         Assert.True(failures.Count == 0, "H2 metals short of 3 uses across 2 stations:\n" + string.Join("\n", failures));
     }
 
+    // ---------------------------------------------------------------- #1200: the generalised economy guard
+
+    /// <summary>Everything an ore block drops (the raw resources a drill brings home).</summary>
+    private HashSet<string> OreDrops()
+        => _c.Blocks.Values.Where(b => b.Category == "ore").SelectMany(b => b.Drops).Select(d => d.Item).ToHashSet();
+
+    /// <summary>Items a smelt produces: a recipe with ONE input that is an <c>*_ore</c> drop, at a real crafting
+    /// station (the market barters ore away, the factory's raw-ore tier is the bulk shortcut — neither is a smelt),
+    /// whose output is a material/component rather than a placeable or a consumable. That is the ingot/plate/wire
+    /// set plus lithium, uranium, neodymium, sulfur and diamond — not carbon composite, seeds or a ladder.</summary>
+    private HashSet<string> Smeltables()
+    {
+        var ores = OreDrops();
+        return _c.Recipes.Values
+            .Where(r => r.Station is not (CraftingStation.Market or CraftingStation.Factory)
+                && r.Inputs.Count == 1 && r.Inputs[0].Item.EndsWith("_ore", System.StringComparison.Ordinal)
+                && ores.Contains(r.Inputs[0].Item))
+            .SelectMany(r => r.Outputs).Select(o => o.Item)
+            .Where(o => !ores.Contains(o) && _c.GetItem(o) is { } item
+                && item.Category is ItemCategory.Material or ItemCategory.Component
+                && string.IsNullOrEmpty(item.PlacesBlock))
+            .ToHashSet();
+    }
+
+    private static string Describe(List<(string Where, string Station)> list)
+        => $"{list.Count} uses / {list.Select(u => u.Station).Distinct().Count()} stations ({string.Join(", ", list.Select(u => u.Where))})";
+
+    /// <summary>No ore is a dead end: every raw drop feeds at least two recipes at two different stations, so a
+    /// vein is never "mine it for the one smelt and forget it". Before #1200 eleven ores fed only their own smelt.</summary>
+    [Fact]
+    public void EveryOreDrop_HasTwoConsumers_AcrossTwoStations()
+    {
+        var uses = Uses();
+        var failures = new List<string>();
+        foreach (var ore in OreDrops().OrderBy(o => o))
+        {
+            var list = uses.TryGetValue(ore, out var l) ? l : new List<(string Where, string Station)>();
+            if (list.Count < 2 || list.Select(u => u.Station).Distinct().Count() < 2)
+            {
+                failures.Add($"{ore}: {Describe(list)}");
+            }
+        }
+
+        Assert.True(failures.Count == 0, "ore drops short of 2 consumers across 2 stations:\n" + string.Join("\n", failures));
+    }
+
+    /// <summary>Every smelted material matters past its first use: three consumers across two stations (the H2
+    /// rule, now applied to the whole smelt set instead of a hand-picked list).</summary>
+    [Fact]
+    public void EverySmeltable_HasThreeUses_AcrossTwoStations()
+    {
+        var uses = Uses();
+        var smeltables = Smeltables();
+        Assert.True(smeltables.Count >= 15, "the smelt set looks wrong: " + string.Join(", ", smeltables.OrderBy(s => s)));
+
+        var failures = new List<string>();
+        foreach (var item in smeltables.OrderBy(s => s))
+        {
+            var list = uses.TryGetValue(item, out var l) ? l : new List<(string Where, string Station)>();
+            if (list.Count < 3 || list.Select(u => u.Station).Distinct().Count() < 2)
+            {
+                failures.Add($"{item}: {Describe(list)}");
+            }
+        }
+
+        Assert.True(failures.Count == 0, "smeltables short of 3 uses across 2 stations:\n" + string.Join("\n", failures));
+    }
+
+    /// <summary>A station with fewer than three recipes is scenery. The hand and the market are exempt (free
+    /// crafting / barter have their own rules). The three food-and-chemistry stations were filled by #1203's
+    /// station packs — until that lands they may still carry a single recipe, but never none.</summary>
+    [Fact]
+    public void EveryCraftingStation_HasThreeRecipes()
+    {
+        var thinPendingStationFill = new HashSet<CraftingStation>
+        {
+            CraftingStation.Detoxifier, CraftingStation.AlgaeTank, CraftingStation.Campfire, // #1203
+        };
+        var counts = _c.Recipes.Values.GroupBy(r => r.Station).ToDictionary(g => g.Key, g => g.Count());
+        var failures = new List<string>();
+        foreach (var station in System.Enum.GetValues<CraftingStation>())
+        {
+            if (station is CraftingStation.Hand or CraftingStation.Market)
+            {
+                continue;
+            }
+
+            int count = counts.TryGetValue(station, out var c) ? c : 0;
+            int minimum = thinPendingStationFill.Contains(station) ? 1 : 3;
+            if (count < minimum)
+            {
+                failures.Add($"{station}: {count} recipes (wants {minimum})");
+            }
+        }
+
+        Assert.True(failures.Count == 0, "stations short of recipes:\n" + string.Join("\n", failures));
+    }
+
+    /// <summary>Every material is consumed somewhere, and the only components nobody consumes are the END products
+    /// on this list (worn gear, the ship's own gadgets, keys). A new material or component that lands here without a
+    /// sink is a design gap, not a whitelist candidate.</summary>
+    [Fact]
+    public void EveryMaterial_IsConsumed_AndOnlyEndProductComponentsAreNot()
+    {
+        var uses = Uses();
+        foreach (var bp in _c.Blueprints.Values)
+        {
+            foreach (var i in bp.UnlockCost)
+            {
+                uses.TryAdd(i.Item, new List<(string Where, string Station)>());
+            }
+        }
+
+        var deadMaterials = _c.Items.Values
+            .Where(i => i.Category == ItemCategory.Material && !uses.ContainsKey(i.Key))
+            .Select(i => i.Key).OrderBy(k => k).ToList();
+        Assert.True(deadMaterials.Count == 0, "materials nobody consumes: " + string.Join(", ", deadMaterials));
+
+        var endProducts = new[]
+        {
+            "ai_memory_fragment", "access_code", "suit_teleporter", "oxygen_extractor", "stealth_suit", "armor_chest",
+            "armor_legs", "helmet", "oxygen_tank_3", "suit_liner_3", "suit_lamp", "jetpack", "radar_scanner", "galaxy_radio",
+        };
+        var unconsumedComponents = _c.Items.Values
+            .Where(i => i.Category == ItemCategory.Component && !uses.ContainsKey(i.Key))
+            .Select(i => i.Key).OrderBy(k => k).ToList();
+        Assert.Equal(endProducts.OrderBy(k => k), unconsumedComponents);
+    }
+
     [Fact]
     public void RefineryVariants_OutYieldTheWorkshop_AndTheWorkshopFallbackStays()
     {


### PR DESCRIPTION
## Summary

Eleven ores (aluminium, cobalt, diamond, lead, lithium, neodymium, platinum, tin, tungsten, uranium, zinc) fed nothing but their own smelt, `silver_ingot` / `uranium` were thin, the factory's ten recipes all duplicated workshop/refinery outputs, and `MaterialEconomyTests` checked a hand-picked list of 13 metals. This is the #1200 fix: **recipes only, no new items, no locale keys, no client build.**

**`data/recipes.json`** (single-line house style, `#1200` comments at each block):
- **Factory raw-ore tier** — `factory_light_alloy`, `factory_bronze`, `factory_brass`, `factory_power_cell`, `factory_carbide`, `factory_magnet` (as decided) plus `factory_diamond` and `factory_reactor_fuel` (see "beyond the issue"). More ore per step, never a better per-ore yield than the refinery chain. Rosters are seeded per world, so these appear in **new** factories — the manual says so.
- **Market** — `market_sell_uranium` (researchers → data fragments), `market_buy_lead` (miners), `market_sell_silver` and `market_sell_diamond` (traders, like gold).
- **Sinks** — `silver_ingot` → medbay_panel + light_white; `bronze` → workbench + ship_engine; `brass_fitting` → hydro_tray + factory_pipe + oxygen_extractor; `sulfur` → new `meat_bait_cured` (hand: meat + sulfur → 4 bait); new `power_cell_irradiated` (refinery: 2 energy cells + uranium → 2 power cells).

**Deliberately NOT done — the transmuter resynth of tungsten / platinum / neodymium ore.** It collides with the transmuter's own I1 invariant, `MatterConverterTests.Transmuter_NeverOutputs_Tier3Materials` (endgame ores stay mining-exclusive — "breaks the mining economy"). I kept the invariant rather than deleting a documented design rule from a content PR; the three ores get their second consumer from the factory tier, so nothing else depended on those recipes. If you want the resynth anyway, say so and I add the three lines + retire the rule.

**Beyond the issue list (needed to make the generalised rule hold, all in its spirit):** the issue's `market_buy_lead` is a *source* of lead ore, not a consumer, and `market_sell_uranium` alone leaves `uranium` at two uses — hence `factory_reactor_fuel` (uranium_ore + lead_ore → reactor fuel; the #1106 rule forbids fuel only as an *input*), `power_cell_irradiated`, `factory_diamond` (diamond_ore was 1/1 too), and `market_sell_silver` / `market_sell_diamond` (both metals had all their sinks at the workshop, i.e. one station).

**`MaterialEconomyTests` generalised (hard-fail):**
- every ore drop ≥ 2 consumers across ≥ 2 stations;
- every smeltable (one `*_ore` input → a material/component) ≥ 3 uses across ≥ 2 stations;
- every station except hand/market ≥ 3 recipes — **detoxifier / algae tank / campfire carry a documented ≥ 1 allowance until #1203's station packs land** (they have exactly one recipe each today; #1203 is parked behind #1202);
- every Material-category item is consumed; the un-consumed Component set must equal an explicit 14-entry end-product whitelist.
The H2 13-metal test stays as the historical anchor. `RefineryProgressionTests` (pre-refinery reachability) is untouched — every sink edit uses workshop-smelted metals.

**Docs:** USER_MANUAL — factory raw-ore tier + "new worlds only" note, transmuter resynth line, market vendor themes; TODO.md. `whatsnew.json` is the release-time export, not touched here.

## Tests

Local: full fast-tier server suite run once on the first revision — the only failure was the I1 transmuter test above, resolved by dropping the three resynth recipes; the economy / transmuter / crafting / progression / factory sets re-run green after that (37/37); client tests 412/412; `dotnet format --verify-no-changes` clean. No `client/Assets` change → no Unity build needed; the CI matrix runs the full fast tier.

## Not in this PR

- The station packs (campfire meals, algae/detoxifier recipes, rune/ancient-brick) — #1203, gated by #1202's blueprints. When they land, drop the thin-station allowance in `EveryCraftingStation_HasThreeRecipes`.
- Balance feel of the factory ratios rides the #1227 playtest.

closes #1200

🤖 Generated with [Claude Code](https://claude.com/claude-code)
