### PR TITLE
feat(client): portable data folder — optional portable_data_dir.txt next to the executable (#1285)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ the richer, screenshot-laden versions live there. `(#123)` references the pull r
 
 ## [Unreleased]
 
+### Added
+- 💾 **Portable data folder** — an optional `portable_data_dir.txt` next to the game executable redirects the
+  whole persistent-data root (settings, name token, singleplayer saves, user content, exports, spools, photos)
+  to the folder it names (empty file = `userdata` next to the executable; relative paths anchor at the
+  executable, `%ENV%` expanded, `#` comments). Without the file nothing changes; an unwritable target falls
+  back to the default with a `Player.log` warning. Not for the browser build. (#1285)
+
 ## [2026.8.21] — 2026-08-25
 
 The deepening release — 26 slices of the feature-deepening package (epic #1197) plus the #1048

--- a/TODO.md
+++ b/TODO.md
@@ -145,6 +145,16 @@ step. README family section gained the age paragraph + PARENTS links; the Codex 
 (en+de) gained the content-profile + /report paragraph. Website/itch/glitch.fun texts = the statement block in
 PARENTS.md (Marcel publishes those surfaces). Closes kid-friendly-hints stage 2.
 
+### ★ Portable data folder — `portable_data_dir.txt` next to the executable (#1285, 2026-08-26, branch feat/1285-portable-data-dir)
+The portable zip stored everything in `%LOCALAPPDATA%\..\LocalLow\…` like the installed game. Now an optional
+marker file next to the executable redirects the whole persistent-data root: `AppPaths.Root` (new, Unity side)
+replaces every direct `Application.persistentDataPath` use in the client (settings, token, saves, usercontent,
+portal_saves, spools, Photos, clips, perf, docs, all editor exports); the marker rules (first non-comment line,
+relative → exe folder, `%ENV%`, quotes, BOM, empty = `userdata`) live Unity-free in
+`Client.Core/PortableDataDir.cs` with `PortableDataDirTests`. Unwritable target → default + warning. The
+"Spacecraft" rename migration and WebGL storage adoption stay on Unity's own folder by design. Docs:
+USER_MANUAL §1, DEVELOPER.md (debugging paragraph), CHANGELOG. UNRELEASED.
+
 ### ★ Player-report round 2026-08-23 — ship switch reseat, settler placement, macOS codec fallback, credits (#1247 + #1248 + #1250 + #1251, 2026-08-24, branch fix/player-reports-2026-08-23)
 Two inbox reports (Lyxette on Windows, sasas on macOS, both v2026.8.20), four small fixes in one PR.
 

--- a/client/Assets/BlocksBeyondTheStars/Scripts/AppPaths.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/AppPaths.cs
@@ -1,0 +1,101 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using System.IO;
+using UnityEngine;
+
+namespace BlocksBeyondTheStars.Client
+{
+    /// <summary>
+    /// The one place that knows where the client's persistent data lives. <see cref="Root"/> is Unity's
+    /// <see cref="Application.persistentDataPath"/> unless a <c>portable_data_dir.txt</c> sits next to the
+    /// executable (#1285, rules in <see cref="PortableDataDir"/>) — then it is the folder that file names, so a
+    /// portable copy keeps settings, saves, exports and spools with it. Every <c>persistentDataPath</c> consumer
+    /// goes through here; the only exceptions are the WebGL storage adoption (IDBFS sibling folders) and the
+    /// one-time "Spacecraft" rename migration, which by definition operate on Unity's own folder. Resolved once,
+    /// on the main thread, before anything reads or writes (AppShell.Awake).
+    /// </summary>
+    public static class AppPaths
+    {
+        private static string _root;
+
+        /// <summary>The persistent-data root — with the portable redirect applied when one is configured.</summary>
+        public static string Root
+        {
+            get
+            {
+                if (string.IsNullOrEmpty(_root))
+                {
+                    _root = Resolve();
+                }
+
+                return _root;
+            }
+        }
+
+        /// <summary>True when the root was redirected by a marker file (for the log / diagnostics).</summary>
+        public static bool IsPortableRedirect { get; private set; }
+
+        /// <summary>The folder holding the game executable (next to the <c>.exe</c> / Linux binary; the folder
+        /// containing the <c>.app</c> bundle on macOS; <c>client/</c> in the Editor). Null on WebGL.</summary>
+        public static string ExecutableDirectory
+        {
+            get
+            {
+#if UNITY_WEBGL && !UNITY_EDITOR
+                return null;
+#else
+                string dataPath = Application.dataPath; // <exe dir>/<Product>_Data  |  <X>.app/Contents  |  <repo>/client/Assets
+                return Application.platform == RuntimePlatform.OSXPlayer
+                    ? Path.GetFullPath(Path.Combine(dataPath, "..", ".."))
+                    : Path.GetDirectoryName(dataPath);
+#endif
+            }
+        }
+
+        private static string Resolve()
+        {
+            string fallback = Application.persistentDataPath;
+#if UNITY_WEBGL && !UNITY_EDITOR
+            return fallback;
+#else
+            string exeDir;
+            try
+            {
+                exeDir = ExecutableDirectory;
+            }
+            catch (System.Exception e)
+            {
+                Debug.LogWarning($"[AppPaths] Could not determine the executable folder: {e.Message}");
+                return fallback;
+            }
+
+            if (string.IsNullOrEmpty(exeDir))
+            {
+                return fallback;
+            }
+
+            string redirect = PortableDataDir.ResolveFromMarker(exeDir, out string error);
+            if (error != null)
+            {
+                Debug.LogWarning($"[AppPaths] {error} — using the default data folder '{fallback}'.");
+            }
+
+            if (string.IsNullOrEmpty(redirect))
+            {
+                return fallback;
+            }
+
+            if (!PortableDataDir.TryPrepare(redirect, out string prepareError))
+            {
+                Debug.LogWarning($"[AppPaths] {prepareError} — using the default data folder '{fallback}'.");
+                return fallback;
+            }
+
+            IsPortableRedirect = true;
+            Debug.Log($"[AppPaths] Portable data folder active ({PortableDataDir.MarkerFileName}): '{redirect}'.");
+            return redirect;
+#endif
+        }
+    }
+}

--- a/client/Assets/BlocksBeyondTheStars/Scripts/AppPaths.cs.meta
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/AppPaths.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7a1285e0c4d94f0b9d3a6c1285b0d1a7

--- a/client/Assets/BlocksBeyondTheStars/Scripts/AppShell.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/AppShell.cs
@@ -141,7 +141,7 @@ namespace BlocksBeyondTheStars.Client
 #if !UNITY_WEBGL
             try
             {
-                string dir = Application.persistentDataPath;
+                string dir = AppPaths.Root;
                 System.IO.Directory.CreateDirectory(dir);
                 System.IO.Directory.SetCurrentDirectory(dir);
             }

--- a/client/Assets/BlocksBeyondTheStars/Scripts/AvatarEditor.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/AvatarEditor.cs
@@ -554,7 +554,7 @@ namespace BlocksBeyondTheStars.Client
 
             try
             {
-                string dir = Path.Combine(Application.persistentDataPath, "avatar_exports", key);
+                string dir = Path.Combine(AppPaths.Root, "avatar_exports", key);
                 Directory.CreateDirectory(dir);
                 File.WriteAllText(Path.Combine(dir, "skin.json"), JsonUtility.ToJson(skin, true));
                 SetStatus($"{L("ui.avatar.exported")}\n{dir}");

--- a/client/Assets/BlocksBeyondTheStars/Scripts/BrowserLocalServer.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/BrowserLocalServer.cs
@@ -17,7 +17,7 @@ namespace BlocksBeyondTheStars.Client
     /// (the same simulation the fleet and desktop run), pumped from Unity's Update loop over the
     /// in-memory <see cref="LoopbackTransport"/> — no child process, no sockets, so it works under
     /// WebGL/WASM. Persistence is the fully managed <see cref="MemoryWorldRepository"/>; every server
-    /// save flushes the world as a gzip'd snapshot blob to <see cref="Application.persistentDataPath"/>
+    /// save flushes the world as a gzip'd snapshot blob to <see cref="AppPaths.Root"/>
     /// (IndexedDB in the browser) and raises <see cref="BlobPersisted"/> for the optional cloud sync.
     /// Desktop singleplayer keeps its child-process model (ADR 0005); this component is the WebGL path.
     /// </summary>
@@ -54,7 +54,7 @@ namespace BlocksBeyondTheStars.Client
         private const string BlobFile = "world.blob";
         private const string CloudMetaFile = "cloud.meta.json"; // GlitchCloudSaves' last-synced version, next to the blob
 
-        public static string SaveDirectory => Path.Combine(Application.persistentDataPath, SaveFolder);
+        public static string SaveDirectory => Path.Combine(AppPaths.Root, SaveFolder);
         public static string SaveBlobPath => Path.Combine(SaveDirectory, BlobFile);
 
         /// <summary>Reads the locally persisted save blob, or null when this browser has none yet.

--- a/client/Assets/BlocksBeyondTheStars/Scripts/ClientSettings.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/ClientSettings.cs
@@ -107,7 +107,7 @@ namespace BlocksBeyondTheStars.Client
     /// <summary>
     /// Local, client-only settings (display, audio, input, comfort). These never affect the
     /// authoritative server rules (PvP, aliens, weapons stay server-decided). Persisted as JSON
-    /// in <c>Application.persistentDataPath/client_settings.json</c>. See
+    /// in <c>AppPaths.Root/client_settings.json</c>. See
     /// <c>docs/developer/CLIENT_SHELL_AND_ASSETS.md</c>.
     /// </summary>
     /// <summary>One saved avatar outfit (#1047): a named copy of everything the Avatar Designer produces for a
@@ -682,7 +682,7 @@ namespace BlocksBeyondTheStars.Client
         public static string LoadNoticeKey = "";
 
         private static string StorageDir => string.IsNullOrEmpty(StorageDirOverride)
-            ? Application.persistentDataPath
+            ? AppPaths.Root
             : StorageDirOverride;
 
         private static string FilePath => Path.Combine(StorageDir, "client_settings.json");

--- a/client/Assets/BlocksBeyondTheStars/Scripts/ClipDirector.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/ClipDirector.cs
@@ -642,7 +642,7 @@ namespace BlocksBeyondTheStars.Client
             string repo = Path.GetFullPath(Path.Combine(Application.dataPath, "..", "..")); // dataPath = <repo>/client/Assets
             return Path.Combine(repo, "marketing", "clips");
 #else
-            return Path.Combine(Application.persistentDataPath, "clips");
+            return Path.Combine(AppPaths.Root, "clips");
 #endif
         }
 

--- a/client/Assets/BlocksBeyondTheStars/Scripts/ContentEditor.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/ContentEditor.cs
@@ -258,7 +258,7 @@ namespace BlocksBeyondTheStars.Client
 
             try
             {
-                string dir = Path.Combine(Application.persistentDataPath, "content_exports", key);
+                string dir = Path.Combine(AppPaths.Root, "content_exports", key);
                 Directory.CreateDirectory(dir);
                 File.WriteAllText(Path.Combine(dir, "content.json"), JsonUtility.ToJson(b, true));
                 SetStatus($"{L("ui.content.exported")}\n{dir}");

--- a/client/Assets/BlocksBeyondTheStars/Scripts/CrashReporter.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/CrashReporter.cs
@@ -64,7 +64,7 @@ namespace BlocksBeyondTheStars.Client
             _version = AppShell.Version;
             _platform = Application.platform.ToString();
             _buildGuid = Application.buildGUID ?? string.Empty;
-            _spool = new CrashReportSpool(Path.Combine(Application.persistentDataPath, "crashreports"));
+            _spool = new CrashReportSpool(Path.Combine(AppPaths.Root, "crashreports"));
             _uploader = new FeedbackUploader(FeedbackUploader.DefaultEndpoint, BugReportBuildSecrets.ApiKey);
 
             // Threaded variant so a crash on a worker thread (e.g. chunk meshing) is caught too.

--- a/client/Assets/BlocksBeyondTheStars/Scripts/FeedbackUi.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/FeedbackUi.cs
@@ -71,7 +71,7 @@ namespace BlocksBeyondTheStars.Client
             // A random id groups several reports from one sitting (varies per session; no Unity-restricted Date use).
             _sessionId = Guid.NewGuid().ToString("N");
             _uploader = new FeedbackUploader(FeedbackUploader.DefaultEndpoint, BugReportBuildSecrets.ApiKey);
-            _spool = new FeedbackSpool(Path.Combine(Application.persistentDataPath, "feedback"));
+            _spool = new FeedbackSpool(Path.Combine(AppPaths.Root, "feedback"));
 
             if (_uploader.IsConfigured)
             {

--- a/client/Assets/BlocksBeyondTheStars/Scripts/LocalServerLauncher.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/LocalServerLauncher.cs
@@ -31,7 +31,7 @@ namespace BlocksBeyondTheStars.Client
         public bool IsRunning => _process != null && !_process.HasExited;
 
         /// <summary>Root folder holding the singleplayer save worlds (one subfolder per world).</summary>
-        public static string SavesRoot => Path.Combine(Application.persistentDataPath, "singleplayer-saves");
+        public static string SavesRoot => Path.Combine(AppPaths.Root, "singleplayer-saves");
 
         /// <summary>Existing singleplayer world names (subfolders that contain a world.db), newest first.</summary>
         public static string[] ListWorlds()
@@ -159,12 +159,12 @@ namespace BlocksBeyondTheStars.Client
                 return false;
             }
 
-            string saves = Path.Combine(Application.persistentDataPath, "singleplayer-saves");
+            string saves = Path.Combine(AppPaths.Root, "singleplayer-saves");
             string data = Path.Combine(Application.streamingAssetsPath, "data");
             // Writable folder where the in-game structure editor drops its templates; the server merges
             // them into the world-gen pools so player-built stations/towns appear in new worlds with no
             // Python merge or rebuild (StructureEditor writes <kind>_templates/<key>.json here).
-            string userContent = Path.Combine(Application.persistentDataPath, "usercontent");
+            string userContent = Path.Combine(AppPaths.Root, "usercontent");
             Directory.CreateDirectory(saves);
             Directory.CreateDirectory(userContent);
 

--- a/client/Assets/BlocksBeyondTheStars/Scripts/MaterialEditor.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/MaterialEditor.cs
@@ -288,7 +288,7 @@ namespace BlocksBeyondTheStars.Client
 
             try
             {
-                string dir = Path.Combine(Application.persistentDataPath, "material_exports", key);
+                string dir = Path.Combine(AppPaths.Root, "material_exports", key);
                 Directory.CreateDirectory(dir);
                 File.WriteAllText(Path.Combine(dir, "material.json"), JsonUtility.ToJson(b, true));
                 // Raw RGBA32 tile in the exact layout BlockTextureAtlas.LoadRawTextureData expects.

--- a/client/Assets/BlocksBeyondTheStars/Scripts/PaintTool.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/PaintTool.cs
@@ -126,7 +126,7 @@ namespace BlocksBeyondTheStars.Client
             public string pixels;
         }
 
-        private static string Dir => Path.Combine(Application.persistentDataPath, "paint_designs");
+        private static string Dir => Path.Combine(AppPaths.Root, "paint_designs");
 
         /// <summary>Saves the canvas under the player's name for it (#846); an unnamed save still falls back
         /// to the old "Design NN" numbering. Saving the same NAME again overwrites that entry, so refining a

--- a/client/Assets/BlocksBeyondTheStars/Scripts/PerfProbe.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/PerfProbe.cs
@@ -235,7 +235,7 @@ namespace BlocksBeyondTheStars.Client
             Quit(0);
         }
 
-        private static string SettingsPath => Path.Combine(Application.persistentDataPath, "client_settings.json");
+        private static string SettingsPath => Path.Combine(AppPaths.Root, "client_settings.json");
 
         private void BackupSettingsFile()
         {
@@ -453,7 +453,7 @@ namespace BlocksBeyondTheStars.Client
                 phases = phases.ToArray(),
             };
 
-            string dir = !string.IsNullOrEmpty(_outDir) ? _outDir : Path.Combine(Application.persistentDataPath, "perf");
+            string dir = !string.IsNullOrEmpty(_outDir) ? _outDir : Path.Combine(AppPaths.Root, "perf");
             Directory.CreateDirectory(dir);
             string featureSuffix = string.IsNullOrEmpty(_featureTag) ? "" : $"_{_featureTag}";
             string denseSuffix = _dense ? "_dense" : "";

--- a/client/Assets/BlocksBeyondTheStars/Scripts/PhotoStore.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/PhotoStore.cs
@@ -41,7 +41,7 @@ namespace BlocksBeyondTheStars.Client
         private readonly Dictionary<string, Texture2D> _textures = new();
 
         /// <summary>The root for ALL worlds' photos (one folder per world below this).</summary>
-        public static string Root => Path.Combine(Application.persistentDataPath, "Photos");
+        public static string Root => Path.Combine(AppPaths.Root, "Photos");
 
         /// <summary>The folder this store reads/writes (the per-world directory).</summary>
         public string Directory => _dir;

--- a/client/Assets/BlocksBeyondTheStars/Scripts/ScreenshotDirector.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/ScreenshotDirector.cs
@@ -430,7 +430,7 @@ namespace BlocksBeyondTheStars.Client
             string repo = Path.GetFullPath(Path.Combine(Application.dataPath, "..", "..")); // dataPath = <repo>/client/Assets
             return Path.Combine(repo, "docs", "screenshots", _lang);
 #else
-            return Path.Combine(Application.persistentDataPath, "docs", "screenshots", _lang);
+            return Path.Combine(AppPaths.Root, "docs", "screenshots", _lang);
 #endif
         }
 

--- a/client/Assets/BlocksBeyondTheStars/Scripts/ShapeEditor.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/ShapeEditor.cs
@@ -529,7 +529,7 @@ namespace BlocksBeyondTheStars.Client
             public string voxels;
         }
 
-        private static string Dir => Path.Combine(Application.persistentDataPath, "custom_shapes");
+        private static string Dir => Path.Combine(AppPaths.Root, "custom_shapes");
 
         /// <summary>Saves a form under the player's name for it (a nameless save falls back to "Form N").
         /// Saving the same NAME again overwrites that entry — editing a form and saving it should not leave

--- a/client/Assets/BlocksBeyondTheStars/Scripts/ShipEditor.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/ShipEditor.cs
@@ -832,7 +832,7 @@ namespace BlocksBeyondTheStars.Client
 
             try
             {
-                string dir = Path.Combine(Application.persistentDataPath, "ship_exports", key);
+                string dir = Path.Combine(AppPaths.Root, "ship_exports", key);
                 Directory.CreateDirectory(dir);
                 File.WriteAllText(Path.Combine(dir, "ship.json"), JsonUtility.ToJson(ship, true));
                 File.WriteAllText(Path.Combine(dir, "layout.json"), JsonUtility.ToJson(layout, true));
@@ -856,7 +856,7 @@ namespace BlocksBeyondTheStars.Client
             }
 
             var keys = new List<string>();
-            string root = Path.Combine(Application.persistentDataPath, "ship_exports");
+            string root = Path.Combine(AppPaths.Root, "ship_exports");
             if (Directory.Exists(root))
             {
                 foreach (var d in Directory.GetDirectories(root))
@@ -897,7 +897,7 @@ namespace BlocksBeyondTheStars.Client
         /// <summary>Clears the current build and rebuilds it from a saved design's <c>layout.json</c>.</summary>
         private void LoadDesign(string key)
         {
-            string dir = Path.Combine(Application.persistentDataPath, "ship_exports", key);
+            string dir = Path.Combine(AppPaths.Root, "ship_exports", key);
             string layoutPath = Path.Combine(dir, "layout.json");
             if (!File.Exists(layoutPath))
             {

--- a/client/Assets/BlocksBeyondTheStars/Scripts/StreamingAssetsCache.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/StreamingAssetsCache.cs
@@ -161,7 +161,7 @@ namespace BlocksBeyondTheStars.Client
 
             _loading = true;
             Exception failure = null;
-            string cacheDir = Path.Combine(Application.persistentDataPath, CacheFolder, DataFolder);
+            string cacheDir = Path.Combine(AppPaths.Root, CacheFolder, DataFolder);
             yield return DownloadRemoteData(cacheDir, ex => failure = ex);
 
             if (failure == null)

--- a/client/Assets/BlocksBeyondTheStars/Scripts/StructureEditor.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/StructureEditor.cs
@@ -367,7 +367,7 @@ namespace BlocksBeyondTheStars.Client
             try
             {
                 // 1) Export bundle (the "ship into the game" path via tools/merge_structure.py).
-                string dir = Path.Combine(Application.persistentDataPath, modeName + "_exports", key);
+                string dir = Path.Combine(AppPaths.Root, modeName + "_exports", key);
                 Directory.CreateDirectory(dir);
                 File.WriteAllText(Path.Combine(dir, "structure.json"), JsonUtility.ToJson(meta, true));
                 File.WriteAllText(Path.Combine(dir, "layout.json"), JsonUtility.ToJson(layout, true));
@@ -379,7 +379,7 @@ namespace BlocksBeyondTheStars.Client
                     key = key, name = _name, tier = _tiers[_tier], kind = modeName, pack = pack, weight = weight,
                     width = layout.width, height = layout.height, length = layout.length, cells = layout.cells,
                 };
-                string userDir = Path.Combine(Application.persistentDataPath, "usercontent", modeName + "_templates");
+                string userDir = Path.Combine(AppPaths.Root, "usercontent", modeName + "_templates");
                 Directory.CreateDirectory(userDir);
                 File.WriteAllText(Path.Combine(userDir, key + ".json"), JsonUtility.ToJson(tpl, true));
 
@@ -393,7 +393,7 @@ namespace BlocksBeyondTheStars.Client
 
         private GameObject _loadPicker;
 
-        private string ExportsRoot => Path.Combine(Application.persistentDataPath,
+        private string ExportsRoot => Path.Combine(AppPaths.Root,
             (EditorMode == Mode.Station ? "station" : "settlement") + "_exports");
 
         /// <summary>Lists saved designs of the current mode and lets you load one back in to keep editing.</summary>

--- a/client/Assets/BlocksBeyondTheStars/Scripts/UiMainMenu.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/UiMainMenu.cs
@@ -687,7 +687,7 @@ namespace BlocksBeyondTheStars.Client
             // Secondary portal dialogs (#268-#270).
             PortalTermsResult cachedTerms = null; // rules text+version change per deployment — fetch once
             string cachedTermsLang = null;        // …but re-fetch after the player switched language (#970)
-            string saveBackupDir = System.IO.Path.Combine(Application.persistentDataPath, "portal_saves");
+            string saveBackupDir = System.IO.Path.Combine(AppPaths.Root, "portal_saves");
             var warnCol = new Color(1f, 0.55f, 0.4f);
 
             void CloseModal()

--- a/docs/developer/DEVELOPER.md
+++ b/docs/developer/DEVELOPER.md
@@ -518,6 +518,10 @@ silently misbehaves*. Check them in this order:
 
 **Where to look when debugging the built player:** the player log is at
 `%USERPROFILE%\AppData\LocalLow\JuMaVe Games\Blocks Beyond the Stars\Player.log`.
+The persistent-data root (settings, `singleplayer-saves/`, `usercontent/`, exports, spools, photos) is the
+same folder — unless a `portable_data_dir.txt` next to the executable redirects it (#1285): every consumer
+goes through `AppPaths.Root`; the marker parsing lives Unity-free in `Client.Core/PortableDataDir.cs`
+(`PortableDataDirTests`). Never use `Application.persistentDataPath` directly in new client code.
 Add a `Debug.Log` before the guard that might fail (e.g. log the layer index or whether
 `Shader.Find` returned null) and rebuild.
 

--- a/docs/user/USER_MANUAL.md
+++ b/docs/user/USER_MANUAL.md
@@ -65,6 +65,15 @@ Last updated: 2026-08-11.
 - On a **new world**, the ship AI **VEGA** boots up and walks you through the first hour (see §5 →
   VEGA) — her opening narration is staged like a scene (letterbox, an orbit shot of your landed ship);
   **Esc** skips it. Veteran saves get a one-line "systems online" instead.
+- **Portable data folder** (portable zip, USB stick, several profiles): by default the game keeps its
+  settings, singleplayer saves, photos and exports in your user profile (Windows:
+  `%USERPROFILE%\AppData\LocalLow\JuMaVe Games\Blocks Beyond the Stars\`). To keep them next to the game
+  instead, create a text file named **`portable_data_dir.txt`** in the same folder as the game executable
+  (macOS: next to the `.app`). Leave it **empty** to use a `userdata` folder next to the executable, or write
+  one line with the folder you want — absolute (`D:\Games\BBTS\data`) or relative to the executable
+  (`..\BBTS-Data`); `%ENV%` variables are expanded, `#` lines are comments. Existing data is **not** moved
+  automatically — copy the old folder over once if you want to keep it. A folder that cannot be written falls
+  back to the default with a warning in `Player.log`. Not available in the browser version.
 
 ---
 

--- a/src/BlocksBeyondTheStars.Client.Core/PortableDataDir.cs
+++ b/src/BlocksBeyondTheStars.Client.Core/PortableDataDir.cs
@@ -1,0 +1,142 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using System;
+using System.IO;
+
+namespace BlocksBeyondTheStars.Client
+{
+    /// <summary>
+    /// The optional portable-data redirect (#1285). A file named <see cref="MarkerFileName"/> next to the game
+    /// executable moves the whole persistent-data root (settings, token, singleplayer saves, user content,
+    /// exports, spools, photos …) away from Unity's per-user folder — so a copy on a USB stick keeps its data
+    /// with it. Rules: one directory per file, absolute or relative to the executable's folder; environment
+    /// variables (<c>%LOCALAPPDATA%</c>-style) are expanded; blank lines and <c>#</c> comments are ignored; an
+    /// empty marker means <c>&lt;exe folder&gt;/<see cref="DefaultSubfolder"/></c>. Unity-free so the parsing
+    /// rules are unit-tested; the Unity side (<c>AppPaths</c>) supplies the executable folder and the fallback.
+    /// </summary>
+    public static class PortableDataDir
+    {
+        /// <summary>The marker file a player drops next to the executable.</summary>
+        public const string MarkerFileName = "portable_data_dir.txt";
+
+        /// <summary>Folder used when the marker exists but names no directory.</summary>
+        public const string DefaultSubfolder = "userdata";
+
+        /// <summary>
+        /// The redirected data root for an executable living in <paramref name="exeDir"/>, or null when no
+        /// marker file is present there (= keep the platform default). Never throws: an unreadable marker is
+        /// reported through <paramref name="error"/> and yields null.
+        /// </summary>
+        public static string? ResolveFromMarker(string exeDir, out string? error)
+        {
+            error = null;
+            string marker;
+            try
+            {
+                marker = Path.Combine(exeDir, MarkerFileName);
+                if (!File.Exists(marker))
+                {
+                    return null;
+                }
+            }
+            catch (Exception e)
+            {
+                error = $"Could not look for '{MarkerFileName}' in '{exeDir}': {e.Message}";
+                return null;
+            }
+
+            string content;
+            try
+            {
+                content = File.ReadAllText(marker);
+            }
+            catch (Exception e)
+            {
+                error = $"Could not read '{marker}': {e.Message}";
+                return null;
+            }
+
+            try
+            {
+                return Resolve(exeDir, content);
+            }
+            catch (Exception e)
+            {
+                error = $"'{marker}' does not name a usable directory: {e.Message}";
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Pure resolution of a marker's text: the first non-blank, non-comment line is the directory
+        /// (relative paths are anchored at <paramref name="exeDir"/>, environment variables expanded); no such
+        /// line means <see cref="DefaultSubfolder"/> under <paramref name="exeDir"/>. Returns a full, normalised
+        /// path. Throws on syntactically invalid paths.
+        /// </summary>
+        public static string Resolve(string exeDir, string? markerContent)
+        {
+            string? line = FirstDirective(markerContent);
+            string target = string.IsNullOrEmpty(line)
+                ? Path.Combine(exeDir, DefaultSubfolder)
+                : Environment.ExpandEnvironmentVariables(line!);
+
+            // A quoted path ("C:\My Games\BBTS") is a natural thing to type; accept it.
+            target = target.Trim().Trim('"');
+            if (target.Length == 0)
+            {
+                target = Path.Combine(exeDir, DefaultSubfolder);
+            }
+
+            if (!Path.IsPathRooted(target))
+            {
+                target = Path.Combine(exeDir, target);
+            }
+
+            return Path.GetFullPath(target);
+        }
+
+        /// <summary>
+        /// Makes sure <paramref name="dir"/> exists and is writable (a short-lived probe file is created and
+        /// removed). False with a message when it is not — the caller then falls back to the default root.
+        /// </summary>
+        public static bool TryPrepare(string dir, out string? error)
+        {
+            error = null;
+            try
+            {
+                Directory.CreateDirectory(dir);
+                string probe = Path.Combine(dir, ".write-probe-" + Guid.NewGuid().ToString("N"));
+                File.WriteAllText(probe, "ok");
+                File.Delete(probe);
+                return true;
+            }
+            catch (Exception e)
+            {
+                error = $"Portable data folder '{dir}' is not writable: {e.Message}";
+                return false;
+            }
+        }
+
+        private static string? FirstDirective(string? content)
+        {
+            if (string.IsNullOrEmpty(content))
+            {
+                return null;
+            }
+
+            foreach (string raw in content!.Split('\n'))
+            {
+                string line = raw.Trim().TrimStart('\uFEFF').Trim();
+                if (line.Length == 0 || line.StartsWith("#", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                return line;
+            }
+
+            return null;
+        }
+    }
+}

--- a/tests/BlocksBeyondTheStars.Client.Tests/PortableDataDirTests.cs
+++ b/tests/BlocksBeyondTheStars.Client.Tests/PortableDataDirTests.cs
@@ -1,0 +1,124 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using System;
+using System.IO;
+using Xunit;
+
+namespace BlocksBeyondTheStars.Client.Tests;
+
+/// <summary>
+/// The portable-data redirect (#1285): a <c>portable_data_dir.txt</c> next to the executable moves the
+/// persistent-data root. Rules under test: no marker → null (platform default); empty marker → <c>userdata</c>
+/// next to the exe; relative paths anchor at the exe folder; absolute paths, quotes, comments, blank lines
+/// and environment variables are handled; an unwritable target is reported instead of thrown.
+/// </summary>
+public sealed class PortableDataDirTests : IDisposable
+{
+    private readonly string _exeDir = Path.Combine(Path.GetTempPath(), "bbs-portable-" + Guid.NewGuid().ToString("N"));
+
+    public PortableDataDirTests()
+    {
+        Directory.CreateDirectory(_exeDir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_exeDir, recursive: true); } catch (IOException) { }
+    }
+
+    private void WriteMarker(string content) =>
+        File.WriteAllText(Path.Combine(_exeDir, PortableDataDir.MarkerFileName), content);
+
+    [Fact]
+    public void NoMarker_KeepsTheDefault()
+    {
+        string? root = PortableDataDir.ResolveFromMarker(_exeDir, out string? error);
+        Assert.Null(root);
+        Assert.Null(error);
+    }
+
+    [Fact]
+    public void EmptyMarker_UsesUserdataNextToTheExecutable()
+    {
+        WriteMarker("");
+        string? root = PortableDataDir.ResolveFromMarker(_exeDir, out string? error);
+        Assert.Null(error);
+        Assert.Equal(Path.GetFullPath(Path.Combine(_exeDir, PortableDataDir.DefaultSubfolder)), root);
+    }
+
+    [Fact]
+    public void CommentsAndBlankLinesOnly_CountAsEmpty()
+    {
+        WriteMarker("# where the data goes\r\n\r\n   # nothing yet\n");
+        string? root = PortableDataDir.ResolveFromMarker(_exeDir, out _);
+        Assert.Equal(Path.GetFullPath(Path.Combine(_exeDir, "userdata")), root);
+    }
+
+    [Fact]
+    public void RelativePath_IsAnchoredAtTheExecutableFolder()
+    {
+        WriteMarker("# comment first\n  ../BBTS-Data  \n");
+        string? root = PortableDataDir.ResolveFromMarker(_exeDir, out _);
+        Assert.Equal(Path.GetFullPath(Path.Combine(_exeDir, "..", "BBTS-Data")), root);
+    }
+
+    [Fact]
+    public void AbsolutePath_IsUsedAsIs_QuotesStripped()
+    {
+        string target = Path.Combine(_exeDir, "My Games", "bbts");
+        WriteMarker($"\"{target}\"\n");
+        string? root = PortableDataDir.ResolveFromMarker(_exeDir, out _);
+        Assert.Equal(Path.GetFullPath(target), root);
+    }
+
+    [Fact]
+    public void FirstDirectiveWins_LaterLinesIgnored()
+    {
+        string first = Path.Combine(_exeDir, "first");
+        string second = Path.Combine(_exeDir, "second");
+        Assert.Equal(Path.GetFullPath(first), PortableDataDir.Resolve(_exeDir, first + "\n" + second));
+    }
+
+    [Fact]
+    public void EnvironmentVariables_AreExpanded()
+    {
+        string name = "BBTS_TEST_PORTABLE_" + Guid.NewGuid().ToString("N");
+        string value = Path.Combine(_exeDir, "from-env");
+        Environment.SetEnvironmentVariable(name, value);
+        try
+        {
+            Assert.Equal(Path.GetFullPath(value), PortableDataDir.Resolve(_exeDir, $"%{name}%"));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(name, null);
+        }
+    }
+
+    [Fact]
+    public void ByteOrderMark_DoesNotPoisonTheFirstLine()
+    {
+        Assert.Equal(Path.GetFullPath(Path.Combine(_exeDir, "data")), PortableDataDir.Resolve(_exeDir, "﻿data"));
+    }
+
+    [Fact]
+    public void TryPrepare_CreatesTheFolderAndLeavesNoProbeBehind()
+    {
+        string dir = Path.Combine(_exeDir, "userdata", "nested");
+        Assert.True(PortableDataDir.TryPrepare(dir, out string? error));
+        Assert.Null(error);
+        Assert.True(Directory.Exists(dir));
+        Assert.Empty(Directory.GetFileSystemEntries(dir));
+    }
+
+    [Fact]
+    public void TryPrepare_UnusablePath_ReportsInsteadOfThrowing()
+    {
+        // A directory path that collides with an existing FILE can never be created.
+        string file = Path.Combine(_exeDir, "iam-a-file");
+        File.WriteAllText(file, "x");
+        Assert.False(PortableDataDir.TryPrepare(Path.Combine(file, "sub"), out string? error));
+        Assert.Contains("not writable", error);
+    }
+}


### PR DESCRIPTION
Closes #1285

## What

An optional **`portable_data_dir.txt` next to the game executable** redirects the whole persistent-data root — settings, name token, singleplayer saves, user content, portal saves, crash/feedback spools, photos, clips, perf dumps and every editor export — away from Unity's per-user folder (`%USERPROFILE%\AppData\LocalLow\JuMaVe Games\Blocks Beyond the Stars\`). Without the file nothing changes.

Marker rules (`Client.Core/PortableDataDir.cs`, Unity-free, 10 xunit tests):
- first non-blank, non-`#` line = the directory; absolute or **relative to the executable's folder**; `%ENV%` expanded; surrounding quotes and a BOM tolerated
- **empty** marker → `<exe folder>/userdata`
- unreadable marker / unwritable target → warning in `Player.log`, default folder used — a broken marker never blocks startup

Unity side: new `AppPaths.Root` (resolved once in `AppShell.Awake`, main thread) replaces all ~25 direct `Application.persistentDataPath` uses in the client. Deliberately left on Unity's own folder: the one-time "Spacecraft" rename migration and the WebGL IDBFS sibling adoption (`WebGlStorage`). Executable folder = parent of `Application.dataPath` (macOS: folder holding the `.app`); WebGL returns the default.

## Docs
USER_MANUAL §1 (player how-to), DEVELOPER.md (debugging paragraph + "never use persistentDataPath directly"), CHANGELOG Unreleased, TODO.md work-log.

## Verification
- `dotnet build … -warnaserror`: 0 warnings · Client.Tests 415/415 green · `dotnet format --verify-no-changes` clean
- Local Unity Windows build (worktree, PackageCache + Velopack libs synced): green, no generated files to commit
- Smoke test with the built player (`-batchmode`) and an empty marker: `[AppPaths] Portable data folder active …/userdata` logged, `client_settings.json` + `player_token.txt` created there

Not moved automatically: existing data (documented). Not covered: dedicated server (already portable), WebGL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
