### PR TITLE
fix(client): compass wrap, stale ship blip, crouch edge, honest repair panel — Lyxette round 3, client quartet (#1307 #1308 #1309 #1313)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -9582,6 +9582,30 @@ is **pre-approved** (keys in `tools/ai-assets/.env`, run via `uv`).
 
 ---
 
+## ✅ Done (2026-08-29): the compass, the crouch and an honest repair panel (#1307, #1308, #1309, #1313)
+
+Lyxette's third round of reports (2026-08-27) — the client-only quartet, all four in one PR. Server-side
+follow-ups (fauna vs. player builds, ground drops, fluids, falling blocks, the pad spawn) are their own packages.
+
+* **Compass honours the world wrap (#1307).** `HudUi.PlaceBlip` subtracted a canonical target from the
+  player's *unbounded* scene transform, so across a longitude/latitude seam every blip (ship, waypoint, beacons,
+  markers) flipped its bearing and the distance line jumped by a whole circumference — ">3000 m" to a ship a few
+  blocks away on a 10128-block world. Now measured against `Game.ScenePos(target)`, the same nearest-copy
+  mapping every other world object uses.
+* **No stale ship blip (#1308).** `ShipPosition` was only ever *set* (on `ShipPlacement`) and the server sends
+  nothing when no ship is placed on the new world, so the compass kept pointing at the previous landing site.
+  `OnWorldReset` clears it like it already clears the waypoint; a real placement re-arrives right after.
+* **Crouching reaches the edge (#1309).** The sneak edge-stop probed at `radius + 0.15` = 0.5 blocks ahead of
+  the centre, i.e. it fired in the middle of the last block — building an outer wall face from its top needed
+  scaffolding. The probe is now a short `SneakEdgeProbe` (0.08) plus this frame's step, so the capsule overhangs
+  the edge the way sneaking does in every voxel builder; the per-axis + diagonal-corner rules are unchanged.
+* **Honest ship-repair panel (#1313).** One missing design cell on a full hull raised a "SHIP REPAIR" panel with
+  a full **Hull 100/100** bar and no word about what was wrong. With the hull full the top line now leads with
+  the breach count (`ui.shiprepair.cells_missing`, EN+DE) and the bar is hidden; the bar and its numbers only
+  appear while the hull itself is short.
+
+---
+
 ## ✅ Done (2026-08-26): a Machines crafting tab + the one clear glass (#1273, #1274)
 
 The last two of Lyxette's follow-ups, both crafting-content.

--- a/client/Assets/BlocksBeyondTheStars/Scripts/GameBootstrap.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/GameBootstrap.cs
@@ -2558,6 +2558,11 @@ namespace BlocksBeyondTheStars.Client
             PendingSpeederFx.Clear(); // queued one-shot FX would play at old-world coordinates
             Waypoint = null; // a map-click waypoint is old-world coordinates too — without this the HUD
                              // compass kept pointing at a meaningless spot on every next planet (#592)
+            // #1308: the landed-ship position is old-world coordinates as well, and the server sends NO
+            // ShipPlacement when no ship is placed on the new world (observer, unplaced fleet ship) — so the
+            // compass kept its blip + distance line on the PREVIOUS landing site. Clear it; a real placement
+            // re-arrives right after this reset whenever there is one.
+            ShipPosition = null;
             SpaceWaypointId = null; // the space waypoint is scoped to the space layout it was set in —
             SpaceWaypointPos = null; // a new world means a new system view, so it dies with it (#597)
 

--- a/client/Assets/BlocksBeyondTheStars/Scripts/HudUi.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/HudUi.cs
@@ -1495,7 +1495,13 @@ namespace BlocksBeyondTheStars.Client
             dist = 0f;
             if (blip == null) return;
             if (!active) { blip.gameObject.SetActive(false); return; }
-            float dx = target.x - Game.PlayerPosition.x, dz = target.z - Game.PlayerPosition.z;
+            // #1307: `target` is canonical world space, but the player transform runs UNBOUNDED as it laps the
+            // world — measure against the copy of the target nearest the player (the SceneX/SceneZ mapping every
+            // other world object already uses). Subtracting raw coordinates flipped the bearing and added a whole
+            // circumference to the distance the moment either side sat across a seam (">3000 m" to a ship a few
+            // blocks away, on a 10128-block world).
+            var near = Game.ScenePos(target.x, target.y, target.z);
+            float dx = near.x - Game.PlayerPosition.x, dz = near.z - Game.PlayerPosition.z;
             dist = Mathf.Sqrt(dx * dx + dz * dz);
             float ang = (Mathf.Atan2(dx, dz) * Mathf.Rad2Deg - Game.PlayerYaw) * Mathf.Deg2Rad;
             // Log-scaled radius (#592): the old linear dist*1.2 pinned everything past ~37 m to the rim,
@@ -1809,8 +1815,19 @@ namespace BlocksBeyondTheStars.Client
             if (!show) return;
 
             _shipRepairTitle.text = loc.Get("ui.shiprepair.title");
-            _shipRepairBar.fillAmount = sr.HullMax > 0f ? Mathf.Clamp01(sr.Hull / sr.HullMax) : 1f;
-            _shipRepairProg.text = $"{loc.Get("ui.shiprepair.hull")}  {(int)sr.Hull}/{(int)sr.HullMax}";
+
+            // #1313: a full hull with missing design cells used to sit under a FULL hull bar — a "repair" panel
+            // that showed 100/100 and said nothing about what was wrong. Lead with the breach count in that
+            // case; the hull bar and its numbers only appear while the hull itself is short.
+            bool hullShort = sr.HullMax > 0f && sr.Hull < sr.HullMax;
+            _shipRepairBar.gameObject.SetActive(hullShort);
+            _shipRepairProg.text = hullShort
+                ? $"{loc.Get("ui.shiprepair.hull")}  {(int)sr.Hull}/{(int)sr.HullMax}"
+                : string.Format(loc.Get("ui.shiprepair.cells_missing"), sr.MissingCells);
+            if (hullShort)
+            {
+                _shipRepairBar.fillAmount = Mathf.Clamp01(sr.Hull / sr.HullMax);
+            }
 
             // List the materials the full repair needs (item:count pairs from the server), localized.
             string needs = string.Empty;
@@ -1828,7 +1845,9 @@ namespace BlocksBeyondTheStars.Client
                 needs = "  " + string.Join(", ", parts);
             }
 
-            string cells = sr.MissingCells > 0 ? $"  ({sr.MissingCells} {loc.Get("ui.shiprepair.cells")})" : string.Empty;
+            // The breach count already leads the panel when the hull is full — only repeat it next to the
+            // materials while the top line is busy showing hull numbers.
+            string cells = hullShort && sr.MissingCells > 0 ? $"  ({sr.MissingCells} {loc.Get("ui.shiprepair.cells")})" : string.Empty;
             _shipRepairHint.text = loc.Get("ui.shiprepair.hint") + needs + cells;
 
             var t = _shipRepairBtn.GetComponentInChildren<Text>();

--- a/client/Assets/BlocksBeyondTheStars/Scripts/PlayerController.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/PlayerController.cs
@@ -172,6 +172,7 @@ namespace BlocksBeyondTheStars.Client
         private const float StandHeight = 1.8f;
         private const float CrouchHeight = 1.2f;
         private const float CrouchSpeedMul = 0.4f;
+        private const float SneakEdgeProbe = 0.08f; // how far past the centre the sneak edge-stop looks for floor (#1309)
         private static readonly Vector3 CrouchEye = new Vector3(0f, 1.0f, 0f);
         private bool _crouched;
         private float _crouchT; // 0 = standing, 1 = fully crouched (eases the camera; the collider snaps)
@@ -2847,7 +2848,14 @@ namespace BlocksBeyondTheStars.Client
                 return true;
             }
 
-            Vector3 ahead = transform.position + horizontalDir.normalized * (_controller.radius + 0.15f);
+            // #1309: probe just past the CENTRE, not past the capsule's rim. At radius + 0.15 the sample sat
+            // 0.5 blocks ahead, so the stop fired as soon as the centre came within half a block of the edge —
+            // i.e. in the middle of the last block, which made building an outer wall face from its top
+            // impossible without scaffolding. A short probe lets the capsule overhang the edge the way
+            // sneaking does in every other voxel builder, while the feet still keep their footing. The probe
+            // also covers THIS frame's step, so a long frame cannot carry the centre past the edge unseen.
+            float reach = SneakEdgeProbe + horizontalDir.magnitude * Time.deltaTime;
+            Vector3 ahead = transform.position + horizontalDir.normalized * reach;
             return IsSolidKey(BlockKeyAt(ahead - Vector3.up * 0.5f))
                 || IsSolidKey(BlockKeyAt(ahead - Vector3.up * 1.2f));
         }

--- a/data/locales/de.json
+++ b/data/locales/de.json
@@ -2290,6 +2290,7 @@
   "ui.shiprepair.repair": "Schiff reparieren",
   "ui.shiprepair.hint": "Am Cockpit. Benötigt:",
   "ui.shiprepair.cells": "Hüllenzellen",
+  "ui.shiprepair.cells_missing": "{0} Hüllenzellen fehlen",
   "ui.hud.loot": "G: plündern",
   "ui.loot.out_of_reach": "Der Vorrat ist außer Reichweite — geh näher heran.",
   "ui.dock.title": "Andock-Anfrage",

--- a/data/locales/en.json
+++ b/data/locales/en.json
@@ -2290,6 +2290,7 @@
   "ui.shiprepair.repair": "Repair ship",
   "ui.shiprepair.hint": "At the cockpit. Needs:",
   "ui.shiprepair.cells": "hull cells",
+  "ui.shiprepair.cells_missing": "{0} hull cells missing",
   "ui.hud.loot": "G: loot",
   "ui.loot.out_of_reach": "The cache is out of reach — move closer.",
   "ui.dock.title": "Docking request",


### PR DESCRIPTION
Lyxette's third round of in-game reports (2026-08-27) — the client-only quartet in one PR: the two halves of the "where is my ship" confusion, the crouch edge-stop, and the ship-repair panel that showed a full hull bar while demanding repairs.

closes #1307
closes #1308
closes #1309
closes #1313

## What changed

- **#1307 — the compass honours the world wrap.** `HudUi.PlaceBlip` subtracted a canonical target position from the player's *unbounded* scene transform, so across a longitude/latitude seam every blip (ship, waypoint, beacons, markers) flipped its bearing and the distance line jumped by a whole circumference — ">3000 m" to a ship a few blocks away on a 10128-block world. It now measures against `Game.ScenePos(target)`, the same nearest-copy mapping every other world object already uses.
- **#1308 — no stale ship blip.** `GameBootstrap.ShipPosition` was only ever *set* (on `ShipPlacement`), and the server sends nothing when no ship is placed on the new world, so the compass kept pointing at the previous landing site. `OnWorldReset` now clears it the way it already clears the waypoint; a real placement re-arrives right after the reset whenever there is one. Client-only — no protocol change.
- **#1309 — crouching reaches the edge.** The sneak edge-stop probed at `radius + 0.15` = 0.5 blocks ahead of the centre, i.e. it fired in the middle of the last block, which made building an outer wall face from its top impossible without scaffolding. The probe is now a short `SneakEdgeProbe` (0.08) plus this frame's step (so a long frame cannot carry the centre past the edge unseen); the per-axis and diagonal-corner rules are unchanged.
- **#1313 — an honest ship-repair panel.** One missing design cell on a full hull raised a "SHIP REPAIR" panel with a full **Hull 100/100** bar and no word about what was wrong. With the hull full, the top line now leads with the breach count (`ui.shiprepair.cells_missing`, EN + DE; other locales fall back to English) and the bar is hidden; the bar and its numbers only appear while the hull itself is short. A design deviation still counts as a breach (maintainer decision) — the panel just says so.

## Verification

- Locale tests (server suite, `FullyQualifiedName~Locale`): 50/50 passed.
- Local Unity player build from the worktree (`scripts/build-client.ps1`): see the last commit — PR CI does not build Unity.
- TODO.md work log updated; no manual change needed (the manual already describes crouch as "stop at ledges").

🤖 Generated with [Claude Code](https://claude.com/claude-code)
