### PR TITLE
feat(client): the feedback dialog (F1/F2) holds the world like the Esc menu (#1330)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ the richer, screenshot-laden versions live there. `(#123)` references the pull r
 
 ## [Unreleased]
 
+### ⏸️ The feedback dialog holds the world too (#1330)
+
+- **F1 (F2 in the browser) now pauses like the Esc menu.** The player feedback dialog froze your controls
+  but not the world: hunger kept draining, night kept falling and creatures kept hunting while you typed a
+  bug report. Opening it now asks the server for the same hold the pause menu uses — in singleplayer the
+  world stops right there (and saves, as every hold does); with others joined it only counts as "this
+  player is in a menu" until everyone else is too (#973). Closing the form — Esc, Cancel or the auto-close
+  after a successful send — lets the world run again. The screenshot is still taken before the hold, so it
+  shows live play.
+- Under the hood the Esc menu and the dialog share one `WorldHoldIntent` (intent, release and the 15 s
+  keep-alive the server sweeps dead clients by), so the rule has exactly one copy — and a unit test.
+
 ### 🕹️ Play solo in the browser without an account (#1321, #1322, #1323)
 
 - **Portal landing page:** play.blocksbeyondthestars.de now leads with a player-name field and **"▶ Play

--- a/TODO.md
+++ b/TODO.md
@@ -186,6 +186,21 @@ step. README family section gained the age paragraph + PARENTS links; the Codex 
 (en+de) gained the content-profile + /report paragraph. Website/itch/glitch.fun texts = the statement block in
 PARENTS.md (Marcel publishes those surfaces). Closes kid-friendly-hints stage 2.
 
+### ★ The feedback dialog (F1/F2) holds the world like the Esc menu (#1330, 2026-08-29, branch feat/1330-feedback-dialog-pause)
+Asked in singleplayer: "the game should pause as soon as F1/F2 opens the feedback form." It did not — `FeedbackUi`
+only registered as a menu owner (`SetMenuOwner`: controls frozen, cursor freed) and never sent the `PauseIntent`
+the Esc menu has sent since #612/#908/#973, so hunger, daylight and creatures carried on behind the form.
+**Fix:** the dialog now sends the same hold on open (after the screenshot capture, so the shot still shows live
+play), the release on every close path (Esc, Cancel, auto-close after a send), and repeats the intent every 15 s
+while open — the keep-alive the server sweeps dead-behind-a-menu clients by. No server or protocol change: the
+server already decides per #973 (alone → the world stops and saves; with others joined it only counts as "in a
+menu" until everyone agrees), and `BumpReport` — the `/bump` snapshot the send fires — was already on the paused
+allow-list (#995). The cadence moved out of `AppShell` into a pure `Client.Core` `WorldHoldIntent`
+(`Hold`/`Release`/`Tick`/`Forget`) shared by both menus; `AppShell` forgets its hold silently when the world is
+left, so a stale keep-alive can never put the NEXT world to sleep. Six headless tests (`WorldHoldIntentTests`).
+Deliberately NOT done: holding behind every other panel (inventory, crafting, maps …) — a separate design question.
+Docs: `docs/developer/PLAYER_FEEDBACK.md`, CHANGELOG.
+
 ### ★ Portable data folder — `portable_data_dir.txt` next to the executable (#1285, 2026-08-26, branch feat/1285-portable-data-dir)
 The portable zip stored everything in `%LOCALAPPDATA%\..\LocalLow\…` like the installed game. Now an optional
 marker file next to the executable redirects the whole persistent-data root: `AppPaths.Root` (new, Unity side)

--- a/client/Assets/BlocksBeyondTheStars/Scripts/AppShell.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/AppShell.cs
@@ -1043,6 +1043,7 @@ namespace BlocksBeyondTheStars.Client
             Cursor.lockState = CursorLockMode.None;
             Cursor.visible = true;
             _confirmQuit = false;
+            WorldHold.Forget(); // the world is gone — a stale keep-alive must not put the NEXT one to sleep
             if (_quitDialog != null)
             {
                 UnityEngine.Object.Destroy(_quitDialog);
@@ -1087,28 +1088,33 @@ namespace BlocksBeyondTheStars.Client
         /// </summary>
         private void SetWorldPaused(bool paused)
         {
-            _nextPauseKeepAlive = paused ? Time.realtimeSinceStartup + PauseKeepAliveSeconds : 0f;
-            Boot()?.Network?.SendPause(paused);
+            if (paused)
+            {
+                WorldHold.Hold(Time.realtimeSinceStartup);
+            }
+            else
+            {
+                WorldHold.Release();
+            }
         }
 
-        /// <summary>How often the held intent is re-sent while the menu stays open. Behind an open menu the
-        /// client sends nothing else at all — no movement, no pose — so this repeat is the server's only proof
-        /// that the game is still alive, and the one thing that lets it drop a player who crashed mid-pause
-        /// instead of leaving the world frozen for everybody else (#973, heartbeat from #964).</summary>
-        private const float PauseKeepAliveSeconds = 15f;
+        /// <summary>The menu's hold request, with the keep-alive the server relies on: behind an open menu this
+        /// repeat is what lets it drop a player who crashed mid-pause instead of leaving the world frozen for
+        /// everybody else (#973, heartbeat from #964). The feedback dialog holds through the same class (#1330).</summary>
+        private BlocksBeyondTheStars.Client.WorldHoldIntent _worldHoldOrNull;
 
-        private float _nextPauseKeepAlive;
+        private BlocksBeyondTheStars.Client.WorldHoldIntent WorldHold =>
+            _worldHoldOrNull ??= new BlocksBeyondTheStars.Client.WorldHoldIntent(paused => Boot()?.Network?.SendPause(paused));
 
         /// <summary>Re-sends the pause intent on the keep-alive cadence for as long as the menu session lasts.</summary>
         private void TickPauseKeepAlive()
         {
-            if (!_confirmQuit || Time.realtimeSinceStartup < _nextPauseKeepAlive)
+            if (!_confirmQuit)
             {
-                return;
+                return; // belt and braces — the hold is only ever opened with the menu session
             }
 
-            _nextPauseKeepAlive = Time.realtimeSinceStartup + PauseKeepAliveSeconds;
-            Boot()?.Network?.SendPause(true);
+            WorldHold.Tick(Time.realtimeSinceStartup);
         }
 
         private void CancelQuit()

--- a/client/Assets/BlocksBeyondTheStars/Scripts/FeedbackUi.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/FeedbackUi.cs
@@ -29,6 +29,11 @@ namespace BlocksBeyondTheStars.Client
     ///   • the existing <c>/bump</c> message (<see cref="NetworkClient.SendBumpReport"/>) so the server also
     ///     writes its rich local snapshot (inventory/position/surroundings) when on an own/singleplayer server.
     ///
+    /// While the dialog is open the world is HELD exactly like behind the Esc menu (#1330): the same server intent
+    /// (<see cref="NetworkClient.SendPause"/>, group decision per #973 — a lone writer in multiplayer pauses nobody
+    /// else) with the same keep-alive, so typing a report in singleplayer no longer costs hunger, daylight or a
+    /// creature sneaking up behind the form. The screenshot is taken BEFORE the hold, so it still shows live play.
+    ///
     /// Wired by <see cref="WorldRig"/> next to <see cref="HudUi"/> / <see cref="ChatUi"/>.
     /// </summary>
     public sealed class FeedbackUi : MonoBehaviour
@@ -54,6 +59,13 @@ namespace BlocksBeyondTheStars.Client
         private bool _sending;
         private byte[] _shotJpg;                 // screenshot captured when the dialog opened
         private Task<FeedbackUploadResult> _uploadTask;
+
+        // The dialog's "hold the world while I'm open" request — one class shared with the Esc menu so the
+        // intent, the release and the 15 s keep-alive the server sweeps dead clients by (#973) have one copy.
+        private WorldHoldIntent _worldHoldOrNull;
+
+        private WorldHoldIntent WorldHold =>
+            _worldHoldOrNull ??= new WorldHoldIntent(paused => Game?.Network?.SendPause(paused));
 
         /// <summary>The key that opens the feedback dialog: F2 in browser builds (F1 would fight the browser's
         /// own help shortcut), F1 everywhere else.</summary>
@@ -101,6 +113,9 @@ namespace BlocksBeyondTheStars.Client
                 Close();
             }
 
+            // Keep telling the server we are still here while the dialog holds the world (no-op while closed).
+            WorldHold.Tick(Time.realtimeSinceStartup);
+
             // Marshal the background upload result back onto the main thread.
             if (_uploadTask != null && _uploadTask.IsCompleted)
             {
@@ -144,6 +159,11 @@ namespace BlocksBeyondTheStars.Client
             // dialog opened over (e.g. the landing-pad chooser) keeps its free cursor without us having to
             // save/restore the prior state by hand (#413).
             Game.SetMenuOwner(this, true);
+
+            // Hold the world like the Esc menu does (#1330) — after the screenshot, so the shot shows live play.
+            // The server decides what it means (#973): alone, the world stops right here; with others joined it
+            // only counts as "this player is in a menu" until everyone else is too.
+            WorldHold.Hold(Time.realtimeSinceStartup);
         }
 
         private void Close()
@@ -154,6 +174,7 @@ namespace BlocksBeyondTheStars.Client
             _shotJpg = null;
             if (_dialog != null) _dialog.SetActive(false);
 
+            WorldHold.Release(); // every close path ends here (Esc, Cancel, the auto-close after a send) — sends once
             Game?.SetMenuOwner(this, false); // arbiter re-locks only once NO other owner is open (#413)
         }
 

--- a/docs/developer/PLAYER_FEEDBACK.md
+++ b/docs/developer/PLAYER_FEEDBACK.md
@@ -9,6 +9,15 @@ snapshot. (The key is advertised in the on-foot HUD controls hint, `ui.hud.hint`
 cruise hint, `ui.space.controls`, via the `{feedback_key}` placeholder — it works in both modes;
 only menus/chat/death-prompt block it.)
 
+**The world is held while the dialog is open (#1330).** Opening the form sends the same `PauseIntent` the
+Esc menu sends (see the pause notes on #612/#908/#973): in singleplayer the world stops — and saves — the
+moment the dialog appears, so typing a report costs no hunger, daylight or a creature sneaking up; with
+other players joined it only counts as "this player is in a menu" until everyone else is too. Every close
+path (Esc, Cancel, the auto-close after a send) releases it. Both menus drive this through one pure
+`WorldHoldIntent` (`Client.Core`), which also repeats the intent every 15 s — the keep-alive the server
+uses to drop a client that died behind its menu. The screenshot is captured *before* the hold, so it still
+shows live play; the `/bump` snapshot is on the server's paused allow-list (`PausedMayHandle`, #995).
+
 This is deliberately **player-facing** and separate from the developer `/bump` chat command (which still
 exists and produces the rich local diagnostic snapshot — see [BUG_REPORTS](BUG_REPORTS.md) if present, or
 `GameServerBump.cs`).
@@ -20,6 +29,7 @@ F1  (F2 on WebGL)
    │  capture full-frame JPG  (HUD visible, dialog NOT yet shown)
    ▼
 FeedbackUi dialog  (title, description, optional e-mail, privacy hint)
+   │  world HELD from here (PauseIntent — same hold as the Esc menu, keep-alive every 15 s; released on close, #1330)
    │  Send  (body serialized ONCE on the main thread)
    ├──────────────► HTTPS POST ──►  reports.blocksbeyondthestars.de/api/bugreport
    │                desktop: FeedbackUploader.UploadRawJson on a background Task

--- a/src/BlocksBeyondTheStars.Client.Core/WorldHoldIntent.cs
+++ b/src/BlocksBeyondTheStars.Client.Core/WorldHoldIntent.cs
@@ -1,0 +1,90 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using System;
+
+namespace BlocksBeyondTheStars.Client
+{
+    /// <summary>
+    /// One panel's "hold the world while I'm open" request, with the keep-alive cadence the server relies on.
+    ///
+    /// <para>
+    /// The Esc menu has asked the server to hold the world since #612; the feedback dialog (F1/F2) does the same
+    /// since #1330. Both go through this so there is exactly one copy of the rule: send the intent on open, send the
+    /// release on close, and REPEAT the held intent every <see cref="KeepAliveSeconds"/> while open. The repeat is
+    /// what lets the server drop a client that crashed behind its menu instead of leaving the world frozen for
+    /// everyone else (#973) — and it doubles as the capability probe that tells the server this client sends
+    /// keep-alives at all.
+    /// </para>
+    ///
+    /// Pure (no UnityEngine) so it lives in Client.Core and is unit-tested headless; the Unity layer feeds it
+    /// <c>Time.realtimeSinceStartup</c> and a sender that wraps <c>NetworkClient.SendPause</c>.
+    /// </summary>
+    public sealed class WorldHoldIntent
+    {
+        /// <summary>How often the held intent is re-sent while the panel stays open. Well inside the server's 90 s
+        /// silent-session budget, so a few lost packets never read as a dead client.</summary>
+        public const float KeepAliveSeconds = 15f;
+
+        private readonly Action<bool> _send;
+        private float _nextKeepAlive;
+
+        /// <param name="send">Delivers a pause intent: <c>true</c> = hold, <c>false</c> = release.</param>
+        public WorldHoldIntent(Action<bool> send)
+        {
+            _send = send ?? throw new ArgumentNullException(nameof(send));
+        }
+
+        /// <summary>True between <see cref="Hold"/> and <see cref="Release"/>.</summary>
+        public bool Holding { get; private set; }
+
+        /// <summary>Asks the server to hold the world and starts the keep-alive cadence. Idempotent: a second call
+        /// while already holding sends nothing (the cadence keeps its own schedule).</summary>
+        public void Hold(float now)
+        {
+            if (Holding)
+            {
+                return;
+            }
+
+            Holding = true;
+            _nextKeepAlive = now + KeepAliveSeconds;
+            _send(true);
+        }
+
+        /// <summary>Lets the world run again. Sends nothing when no hold is open, so a panel can call it from every
+        /// close path without checking first.</summary>
+        public void Release()
+        {
+            if (!Holding)
+            {
+                return;
+            }
+
+            Holding = false;
+            _nextKeepAlive = 0f;
+            _send(false);
+        }
+
+        /// <summary>Drops the request WITHOUT telling the server — for a panel whose world is already gone (the
+        /// player left to the main menu). A later <see cref="Hold"/> starts fresh instead of a stale keep-alive
+        /// putting the NEXT world to sleep.</summary>
+        public void Forget()
+        {
+            Holding = false;
+            _nextKeepAlive = 0f;
+        }
+
+        /// <summary>Call once per frame: re-sends the held intent whenever the cadence is due. No-op while not holding.</summary>
+        public void Tick(float now)
+        {
+            if (!Holding || now < _nextKeepAlive)
+            {
+                return;
+            }
+
+            _nextKeepAlive = now + KeepAliveSeconds;
+            _send(true);
+        }
+    }
+}

--- a/tests/BlocksBeyondTheStars.Client.Tests/WorldHoldIntentTests.cs
+++ b/tests/BlocksBeyondTheStars.Client.Tests/WorldHoldIntentTests.cs
@@ -1,0 +1,103 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using BlocksBeyondTheStars.Client;
+using Xunit;
+
+namespace BlocksBeyondTheStars.Client.Tests;
+
+/// <summary>
+/// The one copy of "hold the world while my panel is open" that the Esc menu and the feedback dialog (#1330)
+/// share: intent on open, release on close, and the 15 s keep-alive in between that lets the server sweep a
+/// client that died behind its menu (#973).
+/// </summary>
+public sealed class WorldHoldIntentTests
+{
+    private readonly List<bool> _sent = new();
+    private readonly WorldHoldIntent _hold;
+
+    public WorldHoldIntentTests()
+    {
+        _hold = new WorldHoldIntent(_sent.Add);
+    }
+
+    [Fact]
+    public void Hold_SendsTheIntentOnce_AndReleaseSendsTheRelease()
+    {
+        _hold.Hold(now: 10f);
+        _hold.Hold(now: 11f); // a second open while already holding is a no-op
+
+        Assert.True(_hold.Holding);
+        Assert.Equal(new[] { true }, _sent);
+
+        _hold.Release();
+        _hold.Release(); // every close path may call it — only the first one talks to the server
+
+        Assert.False(_hold.Holding);
+        Assert.Equal(new[] { true, false }, _sent);
+    }
+
+    [Fact]
+    public void Release_WithoutAHold_SendsNothing()
+    {
+        _hold.Release();
+        Assert.Empty(_sent);
+    }
+
+    [Fact]
+    public void WhileHolding_TheIntentIsRepeatedOnTheKeepAliveCadence()
+    {
+        _hold.Hold(now: 0f);
+
+        // Ticks inside the cadence are silent; the first one at/after the deadline re-sends, and the next
+        // deadline is measured from THAT send, so a long stalled frame yields one repeat, not a burst.
+        _hold.Tick(1f);
+        _hold.Tick(WorldHoldIntent.KeepAliveSeconds - 0.01f);
+        Assert.Equal(new[] { true }, _sent);
+
+        _hold.Tick(WorldHoldIntent.KeepAliveSeconds);
+        Assert.Equal(new[] { true, true }, _sent);
+
+        _hold.Tick(WorldHoldIntent.KeepAliveSeconds + 1f);
+        Assert.Equal(2, _sent.Count);
+
+        _hold.Tick(3f * WorldHoldIntent.KeepAliveSeconds); // one stalled frame far past the deadline
+        Assert.Equal(3, _sent.Count);
+        _hold.Tick(3f * WorldHoldIntent.KeepAliveSeconds + 1f);
+        Assert.Equal(3, _sent.Count);
+    }
+
+    [Fact]
+    public void AfterRelease_NoKeepAliveIsSent()
+    {
+        _hold.Hold(now: 0f);
+        _hold.Release();
+
+        _hold.Tick(100f);
+        _hold.Tick(200f);
+
+        Assert.Equal(new[] { true, false }, _sent);
+    }
+
+    [Fact]
+    public void Forget_DropsTheHoldSilently_AndTheNextHoldStartsFresh()
+    {
+        _hold.Hold(now: 0f);
+        _hold.Forget(); // the world is gone — nothing to tell the server
+
+        _hold.Tick(100f); // a stale keep-alive here would put the NEXT world to sleep
+        Assert.False(_hold.Holding);
+        Assert.Equal(new[] { true }, _sent);
+
+        _hold.Hold(now: 100f);
+        Assert.Equal(new[] { true, true }, _sent);
+        _hold.Tick(100f + WorldHoldIntent.KeepAliveSeconds - 1f);
+        Assert.Equal(2, _sent.Count); // the cadence restarted from the new hold, not from the old one
+    }
+
+    [Fact]
+    public void ANullSender_IsRejected()
+    {
+        Assert.Throws<ArgumentNullException>(() => new WorldHoldIntent(null!));
+    }
+}


### PR DESCRIPTION
Closes #1330

## What

The player feedback dialog (**F1**, **F2** in browser builds) froze controls and freed the cursor but never asked the server to hold the world — hunger, daylight and creatures kept running behind the form. It now sends the same `PauseIntent` the Esc menu sends, releases it on every close path (Esc, Cancel, auto-close after a send), and repeats it every 15 s while open (the keep-alive the server sweeps dead-behind-a-menu clients by, #973).

- Singleplayer: the world stops (and saves, as every hold does) the moment the dialog appears.
- Multiplayer: a lone writer pauses nobody — it only counts as "this player is in a menu" until everyone agrees (#973, unchanged server rule).
- The screenshot is still captured *before* the hold, so it shows live play; `/bump` was already on the paused allow-list (#995).

## How

- New pure `Client.Core` class `WorldHoldIntent` (`Hold` / `Release` / `Tick` / `Forget`) — the one copy of the intent + keep-alive cadence, shared by `AppShell` (Esc menu) and `FeedbackUi`.
- `AppShell` forgets its hold silently when the world is left, so a stale keep-alive can never put the *next* world to sleep.
- No server or protocol change.

## Verification

- `dotnet build --no-incremental -c Release -warnaserror`: 0 warnings / 0 errors
- `BlocksBeyondTheStars.Client.Tests`: 425 passed (6 new `WorldHoldIntentTests`)
- `dotnet format --verify-no-changes`: clean
- Local Unity build (worktree): success, 0 `error CS`, fresh `BlocksBeyondTheStars.Client.dll`
- Docs: `docs/developer/PLAYER_FEEDBACK.md`, CHANGELOG (Unreleased), TODO work log

Not in scope: holding behind every other panel (inventory, crafting, maps …) — separate design question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)