### PR TITLE
fix(creatures): fauna respects player builds — embedded sleepers, sealed rooms, no monoculture (#1320 #1314 #1325)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -9582,6 +9582,39 @@ is **pre-approved** (keys in `tools/ai-assets/.env`, run via `uv`).
 
 ---
 
+## ✅ Done (2026-08-29): fauna respects player builds — sleepers, sealed rooms, no monoculture (#1320, #1314, #1325)
+
+Lyxette's reports 5 + 6 ("Kreaturen Spawn", "Elephant im Kühlschrank") and the round-3 base complaint, one
+server-only PR. Root of the "they spawn endlessly in my base" feeling was never the spawn spot alone.
+
+* **Embedded sleepers step clear (#1320).** A sleeping creature skipped every collision gate on the movement
+  path, so a walkway or wall built through a sleeping herd left the bodies in the masonry all night. Sleepers
+  now re-validate their body every tick (a handful of block reads): an embedded one is roused and stepped
+  aside to the nearest clear spot within 6 blocks — same level first, so it steps out of a wall rather than
+  climbing onto the floor built over it — or despawns when boxed in on every side.
+* **Feet snap honours body height + looks further for real ground (#1320).** `StandableAt` accepted a two-cell
+  hollow under a floor for a ten-block titan and held its body inside the floor above; a creature's own column
+  probe now demands the species' collision height of headroom (large land species) and scans ±24 cells before
+  falling back to the generator's pre-excavation surface (which floated animals over fresh pits).
+* **Body-aware ship guard (#1320, "Elephant im Kühlschrank").** `EntityBlockedByShip`/`TryPushOutsideShip` were
+  point-in-box with a 0.5 margin — a titan herd asleep with its centres a block outside the hull filled the
+  cabin. The margin now grows by the species' footprint radius (`Size × 0.5`) for large species at spawn, per
+  step, in the per-tick push-out and in the placement sweep; small fauna keeps the plain test.
+* **No spawns in sealed base rooms (#1314).** The spawner never consulted the base systems. Every placement —
+  ring leader and each herd member — now runs one reject list (`SpawnSpotClear`) that ends with
+  `InSealedBaseRoom` (the cached air fill, effectively free). Walls and materials still change nothing for
+  open-topped yards — that is #1315.
+* **No monoculture (#1325).** 6 → 12 → 36 animals at one base, all one species: a random biome affinity per
+  species + a native-first pass left his swamp with exactly one native, titan herds added 2–4 per spawn,
+  nothing capped a species' share, and nothing despawns while the player stays. Now: per-species share of the
+  live cap (40 %, ≥ 3, ≥ cap ÷ roster) that herds spawn partially against; a biome with fewer than two
+  eligible species skips the native pass (`CreatureBehaviour.BiomePassStarved`); an over-share species sheds its
+  farthest out-of-sight members (> 40 blocks, not provoked). Rosters and saves untouched — only selection changes.
+* Tests: `CreatureBuildRespectTests` (10) — biome-pass starvation, share + herd + crowding, sealed-room seam,
+  walled-in / boxed-in sleeper, titan under a slab, pillar removal, titan beside the hull.
+
+---
+
 ## ✅ Done (2026-08-29): the compass, the crouch and an honest repair panel (#1307, #1308, #1309, #1313)
 
 Lyxette's third round of reports (2026-08-27) — the client-only quartet, all four in one PR. Server-side

--- a/docs/developer/WORLD_GENERATION.md
+++ b/docs/developer/WORLD_GENERATION.md
@@ -308,7 +308,9 @@ live by `GameServerCreatures.cs`.
   roaming members drift gently toward nearby kin so groups stay loosely together.
 - **Per biome:** on multi-biome worlds each species gets a **biome affinity** (`rng.Next(biomeCount)`,
   or −1 = anywhere). Spawning prefers biome natives, then falls back to any species — roughly
-  **one-plus native species per biome** plus the biome-agnostic ones.
+  **one-plus native species per biome** plus the biome-agnostic ones. A biome with fewer than **two**
+  eligible species skips the native pass outright (`CreatureBehaviour.BiomePassStarved`, #1325) —
+  otherwise every spawn in that region was its single native, and a base there drowned in one species.
   Natives are tinted ~45 % toward their biome's anchor hue, so region A's fauna reads green-ish and
   region B's violet-ish on the same world.
 
@@ -316,7 +318,15 @@ live by `GameServerCreatures.cs`.
 world reaches ~25–45, backstopped by a safety ceiling of 64 — #470), ring placement 18–45 blocks out
 (two rotors: the ring slot advances on every attempt, the species on success), habitat gates (water animals only in
 water columns, cave animals only in caves; titans additionally need a 3×3 level-ground clearance),
-despawn beyond 70 blocks (titans 110 — a landmark animal must not evaporate mid-approach). Only
+despawn beyond 70 blocks (titans 110 — a landmark animal must not evaporate mid-approach). **No
+monoculture (#1325):** each species may hold at most a **share** of the live cap — 40 %, never below 3,
+never below cap ÷ roster size — a herd counts its members against it and spawns partially (as against
+the world cap), and a species OVER its share (the cap shrank, an older save) sheds its farthest members
+that are out of sight of every player (> 40 blocks) until it is back at the share. Every placement —
+the ring leader and each herd member — runs the one reject list `SpawnSpotClear`: habitat, the parked-ship
+volume (**body-aware** for large species: the hull margin grows by `Size × 0.5`, #1320), body cells (#855),
+titan flatness, the large-body volume (#750) and a founded base's **sealed rooms** (`InSealedBaseRoom`,
+the cached air fill — #1314: nothing spawns inside a room the player has made airtight). Only
 **awake, hostile** creatures deal damage — sleepers never attack — and the day/night cycle gates
 which species are awake. Bite + aggro ranges grow gently with species size past 2 (bite capped at
 the player's own 6-block attack reach).
@@ -328,7 +338,13 @@ the same discard mechanic as the ship hull and energy fences): land walkers acce
 1 cell; water species never step out of their water body; fliers, cave/lava dwellers and amphibians
 are unaffected. Ground heights come from **real blocks** (#650 — a nearest-standable-cell probe via
 `GetBlockIfLoaded`, generator fallback for unloaded columns), so fauna honours player walls, dug
-pits and built floors, and land walkers **ease** toward the ground at a capped vertical rate (#652;
+pits and built floors; a creature's OWN column probe is species-aware (#1320): a large land body needs its
+whole collision height of headroom (a two-cell hollow under a floor is not "standable" for a titan) and
+looks ±24 cells for real ground before trusting the noise surface (the ±6 window fell back to the
+pre-excavation height and floated animals over fresh pits). **Sleepers** rest in place but re-validate
+their body every tick (#1320 — a wall or floor built through a sleeping herd used to leave the bodies
+embedded until dawn): an embedded sleeper is roused and stepped aside to the nearest clear spot within
+6 blocks (same level first), or despawns when boxed in on every side. Land walkers **ease** toward the ground at a capped vertical rate (#652;
 fliers ease toward hover — no contour-pen terrain tracing; hoppers keep the snap, their pop is the
 motion, and their stride pulses with it, #654). A blocked step first **probes alternative headings**
 (±35°/±70°/±110°, #651) and only re-rolls when boxed in — contour/wall following with the

--- a/docs/user/USER_MANUAL.md
+++ b/docs/user/USER_MANUAL.md
@@ -1079,7 +1079,9 @@ separate unlock; admins can still disable it through server world rules.
 
 ### Creatures
 - Fauna spawn near players (habitat-gated), with temperaments; hostile creatures show visible attacks.
-  Flora regrows when its host block survives.
+  Flora regrows when its host block survives. Nothing spawns inside a **sealed room** of a founded base
+  (the same airtight rooms the base core supplies with air), no single species fills the whole area, and
+  an animal you wall or floor in while it sleeps wakes up and steps clear.
 - **Individuals of a kind vary in size.** Within any one species/type, each plant, tree or animal gets its
   own size (most near the normal size, the occasional runt or giant) — a wood is a mix of saplings and tall
   trees with varying crown widths, a herd has small and large animals. The variation is cosmetic (a creature's

--- a/src/BlocksBeyondTheStars.GameServer/GameServerCreatures.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerCreatures.cs
@@ -44,6 +44,17 @@ public sealed partial class GameServer
     private const float CreatureWakeDistance = 4f;             // a sleeping creature stirs awake when a player comes this close
     private const double CreatureWakeSeconds = 9.0;            // ...and then stays roused (alert/active) for this long
 
+    // #1325: no single species may fill the world — a share of the live cap per species (a herd counts its
+    // members against it and spawns partially, exactly as it already does against the world cap), floored
+    // so a tiny cap still allows a herd, and never below cap/roster so a short roster can still reach the cap.
+    private const float SpeciesShareOfCap = 0.4f;
+    private const int SpeciesShareMin = 3;
+    private const float CreatureCrowdDespawnRange = 40f;       // an over-share member this far from every player wanders off
+
+    // #1320: a sleeper whose body ends up inside blocks is roused + moved to the nearest clear spot within
+    // this many blocks (same level first) — or despawns when boxed in on every side.
+    private const int SleeperRelocateRadius = 6;
+
     private CreatureSpecies[] _speciesRoster = System.Array.Empty<CreatureSpecies>();
     private readonly List<PlayerSession> _creatureTargets = new(); // reused per tick (no per-tick LINQ alloc)
     private readonly Dictionary<string, CreatureSpecies> _speciesById = new();
@@ -198,12 +209,15 @@ public sealed partial class GameServer
 
         // #900: in a storm, a blizzard or an ion squall the wildlife hunkers down — same movement code,
         // just a slower clock, so herds visibly settle while the weather rages and pick up again after.
-        MoveCreatures(targets, dt * WeatherCreatureActivity());
+        if (MoveCreatures(targets, dt * WeatherCreatureActivity()))
+        {
+            BroadcastCreatures(); // a boxed-in sleeper was removed (#1320)
+        }
 
         // Despawn creatures that drifted far from every player so the cap frees up and fauna keeps
         // appearing around players as they explore — life is spread across the whole planet, not just
         // stuck at the start area. (Travel clears creatures entirely via ResetWorldRuntimeState.)
-        if (PruneFarCreatures(targets))
+        if (PruneFarCreatures(targets, cap))
         {
             BroadcastCreatures();
         }
@@ -384,10 +398,13 @@ public sealed partial class GameServer
         int z = (int)System.Math.Floor(player.Position.Z) + dz;
         int surface = _generator.SurfaceHeight(_world.Planet, x, z);
         int biome = _generator.BiomeIndexAt(_world.Planet, x, z);
+        int share = SpeciesShare(cap);
 
         // Two passes: first only species native to this biome (so a multi-biome world shows different fauna in
         // different regions), then any species — so a biome never goes empty if none of its natives fit here.
-        for (int pass = 0; pass < 2; pass++)
+        // A biome with a single native skips the native pass outright (#1325): otherwise every spawn in that
+        // region was that one species, and a base there drowned in a monoculture up to the world cap.
+        for (int pass = CreatureBehaviour.BiomePassStarved(_speciesRoster, biome) ? 1 : 0; pass < 2; pass++)
         {
             for (int n = 0; n < _speciesRoster.Length; n++)
             {
@@ -395,6 +412,11 @@ public sealed partial class GameServer
                 if (pass == 0 && sp.BiomeAffinity >= 0 && sp.BiomeAffinity != biome)
                 {
                     continue; // not native to this biome (relaxed on the second pass)
+                }
+
+                if (WildCountOf(sp.Id) >= share)
+                {
+                    continue; // this species already holds its share of the world (#1325) — let another fill the cap
                 }
 
                 float y;
@@ -446,31 +468,7 @@ public sealed partial class GameServer
                 }
 
                 var pos = new Vector3f(px + 0.5f, y, pz + 0.5f);
-                if (!HabitatSuitable(sp, pos) || EntityBlockedByShip(pos))
-                {
-                    // Reject the SAME volume the movement barrier guards (not just the tight interior box), so a
-                    // creature never spawns in the thin shell where it would immediately be frozen against the hull.
-                    continue; // never spawn inside (or clipping into) a landed ship
-                }
-
-                if (CreatureBodyBlocked(sp, pos))
-                {
-                    continue; // its body would materialise inside a wall / ruin masonry (#855)
-                }
-
-                // Titans need level ground (#638): a 3×3 clearance whose surface stays within ±1 of the
-                // centre column, so a six-block giant doesn't materialise half-buried in a cliff face —
-                // creatures have no colliders, so the spawn spot is the only terrain check they ever get.
-                if (sp.BodyPlan == CreatureBodyPlan.Titan && !TitanGroundClear(px, pz, surface))
-                {
-                    continue;
-                }
-
-                // A big body must actually FIT (#750): flatness alone let titans materialise inside
-                // ruin rooms (stamped floors are perfectly flat) — the only other spatial gate was a
-                // single 1×1 column with two air cells, for bodies that render ~5×10×11 blocks.
-                if (sp.Size >= LargeBodySize && sp.Habitat == CreatureHabitat.Land
-                    && !LargeBodyFits(sp, px, (int)System.Math.Floor(y), pz))
+                if (!SpawnSpotClear(sp, pos, px, pz, surface))
                 {
                     continue;
                 }
@@ -484,6 +482,78 @@ public sealed partial class GameServer
 
         return false;
     }
+
+    /// <summary>The one reject list every spawn placement runs — the ring leader and each herd member
+    /// alike (#1314: the two used to drift apart, and a gate added to one leaked through the other):
+    /// habitat, the parked-ship volume (body-aware for large species, #1320), the body cells (#855), titan
+    /// flatness (#638), the large-body volume (#750) and — new — a founded base's SEALED rooms (#1314): the
+    /// spawner never consulted the base systems, so a room the player had made airtight still filled with
+    /// wildlife. <see cref="InSealedBaseRoom"/> is a cached set lookup, effectively free.</summary>
+    private bool SpawnSpotClear(CreatureSpecies sp, Vector3f pos, int px, int pz, int surface)
+    {
+        if (!HabitatSuitable(sp, pos) || EntityBlockedByShip(pos, CreatureShipMargin(sp)))
+        {
+            // Reject the SAME volume the movement barrier guards (not just the tight interior box), so a
+            // creature never spawns in the thin shell where it would immediately be frozen against the hull.
+            return false; // never spawn inside (or clipping into) a landed ship
+        }
+
+        if (CreatureBodyBlocked(sp, pos))
+        {
+            return false; // its body would materialise inside a wall / ruin masonry (#855)
+        }
+
+        // Titans need level ground (#638): a 3×3 clearance whose surface stays within ±1 of the
+        // centre column, so a six-block giant doesn't materialise half-buried in a cliff face —
+        // creatures have no colliders, so the spawn spot is the only terrain check they ever get.
+        if (sp.BodyPlan == CreatureBodyPlan.Titan && !TitanGroundClear(px, pz, surface))
+        {
+            return false;
+        }
+
+        // A big body must actually FIT (#750): flatness alone let titans materialise inside
+        // ruin rooms (stamped floors are perfectly flat) — the only other spatial gate was a
+        // single 1×1 column with two air cells, for bodies that render ~5×10×11 blocks.
+        if (sp.Size >= LargeBodySize && sp.Habitat == CreatureHabitat.Land
+            && !LargeBodyFits(sp, px, (int)System.Math.Floor(pos.Y), pz))
+        {
+            return false;
+        }
+
+        // #1314: nothing spawns inside a base's sealed rooms — the volume the air fill already knows.
+        var cell = new Vector3i((int)System.Math.Floor(pos.X), (int)System.Math.Floor(pos.Y), (int)System.Math.Floor(pos.Z));
+        return !InSealedBaseRoom(cell);
+    }
+
+    /// <summary>How many live wild individuals of one species a world may hold (#1325): a share of the
+    /// live cap, floored at <see cref="SpeciesShareMin"/> (a herd must still be possible on a sparse
+    /// world) and never below cap ÷ roster size (a two-species world must still reach its cap).</summary>
+    private int SpeciesShare(int cap)
+    {
+        int roster = System.Math.Max(1, _speciesRoster.Length);
+        int share = (int)System.Math.Ceiling(cap * SpeciesShareOfCap);
+        return System.Math.Max(SpeciesShareMin, System.Math.Max(share, (cap + roster - 1) / roster));
+    }
+
+    /// <summary>Live WILD individuals of one species (companions never count, as with the world cap).</summary>
+    private int WildCountOf(string speciesId)
+    {
+        int n = 0;
+        foreach (var c in _creatures)
+        {
+            if (!c.IsCompanion && c.SpeciesId == speciesId)
+            {
+                n++;
+            }
+        }
+
+        return n;
+    }
+
+    /// <summary>The footprint radius a species adds to the parked-ship guard (#1320): large species keep
+    /// their body clear of the hull, small fauna keeps the plain point test (fliers still cross over).</summary>
+    private static float CreatureShipMargin(CreatureSpecies sp)
+        => sp.Size >= LargeBodySize && sp.Habitat != CreatureHabitat.Air ? sp.Size * 0.5f : 0f;
 
     /// <summary>3×3 flatness gate for titan spawns (#638): every neighbouring column's ground must sit
     /// within ±1 block of the centre's. Reads REAL blocks (#650), so a titan neither materialises against
@@ -513,7 +583,8 @@ public sealed partial class GameServer
     private void SpawnGroupAround(CreatureSpecies sp, int x, int z, int cap)
     {
         int group = System.Math.Clamp(sp.SocialGroupSize, 1, 5);
-        for (int k = 1; k < group && WildCreatureCount < cap; k++)
+        int share = SpeciesShare(cap);
+        for (int k = 1; k < group && WildCreatureCount < cap && WildCountOf(sp.Id) < share; k++)
         {
             // Golden-angle bearings with alternating radii — spread out, not a neat ring.
             double a = k * 2.399963;
@@ -553,24 +624,15 @@ public sealed partial class GameServer
             }
             else
             {
-                if (sp.BodyPlan == CreatureBodyPlan.Titan && !TitanGroundClear(mx, mz, surface))
-                {
-                    continue; // herd members need the same level ground the leader did
-                }
-
                 y = sp.Habitat == CreatureHabitat.Air ? surface + 4f : GroundFeetYAt(mx, mz, surface + 1); // real ground (#650)
-
-                if (sp.Size >= LargeBodySize && sp.Habitat == CreatureHabitat.Land
-                    && !LargeBodyFits(sp, mx, (int)System.Math.Floor(y), mz))
-                {
-                    continue; // herd members get the leader's body-volume check too (#750)
-                }
             }
 
+            // Herd members run the leader's full reject list (#638/#750/#855/#1314): the herd stays smaller
+            // rather than planting a member inside a wall, a ship, or a sealed base room.
             var pos = new Vector3f(mx + 0.5f, y, mz + 0.5f);
-            if (!HabitatSuitable(sp, pos) || EntityBlockedByShip(pos) || CreatureBodyBlocked(sp, pos))
+            if (!SpawnSpotClear(sp, pos, mx, mz, surface))
             {
-                continue; // the herd stays smaller rather than planting a member inside a wall (#855)
+                continue;
             }
 
             SpawnCreature(sp, pos);
@@ -658,12 +720,15 @@ public sealed partial class GameServer
     private ushort BlockValueAt(Vector3f at)
         => _world.GetBlock(new Vector3i((int)System.Math.Floor(at.X), (int)System.Math.Floor(at.Y), (int)System.Math.Floor(at.Z))).Value;
 
-    /// <summary>Advances every creature: hunters approach, skittish flee, the rest wander; sleepers rest.</summary>
-    private void MoveCreatures(List<PlayerSession> targets, double dt)
+    private readonly List<CombatEntity> _creatureEvictions = new(); // boxed-in sleepers removed after the move loop (#1320)
+
+    /// <summary>Advances every creature: hunters approach, skittish flee, the rest wander; sleepers rest.
+    /// Returns true when a creature was REMOVED (a boxed-in sleeper, #1320) so the caller re-broadcasts.</summary>
+    private bool MoveCreatures(List<PlayerSession> targets, double dt)
     {
         if (_creatures.Count == 0)
         {
-            return;
+            return false;
         }
 
         double moveDt = System.Math.Min(dt, CreatureMoveDtCap);
@@ -677,9 +742,16 @@ public sealed partial class GameServer
                 continue;
             }
 
+            if (!_speciesById.TryGetValue(creature.SpeciesId, out var sp))
+            {
+                continue;
+            }
+
             // Safety net: a wild creature that somehow ended up inside a parked ship (ship placed/grown over it,
             // an old save, a numeric edge) is pushed back out of the hull this tick instead of being stuck inside.
-            if (TryPushOutsideShip(creature.Position, out var ejected))
+            // Body-aware for large species (#1320): a sleeping titan herd lay with its centres a block outside
+            // the hull and its bodies filling the cabin — the point test never saw it.
+            if (TryPushOutsideShip(creature.Position, out var ejected, CreatureShipMargin(sp)))
             {
                 creature.Position = ejected;
                 continue;
@@ -704,11 +776,6 @@ public sealed partial class GameServer
             if (creature.AwakeOverrideTimer > 0)
             {
                 creature.AwakeOverrideTimer = System.Math.Max(0, creature.AwakeOverrideTimer - dt);
-            }
-
-            if (!_speciesById.TryGetValue(creature.SpeciesId, out var sp))
-            {
-                continue;
             }
 
             // A provoked territorial creature hunts like an aggressor until it calms down.
@@ -757,6 +824,16 @@ public sealed partial class GameServer
             // behaviour (skittish ones flee, hunters seek, others just wander).
             if (!SpeciesActive(sp) && creature.AwakeOverrideTimer <= 0)
             {
+                // #1320: a sleeper skips every collision gate on the movement path, so a player building a
+                // wall or floor THROUGH a sleeping herd left the bodies embedded in the masonry all night.
+                // Re-validate the body BEFORE the feet snap (which would otherwise hop it onto the new wall):
+                // rouse + step aside to the nearest clear spot, or despawn when boxed in. A few block reads
+                // per sleeper per tick — far cheaper than the movement path an awake animal runs.
+                if (DisplaceEmbeddedSleeper(creature, sp))
+                {
+                    continue;
+                }
+
                 creature.Position = AdjustHabitatHeight(sp, creature.Position, 0f, profile, moveDt);
                 continue;
             }
@@ -832,7 +909,7 @@ public sealed partial class GameServer
             // the obstacle (#651) — so it slides along cliff bases, walls and fence lines like an animal
             // skirting an obstacle. Only when every probe is blocked too does it fall back to the re-roll,
             // which preserves the "nothing can ever get stuck" property.
-            if (EntityBlockedByShip(next) || BlockedByEnergyFence(creature.Position, next)
+            if (EntityBlockedByShip(next, CreatureShipMargin(sp)) || BlockedByEnergyFence(creature.Position, next)
                 || StepBlockedByTerrain(sp, creature.Position, next)
                 || CreaturePathBlocked(sp, creature.Position, next))
             {
@@ -852,6 +929,91 @@ public sealed partial class GameServer
                 creature.Position = next;
             }
         }
+
+        if (_creatureEvictions.Count == 0)
+        {
+            return false;
+        }
+
+        foreach (var gone in _creatureEvictions)
+        {
+            _creatures.Remove(gone);
+        }
+
+        _creatureEvictions.Clear();
+        return true;
+    }
+
+    /// <summary>The sleeper's body check (#1320). False when the body sits clear of every colliding block.
+    /// Otherwise the creature is roused (<see cref="CreatureWakeSeconds"/>) and stepped to the nearest
+    /// clear standable spot within <see cref="SleeperRelocateRadius"/> — or, boxed in on every side, queued
+    /// for removal (the caller drops it after the loop; the list can't change mid-iteration).</summary>
+    private bool DisplaceEmbeddedSleeper(CombatEntity creature, CreatureSpecies sp)
+    {
+        if (!CreatureBodyBlocked(sp, creature.Position))
+        {
+            return false;
+        }
+
+        if (TryFindClearSpotNear(sp, creature.Position, out var clear))
+        {
+            creature.Position = clear;
+            creature.AwakeOverrideTimer = CreatureWakeSeconds; // it wakes up and walks off, like a creature you bump
+        }
+        else
+        {
+            _creatureEvictions.Add(creature);
+        }
+
+        return true;
+    }
+
+    private static readonly (int Dx, int Dz)[] RelocateDirs =
+    {
+        (1, 0), (-1, 0), (0, 1), (0, -1), (1, 1), (-1, 1), (1, -1), (-1, -1),
+    };
+
+    /// <summary>The nearest spot around <paramref name="from"/> where the species can actually stand: rings
+    /// of 1..<see cref="SleeperRelocateRadius"/> blocks in eight directions, each column probed for a REAL
+    /// standable feet cell with the species' own headroom, then the body, ship and large-body gates the
+    /// spawner uses. Spots on the creature's own level (±1) are tried first, so an animal steps ASIDE out
+    /// of a wall before it would climb onto the floor built over it. Never falls back to the noise
+    /// surface — no real floor, no relocation.</summary>
+    private bool TryFindClearSpotNear(CreatureSpecies sp, Vector3f from, out Vector3f spot)
+    {
+        int ox = (int)System.Math.Floor(from.X), oz = (int)System.Math.Floor(from.Z);
+        int refY = (int)System.Math.Floor(from.Y);
+        float margin = CreatureShipMargin(sp);
+        bool large = sp.Size >= LargeBodySize && sp.Habitat == CreatureHabitat.Land;
+        int headroom = CreatureHeadroom(sp);
+        for (int pass = 0; pass < 2; pass++)
+        {
+            int vertical = pass == 0 ? 1 : SleeperRelocateRadius;
+            for (int r = 1; r <= SleeperRelocateRadius; r++)
+            {
+                foreach (var (dx, dz) in RelocateDirs)
+                {
+                    int x = ox + dx * r, z = oz + dz * r;
+                    if (!TryGroundFeetYAt(x, z, refY, headroom, vertical, out int feet))
+                    {
+                        continue;
+                    }
+
+                    var cand = new Vector3f(x + 0.5f, feet, z + 0.5f);
+                    if (CreatureBodyBlocked(sp, cand) || EntityBlockedByShip(cand, margin)
+                        || (large && !LargeBodyFits(sp, x, feet, z)))
+                    {
+                        continue;
+                    }
+
+                    spot = cand;
+                    return true;
+                }
+            }
+        }
+
+        spot = from;
+        return false;
     }
 
     private const float CreaturePanicRadius = 12f;    // how far a startle (#653) spreads to same-species kin
@@ -908,7 +1070,7 @@ public sealed partial class GameServer
                     c.Position.Y,
                     c.Position.Z + (float)System.Math.Sin(h) * len);
                 var adjusted = AdjustHabitatHeight(sp, cand, vertWave, prof, dt);
-                if (!EntityBlockedByShip(adjusted) && !BlockedByEnergyFence(c.Position, adjusted)
+                if (!EntityBlockedByShip(adjusted, CreatureShipMargin(sp)) && !BlockedByEnergyFence(c.Position, adjusted)
                     && !StepBlockedByTerrain(sp, c.Position, adjusted)
                     && !CreaturePathBlocked(sp, c.Position, adjusted))
                 {
@@ -1063,20 +1225,44 @@ public sealed partial class GameServer
     private int GroundFeetYAt(int x, int z, int refY)
         => TryGroundFeetYAt(x, z, refY, out int feet) ? feet : _generator.SurfaceHeight(_world.Planet, x, z) + 1;
 
-    /// <summary>Like <see cref="GroundFeetYAt"/> but reports whether a REAL standable cell was found, so
-    /// callers that must never snap to the noise surface (settlement NPCs standing on stamped floors that
-    /// the generator knows nothing about) can keep their current Y when the column is unloaded/blocked.</summary>
+    /// <summary>The species-aware feet snap for a creature's own column (#1320): a large body needs its
+    /// whole height of headroom, not the two cells a mouse gets — the plain probe read a two-cell hollow
+    /// under a floor as "standable" for a ten-block titan and held its body inside the floor above. Also
+    /// looks further for REAL ground before trusting the noise surface: the ±6 window fell back to the
+    /// generator's pre-excavation height, which floated a creature over a freshly dug pit.</summary>
+    private int GroundFeetYAt(CreatureSpecies sp, int x, int z, int refY)
+        => TryGroundFeetYAt(x, z, refY, CreatureHeadroom(sp), maxScan: CreatureWideGroundScan, out int feet)
+            ? feet
+            : _generator.SurfaceHeight(_world.Planet, x, z) + 1;
+
+    private const int CreatureGroundScan = 6;      // the legacy ±window every feet probe scans first
+    private const int CreatureWideGroundScan = 24; // ...and how far a creature's own column keeps looking (#1320)
+
+    /// <summary>Cells of headroom a species' feet cell must offer: its collision body for large land species
+    /// (mirrors <see cref="LargeBodyColumnOpen"/>/<see cref="CreatureBodyBlocked"/>), feet + head otherwise.</summary>
+    private static int CreatureHeadroom(CreatureSpecies sp)
+        => sp.Size >= LargeBodySize && sp.Habitat == CreatureHabitat.Land ? CreatureBodyHeight(sp) : CreatureBodyMinHeight;
+
+    /// <summary>Like <see cref="GroundFeetYAt(int, int, int)"/> but reports whether a REAL standable cell was
+    /// found, so callers that must never snap to the noise surface (settlement NPCs standing on stamped floors
+    /// that the generator knows nothing about) can keep their current Y when the column is unloaded/blocked.</summary>
     private bool TryGroundFeetYAt(int x, int z, int refY, out int feetY)
+        => TryGroundFeetYAt(x, z, refY, CreatureBodyMinHeight, CreatureGroundScan, out feetY);
+
+    /// <summary>Scans outward from <paramref name="refY"/> — downward first at equal distance, so a creature
+    /// under a player bridge keeps the ground instead of snapping onto the deck — for a feet cell with
+    /// <paramref name="headroom"/> air cells, up to <paramref name="maxScan"/> cells away.</summary>
+    private bool TryGroundFeetYAt(int x, int z, int refY, int headroom, int maxScan, out int feetY)
     {
-        for (int r = 0; r <= 6; r++)
+        for (int r = 0; r <= maxScan; r++)
         {
-            if (StandableAt(x, refY - r, z))
+            if (StandableAt(x, refY - r, z, headroom))
             {
                 feetY = refY - r;
                 return true;
             }
 
-            if (r > 0 && StandableAt(x, refY + r, z))
+            if (r > 0 && StandableAt(x, refY + r, z, headroom))
             {
                 feetY = refY + r;
                 return true;
@@ -1088,13 +1274,25 @@ public sealed partial class GameServer
     }
 
     /// <summary>Whether feet placed at <paramref name="y"/> stand on something real: solid (non-water)
-    /// support below, air at feet and head height. Uses the no-load block read.</summary>
-    private bool StandableAt(int x, int y, int z)
+    /// support below, air from the feet up through <paramref name="headroom"/> cells. Uses the no-load
+    /// block read.</summary>
+    private bool StandableAt(int x, int y, int z, int headroom = CreatureBodyMinHeight)
     {
         var below = _world.GetBlockIfLoaded(new Vector3i(x, y - 1, z));
-        return !below.IsAir && below.Value != _creatureWaterId
-            && _world.GetBlockIfLoaded(new Vector3i(x, y, z)).IsAir
-            && _world.GetBlockIfLoaded(new Vector3i(x, y + 1, z)).IsAir;
+        if (below.IsAir || below.Value == _creatureWaterId)
+        {
+            return false;
+        }
+
+        for (int dy = 0; dy < headroom; dy++)
+        {
+            if (!_world.GetBlockIfLoaded(new Vector3i(x, y + dy, z)).IsAir)
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private const float GroupCohesionRange = 24f;   // kin within this count toward the group centre (#639)
@@ -1182,24 +1380,40 @@ public sealed partial class GameServer
     {
         foreach (var creature in _creatures)
         {
-            if (!creature.IsCompanion && TryPushOutsideShip(creature.Position, out var outside))
+            if (creature.IsCompanion)
+            {
+                continue;
+            }
+
+            float margin = _speciesById.TryGetValue(creature.SpeciesId, out var sp) ? CreatureShipMargin(sp) : 0f;
+            if (TryPushOutsideShip(creature.Position, out var outside, margin))
             {
                 creature.Position = outside;
             }
         }
     }
 
-    /// <summary>Spawns a wild creature of the first roster species at an exact position, bypassing the spawn
-    /// habitat/ship checks. Test-only — lets a test plant a creature inside a parked ship to prove it is
-    /// evicted. Returns the new creature's id.</summary>
-    public string SpawnCreatureAtForTest(Vector3f at)
+    /// <summary>Spawns a wild creature of the first roster species (or <paramref name="speciesId"/>) at an
+    /// exact position, bypassing the spawn habitat/ship checks. Test-only — lets a test plant a creature
+    /// inside a parked ship to prove it is evicted. Returns the new creature's id.</summary>
+    public string SpawnCreatureAtForTest(Vector3f at, string? speciesId = null)
     {
-        SpawnCreature(_speciesRoster[0], at);
+        SpawnCreature(speciesId is null ? _speciesRoster[0] : _speciesById[speciesId], at);
         return _creatures[^1].Id;
     }
 
     /// <summary>Runs the placement-time eviction sweep directly (no tick) so a test can isolate it.</summary>
     public void EvictWildlifeFromShipsForTest() => EvictWildlifeFromShips();
+
+    /// <summary>The spawner's full reject list for the first roster species at a spot (#1314 seam).</summary>
+    public bool SpawnSpotClearForTest(Vector3f at)
+    {
+        int x = (int)System.Math.Floor(at.X), z = (int)System.Math.Floor(at.Z);
+        return SpawnSpotClear(_speciesRoster[0], at, x, z, _generator.SurfaceHeight(_world.Planet, x, z));
+    }
+
+    /// <summary>The per-species share of this world's live cap for one player on foot (#1325 seam).</summary>
+    public int SpeciesShareForTest() => SpeciesShare(System.Math.Min(WorldCreatureCap(1), CreatureHardCap));
 
     /// <summary>The movement profile for a species id (falls back to a default if somehow unknown).</summary>
     private LocomotionProfile ProfileFor(string speciesId)
@@ -1289,8 +1503,8 @@ public sealed partial class GameServer
                 // drifters) keep the snap — their vertical wave IS the motion; everyone else eases toward the
                 // ground at a capped rate (#652) so slopes read as walking, not stair-step teleports. The
                 // #648 gates bound every legal step to ≤2 blocks of relief, which is what makes easing safe.
-                int feet = GroundFeetYAt((int)System.Math.Floor(p.X), (int)System.Math.Floor(p.Z),
-                    (int)System.Math.Floor(p.Y));
+                int feet = GroundFeetYAt(sp, (int)System.Math.Floor(p.X), (int)System.Math.Floor(p.Z),
+                    (int)System.Math.Floor(p.Y)); // species-aware headroom + wide real-ground scan (#1320)
                 if (prof.VertAmp > 0f)
                 {
                     float pop = System.Math.Max(0f, prof.VertAmp * vertWave);
@@ -1385,8 +1599,12 @@ public sealed partial class GameServer
 
     /// <summary>Removes creatures farther than <see cref="CreatureDespawnRange"/> from every player
     /// (titans keep a wider leash — <see cref="TitanDespawnRange"/> — so the huge silhouette you are
-    /// walking toward doesn't vanish). Returns true if any were removed (caller re-broadcasts).</summary>
-    private bool PruneFarCreatures(List<PlayerSession> targets)
+    /// walking toward doesn't vanish). Then the crowding pass (#1325): a species OVER its share of
+    /// <paramref name="cap"/> (the cap shrank, or a pre-share save) sheds its farthest members that are
+    /// out of sight of every player — beyond <see cref="CreatureCrowdDespawnRange"/>, not provoked — until
+    /// it is back at its share, so the mix can recover while the player stays at their base. Returns true
+    /// if any were removed (caller re-broadcasts).</summary>
+    private bool PruneFarCreatures(List<PlayerSession> targets, int cap)
     {
         float maxSq = CreatureDespawnRange * CreatureDespawnRange;
         float titanSq = TitanDespawnRange * TitanDespawnRange;
@@ -1403,6 +1621,32 @@ public sealed partial class GameServer
             var nearest = NearestPlayerPosition(targets, c.Position);
             return nearest is not { } np || WrapDistSq(np, c.Position) > limitSq;
         });
+
+        int share = SpeciesShare(System.Math.Min(cap, CreatureHardCap));
+        float crowdSq = CreatureCrowdDespawnRange * CreatureCrowdDespawnRange;
+        foreach (var sp in _speciesRoster)
+        {
+            int over = WildCountOf(sp.Id) - share;
+            if (over <= 0)
+            {
+                continue;
+            }
+
+            // Farthest-from-any-player first, out-of-sight members only — the animals in view stay put.
+            var shed = _creatures
+                .Where(c => !c.IsCompanion && c.SpeciesId == sp.Id && c.ProvokeTimer <= 0)
+                .Select(c => (Creature: c, DistSq: NearestPlayerPosition(targets, c.Position) is { } np ? WrapDistSq(np, c.Position) : double.MaxValue))
+                .Where(t => t.DistSq > crowdSq)
+                .OrderByDescending(t => t.DistSq)
+                .Take(over)
+                .ToList();
+            foreach (var (creature, _) in shed)
+            {
+                _creatures.Remove(creature);
+                removed++;
+            }
+        }
+
         return removed > 0;
     }
 

--- a/src/BlocksBeyondTheStars.GameServer/GameServerShipStructure.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerShipStructure.cs
@@ -541,10 +541,14 @@ public sealed partial class GameServer
     /// True if a position is inside (or right against) a parked ship, so creatures and settlement
     /// NPCs can be kept from walking into the player's ship. Uses a small margin around the bounds;
     /// positions above the hull (flying creatures) are allowed to pass over.
+    /// <paramref name="bodyRadius"/> widens the horizontal margin by an entity's own footprint (#1320):
+    /// the server tracks a single point, so a titan whose centre sat 0.6 blocks outside the hull passed
+    /// the plain test while its 2–3-block body filled the cabin.
     /// </summary>
-    private bool EntityBlockedByShip(Vector3f p)
+    private bool EntityBlockedByShip(Vector3f p, float bodyRadius = 0f)
     {
-        const float m = 0.5f;
+        const float vm = 0.5f;
+        float m = vm + bodyRadius;
         foreach (var rec in _worlds.Active.LandedShips.Values)
         {
             if (!rec.Placed)
@@ -555,7 +559,7 @@ public sealed partial class GameServer
             var s = rec.Structure;
             double dx = WorldConstants.WrapDeltaX(p.X - rec.Origin.X, _world.Circumference);
             if (dx >= -m && dx <= s.Width + m
-                && p.Y >= rec.Origin.Y - 1 - m && p.Y <= rec.Origin.Y + s.Height + m
+                && p.Y >= rec.Origin.Y - 1 - vm && p.Y <= rec.Origin.Y + s.Height + vm
                 && p.Z >= rec.Origin.Z - m && p.Z <= rec.Origin.Z + s.Length + m)
             {
                 return true;
@@ -571,12 +575,14 @@ public sealed partial class GameServer
     /// (keeping the original height). Lets an entity that got enclosed — e.g. the ship was parked or grown
     /// over a wandering creature — be pushed back out of the cabin instead of staying stuck inside. Returns
     /// false (and leaves <paramref name="outside"/> = <paramref name="p"/>) when the position is clear of
-    /// every parked ship.
+    /// every parked ship. <paramref name="bodyRadius"/> is the same footprint widening as in
+    /// <see cref="EntityBlockedByShip"/> (#1320), so a large body is pushed until it is clear of the hull.
     /// </summary>
-    private bool TryPushOutsideShip(Vector3f p, out Vector3f outside)
+    private bool TryPushOutsideShip(Vector3f p, out Vector3f outside, float bodyRadius = 0f)
     {
-        const float m = 0.5f;
+        const float vm = 0.5f;
         const float clear = 0.05f; // step a hair past the margin so the result is unambiguously outside
+        float m = vm + bodyRadius;
         foreach (var rec in _worlds.Active.LandedShips.Values)
         {
             if (!rec.Placed)
@@ -588,7 +594,7 @@ public sealed partial class GameServer
             double dx = WorldConstants.WrapDeltaX(p.X - rec.Origin.X, _world.Circumference);
             double dz = p.Z - rec.Origin.Z;
             if (dx < -m || dx > s.Width + m
-                || p.Y < rec.Origin.Y - 1 - m || p.Y > rec.Origin.Y + s.Height + m
+                || p.Y < rec.Origin.Y - 1 - vm || p.Y > rec.Origin.Y + s.Height + vm
                 || dz < -m || dz > s.Length + m)
             {
                 continue; // not inside this ship

--- a/src/BlocksBeyondTheStars.Shared/Definitions/CreatureBehaviour.cs
+++ b/src/BlocksBeyondTheStars.Shared/Definitions/CreatureBehaviour.cs
@@ -162,6 +162,26 @@ public static class CreatureBehaviour
         }
     }
 
+    /// <summary>Whether the spawner's biome-native pass would starve a spot (#1325): fewer than two roster
+    /// species are native to (or agnostic of) <paramref name="biome"/>. With a 9-species roster spread over
+    /// several biomes a region can easily have exactly ONE native, and the native-first pass then turned
+    /// every spawn around a base in that region into the same species — 36 of one kind at a swamp base.
+    /// A starved spot skips straight to the any-species pass so the region still gets variety.</summary>
+    public static bool BiomePassStarved(System.Collections.Generic.IReadOnlyList<CreatureSpecies> roster, int biome)
+    {
+        int eligible = 0;
+        for (int i = 0; i < roster.Count; i++)
+        {
+            int affinity = roster[i].BiomeAffinity;
+            if (affinity < 0 || affinity == biome)
+            {
+                eligible++;
+            }
+        }
+
+        return eligible < 2;
+    }
+
     /// <summary>Blends a heading toward a target heading by fraction <paramref name="t"/> (0..1) along the
     /// SHORT way around the circle (#651 — school/flock alignment). Pure and wrap-safe, so ±π seams never
     /// produce a spin the long way round.</summary>

--- a/tests/BlocksBeyondTheStars.Tests/CreatureBuildRespectTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/CreatureBuildRespectTests.cs
@@ -1,0 +1,484 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using System.Linq;
+using BlocksBeyondTheStars.Networking.Transport;
+using BlocksBeyondTheStars.Persistence;
+using BlocksBeyondTheStars.Shared.Configuration;
+using BlocksBeyondTheStars.Shared.Content;
+using BlocksBeyondTheStars.Shared.Definitions;
+using BlocksBeyondTheStars.Shared.Geometry;
+using Xunit;
+using SvGameServer = BlocksBeyondTheStars.GameServer.GameServer;
+
+namespace BlocksBeyondTheStars.Tests;
+
+/// <summary>
+/// Fauna vs. player builds — Lyxette's third round (2026-08-27/29): a sleeping titan stayed embedded in a
+/// walkway built around it and lay half inside a parked ship (#1320), wildlife spawned inside sealed base
+/// rooms (#1314), and one species filled the whole world cap around a swamp base (#1325).
+/// </summary>
+public sealed class CreatureBuildRespectTests : IDisposable
+{
+    private readonly string _root;
+    private readonly GameContent _content;
+
+    public CreatureBuildRespectTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "bbts_fauna_builds_" + Guid.NewGuid().ToString("N"));
+        _content = ContentLoader.LoadFromDirectory(TestPaths.DataDir());
+    }
+
+    private SvGameServer Started(string name, out SqliteWorldRepository repo, bool ship = false)
+    {
+        repo = new SqliteWorldRepository(new SaveGamePaths(_root, name));
+        var st = new LoopbackServerTransport(new LoopbackLink());
+        var config = new ServerConfig
+        {
+            WorldName = name,
+            Seed = 4242,
+            StartPlanet = "jungle", // "many" fauna → a full species roster
+            AutoSaveIntervalMinutes = 9999,
+            PlaceStarterShip = ship,
+        };
+        var server = new SvGameServer(config, _content, st, repo);
+        server.Start();
+        return server;
+    }
+
+    // ---------------- arena helpers (a stone pad floating above every natural feature) ----------------
+
+    private static int SurfaceTopY(SvGameServer server, int x, int z)
+    {
+        for (int y = 200; y > -200; y--)
+        {
+            if (!server.World.GetBlock(new Vector3i(x, y, z)).IsAir)
+            {
+                return y;
+            }
+        }
+
+        return 0;
+    }
+
+    private static int MaxTopY(SvGameServer server, int cx, int cz, int r)
+    {
+        int max = int.MinValue;
+        for (int dx = -r; dx <= r; dx++)
+        {
+            for (int dz = -r; dz <= r; dz++)
+            {
+                max = System.Math.Max(max, SurfaceTopY(server, cx + dx, cz + dz));
+            }
+        }
+
+        return max;
+    }
+
+    private void Fill(SvGameServer server, int x0, int y0, int z0, int x1, int y1, int z1, string key = "stone")
+    {
+        var id = key == "air" ? BlocksBeyondTheStars.Shared.Primitives.BlockId.Air : _content.GetBlock(key)!.NumericId;
+        for (int x = x0; x <= x1; x++)
+            for (int y = y0; y <= y1; y++)
+                for (int z = z0; z <= z1; z++)
+                {
+                    server.World.SetBlock(new Vector3i(x, y, z), id);
+                }
+    }
+
+    private void BuildPad(SvGameServer server, int cx, int cz, int r, int padY)
+        => Fill(server, cx - r, padY, cz - r, cx + r, padY, cz + r);
+
+    /// <summary>Roster slot <paramref name="slot"/> forced into a known body: a small plain land walker, or a
+    /// size-4 titan (collision body 8 cells, footprint radius 2). Solitary, passive, and — when
+    /// <paramref name="nocturnal"/> — asleep at the noon the tests pin the clock to.</summary>
+    private static CreatureSpecies Force(SvGameServer server, int slot, bool titan, bool nocturnal)
+    {
+        var sp = server.SpeciesRoster[slot];
+        sp.Habitat = CreatureHabitat.Land;
+        sp.Temperament = CreatureTemperament.Passive;
+        sp.Activity = nocturnal ? CreatureActivity.Nocturnal : CreatureActivity.Cathemeral;
+        sp.BodyPlan = titan ? CreatureBodyPlan.Titan : CreatureBodyPlan.Standard;
+        sp.Size = titan ? 4f : 1f;
+        sp.SocialGroupSize = 1;
+        return sp;
+    }
+
+    private static bool ColumnClear(SvGameServer server, Vector3f at, int cells)
+    {
+        int x = (int)System.Math.Floor(at.X), y = (int)System.Math.Floor(at.Y), z = (int)System.Math.Floor(at.Z);
+        for (int dy = 0; dy < cells; dy++)
+        {
+            if (!server.World.GetBlock(new Vector3i(x, y + dy, z)).IsAir)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static void Ticks(SvGameServer server, int n, double dt = 0.2)
+    {
+        for (int i = 0; i < n; i++)
+        {
+            server.TickForTest(dt);
+        }
+    }
+
+    // ---------------- #1325: no monoculture ----------------
+
+    [Fact]
+    public void BiomePass_StarvesWithASingleNative_NotWithTwoOrAnAgnosticSpecies()
+    {
+        var a = new CreatureSpecies { Id = "a", BiomeAffinity = 0 };
+        var b = new CreatureSpecies { Id = "b", BiomeAffinity = 1 };
+        var c = new CreatureSpecies { Id = "c", BiomeAffinity = 1 };
+        var any = new CreatureSpecies { Id = "any", BiomeAffinity = -1 };
+
+        Assert.True(CreatureBehaviour.BiomePassStarved(new[] { a, b, c }, biome: 0), "one native → starved");
+        Assert.False(CreatureBehaviour.BiomePassStarved(new[] { a, b, c }, biome: 1), "two natives → fine");
+        Assert.False(CreatureBehaviour.BiomePassStarved(new[] { a, b, any }, biome: 0), "a native + an agnostic → fine");
+        Assert.True(CreatureBehaviour.BiomePassStarved(new[] { b, c }, biome: 0), "no native at all → starved");
+    }
+
+    [Fact]
+    public void ASpeciesAtItsShare_StopsSpawning_AndOtherSpeciesFillTheCap()
+    {
+        // Lyxette's base: 6 → 12 → 36 animals within days, every one of them the same titan herd species,
+        // because nothing ever bounded one species' slice of the world cap.
+        var server = Started("share", out var repo);
+        using (repo)
+        {
+            var p = server.AddLocalPlayer("Settler");
+            p.State.AboardShip = false;
+            var sp0 = Force(server, 0, titan: false, nocturnal: true);
+            server.SetDayFractionForTest(0.5); // noon: the planted nocturnals sleep in place
+
+            const int cx = 0, cz = 0;
+            int padY = MaxTopY(server, cx, cz, 8) + 8;
+            BuildPad(server, cx, cz, 8, padY);
+            p.State.Position = new Vector3f(cx + 0.5f, padY + 1, cz + 0.5f);
+
+            int share = server.SpeciesShareForTest();
+            Assert.True(share >= 3, $"a herd must always be possible (share {share})");
+            for (int i = 0; i < share; i++)
+            {
+                server.SpawnCreatureAtForTest(new Vector3f(cx - 4 + i % 8 + 0.5f, padY + 1, cz + 2 + i / 8 + 0.5f));
+            }
+
+            for (int i = 0; i < 30; i++)
+            {
+                server.Tick(2.0); // thirty spawn attempts
+            }
+
+            var wild = server.Creatures.Where(c => !c.IsCompanion).ToList();
+            int ofSp0 = wild.Count(c => c.SpeciesId == sp0.Id);
+            Assert.Equal(share, ofSp0);
+            Assert.True(wild.Count > share,
+                $"other species must keep filling the cap once one holds its share (total {wild.Count}, share {share})");
+        }
+    }
+
+    [Fact]
+    public void AHerd_StopsAddingMembersAtTheSpeciesShare()
+    {
+        var server = Started("herdshare", out var repo);
+        using (repo)
+        {
+            var p = server.AddLocalPlayer("Settler");
+            p.State.AboardShip = false;
+            var sp0 = Force(server, 0, titan: false, nocturnal: true);
+            sp0.SocialGroupSize = 5;
+            server.SetDayFractionForTest(0.5);
+
+            const int cx = 0, cz = 0;
+            int padY = MaxTopY(server, cx, cz, 8) + 8;
+            BuildPad(server, cx, cz, 8, padY);
+            p.State.Position = new Vector3f(cx + 0.5f, padY + 1, cz + 0.5f);
+
+            int share = server.SpeciesShareForTest();
+            for (int i = 0; i < share - 1; i++)
+            {
+                server.SpawnCreatureAtForTest(new Vector3f(cx - 4 + i % 8 + 0.5f, padY + 1, cz + 2 + i / 8 + 0.5f));
+            }
+
+            for (int i = 0; i < 40; i++)
+            {
+                server.Tick(2.0);
+                int ofSp0 = server.Creatures.Count(c => !c.IsCompanion && c.SpeciesId == sp0.Id);
+                Assert.True(ofSp0 <= share, $"a herd spawned past the species share ({ofSp0} > {share})");
+            }
+        }
+    }
+
+    [Fact]
+    public void AnOverShareSpecies_ShedsItsOutOfSightMembers_AndKeepsThoseInView()
+    {
+        var server = Started("crowd", out var repo);
+        using (repo)
+        {
+            var p = server.AddLocalPlayer("Settler");
+            p.State.AboardShip = false;
+            var sp0 = Force(server, 0, titan: false, nocturnal: true);
+            server.SetDayFractionForTest(0.5);
+
+            const int cx = 0, cz = 0;
+            int padY = MaxTopY(server, cx, cz, 60) + 8;
+            BuildPad(server, cx, cz, 6, padY);
+            BuildPad(server, cx + 50, cz, 6, padY); // 50 blocks out: out of sight (40), inside the despawn leash (70)
+            p.State.Position = new Vector3f(cx + 0.5f, padY + 1, cz + 0.5f);
+
+            int share = server.SpeciesShareForTest();
+            string nearA = server.SpawnCreatureAtForTest(new Vector3f(cx + 2.5f, padY + 1, cz + 0.5f));
+            string nearB = server.SpawnCreatureAtForTest(new Vector3f(cx - 2.5f, padY + 1, cz + 0.5f));
+            for (int i = 0; i < share + 5; i++)
+            {
+                server.SpawnCreatureAtForTest(new Vector3f(cx + 50 - 4 + i % 8 + 0.5f, padY + 1, cz - 4 + i / 8 + 0.5f));
+            }
+
+            Ticks(server, 3);
+
+            var ofSp0 = server.Creatures.Where(c => !c.IsCompanion && c.SpeciesId == sp0.Id).ToList();
+            Assert.Equal(share, ofSp0.Count);
+            Assert.Contains(ofSp0, c => c.Id == nearA);
+            Assert.Contains(ofSp0, c => c.Id == nearB);
+        }
+    }
+
+    // ---------------- #1314: sealed base rooms ----------------
+
+    [Fact]
+    public void NothingSpawnsInsideASealedBaseRoom_TheSpawnerConsultsTheAirFill()
+    {
+        // The same room geometry as the sealed-room air tests: a stone shell with an energy door facing a
+        // base core; the interior beyond the radius-8 cube breathes only through the sealed-room fill.
+        var server = Started("sealed", out var repo);
+        using (repo)
+        {
+            var p = server.AddLocalPlayer("Builder");
+            p.State.AboardShip = false;
+            Force(server, 0, titan: false, nocturnal: false);
+
+            int oy = MaxTopY(server, 10, 0, 24) + 10; // mid-air, clear of every natural feature
+            int coreX = 1, coreZ = 0;
+            p.State.Position = new Vector3f(coreX - 1, oy, coreZ);
+            p.State.Inventory.Add("base_core", 2, 16);
+            server.PlaceBlock("Builder", coreX, oy, coreZ, "base_core");
+            int baseId = server.BaseSnapshots.Single().Id;
+
+            // Shell x[5..15] y[oy-1..oy+3] z[-3..3], interior hollow, a 1×3 doorway at x=5 facing the core.
+            var stone = _content.GetBlock("stone")!.NumericId;
+            for (int x = 5; x <= 15; x++)
+                for (int y = oy - 1; y <= oy + 3; y++)
+                    for (int z = -3; z <= 3; z++)
+                    {
+                        bool interior = x > 5 && x < 15 && y > oy - 1 && y < oy + 3 && z > -3 && z < 3;
+                        bool doorway = x == 5 && z == 0 && y >= oy && y <= oy + 2;
+                        if (!interior && !doorway)
+                        {
+                            server.World.SetBlock(new Vector3i(x, y, z), stone);
+                        }
+                    }
+
+            p.State.Inventory.Add("door_energy", 2, 16);
+            p.State.Position = new Vector3f(4, oy, 0.5f);
+            server.PlaceBlock("Builder", 5, oy, 0, "door_energy");
+
+            var inside = new Vector3f(13.5f, oy, 0.5f); // beyond the cube — supplied only by the sealed fill
+            for (int i = 0; i < 6; i++)
+            {
+                p.State.Position = inside;
+                server.TickForTest(0.5); // covers the 1.5 s recompute interval
+            }
+
+            Assert.True(server.BaseAirForTest(baseId).Cells > 0, "the room must read as sealed for this test to mean anything");
+
+            Assert.False(server.SpawnSpotClearForTest(inside), "a spawn candidate inside the sealed room must be rejected");
+            Assert.True(server.SpawnSpotClearForTest(new Vector3f(24.5f, oy, 0.5f)), "open air beside the room stays spawnable");
+
+            // Knock a hole in the roof: the pocket leaks, the fill empties, and the spot is spawnable again.
+            server.World.SetBlock(new Vector3i(13, oy + 3, 0), BlocksBeyondTheStars.Shared.Primitives.BlockId.Air);
+            for (int i = 0; i < 6; i++)
+            {
+                p.State.Position = inside;
+                server.TickForTest(0.5);
+            }
+
+            Assert.True(server.SpawnSpotClearForTest(inside), "an unsealed room is ordinary terrain to the spawner");
+        }
+    }
+
+    // ---------------- #1320: sleepers vs walls, floors and hulls ----------------
+
+    [Fact]
+    public void ASleeperWalledIn_WakesAndStepsClear()
+    {
+        var server = Started("walledin", out var repo);
+        using (repo)
+        {
+            var p = server.AddLocalPlayer("Mason");
+            p.State.AboardShip = false;
+            Force(server, 0, titan: false, nocturnal: true);
+            server.SetDayFractionForTest(0.5);
+
+            const int cx = 40, cz = 40;
+            int padY = MaxTopY(server, cx, cz, 10) + 8;
+            BuildPad(server, cx, cz, 8, padY);
+            p.State.Position = new Vector3f(cx + 10, padY + 1, cz); // beyond wake distance, inside the leash
+
+            var planted = new Vector3f(cx + 0.5f, padY + 1, cz + 0.5f);
+            string id = server.SpawnCreatureAtForTest(planted);
+            Ticks(server, 2);
+            var asleep = server.Creatures.Single(c => c.Id == id);
+            Assert.Equal(0.0, asleep.AwakeOverrideTimer);
+            Assert.Equal(planted.X, asleep.Position.X);
+
+            // Build a wall straight through the sleeper (feet + head cells).
+            Fill(server, cx, padY + 1, cz - 3, cx, padY + 2, cz + 3);
+            Ticks(server, 10);
+
+            var live = server.Creatures.Single(c => c.Id == id);
+            Assert.True(live.AwakeOverrideTimer > 0, "a walled-in sleeper must be roused");
+            Assert.True(ColumnClear(server, live.Position, 2),
+                $"its body must be clear of the wall (at {live.Position.X:F1}/{live.Position.Y:F1}/{live.Position.Z:F1})");
+            Assert.True(System.Math.Abs(live.Position.X - planted.X) >= 0.9f || System.Math.Abs(live.Position.Z - planted.Z) >= 0.9f,
+                "it must have stepped aside, not stayed inside the masonry");
+        }
+    }
+
+    [Fact]
+    public void ASleeperBoxedInOnEverySide_Despawns()
+    {
+        var server = Started("boxedin", out var repo);
+        using (repo)
+        {
+            var p = server.AddLocalPlayer("Mason");
+            p.State.AboardShip = false;
+            Force(server, 0, titan: false, nocturnal: true);
+            server.SetDayFractionForTest(0.5);
+
+            // A tiny 5×5 pad: beyond it there is no floor within the vertical relocation scan (the natural
+            // terrain lies 8+ below), so filling the pad's own columns solid boxes the sleeper in completely.
+            const int cx = -40, cz = 40;
+            int padY = MaxTopY(server, cx, cz, 10) + 8;
+            BuildPad(server, cx, cz, 2, padY);
+            p.State.Position = new Vector3f(cx + 12, padY + 1, cz);
+
+            string id = server.SpawnCreatureAtForTest(new Vector3f(cx + 0.5f, padY + 1, cz + 0.5f));
+            Ticks(server, 2);
+
+            Fill(server, cx - 2, padY + 1, cz - 2, cx + 2, padY + 8, cz + 2); // solid stone, 8 high
+            Ticks(server, 40);
+
+            Assert.DoesNotContain(server.Creatures, c => c.Id == id);
+        }
+    }
+
+    [Fact]
+    public void ASleepingTitanUnderAFloorSlab_EndsUpWithItsBodyClear()
+    {
+        // Lyxette's walkway: concrete two blocks above a sleeping titan's feet. The two-cell feet probe
+        // called the hollow "standable" and held the ten-block body inside the floor above.
+        var server = Started("titanslab", out var repo);
+        using (repo)
+        {
+            var p = server.AddLocalPlayer("Mason");
+            p.State.AboardShip = false;
+            Force(server, 0, titan: true, nocturnal: true);
+            server.SetDayFractionForTest(0.5);
+
+            const int cx = -60, cz = -60;
+            int padY = MaxTopY(server, cx, cz, 12) + 8;
+            BuildPad(server, cx, cz, 10, padY);
+            p.State.Position = new Vector3f(cx + 12, padY + 1, cz);
+
+            string id = server.SpawnCreatureAtForTest(new Vector3f(cx + 0.5f, padY + 1, cz + 0.5f));
+            Ticks(server, 2);
+
+            Fill(server, cx - 2, padY + 3, cz - 2, cx + 2, padY + 3, cz + 2); // the slab, two cells over its feet
+            Ticks(server, 40);
+
+            var live = server.Creatures.Single(c => c.Id == id);
+            Assert.True(ColumnClear(server, live.Position, 8),
+                $"the titan's body column must be clear (at {live.Position.X:F1}/{live.Position.Y:F1}/{live.Position.Z:F1}, slab at y={padY + 3})");
+        }
+    }
+
+    [Fact]
+    public void ACreatureWhosePillarIsRemoved_LandsOnTheRealFloor_NotTheNoiseSurface()
+    {
+        // The ±6 feet probe fell back to the generator's surface — the PRE-excavation height — so a
+        // creature over a fresh 8-block drop floated (or, here, fell through the pad to the terrain below).
+        var server = Started("pillar", out var repo);
+        using (repo)
+        {
+            var p = server.AddLocalPlayer("Digger");
+            p.State.AboardShip = false;
+            Force(server, 0, titan: false, nocturnal: true);
+            server.SetDayFractionForTest(0.5);
+
+            const int cx = 80, cz = -80;
+            int padY = MaxTopY(server, cx, cz, 8) + 8;
+            BuildPad(server, cx, cz, 6, padY);
+            Fill(server, cx, padY + 1, cz, cx, padY + 8, cz); // an 8-block pillar
+            p.State.Position = new Vector3f(cx + 6, padY + 1, cz);
+
+            string id = server.SpawnCreatureAtForTest(new Vector3f(cx + 0.5f, padY + 9, cz + 0.5f));
+            Ticks(server, 2);
+            Assert.Equal(padY + 9, server.Creatures.Single(c => c.Id == id).Position.Y, 1);
+
+            Fill(server, cx, padY + 1, cz, cx, padY + 8, cz, "air"); // knock the pillar away
+            Ticks(server, 10);
+
+            var live = server.Creatures.Single(c => c.Id == id);
+            Assert.True(System.Math.Abs(live.Position.Y - (padY + 1)) <= 1.2f,
+                $"it must come to rest on the real pad floor (Y {live.Position.Y:F1}, pad feet {padY + 1})");
+        }
+    }
+
+    [Fact]
+    public void ASleepingTitanBesideTheHull_IsPushedClear_ASmallAnimalIsNot()
+    {
+        // "Elephant im Kühlschrank": a herd asleep with its centres a block outside the hull and its bodies
+        // filling the cabin — the point-in-box guard never saw it.
+        var server = Started("hull", out var repo, ship: true);
+        using (repo)
+        {
+            var p = server.AddLocalPlayer("Host"); // parks the ship
+            var titan = Force(server, 0, titan: true, nocturnal: true);
+            var small = Force(server, 1, titan: false, nocturnal: true);
+            server.SetDayFractionForTest(0.5);
+
+            var (origin, size) = server.LandedShipBoundsForTest("Host");
+            p.State.AboardShip = false;
+            p.State.Position = new Vector3f(origin.X + size.X + 14f, origin.Y, origin.Z + size.Z / 2f);
+
+            // One block outside the -X face, halfway along the hull.
+            var beside = new Vector3f(origin.X - 1f, origin.Y, origin.Z + size.Z / 2f + 0.5f);
+            string big = server.SpawnCreatureAtForTest(beside, titan.Id);
+            string tiny = server.SpawnCreatureAtForTest(new Vector3f(beside.X, beside.Y, beside.Z + 3f), small.Id);
+
+            Ticks(server, 5);
+
+            var t = server.Creatures.Single(c => c.Id == big);
+            float margin = 0.5f + titan.Size * 0.5f;
+            bool bodyInHull = t.Position.X - origin.X >= -margin && t.Position.X - origin.X <= size.X + margin
+                && t.Position.Z - origin.Z >= -margin && t.Position.Z - origin.Z <= size.Z + margin;
+            Assert.False(bodyInHull, $"the titan's body must be pushed clear of the hull (at dx={t.Position.X - origin.X:F2})");
+
+            var s = server.Creatures.Single(c => c.Id == tiny);
+            Assert.Equal(beside.X, s.Position.X, 2); // a small animal a block from the hull is nobody's problem
+        }
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+            if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true);
+        }
+        catch { }
+    }
+}

--- a/tests/BlocksBeyondTheStars.Tests/EnemyMovementTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/EnemyMovementTests.cs
@@ -52,6 +52,10 @@ public sealed class EnemyMovementTests : IDisposable
         config.Rules.FreeSpaceFlight = true;
         config.Rules.SpaceCombat = SpaceCombatMode.PvE; // hostile NPCs only spawn with combat enabled
         config.Rules.SpaceNpcEnemies = AlienActivity.Normal;
+        // Wildlife off: creatures share the entity-id counter with the machines, and a machine's id seeds its
+        // locomotion (the scan-drone's strafe phase in particular) — so any change to the creature spawner
+        // shifted which id the first fiend got and flipped the hunt assertion below (#1325 did exactly that).
+        config.Rules.CreatureAbundance = AlienActivity.Off;
         var server = new SvGameServer(config, _content, st, repo);
         server.Start();
         return server;


### PR DESCRIPTION
Lyxette's reports 5 + 6 ("Kreaturen Spawn", "Elephant im Kühlschrank") and the round-3 base complaint ("they spawn IN my base and stand in the way") — the server-only trio in one PR. The root of the "endless spawns at my base" feeling was never the spawn spot alone.

closes #1320
closes #1314
closes #1325

## What changed

### #1320 — a sleeping titan stays embedded in a wall built around it
- **Sleepers re-validate their body every tick.** The sleeper branch in `MoveCreatures` only ran the feet snap and `continue`d, skipping every collision gate on the movement path — a walkway built through a sleeping herd left the bodies in the masonry all night. `DisplaceEmbeddedSleeper` now runs *before* the feet snap (otherwise the snap hops the animal onto the new wall first): an embedded sleeper is roused (`AwakeOverrideTimer`) and stepped aside to the nearest clear standable spot within 6 blocks — same level first, then any — or, boxed in on every side, removed after the loop. It is 2–8 block reads per sleeper per tick, far below what an awake animal's movement path costs.
- **Feet snap honours body height + looks further for real ground.** `StandableAt` accepted a two-cell hollow under a floor for a ten-block titan and held its body inside the floor above. A creature's own column probe (`GroundFeetYAt(sp, …)`) now demands the species' collision height of headroom for large land species (mirrors `CreatureBodyBlocked`/`LargeBodyColumnOpen`) and scans ±24 cells before falling back to the generator's pre-excavation surface, which floated animals over fresh pits. The plain 3-arg probe (NPCs, the terrain step gate, titan flatness) is unchanged.
- **Body-aware ship guard ("Elephant im Kühlschrank").** `EntityBlockedByShip`/`TryPushOutsideShip` were point-in-box with a 0.5 margin — a titan herd asleep with its centres a block outside the hull filled the cabin. Both take a `bodyRadius` now (`CreatureShipMargin` = `Size × 0.5` for large non-flying species, 0 otherwise) and it is applied at spawn, per step, in `TrySteerAround`, in the per-tick push-out and in `EvictWildlifeFromShips`. The vertical bounds are unchanged, so fliers still cross over.

### #1314 — creatures spawn inside sealed base rooms
- Every placement — the ring leader in `TrySpawnCreatureNear` **and** each herd member in `SpawnGroupAround` — now runs one reject list, `SpawnSpotClear` (habitat, ship volume, body cells, titan flatness, large-body volume), which ends with `InSealedBaseRoom(cell)`: the cached sealed-room air fill, effectively free. The two lists had drifted apart (the herd path checked titan flatness before computing Y, the leader after); a gate added to one would have leaked through the other.
- Walls and materials still change nothing for an open-topped yard — that is #1315 (the outside-in "walled" fill), deliberately separate.

### #1325 — one species fills the world cap around a base
Four rules compounded: a random `BiomeAffinity` per species + a native-first pass left his swamp with exactly one native; titan herds add 2–4 per spawn; nothing capped one species' share; nothing despawns while the player stays at the base. Now:
- **Per-species share of the live cap** (`SpeciesShare`): 40 % of the cap, never below 3 (a herd must stay possible on a sparse world), never below cap ÷ roster (a two-species world must still reach its cap). `TrySpawnCreatureNear` skips a species at its share; `SpawnGroupAround` stops adding members there, exactly as it already does against the world cap.
- **Starved biome pass** (`CreatureBehaviour.BiomePassStarved`): fewer than two eligible species for the spot's biome → skip straight to the any-species pass.
- **Crowding despawn** in `PruneFarCreatures`: a species over its share (the cap shrank, a pre-share save) sheds its farthest members that are out of sight of every player (> 40 blocks) and not provoked, until it is back at the share. Animals in view stay put.
- Rosters and saves untouched — species stay seed-derived; only the selection changes.

## Verification
- New `CreatureBuildRespectTests` (10): biome-pass starvation (pure), share + herd + crowding, sealed-room seam (`SpawnSpotClearForTest`, incl. the roof-hole un-seal), walled-in sleeper steps clear, boxed-in sleeper despawns, titan under a floor slab ends up clear, pillar removal lands on the real floor, titan beside the hull is pushed clear while a small animal is not.
- Fast tier locally (`Category!=Slow`): see the PR checks / last commit.
- `dotnet format --verify-no-changes` clean, build 0 warnings.
- Docs: `WORLD_GENERATION.md` §7 (biome pass, share, reject list, sleepers, feet probe), `USER_MANUAL.md` creatures blurb, `TODO.md` work log. No client change — no Unity build needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
