### PR TITLE
fix(server): touchdown on the real ground over a pad — median raised by player builds; dug-out rescue readable in chat (#1318)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -9643,6 +9643,26 @@ is **pre-approved** (keys in `tools/ai-assets/.env`, run via `uv`).
 
 ---
 
+## ✅ Done (2026-08-29): touchdown on the real ground over a pad, and a rescue you can read (#1318)
+
+Lyxette's "landed and was suddenly underground" (round 3). Server only.
+
+* **Repro first, as the issue asked — the spread hypothesis does not hold.** A 75-seed probe (25 × `varied`,
+  `swamp`, `highland`, no ship) found 0 entombed spawns: pads are nudged flat and levelled to the median at
+  generation, so the generated centre column never sits above the median. What `PadGroundY` ignores is the
+  REAL blocks — it reads `_generator.SurfaceHeight`. Building on a pad is admin-only, and in singleplayer the
+  first player is the world admin: Lyxette paved his landing site (the #1320 walkways), and every landing put
+  the ship — and his spawn, the hull's heal-tank cell — inside his own floor until `TickVoidRescue` dug him out.
+* **`PadSurfaceY`:** the median, raised over the footprint's real blocks (centre + four corners, ≤ 8 cells,
+  `IsBodyBlockingCell`), never lowered (a pit must not sink the hull). Used by `PlaceLandedShip`, both pad spawns
+  (`HandleTravel`, `RelocateToAssignedPad`), the new-player spawn and `SafeSpawnPoint`. Untouched pads keep the
+  exact old height — existing saves unchanged.
+* **Readable rescue:** the HUD toast has no lifetime (the next `LastMessage` overwrites it, and a landing sends
+  several), so the dug-out notice "flashed". It is now also sent as a plain localized chat line.
+* Tests: `PadSpawnTests` (4) — paved pad without/with ship, untouched pad unchanged, rescue in chat.
+
+---
+
 ## ✅ Done (2026-08-29): walled base areas keep the wildlife out (#1315)
 
 Lyxette's "they spawn inside my walls — and the walls are too high for them" (round 3). Server + data.

--- a/src/BlocksBeyondTheStars.GameServer/GameServer.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServer.cs
@@ -829,7 +829,7 @@ public sealed partial class GameServer
         }
 
         var pad = PlayerPad(session); // the pad claimed above (item 38)
-        int surfaceY = PadGroundY(pad.CenterX, pad.CenterZ); // matches the ship placement's median footprint height
+        int surfaceY = PadSurfaceY(pad.CenterX, pad.CenterZ); // the ship placement's height: median, raised over player builds (#1318)
         var spawn = _shipPlaced ? _healTank : new Vector3f(pad.CenterX + 0.5f, surfaceY + 2f, pad.CenterZ + 0.5f);
         session.State.Position = spawn;
         session.AwaitingSpawnAdopt = true; // #865: the client still streams its pre-landing pose for a beat
@@ -3237,7 +3237,7 @@ public sealed partial class GameServer
             spawnZ = pad.CenterZ;
         }
 
-        int surfaceY = PadGroundY(spawnX, spawnZ); // median footprint height — same level the ship stamps at
+        int surfaceY = PadSurfaceY(spawnX, spawnZ); // the level the ship parks at: median, raised over player builds (#1318)
         var spawn = new Vector3f(spawnX + 0.5f, surfaceY + 2f, spawnZ + 0.5f);
         var state = new PlayerState
         {

--- a/src/BlocksBeyondTheStars.GameServer/GameServerShipStructure.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerShipStructure.cs
@@ -51,7 +51,7 @@ public sealed partial class GameServer
         var rec = CurLanded;
 
         var pad = PlayerPad(_current);
-        int y0 = PadGroundY(pad.CenterX, pad.CenterZ);
+        int y0 = PadSurfaceY(pad.CenterX, pad.CenterZ); // median, raised over whatever the player built on the pad (#1318)
 
         var s = BuildShipStructure(playerId);
         if (s.Cells.Count == 0)

--- a/src/BlocksBeyondTheStars.GameServer/GameServerSpace.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerSpace.cs
@@ -169,6 +169,49 @@ public sealed partial class GameServer
     /// whole ship. Used by every ship-placement consumer.</summary>
     private int PadGroundY(int cx, int cz) => PadGroundY(_world.Planet, cx, cz);
 
+    /// <summary>How far above the generated median the touchdown height looks for player-built ground: a
+    /// paved yard or a raised platform over the pad, not a tower beside it.</summary>
+    private const int PadRaiseScan = 8;
+
+    /// <summary>The height a ship parks on and a player touches down at (#1318): the pad's generated median
+    /// (<see cref="PadGroundY(int,int)"/>), RAISED to whatever has been built over the footprint since — the
+    /// real blocks at the centre and the four corner columns, scanned from the median up to
+    /// <see cref="PadRaiseScan"/> cells. Never lowered: a pit dug at the centre must not sink the hull, and the
+    /// median stays the floor the pad was levelled to at generation. Lyxette paved his landing site with
+    /// concrete walkways; the median ignored them, so every landing put the ship — and him — inside his own
+    /// floor until the entombment rescue dug him out a second later.</summary>
+    private int PadSurfaceY(int cx, int cz)
+    {
+        const int r = 4;
+        int median = PadGroundY(cx, cz);
+        int top = median;
+        foreach (var (dx, dz) in new[] { (0, 0), (-r, -r), (r, -r), (-r, r), (r, r) })
+        {
+            for (int dy = PadRaiseScan; dy >= 1; dy--)
+            {
+                if (IsBodyBlockingCell(cx + dx, median + dy, cz + dz))
+                {
+                    top = System.Math.Max(top, median + dy);
+                    break;
+                }
+            }
+        }
+
+        return top;
+    }
+
+    /// <summary>Test seam: a pad's centre column and generated ground height on the active world.</summary>
+    public (int X, int Y, int Z) LandingPadForTest(int index)
+    {
+        if (_landingPads.Count == 0)
+        {
+            BuildLandingPads();
+        }
+
+        var pad = _landingPads[index];
+        return (pad.CenterX, pad.CenterY, pad.CenterZ);
+    }
+
     /// <summary>As <see cref="PadGroundY(int,int)"/> but for an explicit planet (the generator must already be
     /// configured for that body's circumference) — so pads can be computed for any body, loaded or not.</summary>
     private int PadGroundY(PlanetType planet, int cx, int cz)
@@ -526,7 +569,7 @@ public sealed partial class GameServer
         }
 
         var pad = PlayerPad(session);
-        int surfaceY = PadGroundY(pad.CenterX, pad.CenterZ); // matches the ship placement's median footprint height
+        int surfaceY = PadSurfaceY(pad.CenterX, pad.CenterZ); // the ship placement's height: median, raised over player builds (#1318)
         var spawn = _shipPlaced ? _healTank : new Vector3f(pad.CenterX + 0.5f, surfaceY + 2f, pad.CenterZ + 0.5f);
         session.State.Position = spawn;
         if (!session.Spectating)

--- a/src/BlocksBeyondTheStars.GameServer/GameServerSpawnSafety.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerSpawnSafety.cs
@@ -173,7 +173,7 @@ public sealed partial class GameServer
         var pad = FindSessionByPlayerId(playerId) is { } s ? PlayerPad(s)
             : (_landingPads.Count > 0 ? _landingPads[0] : null);
         int px = pad?.CenterX ?? 0, pz = pad?.CenterZ ?? 0;
-        int surfaceY = _generator.SurfaceHeight(_world.Planet, px, pz);
+        int surfaceY = PadSurfaceY(px, pz); // real ground over the pad, never the generated surface alone (#1318)
         return new Vector3f(px + 0.5f, surfaceY + 2f, pz + 0.5f);
     }
 
@@ -260,6 +260,9 @@ public sealed partial class GameServer
                 s.AwaitingSpawnAdopt = true; // #865: the client's stale stream must not drag them back in
                 _log.Warn($"Player '{p.Name}' was sealed inside blocks; moved to {freed}.");
                 Send(s, new RespawnNotice { X = freed.X, Y = freed.Y, Z = freed.Z, Reason = "@srv.misc.dug_out" });
+                // #1318: the HUD toast is overwritten by the next message (a landing sends several), so the
+                // rescue "flashed too briefly to read" — mirror it into the chat scrollback as plain text.
+                Send(s, new ServerMessage { Text = Localize(s.Locale, "srv.misc.dug_out") });
                 SendPlayerState(s);
                 continue;
             }
@@ -274,6 +277,7 @@ public sealed partial class GameServer
             s.AwaitingSpawnAdopt = true; // #865: the client's stale stream must not drag them back down
             _log.Warn($"Player '{p.Name}' fell into the void; recovered to {safe}.");
             Send(s, new RespawnNotice { X = safe.X, Y = safe.Y, Z = safe.Z, Reason = "@srv.misc.fall_recovered" });
+            Send(s, new ServerMessage { Text = Localize(s.Locale, "srv.misc.fall_recovered") }); // readable in chat too (#1318)
             SendPlayerState(s);
         }
     }

--- a/tests/BlocksBeyondTheStars.Tests/ChunkStreamingTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/ChunkStreamingTests.cs
@@ -31,7 +31,10 @@ public sealed class ChunkStreamingTests : IDisposable
         _content = ContentLoader.LoadFromDirectory(TestPaths.DataDir());
     }
 
-    private int ChunksLoadedAfterOneTick(string name, int budget, double timeBudgetMs = 0)
+    /// <summary>Chunks the streamer SENT to a fresh player in exactly one pass. Counts sends, not cache loads:
+    /// the touchdown height reads the pad's real blocks at join (#1318), so the player's own chunk is already
+    /// resident when the first pass runs — a load delta would miss that guaranteed first send.</summary>
+    private int ChunksStreamedAfterOneTick(string name, int budget, double timeBudgetMs = 0)
     {
         var repo = new SqliteWorldRepository(new SaveGamePaths(_root, name));
         var st = new LoopbackServerTransport(new LoopbackLink());
@@ -47,10 +50,10 @@ public sealed class ChunkStreamingTests : IDisposable
         };
         var server = new SvGameServer(config, _content, st, repo);
         server.Start();
-        server.AddLocalPlayer("Streamer");
-        int before = server.World.LoadedChunkCount;
+        var streamer = server.AddLocalPlayer("Streamer");
+        int before = streamer.SentChunks.Count;
         server.TickForTest(0.1); // exactly one streaming pass
-        int delta = server.World.LoadedChunkCount - before;
+        int delta = streamer.SentChunks.Count - before;
         repo.Dispose();
         return delta;
     }
@@ -60,8 +63,8 @@ public sealed class ChunkStreamingTests : IDisposable
     {
         // A bigger per-tick budget sends (and so caches) more new chunks in a single streaming pass — that is the
         // knob that keeps the wider default view from thawing in slowly at the horizon.
-        int small = ChunksLoadedAfterOneTick("budget_small", 4);
-        int large = ChunksLoadedAfterOneTick("budget_large", 20);
+        int small = ChunksStreamedAfterOneTick("budget_small", 4);
+        int large = ChunksStreamedAfterOneTick("budget_large", 20);
 
         Assert.True(small <= 4, $"one tick must not stream more than the budget (got {small} for budget 4)");
         Assert.True(large > small, $"a larger budget should fill faster (large={large}, small={small})");
@@ -74,8 +77,8 @@ public sealed class ChunkStreamingTests : IDisposable
         // singleplayer): a burst of synchronous first-visit generations must not stall the frame. A
         // near-zero budget is spent after the first send, so exactly one guaranteed chunk goes out —
         // while the same count budget without a time budget streams the full per-tick allowance.
-        int unbudgeted = ChunksLoadedAfterOneTick("timebudget_off", 16);
-        int budgeted = ChunksLoadedAfterOneTick("timebudget_on", 16, timeBudgetMs: 0.000001);
+        int unbudgeted = ChunksStreamedAfterOneTick("timebudget_off", 16);
+        int budgeted = ChunksStreamedAfterOneTick("timebudget_on", 16, timeBudgetMs: 0.000001);
 
         Assert.True(budgeted >= 1, "a spent time budget must still stream at least one chunk (no starvation)");
         Assert.True(budgeted < unbudgeted, $"the time budget should cut the pass short (budgeted={budgeted}, unbudgeted={unbudgeted})");

--- a/tests/BlocksBeyondTheStars.Tests/PadSpawnTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/PadSpawnTests.cs
@@ -1,0 +1,161 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using System;
+using System.Linq;
+using BlocksBeyondTheStars.Networking;
+using BlocksBeyondTheStars.Networking.Messages;
+using BlocksBeyondTheStars.Networking.Transport;
+using BlocksBeyondTheStars.Persistence;
+using BlocksBeyondTheStars.Shared.Configuration;
+using BlocksBeyondTheStars.Shared.Content;
+using BlocksBeyondTheStars.Shared.Geometry;
+using Xunit;
+using SvGameServer = BlocksBeyondTheStars.GameServer.GameServer;
+
+namespace BlocksBeyondTheStars.Tests;
+
+/// <summary>
+/// Touchdown height (#1318): a player landed "suddenly underground" and was dug out a second later. A
+/// 75-seed probe found no case where the pad's generated spread entombs anyone — the pads are nudged flat
+/// and levelled to the median at generation. What the median ignores is what the player BUILT over the pad
+/// since (Lyxette paved his landing site): the ship and the spawn now sit on the real ground, never below it,
+/// and the rescue notice — a toast the next message overwrote — also lands in the chat scrollback.
+/// </summary>
+public sealed class PadSpawnTests : IDisposable
+{
+    private readonly string _root;
+    private readonly GameContent _content;
+
+    public PadSpawnTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "bbts_padspawn_" + Guid.NewGuid().ToString("N"));
+        _content = ContentLoader.LoadFromDirectory(TestPaths.DataDir());
+    }
+
+    private sealed class RecordingTransport : IServerTransport
+    {
+        public event Action<int>? ClientConnected;
+        public event Action<int>? ClientDisconnected;
+        public event Action<int, byte[]>? PayloadReceived;
+        public readonly List<object> Sent = new();
+        public void Start(int port) { }
+        public void Send(int connectionId, byte[] payload, DeliveryMode mode) { if (NetCodec.Decode(payload) is { } m) Sent.Add(m); }
+        public void Broadcast(byte[] payload, DeliveryMode mode) { if (NetCodec.Decode(payload) is { } m) Sent.Add(m); }
+        public void Poll() { _ = ClientConnected; _ = ClientDisconnected; _ = PayloadReceived; }
+        public void Stop() { }
+        public void Dispose() { }
+    }
+
+    private SvGameServer Started(out SqliteWorldRepository repo, string world, bool ship, IServerTransport? transport = null)
+    {
+        repo = new SqliteWorldRepository(new SaveGamePaths(_root, world));
+        var config = new ServerConfig
+        {
+            WorldName = world,
+            Seed = 31,
+            StartPlanet = "rocky",
+            AutoSaveIntervalMinutes = 9999,
+            PlaceStarterShip = ship,
+            PlaceSettlements = false,
+            PlaceWrecks = false,
+        };
+        var server = new SvGameServer(config, _content, transport ?? new LoopbackServerTransport(new LoopbackLink()), repo);
+        server.Start();
+        return server;
+    }
+
+    private static bool CellSolid(SvGameServer server, int x, int y, int z) => !server.World.GetBlock(new Vector3i(x, y, z)).IsAir;
+
+    private static bool Entombed(SvGameServer server, Vector3f pos)
+    {
+        int x = (int)Math.Floor(pos.X), y = (int)Math.Floor(pos.Y), z = (int)Math.Floor(pos.Z);
+        return CellSolid(server, x, y, z) && CellSolid(server, x, y + 1, z);
+    }
+
+    [Fact]
+    public void APavedPad_WithoutAShip_SpawnsThePlayerOnTopOfThePaving()
+    {
+        var server = Started(out var repo, "paved", ship: false);
+        using (repo)
+        {
+            var (px, py, pz) = server.LandingPadForTest(0);
+            var concrete = _content.GetBlock("concrete")!.NumericId;
+            for (int y = py + 1; y <= py + 3; y++)
+            {
+                server.World.SetBlock(new Vector3i(px, y, pz), concrete); // three courses over the pad centre
+            }
+
+            var p = server.AddLocalPlayer("Newcomer");
+            var pos = p.State.Position;
+            Assert.False(Entombed(server, pos), $"the spawn must not sit inside the paving (at {pos})");
+            Assert.Equal(py + 3 + 2, (int)Math.Floor(pos.Y)); // the old spawn was median + 2 = inside the concrete
+        }
+    }
+
+    [Fact]
+    public void APavedPad_WithAShip_ParksTheShipOnThePaving_AndThePilotAboveIt()
+    {
+        var server = Started(out var repo, "pavedship", ship: true);
+        using (repo)
+        {
+            var (px, py, pz) = server.LandingPadForTest(0);
+            var concrete = _content.GetBlock("concrete")!.NumericId;
+            for (int dx = -4; dx <= 4; dx++)
+                for (int dz = -4; dz <= 4; dz++)
+                    for (int y = py + 1; y <= py + 2; y++)
+                    {
+                        server.World.SetBlock(new Vector3i(px + dx, y, pz + dz), concrete); // a 9×9 paved yard, two high
+                    }
+
+            var p = server.AddLocalPlayer("Host");
+            var (origin, _) = server.LandedShipBoundsForTest("Host");
+            Assert.Equal(py + 2 + 1, origin.Y); // the hull's first layer sits ON the paving, not inside it
+            Assert.False(Entombed(server, p.State.Position), $"the pilot must not spawn inside the paving (at {p.State.Position})");
+        }
+    }
+
+    [Fact]
+    public void AnUntouchedPad_KeepsTheOldTouchdownHeight()
+    {
+        var server = Started(out var repo, "plain", ship: false);
+        using (repo)
+        {
+            var (_, py, _) = server.LandingPadForTest(0);
+            var p = server.AddLocalPlayer("Newcomer");
+            Assert.Equal(py + 2, (int)Math.Floor(p.State.Position.Y)); // exactly what every existing save expects
+        }
+    }
+
+    [Fact]
+    public void TheDugOutRescue_AlsoLandsInTheChat()
+    {
+        var transport = new RecordingTransport();
+        var server = Started(out var repo, "rescue", ship: false, transport);
+        using (repo)
+        {
+            var p = server.AddLocalPlayer("Buried");
+            p.State.AboardShip = false;
+            var (px, py, pz) = server.LandingPadForTest(0);
+            p.State.Position = new Vector3f(px + 0.5f, py - 6, pz + 0.5f); // sealed in the rock under the pad
+            Assert.True(Entombed(server, p.State.Position));
+
+            server.RunVoidRescueForTest();
+
+            Assert.False(Entombed(server, p.State.Position));
+            Assert.Contains(transport.Sent, m => m is RespawnNotice n && n.Reason == "@srv.misc.dug_out");
+            var chat = transport.Sent.OfType<ServerMessage>().Select(m => m.Text).ToList();
+            Assert.Contains("You were stuck in the rock — dug out.", chat); // plain text → chat scrollback, not just the toast
+        }
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+            if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true);
+        }
+        catch { }
+    }
+}


### PR DESCRIPTION
Lyxette's "landed and was suddenly underground; a message flashed, then I was back on the surface" (round 3). The issue asked for a repro attempt before a fix — here is what it found, and what changed as a result.

closes #1318

## Repro: the spread hypothesis does not hold
A probe over **75 pads** (25 seeds × `varied`, `swamp`, `highland`, no ship) found **0 entombed spawns** — on every seed the spawn sat exactly 2 above the centre column's top. Pads are nudged to a flat footprint (`NudgePadToDryAndFlat`) and **levelled to the median at generation**, so the generated centre column can never sit 3 above the median the way the issue assumed.

What `PadGroundY` *does* ignore is the **real blocks**: it reads `_generator.SurfaceHeight`, never the world. Building on a pad is refused for regular players but allowed for admins — and in singleplayer the first player **is** the world admin. Lyxette paved his landing site with concrete walkways (the same walkways the titan slept under in #1320). Every landing then parked the ship — and his spawn, the ship's heal-tank cell — inside his own floor, and `TickVoidRescue` dug him out a second later. That is the report.

## What changed
- **`PadSurfaceY(cx, cz)`** (`GameServerSpace.cs`): the generated median, **raised** to whatever has been built over the footprint since — the real blocks at the centre and the four corner columns, scanned from the median up to 8 cells (`IsBodyBlockingCell`, so fluids/flora don't count). Never lowered: a pit at the centre must not sink the hull, and the median remains the floor the pad was levelled to. Used by every touchdown consumer: `PlaceLandedShip` (hull origin), `HandleTravel` and `RelocateToAssignedPad` (pad spawn without a ship), the new-player spawn, and `SafeSpawnPoint` (the rescue's own fallback, which read the generated surface too).
- **The rescue is readable (#1318, second half):** the HUD toast has no lifetime — the next `LastMessage` simply overwrites it, and a landing sends several. `TickVoidRescue` now mirrors the dug-out (and fall-recovered) notice into the chat scrollback as plain localized text, in addition to the `RespawnNotice` toast.
- Test seam `LandingPadForTest(index)`.
- `ChunkStreamingTests` helper now counts chunks *sent* to the player rather than the cache-load delta: the touchdown height reads the pad's real blocks at join, so the player's own chunk is already resident when the first streaming pass runs, and a load delta missed that guaranteed first send (the test's stated intent is "streams at least one chunk").

## Verification
- New `PadSpawnTests` (4): a paved pad without a ship spawns the player on top of the paving (the old spawn was inside it); a paved 9×9 yard parks the hull on the paving and the pilot above it; an untouched pad keeps the exact old touchdown height (every existing save unchanged); the dug-out rescue also arrives as a chat line.
- Spawn/travel/teleport/landing-pad/custom-ship suites green locally (73/73); full fast tier: see the PR checks. `dotnet format --verify-no-changes` clean, build 0 warnings. Server only — no Unity build needed.
- `TODO.md` work log updated; the probe findings are recorded there and in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
