### PR TITLE
fix(client): second dev reply reopens the inbox, fluid-aware outline/held drill/ghost, side-effect-free cloud-save peek (#1351 #1353 #1355)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,15 @@ the richer, screenshot-laden versions live there. `(#123)` references the pull r
   the report, that reports stay until we delete them (no automatic expiry) and are not touched by deleting a
   portal account — and that an e-mail to the address on the page gets them removed.
 
+### 🌊 Outline, held drill and placement ghost agree with the click on water and lava (#1353)
+
+- **What you highlight is what you hit.** Since water and lava became aimable, the click stopped at a fluid
+  but the selection box, the held drill and the slab/stair ghost still marched through it: aiming at lava
+  with a mining beam showed no box (or one on the rock behind), a diamond drill held on lava never finished
+  the cell (its second hit went to the rock behind), and a held slab showed no ghost over water. All three
+  now ask for the same fluid-aware target as the click — and the tool check reads the definition of the
+  fluid actually under the crosshair (water and lava separately) instead of assuming lava stands for both.
+
 ### 🤖 The Guardian machines show their circuits (#1337, #1338)
 
 - **Robots, scan-drones, space drones and UFOs are grey circuit-plated armour, not black silhouettes.**
@@ -80,6 +89,10 @@ the richer, screenshot-laden versions live there. `(#123)` references the pull r
   `player_name` is now persisted like a typed one, and the menu prefills its name field from the saved
   world when the settings are empty.
 - **Docs:** README, user manual and the hosted-worlds notes no longer claim browser play is "online only".
+- **The name lookup no longer eats the cloud save (#1355).** On glitch.fun the deep-linked start peeked at
+  the cloud world to adopt its player name, and that peek marked the cloud version as "already synced" —
+  so the boot right behind it fell back to the older local world. The peek is side-effect free now; the
+  boot receives the newer cloud copy again.
 ### 💬 The developers can answer your F1 report inside the game (#1327, #1328, #1329)
 
 - **Every report now has a reply thread.** An answer shows up as a HUD line plus a window with the conversation
@@ -89,6 +102,9 @@ the richer, screenshot-laden versions live there. `(#123)` references the pull r
   in the glitch.fun arcade (where answers follow your Glitch install across releases). Operators get a
   conversation view + reply form on the ReportHost detail page and `POST /api/reports/{id}/replies` for scripts;
   reports sent by older game versions are answerable too (the reply key is derived from the stored player id).
+- **A second answer on the same report shows up too (#1351).** Once you had acknowledged a reply, a later
+  answer or follow-up question on that report stayed hidden until the next world restart; the game now
+  tracks the individual replies it has shown, so every new one opens the window again.
 
 ## [2026.8.22] — 2026-08-26
 

--- a/TODO.md
+++ b/TODO.md
@@ -7,7 +7,7 @@ plans live under [docs/](docs/) (committed); the long-range direction is the str
 keep it current when controls/features change. Last consolidated 2026-06-04.
 
 **Build:** `scripts/build-client.ps1` (Windows) or `scripts/build-client.sh` (Linux) — publishes shared libs + bundled server + Unity player.
-**Test:** `./scripts/run-tests.sh` — currently **2488 server (non-Slow tier) + 419 client passing** (2026-08-29). Locale parity (en/de) is enforced by a test.
+**Test:** `./scripts/run-tests.sh` — currently **2488 server (non-Slow tier) + 448 client passing** (2026-08-29). Locale parity (en/de) is enforced by a test.
 CI runs two tiers: PRs skip the tests marked `[Trait("Category", "Slow")]`; pushes to `main` and the release workflow run the full suite. CI builds/runs
 tests in Release, and a per-test duration guardrail (`scripts/check-test-durations.py`, PRs only) fails the gate when a non-Slow test exceeds 120 s.
 The server suite is sharded across a 6-runner matrix (`scripts/partition-tests.py` + checked-in weights; `Tests passed` is the required fan-in check) — PR gate ~4:30. The weights decay as test classes are added, so
@@ -9693,6 +9693,34 @@ reports and the #1327 reply channel were missing.
 * Docs: REPORT_HOST.md privacy section points at the wording (update it if retention is enabled);
   PLAYER_FEEDBACK.md's open item "confirm the privacy note" is resolved into a keep-in-step note.
   ⚠ Ships with the WorldHost image redeploy.
+---
+
+## ✅ Done (2026-08-29): client audit follow-ups — second reply, fluid targets, cloud-save peek (#1351, #1353, #1355)
+
+Three follow-ups from the 2026-08-29 client audit of #1328, #1310 and #1322. Client only; Unity build required.
+
+* **A second developer reply on the same report is shown (#1351).** `FeedbackUi` remembered shown threads by
+  REPORT id and never cleared the set, so after the player acknowledged answer A, answer B / a follow-up
+  question on the same report stayed hidden until the world rig restarted. The "which polled threads are new"
+  decision now lives in Client.Core (`Feedback/FeedbackReplyTracker`, keyed by developer reply id: a thread is
+  offered again exactly when it carries an unseen id this session has not queued/shown; a poll that repeats
+  already-shown ids while the ack is in flight stays quiet). Test in `FeedbackReplyTests`.
+* **Outline, held drill and placement ghost use the click's fluid-aware target (#1353).** Since #1310 only the
+  click stopped at water/lava. `MiningFx` dropped its private copy of the voxel march (it skipped fluids
+  unconditionally → no box on lava, or a box on the rock behind it) and asks
+  `PlayerController.AimOutlineCell` — the same `AimTarget` the click uses. The hold-to-mine loop
+  (`HandleDrillAudio`) targets through `AimTarget` too, so a diamond drill (two hits on lava) completes on the
+  lava cell instead of tapping the lava and then holding on the rock behind it (parked-ship cells stay
+  click-only). `UpdatePlacementGhost` passes the place gate, so a held slab/stair shows its ghost over water.
+  `HeldToolMinesFluids` became per-fluid flags (`FluidAim` Water/Lava/Both): the tool check reads the
+  definition of the fluid actually entered instead of `lava` standing for both (same data today, but the
+  client no longer assumes it).
+* **The browser name peek no longer consumes the cloud-save version (#1355).** `ResolveBrowserPlayerNameThenStart`
+  peeked at the cloud blob via `GlitchCloudSaves.FetchLatest`, which wrote `SaveMeta(version)`; the boot's
+  own `FetchLatest` then saw `version <= _lastVersion` with a local blob present and started from the OLDER
+  local world although the name had just been adopted from the newer cloud one. `FetchLatest(done, markSeen)`
+  — the peek passes `markSeen: false` and touches neither `_lastVersion` nor the meta file. The version rule
+  itself moved to Client.Core (`CloudSaveVersions.CloudWins`) with a peek-then-boot test (`CloudSaveVersionsTests`).
 
 ---
 

--- a/client/Assets/BlocksBeyondTheStars/Scripts/AppShell.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/AppShell.cs
@@ -267,13 +267,16 @@ namespace BlocksBeyondTheStars.Client
             byte[] blob = BrowserLocalServer.LoadLocalBlob();
             if (GlitchCloudSaves.Enabled)
             {
+                // A peek only: the boot behind this does its own fetch, and it must still see the cloud
+                // version as new — marking it synced here made that boot start from the older local blob
+                // while the name had just been adopted from the newer cloud world (#1355).
                 yield return GlitchCloudSaves.FetchLatest(cloudBlob =>
                 {
                     if (cloudBlob != null)
                     {
                         blob = cloudBlob;
                     }
-                });
+                }, markSeen: false);
             }
 
             string saved = BlocksBeyondTheStars.Persistence.MemoryWorldSnapshotPeek.SolePlayerId(blob);

--- a/client/Assets/BlocksBeyondTheStars/Scripts/FeedbackUi.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/FeedbackUi.cs
@@ -92,7 +92,7 @@ namespace BlocksBeyondTheStars.Client
         private Task<FeedbackReplyResult> _pollTask;
         private Task<FeedbackReplyResult> _answerTask;
         private readonly Queue<FeedbackReplyThread> _inbox = new Queue<FeedbackReplyThread>();
-        private readonly HashSet<string> _inboxIds = new HashSet<string>();
+        private readonly FeedbackReplyTracker _inboxTracker = new FeedbackReplyTracker(); // by reply id (#1351)
         private readonly object _replyOwner = new object(); // its own menu owner — independent of the F1 dialog
 
         // Reply window (built lazily).
@@ -608,9 +608,12 @@ namespace BlocksBeyondTheStars.Client
             FeedbackReplyThread first = null;
             foreach (var thread in result.Threads)
             {
-                if (thread.UnseenIds.Count == 0 || !_inboxIds.Add(thread.ReportId))
+                // Keyed by reply id, not report id (#1351): a second answer or follow-up question on a report
+                // whose first answer was already acknowledged opens the window again instead of waiting for
+                // the next world restart.
+                if (!_inboxTracker.Offer(thread))
                 {
-                    continue; // nothing new, or already queued/shown this session
+                    continue; // nothing new, or every unseen entry was already queued/shown this session
                 }
 
                 _inbox.Enqueue(thread);

--- a/client/Assets/BlocksBeyondTheStars/Scripts/GlitchCloudSaves.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/GlitchCloudSaves.cs
@@ -61,8 +61,12 @@ namespace BlocksBeyondTheStars.Client
 
         /// <summary>Fetches the latest cloud save before the world starts. Reports the cloud blob when
         /// it is NEWER than what this browser last synced (continuing on another device), else null —
-        /// the caller keeps its local blob. Guests are detected here and stay local-only.</summary>
-        public static IEnumerator FetchLatest(Action<byte[]> done)
+        /// the caller keeps its local blob. Guests are detected here and stay local-only.
+        /// <paramref name="markSeen"/> records the delivered version as "synced" (the boot); a caller that
+        /// only PEEKS at the blob (the deep-linked name lookup, #1322) passes false — recording it there
+        /// made the boot's own fetch right behind it judge the cloud copy as already known and start from
+        /// the older local blob (#1355).</summary>
+        public static IEnumerator FetchLatest(Action<byte[]> done, bool markSeen = true)
         {
             _blocked = false;
             _lastVersion = LoadMeta();
@@ -119,7 +123,7 @@ namespace BlocksBeyondTheStars.Client
                 }
 
                 bool localExists = File.Exists(BrowserLocalServer.SaveBlobPath);
-                if (response.version <= _lastVersion && localExists)
+                if (!CloudSaveVersions.CloudWins(response.version, _lastVersion, localExists))
                 {
                     // This browser already has everything the cloud has (it uploaded that version).
                     done?.Invoke(null);
@@ -136,11 +140,15 @@ namespace BlocksBeyondTheStars.Client
                     Debug.LogWarning("[CloudSave] Cloud payload was not valid base64 — keeping the local world.");
                 }
 
-                if (blob != null)
+                if (blob != null && markSeen)
                 {
                     _lastVersion = response.version;
                     SaveMeta(_lastVersion);
                     Debug.Log($"[CloudSave] Continuing from cloud version {response.version} ({blob.Length} B).");
+                }
+                else if (blob != null)
+                {
+                    Debug.Log($"[CloudSave] Peeked at cloud version {response.version} ({blob.Length} B) — not marked as synced.");
                 }
 
                 done?.Invoke(blob);

--- a/client/Assets/BlocksBeyondTheStars/Scripts/MiningFx.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/MiningFx.cs
@@ -16,7 +16,10 @@ namespace BlocksBeyondTheStars.Client
     {
         public GameBootstrap Game;
         public Camera Camera;
-        public float Reach = 6f;
+
+        /// <summary>The local player rig — the outline asks it for the exact cell the next click would target
+        /// (voxel, parked-ship cell or, with the right tool/item held, a water/lava cell) (#1353).</summary>
+        public PlayerController Player;
 
         private GameObject _outline;
         private Material _outlineMat;
@@ -74,58 +77,28 @@ namespace BlocksBeyondTheStars.Client
             }
         }
 
-        /// <summary>Marches the voxel grid (Amanatides &amp; Woo) along the aim ray and returns the first
-        /// targetable cell within <see cref="Reach"/> — mirroring <c>PlayerController.AimTarget</c> so the
-        /// selection box highlights EXACTLY the block the mine/place click would hit (voxel world OR a parked
-        /// ship cell). Reading the world directly instead of <see cref="Physics.Raycast"/> is what kills the
-        /// "black outline flickers in the air" glitch: the old ray could snap the box onto a creature/ship/
-        /// speeder collider hovering in mid-air, linger on a just-mined cell whose collider hadn't re-baked
-        /// yet, or blink off for a frame while a chunk collider was mid-rebuild (the same B32 desync the drill
-        /// already side-steps). The march sees none of that — it only knows the authoritative block data.</summary>
+        /// <summary>The cell the selection box sits on: <see cref="PlayerController.AimOutlineCell"/>, i.e. the
+        /// SAME voxel march the mine/place click uses (voxel world OR a parked ship cell, and since #1353 a
+        /// water/lava cell whenever the held tool can mine it or the held item would be placed into it) —
+        /// so the highlight can never disagree with the accepted target. This used to be a private copy of
+        /// the march that skipped fluids unconditionally: aiming at lava with a mining beam showed no box, or
+        /// the box sat on the rock BEHIND the lava while the click hit the lava. Reading the world directly
+        /// instead of <see cref="Physics.Raycast"/> is what kills the "black outline flickers in the air"
+        /// glitch: a ray could snap the box onto a creature/ship/speeder collider hovering in mid-air, linger
+        /// on a just-mined cell whose collider hadn't re-baked yet, or blink off for a frame while a chunk
+        /// collider was mid-rebuild (the same B32 desync the drill side-steps).</summary>
         private bool AimVoxel(out int bx, out int by, out int bz)
         {
             bx = by = bz = 0;
-            if (Game?.World == null || Camera == null)
+            if (Player == null || !Player.AimOutlineCell(out var cell))
             {
                 return false;
             }
 
-            Vector3 o = Camera.transform.position;
-            Vector3 dir = Camera.transform.forward;
-            int x = Mathf.FloorToInt(o.x), y = Mathf.FloorToInt(o.y), z = Mathf.FloorToInt(o.z);
-
-            int sx = dir.x >= 0 ? 1 : -1, sy = dir.y >= 0 ? 1 : -1, sz = dir.z >= 0 ? 1 : -1;
-            float invx = Mathf.Abs(dir.x) > 1e-6f ? 1f / Mathf.Abs(dir.x) : float.PositiveInfinity;
-            float invy = Mathf.Abs(dir.y) > 1e-6f ? 1f / Mathf.Abs(dir.y) : float.PositiveInfinity;
-            float invz = Mathf.Abs(dir.z) > 1e-6f ? 1f / Mathf.Abs(dir.z) : float.PositiveInfinity;
-            float tMaxX = float.IsInfinity(invx) ? float.PositiveInfinity : (dir.x > 0 ? (x + 1 - o.x) : (o.x - x)) * invx;
-            float tMaxY = float.IsInfinity(invy) ? float.PositiveInfinity : (dir.y > 0 ? (y + 1 - o.y) : (o.y - y)) * invy;
-            float tMaxZ = float.IsInfinity(invz) ? float.PositiveInfinity : (dir.z > 0 ? (z + 1 - o.z) : (o.z - z)) * invz;
-
-            float t = 0f;
-            for (int i = 0; i < 80 && t <= Reach; i++)
-            {
-                var id = Game.World.GetBlock(x, y, z);
-                if ((!id.IsAir && !IsFluid(id)) || !Game.LandedShipBlockAt(x, y, z, out _, out _).IsAir)
-                {
-                    bx = x; by = y; bz = z;
-                    return true;
-                }
-
-                if (tMaxX <= tMaxY && tMaxX <= tMaxZ) { x += sx; t = tMaxX; tMaxX += invx; }
-                else if (tMaxY <= tMaxZ) { y += sy; t = tMaxY; tMaxY += invy; }
-                else { z += sz; t = tMaxZ; tMaxZ += invz; }
-            }
-
-            return false;
-        }
-
-        /// <summary>Water/lava are passed through when aiming (no collider — you swim/sink into them), matching
-        /// the mine/place march so the box never sits on a fluid you cannot target.</summary>
-        private bool IsFluid(BlocksBeyondTheStars.Shared.Primitives.BlockId id)
-        {
-            var key = Game?.Content?.BlockById(id)?.Key;
-            return key is "water" or "lava";
+            bx = cell.x;
+            by = cell.y;
+            bz = cell.z;
+            return true;
         }
 
         private int _crackX, _crackY, _crackZ;

--- a/client/Assets/BlocksBeyondTheStars/Scripts/PlayerController.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/PlayerController.cs
@@ -1118,7 +1118,10 @@ namespace BlocksBeyondTheStars.Client
             // rebuilt, and a raycast against it can miss for a frame — which stalled the WHOLE drill (no tick, no
             // mine, no sparks) until it settled, then everything resumed. That stall was the "mining gets stuck,
             // then a block suddenly mines and the stuck ones work too" bug (B32). The voxel world never stalls.
-            if (!AimBlock(out var hitCell, out _))
+            // Same fluid-aware target as the click (#1353): a tier-3 drill that needs two hits on lava used to
+            // tap the lava cell and then, held, march through it to the rock behind — the lava never broke.
+            // A parked-ship cell is a structure edit, which stays a per-click action (no hold-drilling hulls).
+            if (!AimTarget(out var hitCell, out _, out var aimedShip, HeldToolFluidAim()) || aimedShip != null)
             {
                 return;
             }
@@ -1201,15 +1204,63 @@ namespace BlocksBeyondTheStars.Client
                 && !string.IsNullOrEmpty(Game.Content?.GetItem(held)?.PlacesBlock);
         }
 
-        /// <summary>True if the selected hotbar tool can mine water/lava by the block data (kind + tier — the
-        /// server applies the same rule, so the client never offers a target it would then reject) (#1310).</summary>
-        private bool HeldToolMinesFluids()
+        /// <summary>Which fluid cells the aim ray may stop at (#1310, #1353) — a flag per fluid so the
+        /// decision is taken against the definition of the fluid actually hit, not "lava stands for both".</summary>
+        [System.Flags]
+        private enum FluidAim
+        {
+            None = 0,
+            Water = 1,
+            Lava = 2,
+            Both = Water | Lava,
+        }
+
+        /// <summary>The fluids the selected hotbar tool can mine by the block data (kind + tier — the server
+        /// applies the same rule, so the client never offers a target it would then reject) (#1310). Water and
+        /// lava are checked separately: a tool that reaches one but not the other stops only at that one.</summary>
+        private FluidAim HeldToolFluidAim()
         {
             string held = Game.ItemInSlot(Game.SelectedHotbarSlot);
             var tool = string.IsNullOrEmpty(held) ? null : Game.Content?.GetItem(held)?.Tool;
-            var lava = Game.Content?.GetBlock("lava");
-            return tool != null && lava != null && lava.Mineable
-                && tool.Kind == lava.RequiredTool && tool.Tier >= lava.MinToolTier;
+            if (tool == null)
+            {
+                return FluidAim.None;
+            }
+
+            var aim = FluidAim.None;
+            if (ToolMines(tool, Game.Content.GetBlock("water")))
+            {
+                aim |= FluidAim.Water;
+            }
+
+            if (ToolMines(tool, Game.Content.GetBlock("lava")))
+            {
+                aim |= FluidAim.Lava;
+            }
+
+            return aim;
+        }
+
+        private static bool ToolMines(BlocksBeyondTheStars.Shared.Definitions.ToolProperties tool,
+            BlocksBeyondTheStars.Shared.Definitions.BlockDefinition fluid)
+            => fluid != null && fluid.Mineable && tool.Kind == fluid.RequiredTool && tool.Tier >= fluid.MinToolTier;
+
+        /// <summary>Both fluids when the held item places a block (the block displaces either, #851), else none.</summary>
+        private FluidAim PlaceFluidAim() => HeldItemPlacesBlock() ? FluidAim.Both : FluidAim.None;
+
+        /// <summary>The cell the selection outline belongs on (#1353): the very target the next click would take
+        /// — mine with the held tool (including the fluids it can mine) or place the held block (into a fluid) —
+        /// so <see cref="MiningFx"/> highlights exactly what <see cref="HandleInteract"/> will accept. Parked-ship
+        /// cells count; a menu or missing rig yields no cell.</summary>
+        public bool AimOutlineCell(out Vector3Int cell)
+        {
+            if (Game == null)
+            {
+                cell = default;
+                return false;
+            }
+
+            return AimTarget(out cell, out _, out _, HeldToolFluidAim() | PlaceFluidAim());
         }
 
         /// <summary>True if the selected hotbar item is a handheld scanner (its primary action scans).</summary>
@@ -3173,7 +3224,7 @@ namespace BlocksBeyondTheStars.Client
             // #851) and for a tool that can actually mine a fluid (a tier-3 drill: mining beam, diamond drill);
             // anything else keeps aiming through them, so a basic drill still reaches the rock under a pond.
             if (!AimTarget(out var hitCell, out var placeCell, out var aimedShip,
-                    fluidSurfaces: mine ? HeldToolMinesFluids() : HeldItemPlacesBlock()))
+                    fluidSurfaces: mine ? HeldToolFluidAim() : PlaceFluidAim()))
             {
                 return;
             }
@@ -3276,8 +3327,9 @@ namespace BlocksBeyondTheStars.Client
         /// and the place cell: a placed block displaces the fluid (#851) and a tier-3 drill mines it, which is
         /// what the block data has promised all along. Over an open lava lake the old march found no target at
         /// all. A ray that STARTS inside fluid (the player is swimming) keeps passing through, so building on
-        /// the seabed from under water is unchanged.</summary>
-        private bool AimTarget(out Vector3Int hitCell, out Vector3Int placeCell, out LandedShipModel ship, bool fluidSurfaces = false)
+        /// the seabed from under water is unchanged. The flags say WHICH fluids stop the ray (#1353): a tool
+        /// that mines lava but not water still aims through a pond to the seabed.</summary>
+        private bool AimTarget(out Vector3Int hitCell, out Vector3Int placeCell, out LandedShipModel ship, FluidAim fluidSurfaces = FluidAim.None)
         {
             hitCell = default;
             placeCell = default;
@@ -3305,7 +3357,8 @@ namespace BlocksBeyondTheStars.Client
             for (int i = 0; i < 80 && t <= Reach; i++)
             {
                 var id = Game.World.GetBlock(x, y, z);
-                bool fluid = !id.IsAir && IsFluidBlock(id);
+                var fluidKind = id.IsAir ? FluidAim.None : FluidKindOf(id);
+                bool fluid = fluidKind != FluidAim.None;
                 if (!id.IsAir && !fluid)
                 {
                     hitCell = new Vector3Int(x, y, z);
@@ -3313,7 +3366,7 @@ namespace BlocksBeyondTheStars.Client
                     return true;
                 }
 
-                if (fluid && fluidSurfaces && !prevFluid)
+                if (fluid && (fluidSurfaces & fluidKind) != 0 && !prevFluid)
                 {
                     hitCell = new Vector3Int(x, y, z);
                     placeCell = hitCell; // into the fluid cell itself — the server displaces it (#851)
@@ -3561,7 +3614,9 @@ namespace BlocksBeyondTheStars.Client
                 Game.HoldingRotatableBlock = rotatable;
             }
 
-            if (!rotatable || !AimTarget(out var hitCell, out var placeCell, out var aimedShip) || aimedShip != null
+            // Same fluid-aware target as the place click (#1353): a held slab/stair gets its ghost over water
+            // and lava, where the click sets the block into the fluid cell.
+            if (!rotatable || !AimTarget(out var hitCell, out var placeCell, out var aimedShip, PlaceFluidAim()) || aimedShip != null
                 || !PendingPlacement(held, hitCell, placeCell, out int shape, out int upFace, out int yaw))
             {
                 _placementGhost?.Hide();
@@ -3668,9 +3723,18 @@ namespace BlocksBeyondTheStars.Client
 
         /// <summary>Water/lava are passed through when aiming (they have no collider — you swim/sink into them).</summary>
         private bool IsFluidBlock(BlocksBeyondTheStars.Shared.Primitives.BlockId id)
+            => FluidKindOf(id) != FluidAim.None;
+
+        /// <summary>Which fluid a block id is (one key lookup — the aim march calls this per cell).</summary>
+        private FluidAim FluidKindOf(BlocksBeyondTheStars.Shared.Primitives.BlockId id)
         {
             var key = Game.Content?.BlockById(id)?.Key;
-            return key is "water" or "lava";
+            return key switch
+            {
+                "water" => FluidAim.Water,
+                "lava" => FluidAim.Lava,
+                _ => FluidAim.None,
+            };
         }
 
         private void SendMovement()

--- a/client/Assets/BlocksBeyondTheStars/Scripts/WorldRig.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/WorldRig.cs
@@ -513,7 +513,7 @@ namespace BlocksBeyondTheStars.Client
             var miningFx = root.AddComponent<MiningFx>();
             miningFx.Game = boot;
             miningFx.Camera = cam;
-            miningFx.Reach = pc.Reach;
+            miningFx.Player = pc; // the outline asks the player rig for the very cell a click would take (#1353)
 
             // Flora spawn/regrow cue: a growing sprout marks a harvested cell while its plant regrows.
             var floraGrowthFx = root.AddComponent<FloraGrowthFx>();

--- a/src/BlocksBeyondTheStars.Client.Core/CloudSaveVersions.cs
+++ b/src/BlocksBeyondTheStars.Client.Core/CloudSaveVersions.cs
@@ -1,0 +1,21 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+namespace BlocksBeyondTheStars.Client
+{
+    /// <summary>
+    /// The one rule behind "does the cloud copy replace the local world?" for the glitch.fun cloud save
+    /// (the Unity <c>GlitchCloudSaves</c> applies it; kept Unity-free so it can be tested). A fetch that
+    /// only PEEKS at the cloud blob (the deep-linked name lookup, #1322) must not record the version it
+    /// saw: recording is what tells the next fetch "this browser already has that version", and a peek
+    /// that recorded it made the boot right after it fall back to the older local blob (#1355).
+    /// </summary>
+    public static class CloudSaveVersions
+    {
+        /// <summary>True when the fetched cloud version should be used instead of the local blob: it is
+        /// newer than the last version this browser synced, or there is no local blob at all (fresh
+        /// browser, cleared site data — then even an already-seen version beats an empty world).</summary>
+        public static bool CloudWins(int cloudVersion, int lastSyncedVersion, bool localExists)
+            => cloudVersion > lastSyncedVersion || !localExists;
+    }
+}

--- a/src/BlocksBeyondTheStars.Client.Core/Feedback/FeedbackReplyTracker.cs
+++ b/src/BlocksBeyondTheStars.Client.Core/Feedback/FeedbackReplyTracker.cs
@@ -1,0 +1,41 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using System.Collections.Generic;
+
+namespace BlocksBeyondTheStars.Client.Feedback
+{
+    /// <summary>
+    /// Decides which polled reply threads are NEW to the player this session (#1351). Keyed by developer
+    /// reply id, not by report id: the first version remembered whole reports, so once the player had
+    /// acknowledged answer A, a later answer B (or a follow-up question) on the same report stayed hidden
+    /// until the world rig restarted. A thread is offered again exactly when it carries an unseen developer
+    /// entry this session has not queued or shown yet; a poll that repeats already-shown ids (the ack has
+    /// not landed yet, or the request failed) does not re-open the window.
+    /// </summary>
+    public sealed class FeedbackReplyTracker
+    {
+        private readonly HashSet<long> _shownReplyIds = new HashSet<long>();
+
+        /// <summary>Number of developer entries queued or shown so far this session.</summary>
+        public int ShownCount => _shownReplyIds.Count;
+
+        /// <summary>True when <paramref name="thread"/> has at least one unseen developer entry that was not
+        /// offered before; those ids are then remembered so the same poll result cannot queue the thread twice.</summary>
+        public bool Offer(FeedbackReplyThread? thread)
+        {
+            if (thread == null)
+            {
+                return false;
+            }
+
+            bool fresh = false;
+            foreach (long id in thread.UnseenIds)
+            {
+                fresh |= _shownReplyIds.Add(id);
+            }
+
+            return fresh;
+        }
+    }
+}

--- a/tests/BlocksBeyondTheStars.Client.Tests/CloudSaveVersionsTests.cs
+++ b/tests/BlocksBeyondTheStars.Client.Tests/CloudSaveVersionsTests.cs
@@ -1,0 +1,59 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using BlocksBeyondTheStars.Client;
+using Xunit;
+
+namespace BlocksBeyondTheStars.Client.Tests;
+
+/// <summary>
+/// The cloud-save version rule (#1355): a newer cloud version replaces the local world, an already-synced
+/// one does not — and a fetch that only peeks (the browser name lookup) must leave the synced version
+/// untouched, or the boot right behind it silently starts from the older local blob.
+/// </summary>
+public sealed class CloudSaveVersionsTests
+{
+    [Theory]
+    [InlineData(5, 4, true, true)]    // newer than what we synced → cloud
+    [InlineData(4, 4, true, false)]   // this browser uploaded that very version → local
+    [InlineData(3, 4, true, false)]   // older than what we synced → local
+    [InlineData(4, 4, false, true)]   // no local blob at all → even a seen version beats an empty world
+    [InlineData(0, 0, false, true)]
+    public void CloudWins_OnlyForNewerVersions_OrWithoutALocalBlob(int cloud, int synced, bool localExists, bool expected)
+    {
+        Assert.Equal(expected, CloudSaveVersions.CloudWins(cloud, synced, localExists));
+    }
+
+    /// <summary>Models the two fetches of a deep-linked browser start: the name peek, then the boot.</summary>
+    private static (bool PeekGotCloud, bool BootGotCloud) PeekThenBoot(bool peekRecordsVersion)
+    {
+        const int cloudVersion = 7;
+        int synced = 3; // the last version this browser uploaded; a newer one waits in the cloud
+        const bool localExists = true;
+
+        bool peek = CloudSaveVersions.CloudWins(cloudVersion, synced, localExists);
+        if (peek && peekRecordsVersion)
+        {
+            synced = cloudVersion; // what FetchLatest(markSeen: true) does
+        }
+
+        bool boot = CloudSaveVersions.CloudWins(cloudVersion, synced, localExists);
+        return (peek, boot);
+    }
+
+    [Fact]
+    public void PeekThatRecordsTheVersion_StarvesTheBoot()
+    {
+        var (peek, boot) = PeekThenBoot(peekRecordsVersion: true);
+        Assert.True(peek);
+        Assert.False(boot); // the bug: the name came from the cloud world, the boot got the old local one
+    }
+
+    [Fact]
+    public void SideEffectFreePeek_LeavesTheCloudVersionForTheBoot()
+    {
+        var (peek, boot) = PeekThenBoot(peekRecordsVersion: false);
+        Assert.True(peek);
+        Assert.True(boot);
+    }
+}

--- a/tests/BlocksBeyondTheStars.Client.Tests/FeedbackReplyTests.cs
+++ b/tests/BlocksBeyondTheStars.Client.Tests/FeedbackReplyTests.cs
@@ -282,6 +282,35 @@ public sealed class FeedbackReplyTests : IDisposable
         Assert.Empty(FeedbackReplyClient.ParseThreads("{\"items\":\"nope\"}"));
     }
 
+    // ---------------- Which polled threads are new (#1351) ----------------
+
+    private static FeedbackReplyThread Thread(string reportId, params long[] unseen)
+    {
+        var t = new FeedbackReplyThread { ReportId = reportId, Title = "t" };
+        t.UnseenIds.AddRange(unseen);
+        return t;
+    }
+
+    [Fact]
+    public void Tracker_ShowsASecondReplyOnTheSameReport_AfterTheFirstWasAcknowledged()
+    {
+        var tracker = new FeedbackReplyTracker();
+
+        Assert.False(tracker.Offer(null));
+        Assert.False(tracker.Offer(Thread("r1")));            // nothing unseen → nothing to show
+        Assert.True(tracker.Offer(Thread("r1", 8)));          // reply A → window
+        Assert.False(tracker.Offer(Thread("r1", 8)));         // same poll result again → not twice
+        Assert.False(tracker.Offer(Thread("r1", 8)));         // ack not landed yet, still id 8 only → quiet
+
+        // The player acknowledged A; the developer posts B on the SAME report. The old report-id set
+        // swallowed this until the world rig restarted.
+        Assert.True(tracker.Offer(Thread("r1", 9)));
+        Assert.True(tracker.Offer(Thread("r1", 8, 10)));      // a mix of old and new → the new one counts
+        Assert.False(tracker.Offer(Thread("r1", 8, 9, 10)));  // everything already shown
+        Assert.True(tracker.Offer(Thread("r2", 11)));         // another report is independent
+        Assert.Equal(4, tracker.ShownCount);
+    }
+
     public void Dispose()
     {
         _running = false;


### PR DESCRIPTION
Follow-ups from the 2026-08-29 audit of the day's merges — client work package.

closes #1351
closes #1353
closes #1355

## What changed
- **#1351 — second developer reply on the same report** — `FeedbackUi` no longer remembers *reports* it showed; a new `FeedbackReplyTracker` (Client.Core, Unity-free) remembers **reply ids**, so a second answer or follow-up question on an already-acknowledged report opens the window again instead of waiting for the next world restart.
- **#1353 — fluid-aware aiming everywhere** — the selection outline (`MiningFx`), the hold-to-mine loop and the placement ghost now use the same fluid-aware `AimTarget` as the click. New `FluidAim` flags decide **per fluid** (water / lava) whether the held tool can mine it or the held item would be placed into it. Fixes: no outline / outline on the rock behind the lava; a diamond drill (two hits) never finishing a lava cell; no slab ghost over water. Hold-drilling a parked ship cell stays a per-click action.
- **#1355 — browser name peek vs. cloud save** — `GlitchCloudSaves.FetchLatest(done, markSeen)`: the deep-linked name peek passes `markSeen: false`, so the boot's own fetch still sees the cloud version as new. The rule lives in `CloudSaveVersions.CloudWins` (testable).

## Verification
- `dotnet test tests/BlocksBeyondTheStars.Client.Tests -c Release`: 448 passed, 0 failed
- Clean rebuild `-c Release --no-incremental`: 0 warnings, 0 errors; `dotnet format --verify-no-changes` clean
- Local Unity build: `Build Finished, Result: Success.`, fresh `BlocksBeyondTheStars.Client.dll`, no generated tracked changes
- TODO.md + CHANGELOG (Unreleased) updated

## Playtest
- Mining beam on lava → outline on the lava cell, one hit; diamond drill held on lava → completes; slab ghost over water.
- #1355 only reproduces on glitch.fun with an older local save + newer cloud save.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
