### PR TITLE
fix(server): ship blip after death, terrain-walking base-wall fill, pets at cliffs, floor-first ground probe, loot merge lifetime, view-aware crowding, awake body check, sliding gates (#1346 #1347 #1348 #1349 #1350 #1356 #1357 #1358)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,30 @@ the richer, screenshot-laden versions live there. `(#123)` references the pull r
   now ask for the same fluid-aware target as the click — and the tool check reads the definition of the
   fluid actually under the crosshair (water and lava separately) instead of assuming lava stands for both.
 
+### 🔧 Server audit — the round-3 fixes, sharpened (#1346, #1347, #1348, #1349, #1350, #1356, #1357, #1358)
+
+- **The ship blip survives dying** (#1346): a death in space, inside the ship or on another body respawned you
+  at the heal tank without the HUD ship marker, distance, map marker and thermal blob — the client clears the
+  marker on every world reset since #1308 and the two death-respawn paths never re-sent the placement.
+- **Land animals around a base in a valley again** (#1347): the walled-yard fill read natural terrain as
+  masonry, so no land animal spawned in any hollow within 48 blocks of a founded base. The fill now walks the
+  terrain like an animal does — one block up or down is a step, two is a wall — so only real walls fence.
+- **A sliding gate is a wall even while it stands open for you** (#1358): standing at your yard's sliding door
+  no longer lets the wildlife spawn inside — proximity doors open only for players and close on their own.
+- **Pets wait at a cliff** (#1348): a walker companion under a ledge it cannot jump hopped in place for as long
+  as you stood above; a crawler companion levitated straight up the wall. Both now wait at the base (the leash
+  still brings them along when you walk on); one-block steps are still taken.
+- **Animals fall into a pit dug under them instead of rising through the ceiling** (#1349): the ground probe
+  preferred the nearest floor in either direction, lifting a ground-floor animal onto the storey above.
+- **Fresh creature loot no longer expires with an old bundle** (#1350): a kill next to an almost-expired loot
+  packet merged into it and vanished with it seconds later; the merge now restarts the five-minute clock.
+- **No pop-out at the edge of view** (#1356): the crowding despawn shed animals 40 blocks out — in plain sight
+  at larger view distances — and could remove a hunter mid-charge; it now respects the widest joined
+  player's view distance and never sheds a creature that is hunting.
+- **An awake animal walled in by a block steps out** (#1357): only sleepers re-checked their body cells; a
+  cathemeral grazer built into a wall stood in it for good. Every creature checks every two seconds, and at
+  once when a block is placed into it.
+
 ### 🤖 The Guardian machines show their circuits (#1337, #1338)
 
 - **Robots, scan-drones, space drones and UFOs are grey circuit-plated armour, not black silhouettes.**

--- a/TODO.md
+++ b/TODO.md
@@ -7,7 +7,7 @@ plans live under [docs/](docs/) (committed); the long-range direction is the str
 keep it current when controls/features change. Last consolidated 2026-06-04.
 
 **Build:** `scripts/build-client.ps1` (Windows) or `scripts/build-client.sh` (Linux) — publishes shared libs + bundled server + Unity player.
-**Test:** `./scripts/run-tests.sh` — currently **2488 server (non-Slow tier) + 448 client passing** (2026-08-29). Locale parity (en/de) is enforced by a test.
+**Test:** `./scripts/run-tests.sh` — currently **2545 server (non-Slow tier) + 448 client passing** (2026-08-29). Locale parity (en/de) is enforced by a test.
 CI runs two tiers: PRs skip the tests marked `[Trait("Category", "Slow")]`; pushes to `main` and the release workflow run the full suite. CI builds/runs
 tests in Release, and a per-test duration guardrail (`scripts/check-test-durations.py`, PRs only) fails the gate when a non-Slow test exceeds 120 s.
 The server suite is sharded across a 6-runner matrix (`scripts/partition-tests.py` + checked-in weights; `Tests passed` is the required fan-in check) — PR gate ~4:30. The weights decay as test classes are added, so
@@ -9721,6 +9721,58 @@ Three follow-ups from the 2026-08-29 client audit of #1328, #1310 and #1322. Cli
   local world although the name had just been adopted from the newer cloud one. `FetchLatest(done, markSeen)`
   — the peek passes `markSeen: false` and touches neither `_lastVersion` nor the meta file. The version rule
   itself moved to Client.Core (`CloudSaveVersions.CloudWins`) with a peek-then-boot test (`CloudSaveVersionsTests`).
+---
+
+## ✅ Done (2026-08-29): server audit after the round-3 merges — eight follow-ups (#1346 #1347 #1348 #1349 #1350 #1356 #1357 #1358, branch fix/audit-0829-server)
+
+A code audit of the six round-3 PRs (#1324–#1345) before their release. Server only, no Unity build, no new
+locale keys.
+
+* **Ship blip after a death (#1346, HIGH, regression from #1308).** The client clears its ship marker on every
+  `WorldReset`; `RecoverToShip` and the heal-tank `TryCustomRespawn` sent the reset without a
+  `SendShipPlacement` → no blip, distance, map marker or thermal blob until the next landing. Both paths now
+  send the placement right after the landed-ship list, like the travel/join resets. Tests: two death paths
+  in `LanPlaytestRegressionTests` (ship + home-tank respawn) assert the placement follows the reset.
+* **Walled-base fill walks the terrain (#1347, HIGH).** `ComputeReachableFromOutside` flooded ONE horizontal
+  slice and read natural terrain as masonry: every hollow within a base's 97×97 reach box was "fenced in" —
+  no land spawns in any valley around a base. The fill now steps ±1 like a walker (up onto a supported cell,
+  down through a free one; 2+ is a wall), seeds the boundary at the level AND at every supported cell within
+  ±12, keeps the original same-level pass-through (the boundary is rarely on the yard's level), memoises block
+  reads in a scratch box, budget 60k with fail-open on exhaustion. Same (base, level) cache. Tests: a terraced
+  bowl on REAL jungle terrain — open with a core in it, fenced by a 2-high ring on the plateau, open again
+  with a 1-high edge; the four floating-slab tests keep passing unchanged.
+* **Sliding gates are walls (#1358).** The fill counted a door as wall only while shut; a player standing at
+  their yard's sliding gate held it open (OpenRange 4.5, auto-close) and the fill read a gap. Proximity doors
+  (slide, energy) count as walls in any state — they open only for players and close by themselves; hand
+  doors keep the open/shut rule. Test: sliding gate + player beside it → still fenced.
+* **Pets under a cliff (#1348).** Companions skip the terrain gate, so `PreviewStep` reported a 3–10-block
+  rise as "needs rise": a walker pet was launched every tick (hopping in place), a crawler/giant pet got
+  `BeginClimb` to the cliff top and levitated. `ApplyCreatureStep` now refuses to start a jump/climb for a
+  rise past `StepUpLimit` (1) — for everyone; wild fauna was already gated — and the pet waits at the base
+  (steer-around / re-roll; the leash teleport stays the fallback). Tests: walker + crawler pet below a 3-block
+  cliff (never airborne / never climbing, Y constant), walker still jumps a 1-block ledge to follow.
+* **Ground probe prefers the floor below (#1349).** `TryGroundFeetYAt` took the NEAREST standable cell in
+  ±24, so a pit ≥ 5 deep under a ground-floor animal lifted it through the ceiling onto the storey above.
+  It now scans downward first through everything reachable by falling (stopping at the first supporting
+  block) and looks upward only when nothing below is standable (the entombed recovery). Arena tests: pit →
+  falls into it; no floor at all → still lifted.
+* **Loot merge keeps the freshest timer (#1350).** Creature loot merged into an aging packet inherited its
+  `LifetimeLeft` (10 s left → the new kill vanished with it). Merge sets `Max(existing, LootPacketLifetime)`.
+  Test: 290 s old packet + second kill → full lifetime again, survives the old expiry.
+* **Crowding despawn out of sight, never a hunter (#1356).** The shed distance was a fixed 40 blocks while the
+  view distance goes to 8 chunks (128) — animals popped out 50 m away in plain view — and only
+  `ProvokeTimer <= 0` was excluded. "Out of sight" is now the widest joined player's streaming radius
+  (`(view chunks + 1) × 16`, at least 40), and a creature in `Seek` mode (a live hunt/approach) is never shed.
+  Note: the unconditional far-prune at 70 (titans 110) is untouched — with an 8-chunk view the crowd pass
+  simply never fires and the 70-block leash does the shedding. Tests: 8-chunk view keeps the far herd, 1-chunk
+  view sheds it, a Seek member survives.
+* **Awake creatures leave a wall (#1357).** The embedded-body check ran in the sleeper branch only. It now runs
+  for awake creatures too, every 2 s per creature (`NextBodyCheckAt`) and immediately when a player places a
+  block into a creature's body column (`NudgeCreatureBodyChecks` from `HandlePlace`) — so the sideways
+  step-aside wins over the vertical resolve hopping it onto the wall. Test: paused cathemeral grazer, two stone
+  blocks placed through it → clear and stepped aside within a second.
+* Playtest: hollows/valleys around Lyxette's varied-world base should show land animals again while his walled
+  yard stays quiet; watch pets at cliffs and the 70-block far-prune pop-out on a plain (not in scope here).
 
 ---
 

--- a/src/BlocksBeyondTheStars.GameServer/GameServer.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServer.cs
@@ -2048,6 +2048,7 @@ public sealed partial class GameServer
         SendEnvironment(session);
         SendInventory(session);
         SendLandedShips(session); // the respawn world's parked ship objects
+        SendShipPlacement(session); // #1346: the client clears its ship marker on every WorldReset (#1308) — re-arm the blip
         SendPlanetPois(session);
         SendCreatures(session);
         SendContainers(session);

--- a/src/BlocksBeyondTheStars.GameServer/GameServer.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServer.cs
@@ -4350,6 +4350,7 @@ public sealed partial class GameServer
         }
 
         BroadcastToWorld(new BlockChanged { X = pos.X, Y = pos.Y, Z = pos.Z, Block = blockDef.NumericId.Value, Tint = placeTint, Glow = placeGlow, Shape = placeShape });
+        NudgeCreatureBodyChecks(pos); // #1357: an animal the block landed in steps aside on its next tick
         if (IsFluid(blockDef.NumericId.Value))
         {
             RegisterFluidSource(pos); // placed water/lava starts flowing

--- a/src/BlocksBeyondTheStars.GameServer/GameServerBaseWalls.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerBaseWalls.cs
@@ -3,6 +3,7 @@
 // This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
 using System.Collections.Generic;
 using System.Linq;
+using BlocksBeyondTheStars.Shared.Definitions;
 using BlocksBeyondTheStars.Shared.Geometry;
 using BlocksBeyondTheStars.Shared.World;
 
@@ -18,20 +19,34 @@ namespace BlocksBeyondTheStars.GameServer;
 /// seed every boundary column at the query's feet level, and flood INWARD through cells a walking animal
 /// could pass. Everything inside the box the fill never reaches is <b>enclosed</b> — one fill answers every
 /// yard, courtyard and room at that level, however many there are.</item>
+/// <item>The fill <b>walks</b> (#1347): it steps ±1 block vertically like a walker (<see cref="CreatureMotion.StepUpLimit"/>
+/// = 1) — up onto a supported cell, down through a free one — so a one-block terrain step, a garden edge or
+/// the slope of a hollow is passable and a 2+ block rise is a wall. The first version flooded a single
+/// horizontal slice and read natural terrain as masonry: every hollow within 48 blocks of a base was
+/// "fenced in" and no land animal spawned in it. The query's own level additionally passes through any
+/// non-colliding cell (the original rule, kept): the boundary is 48 blocks out and rarely on the yard's
+/// level, so the fill needs to cross lower ground to get there at all.</item>
 /// <item>Cached per (base, feet level) like <c>_baseAir</c>: the same recompute interval, a bounded budget,
 /// <see cref="ServerWorld.GetBlockIfLoaded"/> so an idle base never drags chunk generation. <b>Fail-open</b>:
 /// an unloaded column reads as air, the fill leaks in, the spawn is allowed — the same direction the air
-/// system fails.</item>
+/// system fails; a fill that runs out of budget answers "open" for everything at that level as well.</item>
 /// <item><b>Closed doors count as walls</b> (a deliberate divergence from the air model, where mechanical
-/// doors leak): a shut wooden gate keeps animals out; an open one is a gap.</item>
+/// doors leak): a shut wooden gate keeps animals out; an open one is a gap. Proximity-operated doors (slide,
+/// energy) count as walls whatever their state (#1358): they open only for a player and close by themselves,
+/// so an animal never passes one — and a player standing at their yard's sliding gate used to hold it open
+/// for the fill.</item>
 /// <item>Fliers spawn above the walls and stay ungated; cave dwellers below them too; hostile machines are
 /// out of scope on purpose — they SHOULD threaten a base, that is what the sentry post is for.</item>
 /// </list>
 /// </summary>
 public sealed partial class GameServer
 {
-    /// <summary>Cells the outside-in fill may visit per level — the whole 97×97 footprint and a little.</summary>
-    private const int WalledFillBudget = 12000;
+    /// <summary>Cells the outside-in fill may visit per level: the level's own 97×97 slice, the walkable
+    /// terrain within the band and a fair amount of cave on top of that.</summary>
+    private const int WalledFillBudget = 60000;
+
+    /// <summary>How far above/below the queried feet level the walking fill follows the terrain (#1347).</summary>
+    private const int WalledFillBand = 12;
 
     /// <summary>Levels cached per base before the stalest are dropped (a hilly base is queried at a few dozen feet levels).</summary>
     private const int WalledLevelsPerBase = 24;
@@ -41,10 +56,16 @@ public sealed partial class GameServer
     {
         public string Body = string.Empty;
         public HashSet<Vector3i> Reachable = new();
+        public bool FailOpen; // the fill ran out of budget — nothing at this level reads as enclosed
         public double ComputedAt = double.NegativeInfinity;
     }
 
     private readonly Dictionary<(int BaseId, int FeetY), WalledLevel> _baseWalls = new();
+
+    /// <summary>Scratch classification of the fill's box (one byte per cell, reused across fills).</summary>
+    private byte[]? _wallScratch;
+
+    private static readonly (int Dx, int Dz)[] WallFillDirs = { (1, 0), (-1, 0), (0, 1), (0, -1) };
 
     /// <summary>True if the cell lies inside a founded base's reach box on this world and the outside-in fill
     /// at that feet level cannot reach it — i.e. walls (or shut doors) close it off from the open terrain.
@@ -63,7 +84,8 @@ public sealed partial class GameServer
                 continue;
             }
 
-            if (!RefreshBaseWalls(b, canonical.Y).Reachable.Contains(canonical))
+            var level = RefreshBaseWalls(b, canonical.Y);
+            if (!level.FailOpen && !level.Reachable.Contains(canonical))
             {
                 return true;
             }
@@ -92,79 +114,171 @@ public sealed partial class GameServer
         {
             level.Body = body;
             level.ComputedAt = _uptime;
-            level.Reachable = ComputeReachableFromOutside(b, feetY);
+            level.Reachable = ComputeReachableFromOutside(b, feetY, out bool failOpen);
+            level.FailOpen = failOpen;
         }
 
         return level;
     }
 
-    /// <summary>The 4-neighbour flood from the reach box's boundary at <paramref name="feetY"/> through
-    /// passable cells. A cell is passable when a walking animal could stand in it: not a colliding block
-    /// (fluids and walk-through props pass, exactly as the creature body gate reads them) and not covered by
-    /// a shut door.</summary>
-    private HashSet<Vector3i> ComputeReachableFromOutside(ServerBase b, int feetY)
+    // Scratch cell classes: bits 0–1 = free (unknown / free / solid), bits 2–3 = carries feet (unknown / yes / no).
+    private const byte WallFreeMask = 0x03, WallFree = 0x01, WallSolid = 0x02;
+    private const byte WallSupportMask = 0x0C, WallSupports = 0x04, WallNoSupport = 0x08;
+
+    /// <summary>
+    /// The walking flood from the reach box's boundary through cells an animal could pass (#1315, #1347):
+    /// a cell is <i>free</i> when it is neither a colliding block nor a fluid (walk-through props pass, as
+    /// the creature body gate reads them) and not covered by a door that counts as wall; the fill may stand in
+    /// a free cell that is <i>supported</i> (a colliding block or a fluid under it — so a pond is crossed on
+    /// its surface rather than read as a moat, and never flooded through its volume; grass, props and tree
+    /// canopies carry no feet, which also keeps the fill out of every tree crown) or that lies on the queried
+    /// level itself (the original horizontal slice). From a
+    /// cell it steps to the four neighbour columns at the same height, one up (onto a supported cell — a
+    /// step, never a levitation) or one down (through a free cell above the landing). Seeds: every boundary
+    /// column's free cells on the level, plus its supported free cells within <see cref="WalledFillBand"/>,
+    /// so the fill can come down a slope from higher ground. The band also bounds the flood, so a deep cave
+    /// system under the base cannot eat the budget.
+    /// </summary>
+    private HashSet<Vector3i> ComputeReachableFromOutside(ServerBase b, int feetY, out bool failOpen)
     {
         int circ = _world.Circumference;
-        var shutDoors = DoorCellsWhere(d => !d.Open);
+        int r = SealedRoomMaxReach;
+        int side = 2 * r + 1;
+        int yMin = System.Math.Max(feetY - WalledFillBand, b.Cell.Y - r);
+        int yMax = System.Math.Min(feetY + WalledFillBand, b.Cell.Y + r);
+        int rows = yMax - yMin + 3; // the band plus the support row under it and the head row above it
+        int cells = side * side * rows;
+        if (_wallScratch is null || _wallScratch.Length < cells)
+        {
+            _wallScratch = new byte[cells];
+        }
+
+        var scratch = _wallScratch;
+        System.Array.Clear(scratch, 0, cells);
+        var wallDoors = DoorCellsWhere(d => !d.Open || !IsHandOperated(d.Kind)); // #1358: proximity doors are walls in any state
         var reachable = new HashSet<Vector3i>();
         var frontier = new Queue<Vector3i>();
-        int r = SealedRoomMaxReach;
+        failOpen = false;
 
-        void Seed(int x, int z)
+        // dx/dz are box-relative (0..side-1); y is absolute and may run one row past the band on each side.
+        Vector3i World(int dx, int y, int dz)
+            => WorldConstants.CanonicalBlock(new Vector3i(b.Cell.X - r + dx, y, b.Cell.Z - r + dz), circ);
+
+        bool Free(int dx, int y, int dz)
         {
-            var c = WorldConstants.CanonicalBlock(new Vector3i(x, feetY, z), circ);
-            if (reachable.Add(c))
+            if (y < yMin - 1 || y > yMax + 1)
             {
-                frontier.Enqueue(c);
+                return false; // outside the band (and its one-row margins) — nothing is walked there
+            }
+
+            int i = ((y - (yMin - 1)) * side + dx) * side + dz;
+            byte v = (byte)(scratch[i] & WallFreeMask);
+            if (v == 0)
+            {
+                var c = World(dx, y, dz);
+                bool free = !wallDoors.Contains(c)
+                    && !IsCollidingBlock(_world.GetBlockIfLoaded(c), fluidsPass: false, foliagePasses: false);
+                v = free ? WallFree : WallSolid;
+                scratch[i] |= v;
+            }
+
+            return v == WallFree;
+        }
+
+        // Whether the cell UNDER (dx, y, dz) carries feet: a colliding block or a fluid — not air, grass, a prop or a canopy.
+        bool Supported(int dx, int y, int dz)
+        {
+            int by = y - 1;
+            if (by < yMin - 1)
+            {
+                return false;
+            }
+
+            int i = ((by - (yMin - 1)) * side + dx) * side + dz;
+            byte v = (byte)(scratch[i] & WallSupportMask);
+            if (v == 0)
+            {
+                bool supports = IsCollidingBlock(_world.GetBlockIfLoaded(World(dx, by, dz)), fluidsPass: false, foliagePasses: true);
+                v = supports ? WallSupports : WallNoSupport;
+                scratch[i] |= v;
+            }
+
+            return v == WallSupports;
+        }
+
+        // Where the fill may stand: a free cell in the band that is on the queried level or has something under it.
+        bool Standable(int dx, int y, int dz)
+            => y >= yMin && y <= yMax && Free(dx, y, dz) && (y == feetY || Supported(dx, y, dz));
+
+        void Visit(int dx, int y, int dz)
+        {
+            if (reachable.Add(World(dx, y, dz)))
+            {
+                frontier.Enqueue(new Vector3i(dx, y, dz)); // box-relative on the queue
             }
         }
 
-        for (int d = -r; d <= r; d++)
+        void Seed(int dx, int dz)
         {
-            Seed(b.Cell.X + d, b.Cell.Z - r);
-            Seed(b.Cell.X + d, b.Cell.Z + r);
-            Seed(b.Cell.X - r, b.Cell.Z + d);
-            Seed(b.Cell.X + r, b.Cell.Z + d);
+            for (int y = yMin; y <= yMax; y++)
+            {
+                if (Standable(dx, y, dz))
+                {
+                    Visit(dx, y, dz);
+                }
+            }
+        }
+
+        for (int d = 0; d < side; d++)
+        {
+            Seed(d, 0);
+            Seed(d, side - 1);
+            Seed(0, d);
+            Seed(side - 1, d);
         }
 
         int budget = WalledFillBudget;
-        while (frontier.Count > 0 && budget-- > 0)
+        while (frontier.Count > 0)
         {
-            var cell = frontier.Dequeue();
-            if (!Passable(cell))
+            if (budget-- <= 0)
             {
-                continue; // a boundary seed inside a wall block stays in the set (harmless: solid cells never host a spawn)
+                failOpen = true; // too much open ground to walk — nothing at this level may read as fenced in
+                break;
             }
 
-            foreach (var n in new[]
+            var cell = frontier.Dequeue();
+            foreach (var (ddx, ddz) in WallFillDirs)
             {
-                new Vector3i(cell.X + 1, feetY, cell.Z), new Vector3i(cell.X - 1, feetY, cell.Z),
-                new Vector3i(cell.X, feetY, cell.Z + 1), new Vector3i(cell.X, feetY, cell.Z - 1),
-            })
-            {
-                var c = WorldConstants.CanonicalBlock(n, circ);
-                if (WrapAbs(c.X - b.Cell.X) > r || System.Math.Abs(c.Z - b.Cell.Z) > r || reachable.Contains(c))
+                int nx = cell.X + ddx, nz = cell.Z + ddz, y = cell.Y;
+                if (nx < 0 || nx >= side || nz < 0 || nz >= side)
                 {
                     continue;
                 }
 
-                if (Passable(c))
+                if (Standable(nx, y, nz))
                 {
-                    reachable.Add(c);
-                    frontier.Enqueue(c);
+                    Visit(nx, y, nz); // a level step
+                }
+
+                if (Standable(nx, y + 1, nz))
+                {
+                    Visit(nx, y + 1, nz); // one step up onto something (a supported cell, or the level slice)
+                }
+
+                if (Free(nx, y, nz) && Standable(nx, y - 1, nz))
+                {
+                    Visit(nx, y - 1, nz); // one step down, through the free cell above the landing
                 }
             }
         }
 
         return reachable;
-
-        bool Passable(Vector3i c)
-            => !shutDoors.Contains(c) && !IsCollidingBlock(_world.GetBlockIfLoaded(c), fluidsPass: true, foliagePasses: false);
     }
 
     /// <summary>Cells covered by the doors that satisfy <paramref name="pick"/> in the active world: the door's
     /// width along its wall axis × the 3-tall doorway column, canonical. The wall fill takes every SHUT door
-    /// (a gate keeps animals out); the air fill keeps its own energy-door map (the curtain seals open or shut).</summary>
+    /// and every proximity-operated one (a gate keeps animals out — #1358); the air fill keeps its own
+    /// energy-door map (the curtain seals open or shut).</summary>
     private HashSet<Vector3i> DoorCellsWhere(System.Func<ServerDoor, bool> pick)
     {
         var cells = new HashSet<Vector3i>();
@@ -204,4 +318,23 @@ public sealed partial class GameServer
 
     /// <summary>Test seam: whether a cell reads as fenced in by a base's walls right now (cache refreshed).</summary>
     public bool InWalledBaseAreaForTest(int x, int y, int z) => InWalledBaseArea(new Vector3i(x, y, z));
+
+    /// <summary>Test seam: the size of the outside-in fill at a cell's level for the first base in reach, and
+    /// whether that fill ran out of budget (an answer of "open" that means nothing).</summary>
+    public (int Reachable, bool FailOpen) WalledFillForTest(int x, int y, int z)
+    {
+        var canonical = WorldConstants.CanonicalBlock(new Vector3i(x, y, z), _world.Circumference);
+        foreach (var b in _bases)
+        {
+            if (b.Planet == _world.LocationId && WrapAbs(canonical.X - b.Cell.X) <= SealedRoomMaxReach
+                && System.Math.Abs(canonical.Y - b.Cell.Y) <= SealedRoomMaxReach
+                && System.Math.Abs(canonical.Z - b.Cell.Z) <= SealedRoomMaxReach)
+            {
+                var level = RefreshBaseWalls(b, canonical.Y);
+                return (level.Reachable.Count, level.FailOpen);
+            }
+        }
+
+        return (0, false);
+    }
 }

--- a/src/BlocksBeyondTheStars.GameServer/GameServerCreatures.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerCreatures.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using BlocksBeyondTheStars.Networking.Messages;
 using BlocksBeyondTheStars.Shared.Definitions;
 using BlocksBeyondTheStars.Shared.Geometry;
+using BlocksBeyondTheStars.Shared.World;
 using BlocksBeyondTheStars.WorldGeneration;
 
 namespace BlocksBeyondTheStars.GameServer;
@@ -49,11 +50,15 @@ public sealed partial class GameServer
     // so a tiny cap still allows a herd, and never below cap/roster so a short roster can still reach the cap.
     private const float SpeciesShareOfCap = 0.4f;
     private const int SpeciesShareMin = 3;
-    private const float CreatureCrowdDespawnRange = 40f;       // an over-share member this far from every player wanders off
+    private const float CreatureCrowdDespawnRange = 40f;       // an over-share member at least this far from every player wanders off (#1356: and past every player's streaming radius)
 
     // #1320: a sleeper whose body ends up inside blocks is roused + moved to the nearest clear spot within
     // this many blocks (same level first) — or despawns when boxed in on every side.
     private const int SleeperRelocateRadius = 6;
+
+    // #1357: an awake creature re-validates its own body cells this often (sleepers do it every tick — they
+    // run nothing else), so one walled in by the player steps out instead of standing in the block for good.
+    private const double AwakeBodyCheckInterval = 2.0;
 
     private CreatureSpecies[] _speciesRoster = System.Array.Empty<CreatureSpecies>();
     private readonly List<PlayerSession> _creatureTargets = new(); // reused per tick (no per-tick LINQ alloc)
@@ -832,18 +837,28 @@ public sealed partial class GameServer
             // falls through to normal temperament-driven behaviour (skittish ones flee, hunters seek, others
             // just wander).
             var motion = EffectiveMotion(creature, sp);
-            if (!SpeciesActive(sp) && creature.AwakeOverrideTimer <= 0)
+            bool asleep = !SpeciesActive(sp) && creature.AwakeOverrideTimer <= 0;
+
+            // #1320: a sleeper skips every collision gate on the movement path, so a player building a wall
+            // or floor THROUGH a sleeping herd left the bodies embedded in the masonry all night. Re-validate
+            // the body BEFORE the vertical resolve (which would otherwise hop it onto the new wall): rouse +
+            // step aside to the nearest clear spot, or despawn when boxed in. A few block reads per sleeper
+            // per tick — far cheaper than the movement path an awake animal runs.
+            // #1357: an AWAKE animal walled in by the player never checked its own cell either — the swept
+            // step check samples only the cells ahead, so every step out of the block read as blocked and a
+            // cathemeral grazer stood inside the masonry for good. Same check, rate-limited per creature.
+            if (asleep || _uptime >= creature.NextBodyCheckAt)
             {
-                // #1320: a sleeper skips every collision gate on the movement path, so a player building a
-                // wall or floor THROUGH a sleeping herd left the bodies embedded in the masonry all night.
-                // Re-validate the body BEFORE the vertical resolve (which would otherwise hop it onto the new
-                // wall): rouse + step aside to the nearest clear spot, or despawn when boxed in. A few block
-                // reads per sleeper per tick — far cheaper than the movement path an awake animal runs.
-                if (DisplaceEmbeddedSleeper(creature, sp))
+                creature.NextBodyCheckAt = _uptime + AwakeBodyCheckInterval;
+                if (DisplaceEmbeddedCreature(creature, sp))
                 {
                     continue;
                 }
+            }
 
+            // Sleepers rest in place during their off-phase — only their vertical state runs (#1331/#1332).
+            if (asleep)
+            {
                 creature.Position = ResolveVertical(creature, sp, motion, creature.Position, 0f, profile, moveDt,
                     asleep: true, MoveMode.Roam, moving: false);
                 continue;
@@ -950,7 +965,15 @@ public sealed partial class GameServer
         if (!hold)
         {
             var cand = PreviewStep(sp, motion, cur, stepped, out bool needsRise, out int riseFeet);
-            if (StepBlocked(c, sp, motion, cur, cand, needsRise, terrainGates))
+
+            // #1348: a ground mover never STARTS a jump or a climb for a rise past its step-up limit. Wild
+            // fauna is already walled by the terrain gate; a companion keeps its freedom from that gate
+            // (water, drops — it must follow its owner down anything) but not from this one — without it a
+            // walker pet under a cliff hopped in place for as long as the owner stood above, and a crawler
+            // pet levitated straight up the wall (BeginClimb to the cliff top). Blocked, it waits at the
+            // base like any animal; the leash teleport remains the fallback.
+            bool riseTooHigh = needsRise && riseFeet - (int)System.Math.Floor(cur.Y) > CreatureMotion.StepUpLimit(motion);
+            if (riseTooHigh || StepBlocked(c, sp, motion, cur, cand, needsRise, terrainGates))
             {
                 // Creatures don't walk into the player's ship — hold position at the hull. Energy fences pen
                 // them in the same way, and terrain gates (#648) reuse the exact same mechanic. Instead of only
@@ -1044,11 +1067,12 @@ public sealed partial class GameServer
         return CreatureMotion.EffectiveClass(sp, c.Vert.InWater);
     }
 
-    /// <summary>The sleeper's body check (#1320). False when the body sits clear of every colliding block.
-    /// Otherwise the creature is roused (<see cref="CreatureWakeSeconds"/>) and stepped to the nearest
-    /// clear standable spot within <see cref="SleeperRelocateRadius"/> — or, boxed in on every side, queued
-    /// for removal (the caller drops it after the loop; the list can't change mid-iteration).</summary>
-    private bool DisplaceEmbeddedSleeper(CombatEntity creature, CreatureSpecies sp)
+    /// <summary>The embedded-body check (#1320 sleepers, #1357 awake creatures too). False when the body sits
+    /// clear of every colliding block. Otherwise the creature is roused (<see cref="CreatureWakeSeconds"/>)
+    /// and stepped to the nearest clear standable spot within <see cref="SleeperRelocateRadius"/> — or, boxed
+    /// in on every side, queued for removal (the caller drops it after the loop; the list can't change
+    /// mid-iteration).</summary>
+    private bool DisplaceEmbeddedCreature(CombatEntity creature, CreatureSpecies sp)
     {
         if (!CreatureBodyBlocked(sp, creature.Position))
         {
@@ -1066,6 +1090,22 @@ public sealed partial class GameServer
         }
 
         return true;
+    }
+
+    /// <summary>A block the player just placed may have landed inside an awake creature's body (#1357): every
+    /// creature whose body column holds the cell re-validates on its next tick instead of waiting out
+    /// <see cref="AwakeBodyCheckInterval"/> — and before the vertical resolve could hop it onto the new block.</summary>
+    private void NudgeCreatureBodyChecks(Vector3i cell)
+    {
+        foreach (var c in _creatures)
+        {
+            int x = (int)System.Math.Floor(c.Position.X), y = (int)System.Math.Floor(c.Position.Y), z = (int)System.Math.Floor(c.Position.Z);
+            if (z == cell.Z && cell.Y >= y && cell.Y < y + CreatureBodyMaxHeight
+                && WorldConstants.WrapDeltaX(x - cell.X, _world.Circumference) == 0)
+            {
+                c.NextBodyCheckAt = 0;
+            }
+        }
     }
 
     private static readonly (int Dx, int Dz)[] RelocateDirs =
@@ -1419,20 +1459,34 @@ public sealed partial class GameServer
     private bool TryGroundFeetYAt(int x, int z, int refY, out int feetY)
         => TryGroundFeetYAt(x, z, refY, CreatureBodyMinHeight, CreatureGroundScan, out feetY);
 
-    /// <summary>Scans outward from <paramref name="refY"/> — downward first at equal distance, so a creature
-    /// under a player bridge keeps the ground instead of snapping onto the deck — for a feet cell with
-    /// <paramref name="headroom"/> air cells, up to <paramref name="maxScan"/> cells away.</summary>
+    /// <summary>The feet cell a body at <paramref name="refY"/> comes to rest on (#1349): first DOWNWARD —
+    /// the reference cell itself, then everything below it that can be reached by falling, i.e. until the
+    /// scan meets the first supporting block — so a creature over a fresh pit finds the pit floor, never the
+    /// storey above it (the old nearest-in-either-direction probe lifted a ground-floor animal through the
+    /// ceiling when a deep pit opened under it). Only when nothing below is standable (entombed, the floor
+    /// removed under a low ceiling) does it look UPWARD for the nearest standable cell — the one recovery a
+    /// creature makes by being lifted. Both directions reach <paramref name="maxScan"/> cells; a feet cell
+    /// needs <paramref name="headroom"/> air cells.</summary>
     private bool TryGroundFeetYAt(int x, int z, int refY, int headroom, int maxScan, out int feetY)
     {
         for (int r = 0; r <= maxScan; r++)
         {
-            if (StandableAt(x, refY - r, z, headroom))
+            int y = refY - r;
+            if (StandableAt(x, y, z, headroom))
             {
-                feetY = refY - r;
+                feetY = y;
                 return true;
             }
 
-            if (r > 0 && StandableAt(x, refY + r, z, headroom))
+            if (IsSupportCell(x, y, z))
+            {
+                break; // a supporting block — nothing deeper can be reached by falling
+            }
+        }
+
+        for (int r = 1; r <= maxScan; r++)
+        {
+            if (StandableAt(x, refY + r, z, headroom))
             {
                 feetY = refY + r;
                 return true;
@@ -1443,13 +1497,20 @@ public sealed partial class GameServer
         return false;
     }
 
+    /// <summary>Whether a cell carries feet: anything but air and water (lava included — a lava dweller's
+    /// column is handled before the probe). No-load read.</summary>
+    private bool IsSupportCell(int x, int y, int z)
+    {
+        var id = _world.GetBlockIfLoaded(new Vector3i(x, y, z));
+        return !id.IsAir && id.Value != _creatureWaterId;
+    }
+
     /// <summary>Whether feet placed at <paramref name="y"/> stand on something real: solid (non-water)
     /// support below, air from the feet up through <paramref name="headroom"/> cells. Uses the no-load
     /// block read.</summary>
     private bool StandableAt(int x, int y, int z, int headroom = CreatureBodyMinHeight)
     {
-        var below = _world.GetBlockIfLoaded(new Vector3i(x, y - 1, z));
-        if (below.IsAir || below.Value == _creatureWaterId)
+        if (!IsSupportCell(x, y - 1, z))
         {
             return false;
         }
@@ -1926,7 +1987,12 @@ public sealed partial class GameServer
         });
 
         int share = SpeciesShare(System.Math.Min(cap, CreatureHardCap));
-        float crowdSq = CreatureCrowdDespawnRange * CreatureCrowdDespawnRange;
+
+        // #1356: "out of sight" is the players' real streaming radius, not a fixed 40 blocks — at the 8-chunk
+        // view distance a herd 50 m out on a plain is in plain view, and a member vanishing there was exactly
+        // the pop-out reported. Whatever the widest view among the players streams stays put.
+        float crowdRange = System.Math.Max(CreatureCrowdDespawnRange, MaxStreamRadiusBlocks(targets));
+        float crowdSq = crowdRange * crowdRange;
         foreach (var sp in _speciesRoster)
         {
             int over = WildCountOf(sp.Id) - share;
@@ -1935,9 +2001,10 @@ public sealed partial class GameServer
                 continue;
             }
 
-            // Farthest-from-any-player first, out-of-sight members only — the animals in view stay put.
+            // Farthest-from-any-player first, out-of-sight members only — the animals in view stay put, and so
+            // does a hunter mid-charge (#1356: a Seek intent is a live hunt/approach, not just a provoked one).
             var shed = _creatures
-                .Where(c => !c.IsCompanion && c.SpeciesId == sp.Id && c.ProvokeTimer <= 0)
+                .Where(c => !c.IsCompanion && c.SpeciesId == sp.Id && c.ProvokeTimer <= 0 && c.Loco.Mode != MoveMode.Seek)
                 .Select(c => (Creature: c, DistSq: NearestPlayerPosition(targets, c.Position) is { } np ? WrapDistSq(np, c.Position) : double.MaxValue))
                 .Where(t => t.DistSq > crowdSq)
                 .OrderByDescending(t => t.DistSq)
@@ -1951,6 +2018,19 @@ public sealed partial class GameServer
         }
 
         return removed > 0;
+    }
+
+    /// <summary>The farthest block any of these players streams (#1356): their widest view radius in chunks,
+    /// plus the player's own chunk, in blocks. Anything inside it may be on screen.</summary>
+    private float MaxStreamRadiusBlocks(List<PlayerSession> targets)
+    {
+        int chunks = 0;
+        foreach (var s in targets)
+        {
+            chunks = System.Math.Max(chunks, EffectiveViewRadius(s));
+        }
+
+        return (chunks + 1) * WorldConstants.ChunkSize;
     }
 
     private Vector3f? NearestPlayerPosition(List<PlayerSession> targets, Vector3f from)

--- a/src/BlocksBeyondTheStars.GameServer/GameServerDropPackets.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerDropPackets.cs
@@ -99,6 +99,13 @@ public sealed partial class GameServer
         foreach (var amount in pending)
         {
             var packet = FindOrCreatePacket(cell, amount.Item, creatureLoot);
+            if (creatureLoot)
+            {
+                // #1350: fresh loot merged into an aging packet used to inherit ITS timer — a kill next to a
+                // 4:50-old bundle vanished with it ten seconds later. The merge restarts the clock instead.
+                packet.LifetimeLeft = System.Math.Max(packet.LifetimeLeft, LootPacketLifetime);
+            }
+
             var stack = packet.Items.FirstOrDefault(s => s.Item == amount.Item);
             if (stack is null)
             {

--- a/src/BlocksBeyondTheStars.GameServer/GameServerHealTanks.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerHealTanks.cs
@@ -285,6 +285,7 @@ public sealed partial class GameServer
         SendEnvironment(session);
         SendInventory(session);
         SendLandedShips(session);
+        SendShipPlacement(session); // #1346: the client clears its ship marker on every WorldReset (#1308) — re-arm the blip
         SendPlanetPois(session);
         SendCreatures(session);
         SendContainers(session);

--- a/src/BlocksBeyondTheStars.GameServer/GameServerSpaceCombat.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerSpaceCombat.cs
@@ -82,6 +82,10 @@ public sealed class CombatEntity
     /// ignore it (they charge instead). Server-only, never persisted.</summary>
     public double PanicTimer { get; set; }
 
+    /// <summary>Server uptime at which this creature next re-validates that its body sits clear of every
+    /// colliding block (#1357; sleepers check every tick regardless). Server-only, never persisted.</summary>
+    public double NextBodyCheckAt { get; set; }
+
     /// <summary>What this entity drops when destroyed.</summary>
     public List<ItemAmount> Loot { get; set; } = new();
 

--- a/src/BlocksBeyondTheStars.GameServer/GameServerTaming.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerTaming.cs
@@ -554,9 +554,11 @@ public sealed partial class GameServer
         // Companions respect energy fences like wild fauna do — a penned companion stays penned even
         // when its owner steps out through the gate membrane (that is the point of the pen). Walls stop them
         // like they stop wild fauna (#855) — a pet used to walk straight through the player's own base.
-        // They keep their freedom from the TERRAIN gate (a pet must be able to follow its owner up and down
-        // anything), but run the same vertical mechanics (#1331): a walker pet jumps the doorstep and falls
-        // off the porch, a flier pet perches beside a resting owner.
+        // They keep their freedom from the TERRAIN gate (a pet must be able to follow its owner down anything
+        // and across water), but run the same vertical mechanics (#1331): a walker pet jumps the doorstep and
+        // falls off the porch, a flier pet perches beside a resting owner — and, like everyone, never starts a
+        // jump or climb for a rise past the one-block step-up limit (#1348): under a cliff it waits at the
+        // base instead of hopping in place or levitating up the wall; the leash above catches up later.
         ApplyCreatureStep(c, sp, EffectiveMotion(c, sp), res.Position, res.VertWave, profile, moveDt,
             res.State.Mode == MoveMode.Seek ? MoveMode.Seek : MoveMode.Roam, res.Moving, terrainGates: false);
     }

--- a/tests/BlocksBeyondTheStars.Tests/BaseWalledYardTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/BaseWalledYardTests.cs
@@ -31,7 +31,7 @@ public sealed class BaseWalledYardTests : IDisposable
         _content = ContentLoader.LoadFromDirectory(TestPaths.DataDir());
     }
 
-    private SvGameServer Started(out SqliteWorldRepository repo, string world)
+    private SvGameServer Started(out SqliteWorldRepository repo, string world, string planet = "jungle")
     {
         repo = new SqliteWorldRepository(new SaveGamePaths(_root, world));
         var st = new LoopbackServerTransport(new LoopbackLink());
@@ -39,7 +39,7 @@ public sealed class BaseWalledYardTests : IDisposable
         {
             WorldName = world,
             Seed = 4242,
-            StartPlanet = "jungle", // a full roster for the spawn-seam checks
+            StartPlanet = planet, // jungle: a full roster for the spawn-seam checks
             AutoSaveIntervalMinutes = 9999,
             PlaceStarterShip = false,
             PlaceSettlements = false,
@@ -206,6 +206,155 @@ public sealed class BaseWalledYardTests : IDisposable
 
             sp.Habitat = CreatureHabitat.Air;
             Assert.True(server.SpawnSpotClearForTest(new Vector3f(Cx + 2.5f, padY + 5, Cz + 0.5f)), "a flier does not care about walls");
+        }
+    }
+
+    // ---------------- #1358: a proximity door is a wall whatever it shows ----------------
+
+    [Fact]
+    public void ASlidingGate_KeepsTheYardClosed_WhileThePlayerStandsAtIt()
+    {
+        var server = Started(out var repo, "slidegate");
+        using (repo)
+        {
+            var (p, padY) = Yard(server);
+            int feet = padY + 1;
+
+            // The same 1-wide gateway as the wooden-door test, filled with a sliding door.
+            server.RemoveBlockForTest(Cx + Ring, padY + 1, Cz);
+            server.RemoveBlockForTest(Cx + Ring, padY + 2, Cz);
+            p.State.Inventory.Add("door_slide", 2, 16);
+            p.State.Position = new Vector3f(Cx + Ring + 1.5f, feet, Cz + 0.5f);
+            server.PlaceBlock("Builder", Cx + Ring, padY + 1, Cz, "door_slide");
+            var door = server.DoorSnapshots.Single(d => d.Kind == "slide");
+
+            // The player stays right at the gate: the proximity tick holds it OPEN…
+            Settle(server);
+            Assert.True(server.DoorSnapshots.Single(d => d.Id == door.Id).Open, "sanity: a player beside a sliding door opens it");
+            // …and it still reads as wall — it opens only for players and closes by itself, no animal passes it.
+            Assert.True(server.InWalledBaseAreaForTest(Cx + 2, feet, Cz), "an open sliding gate is no gap for the wildlife (#1358)");
+        }
+    }
+
+    // ---------------- #1347: real terrain is not masonry ----------------
+
+    /// <summary>A terraced bowl in a terraced plateau, built on REAL generated terrain at the ring's centre:
+    /// Chebyshev ring k from the centre carries its top at H−3 (k ≤ 1, the bowl floor), H−2 (k = 2), H−1
+    /// (k = 3), H (k = 4…7, the plateau), H−1 (k = 8), H−2 (k = 9) and H−3 (k = 10); beyond that the natural
+    /// ground stays. Every ring differs from its neighbours by exactly one block, so a walking animal — and the
+    /// walking fill — can get in and out; each top sits on four blocks of stone (a tree's air pockets below
+    /// don't matter) and everything above it is cleared. H is the highest natural cell within 30 blocks, so
+    /// nothing nearby towers over the plateau. Returns H.</summary>
+    /// <summary>The first of a few fixed candidate centres whose 25×25 surroundings are dry ground (no fluid at
+    /// the top of any sampled column) — the seed's start area at (40, 40) turned out to be open sea.</summary>
+    private (int Cx, int Cz) LandSpot(SvGameServer server)
+    {
+        foreach (var (cx, cz) in new[] { (40, 40), (-120, 80), (200, -160), (-260, -220), (340, 300), (-400, 120) })
+        {
+            bool dry = true;
+            for (int dx = -12; dx <= 12 && dry; dx += 2)
+                for (int dz = -12; dz <= 12 && dry; dz += 2)
+                {
+                    int top = SurfaceTopY(server, cx + dx, cz + dz);
+                    var key = _content.BlockById(server.World.GetBlock(new Vector3i(cx + dx, top, cz + dz)))?.Key;
+                    dry = key is not ("water" or "lava");
+                }
+
+            if (dry)
+            {
+                return (cx, cz);
+            }
+        }
+
+        throw new InvalidOperationException("no dry 25×25 spot among the candidates — pick another seed/planet");
+    }
+
+    private int TerracedBowl(SvGameServer server, int cx, int cz)
+    {
+        var stone = _content.GetBlock("stone")!.NumericId;
+        int h = MaxTopY(server, cx, cz, 30);
+        for (int dx = -10; dx <= 10; dx++)
+            for (int dz = -10; dz <= 10; dz++)
+            {
+                int k = System.Math.Max(System.Math.Abs(dx), System.Math.Abs(dz));
+                int top = k switch
+                {
+                    <= 1 => h - 3,
+                    2 => h - 2,
+                    3 => h - 1,
+                    <= 7 => h,
+                    8 => h - 1,
+                    9 => h - 2,
+                    _ => h - 3,
+                };
+                for (int y = top - 4; y <= top; y++)
+                {
+                    server.World.SetBlock(new Vector3i(cx + dx, y, cz + dz), stone);
+                }
+
+                for (int y = top + 1; y <= h + 8; y++)
+                {
+                    server.World.SetBlock(new Vector3i(cx + dx, y, cz + dz), BlockId.Air);
+                }
+            }
+
+        return h;
+    }
+
+    [Fact]
+    public void ABaseInAHollow_LeavesTheHollowOpen_UntilARealWallRingsIt()
+    {
+        // The first fill flooded ONE horizontal slice and treated natural terrain as a wall: a spawn candidate
+        // on the floor of any hollow within a base's reach had a closed solid contour at its own level and read
+        // as "fenced in" — no land animal around a base built in a valley.
+        var server = Started(out var repo, "hollow", planet: "desert"); // dry land, gentle relief
+        using (repo)
+        {
+            var (cx, cz) = LandSpot(server);
+            int h = TerracedBowl(server, cx, cz);
+            int floorFeet = h - 2; // the bowl floor's feet cell (floor top at h − 3)
+
+            var p = server.AddLocalPlayer("Builder");
+            p.State.AboardShip = false;
+            p.State.Position = new Vector3f(cx - 1.5f, floorFeet, cz + 0.5f);
+            p.State.Inventory.Add("base_core", 2, 16);
+            server.PlaceBlock("Builder", cx, floorFeet, cz, "base_core"); // founded on the bowl floor
+            Assert.Single(server.BaseSnapshots);
+
+            Assert.False(server.InWalledBaseAreaForTest(cx + 1, floorFeet, cz), "a terraced hollow is open ground, not a yard (#1347)");
+            var (reachable, failOpen) = server.WalledFillForTest(cx + 1, floorFeet, cz);
+            Assert.False(failOpen, $"the fill must not run out of budget on real jungle terrain ({reachable} cells)");
+            Assert.False(server.InWalledBaseAreaForTest(cx + 5, h + 1, cz), "the plateau above it is open too");
+            Assert.False(server.InWalledBaseAreaForTest(cx, h, cz + 2), "a one-block terrain step is no wall");
+
+            // A 2-high stone ring on the plateau (k = 6, flat ground on both sides) encloses the bowl…
+            var stone = _content.GetBlock("stone")!.NumericId;
+            for (int dx = -6; dx <= 6; dx++)
+                for (int dz = -6; dz <= 6; dz++)
+                {
+                    if (System.Math.Abs(dx) == 6 || System.Math.Abs(dz) == 6)
+                    {
+                        server.World.SetBlock(new Vector3i(cx + dx, h + 1, cz + dz), stone);
+                        server.World.SetBlock(new Vector3i(cx + dx, h + 2, cz + dz), stone);
+                    }
+                }
+
+            Settle(server);
+            Assert.True(server.InWalledBaseAreaForTest(cx + 1, floorFeet, cz), "a 2-high wall ring on real ground fences the hollow in");
+            Assert.False(server.InWalledBaseAreaForTest(cx + 9, h - 1, cz), "outside the ring the terraces stay open");
+
+            // …while the same ring one block high is a garden edge the animals step over.
+            for (int dx = -6; dx <= 6; dx++)
+                for (int dz = -6; dz <= 6; dz++)
+                {
+                    if (System.Math.Abs(dx) == 6 || System.Math.Abs(dz) == 6)
+                    {
+                        server.World.SetBlock(new Vector3i(cx + dx, h + 2, cz + dz), BlockId.Air);
+                    }
+                }
+
+            Settle(server);
+            Assert.False(server.InWalledBaseAreaForTest(cx + 1, floorFeet, cz), "a one-block raised edge is no fence");
         }
     }
 

--- a/tests/BlocksBeyondTheStars.Tests/CreatureBuildRespectTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/CreatureBuildRespectTests.cs
@@ -212,37 +212,92 @@ public sealed class CreatureBuildRespectTests : IDisposable
         }
     }
 
+    /// <summary>The crowding arena (#1325/#1356): two sleeping animals beside the player and share + 5 more on a
+    /// pad 50 blocks out — inside the 70-block despawn leash, beyond the 40-block crowd range, and in or out
+    /// of the player's view depending on <paramref name="viewChunks"/>. Returns the near pair and the far ids.</summary>
+    private (string NearA, string NearB, List<string> Far, string SpeciesId) CrowdedArena(SvGameServer server, int viewChunks)
+    {
+        var p = server.AddLocalPlayer("Settler");
+        p.State.AboardShip = false;
+        p.ViewDistance = viewChunks; // the streaming radius the "out of sight" rule keys on (#1356)
+        var sp0 = Force(server, 0, titan: false, nocturnal: true);
+        server.SetDayFractionForTest(0.5);
+
+        const int cx = 0, cz = 0;
+        int padY = MaxTopY(server, cx, cz, 60) + 8;
+        BuildPad(server, cx, cz, 6, padY);
+        BuildPad(server, cx + 50, cz, 6, padY);
+        p.State.Position = new Vector3f(cx + 0.5f, padY + 1, cz + 0.5f);
+
+        int share = server.SpeciesShareForTest();
+        string nearA = server.SpawnCreatureAtForTest(new Vector3f(cx + 2.5f, padY + 1, cz + 0.5f));
+        string nearB = server.SpawnCreatureAtForTest(new Vector3f(cx - 2.5f, padY + 1, cz + 0.5f));
+        var far = new List<string>();
+        for (int i = 0; i < share + 5; i++)
+        {
+            far.Add(server.SpawnCreatureAtForTest(new Vector3f(cx + 50 - 4 + i % 8 + 0.5f, padY + 1, cz - 4 + i / 8 + 0.5f)));
+        }
+
+        return (nearA, nearB, far, sp0.Id);
+    }
+
     [Fact]
     public void AnOverShareSpecies_ShedsItsOutOfSightMembers_AndKeepsThoseInView()
     {
         var server = Started("crowd", out var repo);
         using (repo)
         {
-            var p = server.AddLocalPlayer("Settler");
-            p.State.AboardShip = false;
-            var sp0 = Force(server, 0, titan: false, nocturnal: true);
-            server.SetDayFractionForTest(0.5);
-
-            const int cx = 0, cz = 0;
-            int padY = MaxTopY(server, cx, cz, 60) + 8;
-            BuildPad(server, cx, cz, 6, padY);
-            BuildPad(server, cx + 50, cz, 6, padY); // 50 blocks out: out of sight (40), inside the despawn leash (70)
-            p.State.Position = new Vector3f(cx + 0.5f, padY + 1, cz + 0.5f);
-
+            // A one-chunk view streams 32 blocks: the far pad at 50 is out of sight.
+            var (nearA, nearB, _, speciesId) = CrowdedArena(server, viewChunks: 1);
             int share = server.SpeciesShareForTest();
-            string nearA = server.SpawnCreatureAtForTest(new Vector3f(cx + 2.5f, padY + 1, cz + 0.5f));
-            string nearB = server.SpawnCreatureAtForTest(new Vector3f(cx - 2.5f, padY + 1, cz + 0.5f));
-            for (int i = 0; i < share + 5; i++)
-            {
-                server.SpawnCreatureAtForTest(new Vector3f(cx + 50 - 4 + i % 8 + 0.5f, padY + 1, cz - 4 + i / 8 + 0.5f));
-            }
 
             Ticks(server, 3);
 
-            var ofSp0 = server.Creatures.Where(c => !c.IsCompanion && c.SpeciesId == sp0.Id).ToList();
+            var ofSp0 = server.Creatures.Where(c => !c.IsCompanion && c.SpeciesId == speciesId).ToList();
             Assert.Equal(share, ofSp0.Count);
             Assert.Contains(ofSp0, c => c.Id == nearA);
             Assert.Contains(ofSp0, c => c.Id == nearB);
+        }
+    }
+
+    [Fact]
+    public void TheCrowdingPass_NeverShedsAnAnimalInsideThePlayersView()
+    {
+        // #1356: the shed distance was a fixed 40 blocks while the view distance goes to 8 chunks — on a
+        // plain the player watched animals 50 m away simply pop out of existence.
+        var server = Started("crowdview", out var repo);
+        using (repo)
+        {
+            var (_, _, far, speciesId) = CrowdedArena(server, viewChunks: 8); // 144 blocks streamed: the far pad is in plain view
+            int share = server.SpeciesShareForTest();
+
+            Ticks(server, 3);
+
+            var ofSp0 = server.Creatures.Where(c => !c.IsCompanion && c.SpeciesId == speciesId).ToList();
+            Assert.Equal(share + 7, ofSp0.Count); // over its share, but nothing in view is shed
+            Assert.All(far, id => Assert.Contains(ofSp0, c => c.Id == id));
+        }
+    }
+
+    [Fact]
+    public void TheCrowdingPass_NeverShedsAHunterMidCharge()
+    {
+        var server = Started("crowdhunt", out var repo);
+        using (repo)
+        {
+            var (_, _, far, speciesId) = CrowdedArena(server, viewChunks: 1);
+            int share = server.SpeciesShareForTest();
+
+            // One far member is charging (a live Seek intent — the sleepers' controller is never stepped, so
+            // the mode sticks); it must be passed over even though it is the farthest thing out there.
+            var hunter = server.Creatures.Single(c => c.Id == far[^1]);
+            hunter.Loco.Mode = MoveMode.Seek;
+
+            Ticks(server, 3);
+
+            var ofSp0 = server.Creatures.Where(c => !c.IsCompanion && c.SpeciesId == speciesId).ToList();
+            Assert.Equal(share, ofSp0.Count);
+            Assert.Contains(ofSp0, c => c.Id == hunter.Id);
         }
     }
 
@@ -481,6 +536,50 @@ public sealed class CreatureBuildRespectTests : IDisposable
 
             var s = server.Creatures.Single(c => c.Id == tiny);
             Assert.Equal(beside.X, s.Position.X, 2); // a small animal a block from the hull is nobody's problem
+        }
+    }
+
+    // ---------------- #1357: awake creatures vs walls ----------------
+
+    [Fact]
+    public void AnAwakeGrazerWalledIn_StepsAsideWithinSeconds()
+    {
+        // The body check ran for sleepers only: an awake (cathemeral) animal walled in by the player never
+        // re-checked its own cells, and every step out of the block read as blocked.
+        var server = Started("awakewall", out var repo);
+        using (repo)
+        {
+            var p = server.AddLocalPlayer("Mason");
+            p.State.AboardShip = false;
+            p.State.Inventory.Add("stone", 8, 64);
+            Force(server, 0, titan: false, nocturnal: false); // cathemeral: awake at the noon the clock is pinned to
+            server.SetDayFractionForTest(0.5);
+
+            const int cx = 80, cz = -40;
+            int padY = MaxTopY(server, cx, cz, 10) + 8;
+            BuildPad(server, cx, cz, 8, padY);
+            p.State.Position = new Vector3f(cx + 4.5f, padY + 1, cz + 0.5f); // within build reach of the animal
+
+            var planted = new Vector3f(cx + 0.5f, padY + 1, cz + 0.5f);
+            string id = server.SpawnCreatureAtForTest(planted);
+            server.PauseCreatureForTest(id, 30f); // a roam pause: it holds still while the wall goes up through it
+            Ticks(server, 2);
+            var live = server.Creatures.Single(c => c.Id == id);
+            Assert.Equal(0.0, live.AwakeOverrideTimer);
+            Assert.Equal(planted.X, live.Position.X);
+
+            // The player builds a wall THROUGH the standing animal: its feet and head cells.
+            server.PlaceBlock("Mason", cx, padY + 1, cz, "stone");
+            server.PlaceBlock("Mason", cx, padY + 2, cz, "stone");
+            Assert.False(ColumnClear(server, planted, 2), "sanity: the wall now runs through the body");
+
+            Ticks(server, 5); // one second
+            live = server.Creatures.Single(c => c.Id == id);
+            Assert.True(ColumnClear(server, live.Position, 2),
+                $"an awake animal must leave the masonry (at {live.Position.X:F1}/{live.Position.Y:F1}/{live.Position.Z:F1})");
+            Assert.True(System.Math.Abs(live.Position.X - planted.X) >= 0.9f || System.Math.Abs(live.Position.Z - planted.Z) >= 0.9f,
+                "it must have stepped ASIDE, not been hopped onto the wall");
+            Assert.Equal(padY + 1, live.Position.Y, 2);
         }
     }
 

--- a/tests/BlocksBeyondTheStars.Tests/CreatureMotionArenaTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/CreatureMotionArenaTests.cs
@@ -10,6 +10,7 @@ using BlocksBeyondTheStars.Shared.Configuration;
 using BlocksBeyondTheStars.Shared.Content;
 using BlocksBeyondTheStars.Shared.Definitions;
 using BlocksBeyondTheStars.Shared.Geometry;
+using BlocksBeyondTheStars.Shared.Primitives;
 using Xunit;
 using SvGameServer = BlocksBeyondTheStars.GameServer.GameServer;
 
@@ -382,6 +383,86 @@ public sealed class CreatureMotionArenaTests : IDisposable
 
             Assert.True(server.Creatures.First(x => x.Id == wet).Vert.InWater, "in the pool it swims (#1334)");
             Assert.False(server.Creatures.First(x => x.Id == dry).Vert.InWater, "ashore it walks");
+        }
+    }
+
+    // ---------------- #1349: the ground probe prefers the floor below ----------------
+
+    /// <summary>A grazer holding still on a pad under a stone ceiling (feet cells padY+1..+3 free, slab at
+    /// padY+4, upper-floor feet at padY+5); the player well outside. Returns the creature id.</summary>
+    private string GrazerUnderACeiling(SvGameServer server, int cx, int cz, int padY)
+    {
+        var p = server.AddLocalPlayer("Digger");
+        p.State.AboardShip = false;
+        Force(server, CreatureHabitat.Land, legs: 4, LocomotionStyle.Grazer);
+        BuildPad(server, cx, cz, 6, padY);
+        var stone = _content.GetBlock("stone")!.NumericId;
+        for (int dx = -6; dx <= 6; dx++)
+        {
+            for (int dz = -6; dz <= 6; dz++)
+            {
+                server.World.SetBlock(new Vector3i(cx + dx, padY + 4, cz + dz), stone); // the ceiling / upper floor
+            }
+        }
+
+        p.State.Position = new Vector3f(cx + 14, padY + 1, cz);
+        string id = server.SpawnCreatureAtForTest(new Vector3f(cx + 0.5f, padY + 1, cz + 0.5f));
+        server.PauseCreatureForTest(id, 30f);
+        server.TickForTest(0.1);
+        server.TickForTest(0.1);
+        Assert.Equal(padY + 1, server.Creatures.First(x => x.Id == id).Position.Y, 2);
+        return id;
+    }
+
+    [Fact]
+    public void APitDugUnderAGroundFloorAnimal_DropsItIntoThePit_NotThroughTheCeiling()
+    {
+        var server = Started(out var repo);
+        using (repo)
+        {
+            const int cx = 240, cz = 240;
+            int padY = MaxTopY(server, cx, cz, 8) + 8;
+            string id = GrazerUnderACeiling(server, cx, cz, padY);
+
+            // A six-deep pit under its feet: the upper floor (+4) is now the NEAREST standable cell, the pit
+            // floor (−6) the right one.
+            var stone = _content.GetBlock("stone")!.NumericId;
+            server.World.SetBlock(new Vector3i(cx, padY - 6, cz), stone);
+            server.World.SetBlock(new Vector3i(cx, padY, cz), BlockId.Air);
+
+            for (int i = 0; i < 30; i++)
+            {
+                server.TickForTest(0.1);
+                var c = server.Creatures.First(x => x.Id == id);
+                Assert.True(c.Position.Y <= padY + 1.01f, $"it must never rise (Y {c.Position.Y:F2} at tick {i}) — the old probe lifted it through the ceiling");
+            }
+
+            var landed = server.Creatures.First(x => x.Id == id);
+            Assert.Equal(padY - 5, landed.Position.Y, 2);
+            Assert.False(landed.Vert.Airborne);
+        }
+    }
+
+    [Fact]
+    public void AnAnimalWithNoFloorBelowAtAll_StillRecoversUpward()
+    {
+        var server = Started(out var repo);
+        using (repo)
+        {
+            // The pad floats more than a full scan (24) above the terrain, so once its floor is gone nothing
+            // below is standable — the upward fallback (the entombed-recovery path) must still lift it.
+            const int cx = -240, cz = 240;
+            int padY = MaxTopY(server, cx, cz, 8) + 30;
+            string id = GrazerUnderACeiling(server, cx, cz, padY);
+
+            server.World.SetBlock(new Vector3i(cx, padY, cz), BlockId.Air);
+            for (int i = 0; i < 30; i++)
+            {
+                server.TickForTest(0.1);
+            }
+
+            var c = server.Creatures.First(x => x.Id == id);
+            Assert.Equal(padY + 5, c.Position.Y, 2); // on the upper floor
         }
     }
 }

--- a/tests/BlocksBeyondTheStars.Tests/CreatureTamingTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/CreatureTamingTests.cs
@@ -424,6 +424,130 @@ public sealed class CreatureTamingTests : IDisposable
         Assert.True(d1 < d0, "a companion that has fallen behind should move toward its owner");
     }
 
+    // ---------------- #1348: a pet under a cliff waits ----------------
+
+    private static int MaxTopY(SvGameServer server, int cx, int cz, int r)
+    {
+        int max = int.MinValue;
+        for (int dx = -r; dx <= r; dx++)
+        {
+            for (int dz = -r; dz <= r; dz++)
+            {
+                max = System.Math.Max(max, SurfaceTopY(server, cx + dx, cz + dz));
+            }
+        }
+
+        return max;
+    }
+
+    private void Fill(SvGameServer server, int x0, int y0, int z0, int x1, int y1, int z1)
+    {
+        var stone = _content.GetBlock("stone")!.NumericId;
+        for (int x = x0; x <= x1; x++)
+        {
+            for (int y = y0; y <= y1; y++)
+            {
+                for (int z = z0; z <= z1; z++)
+                {
+                    server.World.SetBlock(new Vector3i(x, y, z), stone);
+                }
+            }
+        }
+    }
+
+    /// <summary>A tamed land companion of the wanted shape on a stone corridor floating above every natural
+    /// feature: pad radius 8 at <paramref name="padY"/>, 3-high rims on the −X and both Z sides, and a ledge
+    /// of <paramref name="ledgeHeight"/> filling the +X half from dx = 1. The pet stands at dx = −2.5, its
+    /// owner on the ledge at dx = +6.5 — past the follow distance, inside the leash.</summary>
+    private BlocksBeyondTheStars.GameServer.CombatEntity PetBelowALedge(SvGameServer server, int cx, int cz, int legs, int ledgeHeight, out int padY)
+    {
+        var p = Ranger(server);
+        server.Tick(6.0);
+        var target = FirstWild(server, CreatureTemperament.Passive);
+        Assert.True(TameNearest(server, p, target));
+        var pet = Assert.Single(server.CompanionEntitiesForTest("Ranger"));
+        var sp = server.SpeciesRoster.First(s => s.Id == pet.SpeciesId);
+        sp.Habitat = CreatureHabitat.Land;
+        sp.Legs = legs;
+        sp.LocoStyle = legs == 0 ? LocomotionStyle.Slitherer : LocomotionStyle.Strider;
+        sp.HasWings = false;
+        sp.HasGasSac = false;
+        sp.Size = 1f;
+        sp.BodyPlan = CreatureBodyPlan.Standard;
+
+        padY = MaxTopY(server, cx, cz, 10) + 8;
+        Fill(server, cx - 8, padY, cz - 8, cx + 8, padY, cz + 8);                    // the pad
+        Fill(server, cx + 1, padY + 1, cz - 8, cx + 8, padY + ledgeHeight, cz + 8);   // the ledge / cliff
+        Fill(server, cx - 8, padY + 1, cz - 8, cx - 8, padY + 3, cz + 8);             // rim behind the pet…
+        Fill(server, cx - 8, padY + 1, cz - 8, cx + 8, padY + 3, cz - 8);             // …and along both sides
+        Fill(server, cx - 8, padY + 1, cz + 8, cx + 8, padY + 3, cz + 8);
+
+        pet.Position = new Vector3f(cx - 2.5f, padY + 1, cz + 0.5f);
+        pet.Vert = default;
+        p.State.Position = new Vector3f(cx + 6.5f, padY + 1 + ledgeHeight, cz + 0.5f);
+        return pet;
+    }
+
+    [Fact]
+    public void AWalkerPet_UnderAThreeBlockCliff_WaitsInsteadOfHoppingInPlace()
+    {
+        var server = Started(out var repo);
+        using (repo)
+        {
+            const int cx = 200, cz = 200;
+            var pet = PetBelowALedge(server, cx, cz, legs: 4, ledgeHeight: 3, out int padY);
+            for (int i = 0; i < 60; i++)
+            {
+                server.Tick(0.1);
+                var live = server.CompanionEntitiesForTest("Ranger").Single();
+                Assert.False(live.Vert.Airborne, $"a walker pet must not jump at a cliff it cannot clear (tick {i})");
+                Assert.Equal(padY + 1, live.Position.Y, 1);
+                Assert.True(live.Position.X < cx + 1f, $"it must stay below the cliff (x {live.Position.X:F2})");
+            }
+
+            Assert.Same(pet, server.CompanionEntitiesForTest("Ranger").Single());
+        }
+    }
+
+    [Fact]
+    public void ACrawlerPet_UnderAThreeBlockCliff_NeverLevitatesUpIt()
+    {
+        var server = Started(out var repo);
+        using (repo)
+        {
+            const int cx = -200, cz = 200;
+            PetBelowALedge(server, cx, cz, legs: 0, ledgeHeight: 3, out int padY);
+            for (int i = 0; i < 60; i++)
+            {
+                server.Tick(0.1);
+                var live = server.CompanionEntitiesForTest("Ranger").Single();
+                Assert.Equal(0f, live.Vert.ClimbTargetY);
+                Assert.Equal(padY + 1, live.Position.Y, 1);
+                Assert.True(live.Position.X < cx + 1f, $"it must stay below the cliff (x {live.Position.X:F2})");
+            }
+        }
+    }
+
+    [Fact]
+    public void AWalkerPet_StillJumpsAOneBlockLedge_ToFollow()
+    {
+        var server = Started(out var repo);
+        using (repo)
+        {
+            const int cx = 200, cz = -200;
+            PetBelowALedge(server, cx, cz, legs: 4, ledgeHeight: 1, out int padY);
+            bool crossed = false;
+            for (int i = 0; i < 120 && !crossed; i++)
+            {
+                server.Tick(0.1);
+                var live = server.CompanionEntitiesForTest("Ranger").Single();
+                crossed = live.Position.X >= cx + 1.2f && System.Math.Abs(live.Position.Y - (padY + 2)) < 0.05f;
+            }
+
+            Assert.True(crossed, "a one-block ledge is still taken (Q1a) — only the cliff is refused");
+        }
+    }
+
     public void Dispose()
     {
         try

--- a/tests/BlocksBeyondTheStars.Tests/DropLootTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/DropLootTests.cs
@@ -243,6 +243,39 @@ public sealed class DropLootTests : IDisposable
         }
     }
 
+    [Fact]
+    public void FreshLootMergedIntoAnAgingPacket_RestartsItsTimer()
+    {
+        // #1350: the merge kept the OLD packet's LifetimeLeft — a second kill beside a 4:50-old bundle put the
+        // fresh meat into it, and everything vanished ten seconds later.
+        var server = Started(out var repo, "merge-timer");
+        using (repo)
+        {
+            var p = server.AddLocalPlayer("Settler");
+            p.State.AboardShip = false;
+            p.State.Position = new Vector3f(0.5f, SurfaceTopY(server, 0, 0) + 1, 0.5f); // far from the packet (no pickup)
+            int top = SurfaceTopY(server, 30, 30);
+            var origin = new Vector3i(30, top + 1, 30);
+            server.SpillToGroundForTest(origin, "iron_ore", 3, creatureLoot: true);
+            for (int i = 0; i < 29; i++)
+            {
+                server.Tick(10.0); // 290 s with a player on the world: ten seconds left
+            }
+
+            var aging = Assert.Single(server.DropPackets);
+            Assert.InRange(aging.LifetimeLeft, 1.0, 20.0);
+
+            server.SpillToGroundForTest(origin, "iron_ore", 2, creatureLoot: true); // a second kill next to it
+            var merged = Assert.Single(server.DropPackets); // merged into the bundle, not a new one
+            Assert.Equal(aging.Id, merged.Id);
+            Assert.Equal(5, merged.Items.Single(s => s.Item == "iron_ore").Count);
+            Assert.InRange(merged.LifetimeLeft, 290.0, 300.0);
+
+            server.Tick(20.0); // the old expiry passes…
+            Assert.Single(server.DropPackets); // …and the bundle is still there
+        }
+    }
+
     // ---------------- #1317: the stow toast ----------------
 
     private SvGameServer SpaceServer(string world, RecordingTransport transport, out SqliteWorldRepository repo)

--- a/tests/BlocksBeyondTheStars.Tests/LanPlaytestRegressionTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/LanPlaytestRegressionTests.cs
@@ -682,4 +682,76 @@ public sealed class LanPlaytestRegressionTests : IDisposable
         Assert.DoesNotContain(transport.Sent, x => x.Conn == ann.ConnectionId && x.Msg is RespawnNotice);
         Assert.Contains(transport.Sent, x => x.Conn == ann.ConnectionId && x.Msg is InventoryUpdate); // the hold still refreshes
     }
+
+    // ---------------- #1346: the ship blip survives a death respawn ----------------
+
+    /// <summary>Since #1308 the client clears its ship marker on EVERY WorldReset; a reset that is not followed
+    /// by a ShipPlacement leaves the HUD without blip, distance, map marker and thermal blob.</summary>
+    private static void AssertShipPlacementFollowsTheReset(RecordingTransport transport, PlayerSession session)
+    {
+        var msgs = transport.Sent.Where(x => x.Conn == session.ConnectionId).Select(x => x.Msg).ToList();
+        int reset = msgs.FindIndex(m => m is WorldReset);
+        int placement = msgs.FindIndex(m => m is ShipPlacement);
+        Assert.True(reset >= 0, "a death away from the ship's world must reset the world");
+        Assert.True(placement > reset, "…and re-arm the ship marker AFTER that reset (#1346)");
+    }
+
+    [Fact]
+    public void DyingInSpace_ResendsTheShipPlacement_AfterTheWorldReset()
+    {
+        // RecoverToShip sent the WorldReset without the SendShipPlacement every travel/join reset has — the
+        // blip was gone until the next landing or rejoin.
+        var transport = new RecordingTransport();
+        var server = NewServer("death_blip_ship", transport);
+        var host = server.AddLocalPlayer("Host");
+        server.EnterSpace("Host"); // die away from the surface → the RecoverToShip (world-transition) path
+        transport.Sent.Clear();
+
+        server.KillPlayerForTest(host, "@srv.death.wildlife");
+
+        Assert.True(host.State.AboardShip);
+        AssertShipPlacementFollowsTheReset(transport, host);
+    }
+
+    [Fact]
+    public void DyingInSpace_AndWakingAtTheHomeTank_ResendsTheShipPlacement_Too()
+    {
+        // The heal-tank respawn (TryCustomRespawn, full world transition) had the same gap.
+        var transport = new RecordingTransport();
+        var server = NewServer("death_blip_home", transport);
+        var host = server.AddLocalPlayer("Host");
+        server.SetInstantTravelForTest(true);
+
+        // A real galaxy body (the fresh start world runs under its legacy planet-type key, which the home
+        // spawn cannot resolve to a body), reached by a real travel so the ship record carries its id.
+        var body = server.Galaxy.AllBodies().First(b =>
+            b.Kind == CelestialKind.Planet
+            && !string.IsNullOrEmpty(b.PlanetType)
+            && _content.GetPlanet(b.PlanetType!) is not null
+            && b.Id != host.CurrentLocationId);
+        server.RequestLandingPadsForTest(host, host.CurrentLocationId);
+        server.Ship.Modules.Add("jump_generator");
+        Assert.True(server.QuickTravelForTest("Host", body.Id));
+
+        // A heal tank just outside the parked hull becomes the home spawn.
+        var (origin, size) = server.LandedShipBoundsForTest("Host");
+        var tank = new Vector3i((int)origin.X + (int)size.X + 3, (int)origin.Y, (int)origin.Z);
+        server.World.SetBlock(tank, _content.GetBlock("heal_tank")!.NumericId);
+        host.State.AboardShip = false;
+        host.State.Position = new Vector3f(tank.X + 1.5f, tank.Y, tank.Z + 0.5f);
+        server.SetSpawnPoint(host.State.PlayerId, tank.X, tank.Y, tank.Z);
+        Assert.Equal(body.Id, host.State.CustomSpawnBodyId);
+
+        host.State.Position = server.HealTank;
+        host.State.AboardShip = true;
+        server.EnterSpace("Host");
+        transport.Sent.Clear();
+
+        server.KillPlayerForTest(host, "@srv.death.wildlife"); // deferred: home vs ship (#462)
+        server.ChooseRespawn(host.State.PlayerId, useCustomSpawn: true);
+
+        Assert.Equal(body.Id, host.CurrentLocationId);
+        Assert.False(host.State.AboardShip); // woke at the home tank, on foot
+        AssertShipPlacementFollowsTheReset(transport, host);
+    }
 }


### PR DESCRIPTION
Follow-ups from the 2026-08-29 audit of the day's merges — server work package (the two HIGH findings plus six medium ones).

closes #1346
closes #1347
closes #1348
closes #1349
closes #1350
closes #1356
closes #1357
closes #1358

## What changed
- **#1346 (HIGH) — ship blip survives dying.** `RecoverToShip` and `TryCustomRespawn` send `SendShipPlacement` right after the `WorldReset` (the client clears its ship marker on every reset since #1308). Tests: two death paths in `LanPlaytestRegressionTests` assert the placement follows the reset.
- **#1347 (HIGH) — the walled-base fill walks the terrain.** `GameServerBaseWalls` no longer floods a single horizontal slice (which read every terrain hollow within 48 blocks of a base as "fenced in" → no land spawns there). The fill now steps ±1 vertically like a walker (`StepUpLimit` = 1): up onto a supported cell, down through a free one; 2+ rises stay walls; fluids are walls to walk *through* but support to walk *on* (a pond is crossed on its surface, never flooded); canopies/grass carry no feet. Block reads memoised in a reused scratch box, budget 60k with **fail-open** on exhaustion, same (base, level) cache. Test on real generated terrain: base in a terraced hollow → open; 2-high ring → closed; 1-high edge → open. The four floating-slab tests pass unchanged.
- **#1358 — proximity doors are walls in any state.** Slide/energy doors count as walls for the fill whatever their state (they open only for a player and close by themselves); hinge/wood keep the open/shut rule. Test: sliding gate with the player standing at it keeps the yard closed.
- **#1348 — pets wait at cliffs.** `ApplyCreatureStep` never starts a jump or climb for a rise above the step-up limit (`riseTooHigh`), so a walker pet under a cliff no longer hops in place and a crawler pet no longer levitates up the wall; the leash teleport stays the fallback. Tests in `CreatureTamingTests`.
- **#1349 — floor-first ground probe.** `TryGroundFeetYAt` scans downward until the first supporting block and only looks upward when nothing below is standable — a pit dug under a ground-floor animal drops it into the pit instead of lifting it through the ceiling. Arena tests for both directions.
- **#1350 — merged loot keeps a full lifetime.** Fresh creature loot merged into an aging packet resets `LifetimeLeft = Max(existing, LootPacketLifetime)`. Test.
- **#1356 — view-aware crowding.** The crowd-despawn "out of sight" distance is `Max(40, widest player stream radius)`, and a creature in `Seek` (a live hunt/approach) is never shed. Tests. *Note:* the unconditional far-prune at 70 blocks (110 for titans) is untouched and out of scope.
- **#1357 — awake creatures re-validate their body.** The embedded-body check now runs for awake creatures every 2 s and immediately when a player places a block into a creature's body column (`NudgeCreatureBodyChecks` from `HandlePlace`), so a walled-in grazer steps aside instead of standing in the masonry for good. Test.

## Verification
- Full suite `-c Release --filter "Category!=Slow"`: **2494 passed, 0 failed** (on the branch before the rebase onto #1360/#1361; docs-only conflicts resolved)
- Clean rebuild: 0 warnings, 0 errors; `dotnet format --verify-no-changes` clean
- TODO.md + CHANGELOG (Unreleased) updated; no locale strings needed

## Playtest
- Base in a valley / on hilly `varied` terrain: land animals spawn around it again; Lyxette's walled yard stays empty (also with a sliding gate while standing at it).
- Die in space → respawn at the tank → ship blip + distance present.
- Pet below a 3-block ledge with the owner above: waits, no hopping/levitating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
