### PR TITLE
test(reports): one in-process ReportHost per test class — the slow first Kestrel start stays off the fast-tier clock (#1362)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -9643,6 +9643,12 @@ is **pre-approved** (keys in `tools/ai-assets/.env`, run via `uv`).
 
 ---
 
+## ✅ Done (2026-08-29): ReportHostHttpTests share one in-process host — the first Kestrel start no longer lands on a test's clock (#1362)
+
+The first Kestrel host a test process starts costs 84–134 s on the Linux CI runners (under a second locally); with one host per test that cost hit whichever test ran first and blew the 120 s fast-tier budget on PR #1360. Now `IClassFixture<ReportHostHttpFixture>` starts the host once per class; tests keep their ingest-limiter isolation via `TrustProxy = true` + a per-test `X-Forwarded-For` address; the client is disposed before the host stops; `HostStartup_IsReportedForTheCiLogAsync` writes Create / StartAsync / first-request milliseconds into the test output. The cause of the slow first start is still open in #1362.
+
+---
+
 ## ✅ Done (2026-08-29): reply polling no longer spends the report budget — a class behind one NAT can poll and still report (#1352)
 
 Follow-up to #1327. `GET /api/replies` and `POST /api/replies/ack` went through `GuardPlayerRoute`, which shared

--- a/tests/BlocksBeyondTheStars.Tests/ReportHostHttpTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/ReportHostHttpTests.cs
@@ -3,37 +3,48 @@
 // This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Text;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using BlocksBeyondTheStars.ReportHost;
 using BlocksBeyondTheStars.Shared.Feedback;
 using BlocksBeyondTheStars.Shared.Notifications;
 using Microsoft.AspNetCore.Builder;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace BlocksBeyondTheStars.Tests;
 
 /// <summary>
-/// The ReportHost over real HTTP: the same <see cref="ReportHostApp"/> the container runs, started
-/// in-process on a loopback port. Covers the player reply routes end to end (issue #1327 had only
-/// store-level tests) and the limiter split of issue #1352 — polling for answers must never spend the
-/// per-IP budget a real F1 report from the same NAT needs.
+/// One in-process ReportHost for the whole <see cref="ReportHostHttpTests"/> class. The first Kestrel
+/// host a test process starts costs 84–134 s on the Linux CI runners (under a second locally), which
+/// blew the fast-tier budget when every test started its own host and the cost landed on whichever test
+/// ran first (#1362). Starting the host once per class pays that price once, outside any test's clock;
+/// the timings are kept so <see cref="ReportHostHttpTests.HostStartup_IsReportedForTheCiLogAsync"/> can put
+/// them into the test log where the CI artifact keeps them.
 /// </summary>
-public sealed class ReportHostHttpTests : IAsyncLifetime, IDisposable
+public sealed class ReportHostHttpFixture : IAsyncLifetime
 {
-    private const string WriteKey = "write-key-for-tests";
-    private const int IngestPerMinute = 2;
-    private const int ReplyPerMinute = 5;
+    public const string WriteKey = "write-key-for-tests";
+    public const int IngestPerMinute = 2;
+    public const int ReplyPerMinute = 5;
 
     private readonly string _root = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "bbts_rhh_" + Guid.NewGuid().ToString("N"));
-    private ReportStore _store = null!;
     private WebApplication _app = null!;
-    private HttpClient _client = null!;
-    private bool _disposed;
+
+    public ReportStore Store { get; private set; } = null!;
+    public HttpClient Client { get; private set; } = null!;
+
+    /// <summary>Milliseconds <see cref="ReportHostApp.Create"/> took (builder + store start-up work).</summary>
+    public long CreateMs { get; private set; }
+
+    /// <summary>Milliseconds <c>StartAsync</c> took (Kestrel bind + host start).</summary>
+    public long StartMs { get; private set; }
 
     public async Task InitializeAsync()
     {
@@ -46,32 +57,29 @@ public sealed class ReportHostHttpTests : IAsyncLifetime, IDisposable
             WriteKey = WriteKey,
             IngestPerMinute = IngestPerMinute,
             ReplyPerMinute = ReplyPerMinute,
+            // The per-IP ingest limiter reads X-Forwarded-For when the proxy is trusted — every test sends
+            // its own address, so the tests share one host without sharing its ingest budget.
+            TrustProxy = true,
         };
-        _store = new ReportStore(config, System.IO.Path.Combine(_root, "reports.db"));
-        _app = ReportHostApp.Create(config, _store, new AdminNotifier(string.Empty, "reports"), Array.Empty<string>());
+        Store = new ReportStore(config, System.IO.Path.Combine(_root, "reports.db"));
+
+        var sw = Stopwatch.StartNew();
+        _app = ReportHostApp.Create(config, Store, new AdminNotifier(string.Empty, "reports"), Array.Empty<string>());
+        CreateMs = sw.ElapsedMilliseconds;
+
+        sw.Restart();
         await _app.StartAsync();
-        _client = new HttpClient { BaseAddress = new Uri(_app.Urls.First()) };
+        StartMs = sw.ElapsedMilliseconds;
+
+        Client = new HttpClient { BaseAddress = new Uri(_app.Urls.First()) };
     }
 
     public async Task DisposeAsync()
     {
+        Client.Dispose(); // close the keep-alive connection before the host stops, so the stop never waits for it
         await _app.StopAsync();
         await _app.DisposeAsync();
-        Dispose();
-    }
-
-    /// <summary>xunit drives <see cref="DisposeAsync"/>; this is the synchronous half (client, store,
-    /// temp dir) it ends with — idempotent, so an extra call is harmless.</summary>
-    public void Dispose()
-    {
-        if (_disposed)
-        {
-            return;
-        }
-
-        _disposed = true;
-        _client.Dispose();
-        _store.Dispose();
+        Store.Dispose();
         try
         {
             System.IO.Directory.Delete(_root, recursive: true);
@@ -81,6 +89,35 @@ public sealed class ReportHostHttpTests : IAsyncLifetime, IDisposable
             // Windows can hold SQLite WAL handles briefly; temp cleanup is best-effort.
         }
     }
+}
+
+/// <summary>
+/// The ReportHost over real HTTP: the same <see cref="ReportHostApp"/> the container runs, started
+/// in-process on a loopback port. Covers the player reply routes end to end (issue #1327 had only
+/// store-level tests) and the limiter split of issue #1352 — polling for answers must never spend the
+/// per-IP budget a real F1 report from the same NAT needs.
+/// </summary>
+public sealed class ReportHostHttpTests : IClassFixture<ReportHostHttpFixture>
+{
+    private const string WriteKey = ReportHostHttpFixture.WriteKey;
+    private const int IngestPerMinute = ReportHostHttpFixture.IngestPerMinute;
+    private const int ReplyPerMinute = ReportHostHttpFixture.ReplyPerMinute;
+
+    private static int _nextClientIp;
+
+    private readonly ReportHostHttpFixture _host;
+    private readonly ITestOutputHelper _output;
+    private readonly string _clientIp = "10.0.0." + Interlocked.Increment(ref _nextClientIp); // one NAT address per test
+
+    public ReportHostHttpTests(ReportHostHttpFixture host, ITestOutputHelper output)
+    {
+        _host = host;
+        _output = output;
+    }
+
+    private HttpClient Client => _host.Client;
+
+    private ReportStore Store => _host.Store;
 
     // ---------------- helpers ----------------
 
@@ -104,6 +141,7 @@ public sealed class ReportHostHttpTests : IAsyncLifetime, IDisposable
     private HttpRequestMessage Request(HttpMethod method, string path, string? json = null, string? writeKey = WriteKey)
     {
         var request = new HttpRequestMessage(method, path);
+        request.Headers.Add("X-Forwarded-For", _clientIp);
         if (writeKey != null)
         {
             request.Headers.Add("x-bugreport-key", writeKey);
@@ -119,15 +157,28 @@ public sealed class ReportHostHttpTests : IAsyncLifetime, IDisposable
 
     private async Task<HttpStatusCode> PollAsync(string key)
     {
-        using var response = await _client.SendAsync(Request(HttpMethod.Get, "/api/replies?key=" + key));
+        using var response = await Client.SendAsync(Request(HttpMethod.Get, "/api/replies?key=" + key));
         return response.StatusCode;
     }
 
     private async Task<(HttpStatusCode Status, JsonDocument? Body)> PostReportAsync(string playerId)
     {
-        using var response = await _client.SendAsync(Request(HttpMethod.Post, "/api/bugreport", FeedbackPayload(playerId)));
+        using var response = await Client.SendAsync(Request(HttpMethod.Post, "/api/bugreport", FeedbackPayload(playerId)));
         string text = await response.Content.ReadAsStringAsync();
         return (response.StatusCode, text.Length > 0 ? JsonDocument.Parse(text) : null);
+    }
+
+    // ---------------- host start-up cost (#1362) ----------------
+
+    [Fact]
+    public async Task HostStartup_IsReportedForTheCiLogAsync()
+    {
+        // No budget assertion — the point is the number in the log: the first Kestrel host of a test
+        // process takes 84–134 s on the Linux CI runners and under a second locally, and the cause is
+        // still open (#1362). One more request here so the first-request cost is on record too.
+        var sw = Stopwatch.StartNew();
+        Assert.Equal(HttpStatusCode.OK, await PollAsync(KeyFor("startup-probe")));
+        _output.WriteLine($"ReportHost host: Create {_host.CreateMs} ms, StartAsync {_host.StartMs} ms, first request {sw.ElapsedMilliseconds} ms");
     }
 
     // ---------------- #1352: polling never spends the ingest budget ----------------
@@ -193,17 +244,17 @@ public sealed class ReportHostHttpTests : IAsyncLifetime, IDisposable
         string key = KeyFor("token-abc");
 
         // Nothing to show until a developer writes something.
-        using (var empty = await _client.SendAsync(Request(HttpMethod.Get, "/api/replies?key=" + key)))
+        using (var empty = await Client.SendAsync(Request(HttpMethod.Get, "/api/replies?key=" + key)))
         {
             Assert.Equal(HttpStatusCode.OK, empty.StatusCode);
             using var doc = JsonDocument.Parse(await empty.Content.ReadAsStringAsync());
             Assert.Equal(0, doc.RootElement.GetProperty("items").GetArrayLength());
         }
 
-        long replyId = _store.AddDevReply(reportId, "Does it happen always?", isQuestion: true, nowUnix: DateTimeOffset.UtcNow.ToUnixTimeSeconds());
+        long replyId = Store.AddDevReply(reportId, "Does it happen always?", isQuestion: true, nowUnix: DateTimeOffset.UtcNow.ToUnixTimeSeconds());
 
         // The poll returns the thread with the unread developer entry…
-        using (var poll = await _client.SendAsync(Request(HttpMethod.Get, "/api/replies?key=" + key)))
+        using (var poll = await Client.SendAsync(Request(HttpMethod.Get, "/api/replies?key=" + key)))
         {
             Assert.Equal(HttpStatusCode.OK, poll.StatusCode);
             Assert.Equal("*", poll.Headers.GetValues("Access-Control-Allow-Origin").Single()); // WebGL client
@@ -216,14 +267,14 @@ public sealed class ReportHostHttpTests : IAsyncLifetime, IDisposable
 
         // …the ack marks it read, so the next poll is empty again…
         string ack = JsonSerializer.Serialize(new { key, replyIds = new[] { replyId } });
-        using (var acked = await _client.SendAsync(Request(HttpMethod.Post, "/api/replies/ack", ack)))
+        using (var acked = await Client.SendAsync(Request(HttpMethod.Post, "/api/replies/ack", ack)))
         {
             Assert.Equal(HttpStatusCode.OK, acked.StatusCode);
             using var doc = JsonDocument.Parse(await acked.Content.ReadAsStringAsync());
             Assert.Equal(1, doc.RootElement.GetProperty("acked").GetInt32());
         }
 
-        using (var again = await _client.SendAsync(Request(HttpMethod.Get, "/api/replies?key=" + key)))
+        using (var again = await Client.SendAsync(Request(HttpMethod.Get, "/api/replies?key=" + key)))
         {
             using var doc = JsonDocument.Parse(await again.Content.ReadAsStringAsync());
             Assert.Equal(0, doc.RootElement.GetProperty("items").GetArrayLength());
@@ -231,16 +282,16 @@ public sealed class ReportHostHttpTests : IAsyncLifetime, IDisposable
 
         // …and the player's answer lands in the thread and flips the status.
         string answer = JsonSerializer.Serialize(new { key, reportId, text = "Yes, every time." });
-        using (var answered = await _client.SendAsync(Request(HttpMethod.Post, "/api/replies", answer)))
+        using (var answered = await Client.SendAsync(Request(HttpMethod.Post, "/api/replies", answer)))
         {
             Assert.Equal(HttpStatusCode.Created, answered.StatusCode);
         }
 
-        Assert.Equal(BugReportStatus.PlayerReplied, _store.Get(reportId)!.Status);
-        Assert.Equal(2, _store.ListReplies(reportId).Count);
+        Assert.Equal(BugReportStatus.PlayerReplied, Store.Get(reportId)!.Status);
+        Assert.Equal(2, Store.ListReplies(reportId).Count);
 
         // Another install's key sees none of it.
-        using (var foreign = await _client.SendAsync(Request(HttpMethod.Get, "/api/replies?key=" + KeyFor("someone-else"))))
+        using (var foreign = await Client.SendAsync(Request(HttpMethod.Get, "/api/replies?key=" + KeyFor("someone-else"))))
         {
             using var doc = JsonDocument.Parse(await foreign.Content.ReadAsStringAsync());
             Assert.Equal(0, doc.RootElement.GetProperty("items").GetArrayLength());
@@ -251,10 +302,10 @@ public sealed class ReportHostHttpTests : IAsyncLifetime, IDisposable
     public async Task ReplyRoutes_StillRequireTheWriteKeyAsync()
     {
         string key = KeyFor("token-abc");
-        using var wrong = await _client.SendAsync(Request(HttpMethod.Get, "/api/replies?key=" + key, writeKey: "nope"));
+        using var wrong = await Client.SendAsync(Request(HttpMethod.Get, "/api/replies?key=" + key, writeKey: "nope"));
         Assert.Equal(HttpStatusCode.Forbidden, wrong.StatusCode);
 
-        using var missing = await _client.SendAsync(Request(HttpMethod.Post, "/api/replies/ack", "{}", writeKey: null));
+        using var missing = await Client.SendAsync(Request(HttpMethod.Post, "/api/replies/ack", "{}", writeKey: null));
         Assert.Equal(HttpStatusCode.Forbidden, missing.StatusCode);
     }
 }


### PR DESCRIPTION
closes #1362

Found while merging #1360: the fast-tier guardrail failed on shard 3 because `ReportHostHttpTests.ReplyRoutes_StillRequireTheWriteKeyAsync` took 134 s (84 s on #1361's own run, 950 ms locally). It is the **first Kestrel host of the test process** that is slow on the Ubuntu runner, and with one host per test that cost landed on whichever test ran first.

## What changed
- `IClassFixture<ReportHostHttpFixture>`: one host per class, started outside any test's clock.
- Tests keep their per-IP ingest-limiter isolation: the fixture sets `TrustProxy = true` and every test sends its own `X-Forwarded-For` address.
- The client is disposed before the host stops (no wait on a keep-alive connection).
- `HostStartup_IsReportedForTheCiLogAsync` writes Create / StartAsync / first-request milliseconds into the test output, so the CI TRX artifact records where the time goes — the root cause stays tracked in #1362.

## Verification
- `dotnet test --filter ReportHostHttpTests`: 5/5 passed locally (first test 220 ms — fixture time is not attributed to a test)
- Test project build: 0 warnings; `dotnet format --verify-no-changes` clean
- TODO.md entry added

🤖 Generated with [Claude Code](https://claude.com/claude-code)