### PR TITLE
fix(reports): one F1 report = one inbox row; server rows never carry name-derived reply keys (#1359)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,19 @@ the richer, screenshot-laden versions live there. `(#123)` references the pull r
   now ask for the same fluid-aware target as the click — and the tool check reads the definition of the
   fluid actually under the crosshair (water and lava separately) instead of assuming lava stands for both.
 
+### 📬 One F1 report, one inbox row — and answers that actually arrive (#1359)
+
+- **The report inbox no longer lists every F1 report twice.** Each in-game report reaches the inbox on two
+  paths by design (straight from the game, and as the server's rich `/bump` snapshot with the screenshot), and
+  the admin list was meant to fold the pair into one row since #618 — but it compared a field the two halves
+  never agreed on (the game sends the install token as its player id, the server the player name), so not one
+  report ever paired. The list now recognises the halves by their shared reply key, or by player name for
+  older builds.
+- **A developer answer reaches you from either half.** The `/bump` snapshot now carries the same reply key as
+  the direct upload, so an answer typed on the richer row (the one with the screenshot) arrives in-game like any
+  other — before, it would have been stored under a key derived from your player name that your game never
+  asks for. The inbox stops minting such name-derived keys for server rows (a public name must not unlock a
+  thread) and clears the ones it had already made.
 ### 🔧 Server audit — the round-3 fixes, sharpened (#1346, #1347, #1348, #1349, #1350, #1356, #1357, #1358)
 
 - **The ship blip survives dying** (#1346): a death in space, inside the ship or on another body respawned you

--- a/TODO.md
+++ b/TODO.md
@@ -9954,6 +9954,25 @@ half; the portal half ships with the next WorldHost image.
 
 ---
 
+## ✅ Done (2026-08-29): one F1 report, one inbox row — pair-collapsing never matched, server rows carried guessable reply keys (#1359)
+
+Every in-game F1 report reaches the ReportHost twice by design (client-direct POST + the server's `/bump`
+forward with snapshot and screenshot), and `ReportHostPages.GroupDuplicates` (#618) was meant to show the
+pair as one admin row. It compared `PlayerId` — which the halves never share: the client sends the install
+token (`Settings.PlayerToken`), the server forwards `PlayerState.PlayerId`, i.e. the player NAME. Checked
+against the live inbox: 0 of 32 client rows paired, all failing on that one field (Δt 0–3 s, text check
+passes); the unit test had used "Pilot" on both sides. Knock-on for the reply channel (#1327): server rows got
+`reply_key = Derive(playerName)` — unreachable for the client (it polls `Derive(token)`), guessable from a
+public name, and the admin list links exactly that row as primary, so an answer typed there never arrived.
+**Fix:** `IsSameReport` pairs by reply key when both halves carry one, else by player name (never by id);
+`BumpReport.ReplyKey` (additive MessagePack field) carries the client's key through `/bump`, the server
+forwards it verbatim when well-formed (never derives one — it only holds the name); `ReportStore` no longer
+derives keys for `source == "server"` rows (insert + back-fill) and `RevokeNameDerivedServerKeys()` blanks the
+ones already stamped, once at startup. Docs: REPORT_HOST.md. Tests: production-shaped grouping fixture
+(token vs. name) + key/name identity cases, store tests for server rows/back-fill/revoke, bump forward
+carries/omits the key. Needs the ReportHost image redeploy that #1327 needs anyway, before the next client
+release.
+
 ## ✅ Done (2026-08-29): the way back — developer answers and follow-up questions reach the reporter in-game (#1327, #1328, #1329)
 
 Until now the F1 inbox was a dead end: an operator could flip a report's status or delete it, and every

--- a/client/Assets/BlocksBeyondTheStars/Scripts/FeedbackUi.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/FeedbackUi.cs
@@ -29,7 +29,8 @@ namespace BlocksBeyondTheStars.Client
     ///     WebGL, where HttpClient/threads don't exist) — reaches the devs on any server, even someone else's
     ///     dedicated server;
     ///   • the existing <c>/bump</c> message (<see cref="NetworkClient.SendBumpReport"/>) so the server also
-    ///     writes its rich local snapshot (inventory/position/surroundings) when on an own/singleplayer server.
+    ///     writes its rich local snapshot (inventory/position/surroundings) when on an own/singleplayer server —
+    ///     carrying the same reply key as the direct upload, so the inbox can pair the two rows (#1359).
     ///
     /// While the dialog is open the world is HELD exactly like behind the Esc menu (#1330): the same server intent
     /// (<see cref="NetworkClient.SendPause"/>, group decision per #973 — a lone writer in multiplayer pauses nobody
@@ -325,9 +326,11 @@ namespace BlocksBeyondTheStars.Client
             var report = BuildReport(title, desc, email);
             byte[] jpg = _shotJpg;
 
-            // Path A — rich server snapshot via the existing /bump pipeline (meaningful on own/SP servers).
+            // Path A — rich server snapshot via the existing /bump pipeline (meaningful on own/SP servers). The
+            // reply key rides along (#1359) so the server's forwarded row carries the same thread credential as
+            // the direct upload below: the inbox pairs the two rows by it, and an answer on either one reaches us.
             string serverNote = string.IsNullOrEmpty(title) ? desc : title + " — " + desc;
-            Game?.Network?.SendBumpReport("[feedback] " + serverNote, jpg ?? Array.Empty<byte>(), AppShell.Version);
+            Game?.Network?.SendBumpReport("[feedback] " + serverNote, jpg ?? Array.Empty<byte>(), AppShell.Version, _replyKey);
 
             // Path B — client-direct upload to the report inbox. The body is serialized ONCE here on the
             // main thread; only the POST leaves the game loop.

--- a/docs/developer/REPORT_HOST.md
+++ b/docs/developer/REPORT_HOST.md
@@ -81,10 +81,15 @@ pulls and shows (see [PLAYER_FEEDBACK](PLAYER_FEEDBACK.md)).
 **Who may read a thread — the reply key.** The client sends `replyKey` with each report: lowercase-hex
 `SHA256("bbs-reply:" + <install secret>)` (`Shared/Feedback/FeedbackReplyKey.cs`, shared by client and
 inbox). The secret is the install's name-claim token (desktop, play.*) or the Glitch install id (arcade);
-the key is one-way, so a leaked key reads replies but can never claim a name. A report that arrives
-**without** a well-formed key (pre-#1327 client) gets one derived from its `playerId` at ingest, and
-`BackfillReplyKeys()` does the same once at startup for rows stored before the feature — older reporters
-become answerable as soon as they update. Server crash reports carry no player id → no key → the admin
+the key is one-way, so a leaked key reads replies but can never claim a name. A **client-direct** report
+that arrives **without** a well-formed key (pre-#1327 client) gets one derived from its `playerId` at
+ingest, and `BackfillReplyKeys()` does the same once at startup for rows stored before the feature — older
+reporters become answerable as soon as they update. **Server forwards** (`reportJson.source == "server"`:
+`/bump`, paint/shape reports, crashes) are the exception (#1359): their `playerId` is the public player
+**name**, and a key derived from that would be guessable by anyone who knows the name — and is never what
+the client polls with. Such a row carries only the key the client passed through `/bump`
+(`BumpReport.ReplyKey`, #1359 clients) or none at all; `RevokeNameDerivedServerKeys()` blanks the
+name-derived keys older stores had already stamped, once at startup. A row without a key → the admin
 page says so instead of offering a form. `PUT`-style overwrite/clear: `ReportStore.SetReplyKey` (no HTTP
 route on purpose).
 
@@ -148,7 +153,17 @@ reports.example.com {
   `screenshot` node (base64 JPG), so it stores + shows in the admin detail view exactly like an F1
   screenshot — the server forward is the reliable path for it, since the client-direct F1 upload may not
   run on older builds. Oversized shots are dropped upstream (2 MB cap) / by the ReportHost base64 cap,
-  keeping the report either way. The local `bumps/` file stays authoritative.
+  keeping the report either way. The reporter's `replyKey` rides along as a top-level node when the client
+  sent one with the `/bump` (#1359), so both halves of one report share the thread credential. The local
+  `bumps/` file stays authoritative.
+- **One F1 report = two rows, one admin row** — an in-game F1 report reaches the inbox twice by design
+  (client-direct + server forward; see above). Ingest keeps both (it must never drop a player report) and the
+  read API returns both; only the admin list collapses the pair (`ReportHostPages.GroupDuplicates`) into one
+  row with a `+1` link to the other half: same category and version, stamped within 8 s, one description
+  containing the other, and the **same reporter** — by reply key when both halves carry one, by player
+  **name** otherwise. Not by `playerId`: the client row carries the install token, the server row the
+  player name, so the two never agree (the original #618 check compared exactly that and never paired a
+  single report in production — #1359).
 - **`/reportpaint` / `/reportshape` reports** (#938) — any server with a configured sink also forwards
   each in-game paint/shape report to the inbox, shaped like a `/bump` (no `reportJson.kind` → category
   *feedback*, `source: "server"`) with `reportJson.reportType: "paint-report"` / `"shape-report"` and

--- a/src/BlocksBeyondTheStars.Client.Core/NetworkClient.cs
+++ b/src/BlocksBeyondTheStars.Client.Core/NetworkClient.cs
@@ -380,13 +380,15 @@ namespace BlocksBeyondTheStars.Client
         /// <summary>Sends a <c>/bump</c> bug report with an optional in-game screenshot (JPG bytes). The server
         /// persists a rich snapshot of the reporter's situation and writes the image alongside it. The
         /// caller passes the client's build version so a forwarded report shows the reporter's build rather
-        /// than the server's (see <see cref="BumpReport.ClientVersion"/>).</summary>
-        public void SendBumpReport(string description, byte[] image, string clientVersion = "")
+        /// than the server's (see <see cref="BumpReport.ClientVersion"/>), and its reply key so the forwarded
+        /// row shares the reporter's thread credential (see <see cref="BumpReport.ReplyKey"/>, #1359).</summary>
+        public void SendBumpReport(string description, byte[] image, string clientVersion = "", string replyKey = "")
             => Send(new BumpReport
             {
                 Description = description ?? string.Empty,
                 Image = image ?? Array.Empty<byte>(),
                 ClientVersion = clientVersion ?? string.Empty,
+                ReplyKey = replyKey ?? string.Empty,
             });
 
         // Admin/cheat console (server validates IsAdmin + the CheatsAllowed rule and replies with a ServerMessage).

--- a/src/BlocksBeyondTheStars.GameServer/GameServerBump.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerBump.cs
@@ -9,6 +9,7 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using BlocksBeyondTheStars.Networking.Messages;
 using BlocksBeyondTheStars.Persistence;
+using BlocksBeyondTheStars.Shared.Feedback;
 using BlocksBeyondTheStars.Shared.Geometry;
 
 namespace BlocksBeyondTheStars.GameServer;
@@ -99,7 +100,7 @@ public sealed partial class GameServer
             image = null;
         }
 
-        HandleBump(session, SanitizeBumpDescription(report.Description), image, report.ClientVersion);
+        HandleBump(session, SanitizeBumpDescription(report.Description), image, report.ClientVersion, report.ReplyKey);
     }
 
     /// <summary>Bounds + cleans a client-supplied bump description before it is written to the log and a
@@ -124,7 +125,7 @@ public sealed partial class GameServer
         return sb.ToString().Trim();
     }
 
-    private void HandleBump(PlayerSession session, string description, byte[]? image = null, string clientVersion = "")
+    private void HandleBump(PlayerSession session, string description, byte[]? image = null, string clientVersion = "", string replyKey = "")
     {
         // Everything below reads through the ACTIVE world cursor — _world, _meta, _creatures, _npcs,
         // _generator. A bump can arrive while that cursor points at somebody else's planet (the tick loop
@@ -141,7 +142,7 @@ public sealed partial class GameServer
 
         try
         {
-            CaptureBump(session, description, image, clientVersion);
+            CaptureBump(session, description, image, clientVersion, replyKey);
         }
         finally
         {
@@ -152,7 +153,7 @@ public sealed partial class GameServer
         }
     }
 
-    private void CaptureBump(PlayerSession session, string description, byte[]? image, string clientVersion)
+    private void CaptureBump(PlayerSession session, string description, byte[]? image, string clientVersion, string replyKey)
     {
         var p = session.State;
         var (systemName, planetName) = ActiveLocationNames();
@@ -344,7 +345,7 @@ public sealed partial class GameServer
             // (#380) is best-effort and may not run for older/native builds, so this is the only reliable way
             // the picture reaches the inbox. The local file above stays the source of truth; this send is one
             // best-effort attempt with no retry queue.
-            ForwardBumpSnapshot(description, p.PlayerId, p.Name, snapshot, hasImage ? image : null, imageName, clientVersion);
+            ForwardBumpSnapshot(description, p.PlayerId, p.Name, snapshot, hasImage ? image : null, imageName, clientVersion, replyKey);
         }
         catch (Exception e)
         {
@@ -364,8 +365,11 @@ public sealed partial class GameServer
     /// it shows in the admin detail view. No-op when no sink is configured; never throws into the tick.
     /// The report's <c>gameVersion</c> is the reporter's client build (<paramref name="clientVersion"/>) when
     /// the client sent one — so the inbox shows the player's build, not the server's — and falls back to the
-    /// server version for older clients / the text-only <c>/bump</c>.</summary>
-    private void ForwardBumpSnapshot(string description, string playerId, string playerName, object snapshot, byte[]? image, string? imageName, string clientVersion = "")
+    /// server version for older clients / the text-only <c>/bump</c>. The reporter's <paramref name="replyKey"/>
+    /// (#1359) is passed through when it is well-formed — the forwarded row then shares the direct upload's
+    /// thread credential, so the inbox pairs the two rows and answers on either one reach the player; it is
+    /// never derived here, because the only id the server holds is the public player name.</summary>
+    private void ForwardBumpSnapshot(string description, string playerId, string playerName, object snapshot, byte[]? image, string? imageName, string clientVersion = "", string replyKey = "")
     {
         var sink = CrashUploader;
         if (sink is null || !sink.IsConfigured)
@@ -389,6 +393,7 @@ public sealed partial class GameServer
                 sessionId = string.Empty,
                 platform = "server",
                 clientTimestamp = DateTime.UtcNow.ToString("o"),
+                replyKey = FeedbackReplyKey.IsWellFormed(replyKey) ? replyKey : string.Empty,
                 // The screenshot (when the client sent one) as base64, matching the F1 wire contract the
                 // ReportHost already decodes (ReportIngest.ExtractScreenshot reads screenshot.base64 +
                 // mimeType). Null when there is no image → the ingest simply skips it. Oversized shots were

--- a/src/BlocksBeyondTheStars.Networking/Messages.cs
+++ b/src/BlocksBeyondTheStars.Networking/Messages.cs
@@ -1919,6 +1919,13 @@ public sealed class BumpReport
     /// server's. Empty from older clients (and the text-only <c>/bump</c>), in which case the server falls
     /// back to its own version. MessagePack is contractless, so this extra field is backward compatible.</summary>
     public string ClientVersion { get; set; } = string.Empty;
+
+    /// <summary>The reporter's reply-thread credential (#1359): the same one-way hash of the install secret
+    /// the client sends on its direct F1 upload (<c>Shared/Feedback/FeedbackReplyKey</c>). The server forwards
+    /// it verbatim so the inbox can pair the two rows of one report and route an answer on either row to the
+    /// player; the server never sees the secret itself. Empty from older clients and the text-only
+    /// <c>/bump</c>. MessagePack is contractless, so the extra field is backward compatible.</summary>
+    public string ReplyKey { get; set; } = string.Empty;
 }
 
 /// <summary>A broadcast chat line (server→clients).</summary>

--- a/src/BlocksBeyondTheStars.ReportHost/ReportHostApp.cs
+++ b/src/BlocksBeyondTheStars.ReportHost/ReportHostApp.cs
@@ -43,6 +43,14 @@ public static class ReportHostApp
             log.LogInformation("Back-filled reply keys for {Count} pre-existing report(s).", backfilled);
         }
 
+        // Server forwards that got a key derived from the player NAME (guessable, and never what the client
+        // polls with — #1359) lose it again. Idempotent — a no-op once repaired.
+        int revoked = store.RevokeNameDerivedServerKeys();
+        if (revoked > 0)
+        {
+            log.LogInformation("Revoked name-derived reply keys on {Count} server-forwarded report(s).", revoked);
+        }
+
         log.LogInformation(
             "ReportHost on {Bind}:{Port} — ingest {Ingest}, read API {Read}, admin UI {Admin}, retention {Retention}, pruned {Pruned} at start.",
             config.BindAddress, config.Port,

--- a/src/BlocksBeyondTheStars.ReportHost/ReportHostPages.cs
+++ b/src/BlocksBeyondTheStars.ReportHost/ReportHostPages.cs
@@ -116,9 +116,13 @@ public static class ReportHostPages
     /// report. Grouping happens at RENDER time only — ingest still stores both rows (it must never drop a player
     /// report) and the read API still returns both.
     /// </para>
-    /// Rows pair up when they were stamped within <see cref="DuplicateWindowSeconds"/> of each other and one
-    /// description contains the other: the server forward wraps the player's text as
+    /// Rows pair up when they were stamped within <see cref="DuplicateWindowSeconds"/> of each other, belong to
+    /// the same reporter and one description contains the other: the server forward wraps the player's text as
     /// <c>[feedback] &lt;title&gt; — &lt;description&gt;</c>, so the client row's text is a substring of it.
+    /// "Same reporter" is NOT the player id (#1359): the client row carries the install token, the server
+    /// forward the player name, so the two halves never agreed on it and nothing ever paired. It is the reply
+    /// key when both halves carry one (a #1359 client passes the same key through <c>/bump</c>), and the player
+    /// name otherwise (older client or server builds).
     /// </summary>
     public static List<List<BugReportRecord>> GroupDuplicates(IReadOnlyList<BugReportRecord> items)
     {
@@ -159,7 +163,7 @@ public static class ReportHostPages
 
         // Only the two halves of ONE report pair up — never a client report with an unrelated crash, and never
         // two rows from different players/builds that happen to collide in time.
-        if (a.Category != b.Category || a.GameVersion != b.GameVersion || a.PlayerId != b.PlayerId)
+        if (a.Category != b.Category || a.GameVersion != b.GameVersion || !SameReporter(a, b))
         {
             return false;
         }
@@ -172,6 +176,19 @@ public static class ReportHostPages
         }
 
         return da.Contains(db, StringComparison.Ordinal) || db.Contains(da, StringComparison.Ordinal);
+    }
+
+    /// <summary>Whether two rows come from the same reporter — by reply key when both carry one (exact: two
+    /// installs never share a key), by player name otherwise. Never by player id, which the two halves of one
+    /// report do not share (install token vs. player name, #1359).</summary>
+    private static bool SameReporter(BugReportRecord a, BugReportRecord b)
+    {
+        if (a.ReplyKey.Length > 0 && b.ReplyKey.Length > 0)
+        {
+            return a.ReplyKey == b.ReplyKey;
+        }
+
+        return a.PlayerName.Length > 0 && a.PlayerName == b.PlayerName;
     }
 
     /// <summary>Collapses whitespace so the two wordings compare cleanly.</summary>

--- a/src/BlocksBeyondTheStars.ReportHost/ReportStore.cs
+++ b/src/BlocksBeyondTheStars.ReportHost/ReportStore.cs
@@ -145,7 +145,8 @@ public sealed class ReportStore : IDisposable
     /// <summary>Stores a parsed report (and its screenshot file, when present) and returns the new id.
     /// <paramref name="nowUnix"/> is injectable for tests; production passes the current time. A report
     /// that came without a <c>replyKey</c> (pre-#1327 client) gets one derived from its player id, so
-    /// the reporter can still receive answers once they update.</summary>
+    /// the reporter can still receive answers once they update — except a server forward (#1359): its
+    /// player id is the public player NAME, and a key derived from that would be guessable.</summary>
     public string Add(ParsedReport report, long nowUnix)
     {
         string id = Guid.NewGuid().ToString("N");
@@ -157,7 +158,9 @@ public sealed class ReportStore : IDisposable
             File.WriteAllBytes(Path.Combine(_screenshotsDir, screenshotFile), report.ScreenshotBytes);
         }
 
-        string replyKey = report.ReplyKey.Length > 0 ? report.ReplyKey : FeedbackReplyKey.Derive(report.PlayerId);
+        string replyKey = report.ReplyKey.Length > 0 ? report.ReplyKey
+            : report.Source == ServerSource ? string.Empty
+            : FeedbackReplyKey.Derive(report.PlayerId);
 
         lock (_gate)
         {
@@ -193,9 +196,14 @@ public sealed class ReportStore : IDisposable
         return id;
     }
 
+    /// <summary><c>reportJson.source</c> of a game server's forward (<c>/bump</c>, paint/shape reports, crashes).
+    /// Such rows identify the player by NAME, not by the install secret — see <see cref="Add"/>.</summary>
+    public const string ServerSource = "server";
+
     /// <summary>One-time migration for rows stored before the reply channel existed: derives the reply
     /// key from the stored player id with the client's own formula. Idempotent (only touches rows with
-    /// an empty key); returns how many rows were filled. Called at startup.</summary>
+    /// an empty key); returns how many rows were filled. Called at startup. Server forwards are skipped
+    /// for the reason given on <see cref="Add"/> (#1359).</summary>
     public int BackfillReplyKeys()
     {
         lock (_gate)
@@ -203,7 +211,8 @@ public sealed class ReportStore : IDisposable
             var pending = new List<(string Id, string PlayerId)>();
             using (var select = _db.CreateCommand())
             {
-                select.CommandText = "SELECT id, player_id FROM bugreport WHERE reply_key = '' AND player_id != '';";
+                select.CommandText = "SELECT id, player_id FROM bugreport WHERE reply_key = '' AND player_id != '' AND source != $server;";
+                select.Parameters.AddWithValue("$server", ServerSource);
                 using var reader = select.ExecuteReader();
                 while (reader.Read())
                 {
@@ -221,6 +230,42 @@ public sealed class ReportStore : IDisposable
             }
 
             return pending.Count;
+        }
+    }
+
+    /// <summary>One-time repair for server-forwarded rows (#1359): before the fix, a forward without a reply
+    /// key got one derived from its player id — for a server row that is the public player NAME, i.e. a key
+    /// anyone who knows the name can compute (and the client never polls with it). Blanks exactly those keys;
+    /// a key the client passed through <c>/bump</c> does not equal the name derivation and stays. Idempotent;
+    /// returns how many rows were cleared. Called at startup after <see cref="BackfillReplyKeys"/>.</summary>
+    public int RevokeNameDerivedServerKeys()
+    {
+        lock (_gate)
+        {
+            var derived = new List<string>();
+            using (var select = _db.CreateCommand())
+            {
+                select.CommandText = "SELECT id, player_id, reply_key FROM bugreport WHERE source = $server AND reply_key != '';";
+                select.Parameters.AddWithValue("$server", ServerSource);
+                using var reader = select.ExecuteReader();
+                while (reader.Read())
+                {
+                    if (reader.GetString(2) == FeedbackReplyKey.Derive(reader.GetString(1)))
+                    {
+                        derived.Add(reader.GetString(0));
+                    }
+                }
+            }
+
+            foreach (string id in derived)
+            {
+                using var update = _db.CreateCommand();
+                update.CommandText = "UPDATE bugreport SET reply_key = '' WHERE id = $id;";
+                update.Parameters.AddWithValue("$id", id);
+                update.ExecuteNonQuery();
+            }
+
+            return derived.Count;
         }
     }
 

--- a/tests/BlocksBeyondTheStars.Tests/BumpTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/BumpTests.cs
@@ -92,7 +92,8 @@ public sealed class BumpTests : IDisposable
         server.CrashUploader = sink;
 
         var image = new byte[] { 0xFF, 0xD8, 0xFF, 0xE0, 9, 8, 7, 6, 5 };
-        client.Send(NetCodec.Encode(new BumpReport { Description = "[feedback] jetpack stuck in ceiling", Image = image, ClientVersion = "0.8.3" }), DeliveryMode.ReliableOrdered);
+        string replyKey = BlocksBeyondTheStars.Shared.Feedback.FeedbackReplyKey.Derive("install-secret");
+        client.Send(NetCodec.Encode(new BumpReport { Description = "[feedback] jetpack stuck in ceiling", Image = image, ClientVersion = "0.8.3", ReplyKey = replyKey }), DeliveryMode.ReliableOrdered);
         server.Tick(0.1);
 
         // The send runs on a background task — wait for the sink, not a fixed sleep.
@@ -106,6 +107,9 @@ public sealed class BumpTests : IDisposable
             // gameVersion is the reporter's client build (not the server's), so the inbox shows the
             // player's version — the whole point of BumpReport.ClientVersion (issue #389).
             Assert.Equal("0.8.3", doc.RootElement.GetProperty("gameVersion").GetString());
+            // The reporter's reply key passes through untouched (#1359), so the inbox can pair this row with
+            // the client-direct upload and route an answer on either one to the player.
+            Assert.Equal(replyKey, doc.RootElement.GetProperty("replyKey").GetString());
 
             var reportJson = doc.RootElement.GetProperty("reportJson");
             Assert.Equal("bump", reportJson.GetProperty("reportType").GetString());
@@ -145,7 +149,26 @@ public sealed class BumpTests : IDisposable
         // A text-only /bump (ChatIntent) carries no client version, so gameVersion falls back to the
         // server's version — never left empty.
         Assert.False(string.IsNullOrEmpty(doc.RootElement.GetProperty("gameVersion").GetString()));
+        // ...and no reply key: the server must never derive one from the player name (#1359).
+        Assert.Equal("", doc.RootElement.GetProperty("replyKey").GetString());
         Assert.Equal(1, server.BumpsWritten);
+    }
+
+    [Fact]
+    public void BumpReport_WithMalformedReplyKey_ForwardsAnEmptyKey()
+    {
+        var (server, client, _) = StartWorld();
+        var sink = new ForwardSink();
+        server.CrashUploader = sink;
+
+        // Whatever a tampered client puts in the field, only a well-formed key (64 lowercase hex) is passed on —
+        // the ReportHost would ignore anything else anyway, and an empty key means "not answerable here".
+        client.Send(NetCodec.Encode(new BumpReport { Description = "[feedback] odd key", ReplyKey = "not-a-key" }), DeliveryMode.ReliableOrdered);
+        server.Tick(0.1);
+
+        Assert.True(sink.Sent.Wait(TimeSpan.FromSeconds(10)), "bump was not forwarded to the sink");
+        using var doc = System.Text.Json.JsonDocument.Parse(sink.LastJson!);
+        Assert.Equal("", doc.RootElement.GetProperty("replyKey").GetString());
     }
 
     [Fact]

--- a/tests/BlocksBeyondTheStars.Tests/ReportDuplicateGroupingTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/ReportDuplicateGroupingTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
 using BlocksBeyondTheStars.ReportHost;
+using BlocksBeyondTheStars.Shared.Feedback;
 using Xunit;
 
 namespace BlocksBeyondTheStars.Tests;
@@ -10,9 +11,16 @@ namespace BlocksBeyondTheStars.Tests;
 /// Every in-game F1 report reaches the inbox twice by design — the client posts to /api/bugreport itself, and
 /// the game server forwards its /bump snapshot to the same endpoint. The admin list must show one row per
 /// report instead of double-counting, while ingest and the read API keep both records.
+/// <para>
+/// The two halves do NOT share a player id (#1359): the client row carries the install token, the server
+/// forward the player name — which is why the fixture below stamps them differently, exactly like production.
+/// </para>
 /// </summary>
 public sealed class ReportDuplicateGroupingTests
 {
+    /// <summary>What the client-direct row carries as <c>playerId</c>: the install's name-claim token.</summary>
+    private const string Token = "417de473e6b84861afaf0c0ffee0badd";
+
     private static BugReportRecord Row(
         string id,
         string title,
@@ -22,8 +30,9 @@ public sealed class ReportDuplicateGroupingTests
         string screenshot = "",
         string status = "new",
         string category = "feedback",
-        string playerId = "Pilot",
-        string version = "2026.7.22")
+        string playerName = "Pilot",
+        string version = "2026.7.22",
+        string replyKey = "")
         => new(
             Id: id,
             Title: title,
@@ -31,8 +40,9 @@ public sealed class ReportDuplicateGroupingTests
             Email: "",
             GameVersion: version,
             BuildNumber: "",
-            PlayerId: playerId,
-            PlayerName: "Pilot",
+            // The real shape: the server forward's player id is the NAME, the client row's is the token.
+            PlayerId: source == "server" ? playerName : Token,
+            PlayerName: playerName,
             SessionId: "",
             Platform: "",
             ClientTimestamp: "",
@@ -43,11 +53,12 @@ public sealed class ReportDuplicateGroupingTests
             ScreenshotFile: screenshot,
             ReportJson: source == "server" ? "{\"snapshot\":{}}" : "{}",
             CreatedUnix: createdUnix,
-            ReplyKey: "",
+            ReplyKey: replyKey,
             FixedInVersion: "");
 
     /// <summary>The real shape of a pair, taken from a live report: the server forward wraps the player's own
-    /// wording as "[feedback] &lt;title&gt; — &lt;description&gt;", so the client row's text is a substring.</summary>
+    /// wording as "[feedback] &lt;title&gt; — &lt;description&gt;", so the client row's text is a substring —
+    /// and the two rows carry different player ids (token vs. name), which must not keep them apart.</summary>
     [Fact]
     public void TheTwoRowsOfOneReport_CollapseIntoOneGroup()
     {
@@ -59,10 +70,43 @@ public sealed class ReportDuplicateGroupingTests
                 1000, source: "server", screenshot: "bump_1.jpg"),
         };
 
+        Assert.NotEqual(rows[0].PlayerId, rows[1].PlayerId); // the #1359 trap: ids differ by design
+
         var groups = ReportHostPages.GroupDuplicates(rows);
 
         Assert.Single(groups);
         Assert.Equal(2, groups[0].Count);
+    }
+
+    /// <summary>A #1359 client passes its reply key through /bump, so both halves carry the same key — the
+    /// exact identity, which wins over the name (here the player renamed between the two uploads).</summary>
+    [Fact]
+    public void HalvesWithTheSameReplyKey_PairEvenWhenTheNameDiffers()
+    {
+        string key = FeedbackReplyKey.Derive("install-secret");
+        var rows = new[]
+        {
+            Row("client1", "Lampe", "Die Helmlampe geht im Wasser aus.", 1000, playerName: "Pilot", replyKey: key),
+            Row("server1", "Bump [w]: [feedback] Lampe — Die Helmlampe geht im Wasser aus.",
+                "[feedback] Lampe — Die Helmlampe geht im Wasser aus.", 1001, source: "server", playerName: "Justus", replyKey: key),
+        };
+
+        Assert.Single(ReportHostPages.GroupDuplicates(rows));
+    }
+
+    /// <summary>Two installs never share a key: same name, same wording, same second — still two reports when
+    /// both halves carry keys that differ (e.g. two kids both called "Pilot" on two machines).</summary>
+    [Fact]
+    public void DifferentReplyKeys_NeverPair()
+    {
+        var rows = new[]
+        {
+            Row("a", "Absturz", "Das Spiel ist abgestürzt.", 1000, replyKey: FeedbackReplyKey.Derive("machine-1")),
+            Row("b", "Bump [w]: [feedback] Absturz — Das Spiel ist abgestürzt.", "[feedback] Absturz — Das Spiel ist abgestürzt.",
+                1000, source: "server", replyKey: FeedbackReplyKey.Derive("machine-2")),
+        };
+
+        Assert.Equal(2, ReportHostPages.GroupDuplicates(rows).Count);
     }
 
     [Fact]
@@ -95,12 +139,25 @@ public sealed class ReportDuplicateGroupingTests
     {
         var rows = new[]
         {
-            Row("a", "Absturz", "Das Spiel ist abgestürzt.", 1000, playerId: "Justus"),
-            Row("b", "Absturz", "Das Spiel ist abgestürzt.", 1001, playerId: "Severin"),
-            Row("c", "Absturz", "Das Spiel ist abgestürzt.", 1001, playerId: "Justus", version: "2026.7.21"),
+            Row("a", "Absturz", "Das Spiel ist abgestürzt.", 1000, playerName: "Justus"),
+            Row("b", "Absturz", "Das Spiel ist abgestürzt.", 1001, playerName: "Severin"),
+            Row("c", "Absturz", "Das Spiel ist abgestürzt.", 1001, playerName: "Justus", version: "2026.7.21"),
         };
 
         Assert.Equal(3, ReportHostPages.GroupDuplicates(rows).Count);
+    }
+
+    [Fact]
+    public void RowsWithoutAnyReporterIdentity_StayApart()
+    {
+        // No key and no name on either side — nothing to prove they are the same reporter.
+        var rows = new[]
+        {
+            Row("a", "x", "Der Bohrer bohrt nicht.", 1000, playerName: ""),
+            Row("b", "Bump: [feedback] x — Der Bohrer bohrt nicht.", "[feedback] x — Der Bohrer bohrt nicht.", 1000, source: "server", playerName: ""),
+        };
+
+        Assert.Equal(2, ReportHostPages.GroupDuplicates(rows).Count);
     }
 
     [Fact]

--- a/tests/BlocksBeyondTheStars.Tests/ReportHostTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/ReportHostTests.cs
@@ -342,6 +342,82 @@ public sealed class ReportHostTests : IDisposable
         Assert.Equal(0, store.BackfillReplyKeys());
     }
 
+    /// <summary>What the game server forwards for a /bump (GameServerBump.ForwardBumpSnapshot): the player id
+    /// is the player NAME, and the reply key is whatever the client passed through — or nothing.</summary>
+    private static string ServerBumpPayload(string replyKey = "") => JsonSerializer.Serialize(new Dictionary<string, object?>
+    {
+        ["title"] = "Bump [Minecraft]: [feedback] Hat eaten by door — The door on my ship eats my hat.",
+        ["description"] = "[feedback] Hat eaten by door — The door on my ship eats my hat.",
+        ["email"] = "",
+        ["gameVersion"] = "0.4.2",
+        ["playerId"] = "Justus",
+        ["playerName"] = "Justus",
+        ["platform"] = "server",
+        ["replyKey"] = replyKey,
+        ["reportJson"] = new Dictionary<string, object?>
+        {
+            ["schemaVersion"] = 1,
+            ["reportType"] = "bump",
+            ["source"] = "server",
+            ["snapshot"] = new Dictionary<string, object?>(),
+        },
+    });
+
+    /// <summary>#1359: a server forward's player id is the public player name — deriving a key from it would
+    /// hand anyone who knows the name the reply thread, and the client never polls with it anyway. Only a key
+    /// the client passed through /bump is kept.</summary>
+    [Fact]
+    public void ServerForward_NeverGetsAKeyDerivedFromThePlayerName_ButKeepsAPassedThroughOne()
+    {
+        var store = NewStore();
+        var config = new ReportHostConfig();
+
+        string bare = store.Add(ReportIngest.Parse(ServerBumpPayload(), config, out _)!, nowUnix: 1);
+        Assert.Equal("", store.Get(bare)!.ReplyKey);
+
+        string key = KeyFor("token-abc");
+        string keyed = store.Add(ReportIngest.Parse(ServerBumpPayload(key), config, out _)!, nowUnix: 2);
+        Assert.Equal(key, store.Get(keyed)!.ReplyKey);
+
+        // The client-direct half of the same report keeps its derived key — that is the reporter's own secret.
+        string client = store.Add(ReportIngest.Parse(FeedbackPayload(), config, out _)!, nowUnix: 2);
+        Assert.Equal(key, store.Get(client)!.ReplyKey);
+    }
+
+    [Fact]
+    public void BackfillReplyKeys_SkipsServerForwards()
+    {
+        var store = NewStore();
+        var config = new ReportHostConfig();
+        string server = store.Add(ReportIngest.Parse(ServerBumpPayload(), config, out _)!, nowUnix: 1);
+        string client = store.Add(ReportIngest.Parse(FeedbackPayload(), config, out _)!, nowUnix: 1);
+        Assert.True(store.SetReplyKey(client, ""));
+
+        Assert.Equal(1, store.BackfillReplyKeys());
+        Assert.Equal(KeyFor("token-abc"), store.Get(client)!.ReplyKey);
+        Assert.Equal("", store.Get(server)!.ReplyKey);
+    }
+
+    /// <summary>Rows the pre-#1359 store already stamped with a name-derived key are repaired once at startup;
+    /// a key the client passed through, and every client-direct row, stay untouched.</summary>
+    [Fact]
+    public void RevokeNameDerivedServerKeys_ClearsOnlyDerivedKeysOnServerRows()
+    {
+        var store = NewStore();
+        var config = new ReportHostConfig();
+
+        string derived = store.Add(ReportIngest.Parse(ServerBumpPayload(), config, out _)!, nowUnix: 1);
+        Assert.True(store.SetReplyKey(derived, KeyFor("Justus"))); // what the old store did
+        string passedThrough = store.Add(ReportIngest.Parse(ServerBumpPayload(KeyFor("token-abc")), config, out _)!, nowUnix: 2);
+        string client = store.Add(ReportIngest.Parse(FeedbackPayload(), config, out _)!, nowUnix: 3);
+
+        Assert.Equal(1, store.RevokeNameDerivedServerKeys());
+        Assert.Equal("", store.Get(derived)!.ReplyKey);
+        Assert.Equal(KeyFor("token-abc"), store.Get(passedThrough)!.ReplyKey);
+        Assert.Equal(KeyFor("token-abc"), store.Get(client)!.ReplyKey);
+        Assert.Equal(0, store.RevokeNameDerivedServerKeys());
+    }
+
     [Fact]
     public void DevReply_ShowsUpForOwnerOnly_QuestionFlipsStatus_AckHidesIt()
     {


### PR DESCRIPTION
Closes #1359

## Why

Every in-game F1 report reaches the ReportHost twice by design (client-direct POST + the server's `/bump` forward carrying snapshot + screenshot). The admin list has folded such pairs into one row since #618 — on paper. `IsSameReport` compared `PlayerId`, which the two halves never share: the client sends the install token (`Settings.PlayerToken`), the server forwards `PlayerState.PlayerId`, i.e. the player **name**. Checked against the live inbox via the read API: 0 of 32 client rows paired, every one failing on exactly that field (Δt 0–3 s, text check passes). The unit test used `"Pilot"` on both sides, so it never noticed.

The reply channel (#1327) inherited the hole: server rows got `reply_key = Derive(playerName)` — unreachable for the client (it polls `Derive(token)`), guessable from a public name, and the admin list links exactly that (richest) row as primary, so an answer typed there would never have arrived.

## What

**A — pairing (ReportHost, render-time only)**
- `ReportHostPages.IsSameReport` identifies the reporter by **reply key** when both halves carry one, else by **player name** — never by `PlayerId`.

**B — the server row gets the real thread credential**
- `BumpReport.ReplyKey` (additive MessagePack field; `NetworkClient.SendBumpReport(…, replyKey)`), filled by `FeedbackUi` with the same `ComputeReplyKey()` it sends on the direct upload.
- `GameServer` forwards it as top-level `replyKey` when `FeedbackReplyKey.IsWellFormed` — it never derives one (the only id it holds is the name). Text-only `/bump` → empty key, as before.
- `ReportStore`: no derived key for `source == "server"` rows on insert **or** in `BackfillReplyKeys()`; new `RevokeNameDerivedServerKeys()` blanks the name-derived keys older stores already stamped (only those — a passed-through key differs from the derivation and stays). Wired into `ReportHostApp` startup after the back-fill.

**Docs:** `REPORT_HOST.md` (reply-key rules for server rows, how the admin list pairs), CHANGELOG, TODO.

## Tests

- `ReportDuplicateGroupingTests`: fixture now production-shaped (client row = token, server row = name) — the original case fails on `main` and passes here; new cases for same-key/different-name, different keys never pair, no identity at all stays apart.
- `ReportHostTests`: server forward gets no derived key but keeps a passed-through one; back-fill skips server rows; revoke clears only derived keys on server rows and is idempotent.
- `BumpTests`: forward carries the key verbatim, chat `/bump` forwards an empty key, a malformed key is dropped.
- 72 ReportHost/Bump/NetCodec tests green locally, `-warnaserror` clean, `dotnet format --verify-no-changes` clean; local Unity build green (see below).

## Ops

Needs the ReportHost image redeploy (`reports-image.yml`) that #1327/#1352 need anyway — do it before the next client release. Old clients keep working: without `BumpReport.ReplyKey` the pairing falls back to the player name, and their server rows simply carry no key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
