### PR TITLE
test(reports): fixture makes the process's first HTTP request, every request is timed (#1362)

### DIFF
--- a/tests/BlocksBeyondTheStars.Tests/ReportHostHttpTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/ReportHostHttpTests.cs
@@ -21,12 +21,13 @@ using Xunit.Abstractions;
 namespace BlocksBeyondTheStars.Tests;
 
 /// <summary>
-/// One in-process ReportHost for the whole <see cref="ReportHostHttpTests"/> class. The first Kestrel
-/// host a test process starts costs 84–134 s on the Linux CI runners (under a second locally), which
-/// blew the fast-tier budget when every test started its own host and the cost landed on whichever test
-/// ran first (#1362). Starting the host once per class pays that price once, outside any test's clock;
-/// the timings are kept so <see cref="ReportHostHttpTests.HostStartup_IsReportedForTheCiLogAsync"/> can put
-/// them into the test log where the CI artifact keeps them.
+/// One in-process ReportHost for the whole <see cref="ReportHostHttpTests"/> class (#1362). On the Linux
+/// CI runners the very first HTTP request a test process makes has taken 34–134 s (under a second
+/// locally) while the host's Create/StartAsync measured well under a second — with one host per test that
+/// cost landed on whichever test ran first and blew the 120 s fast-tier budget. So the host starts once
+/// per class and makes that first request itself, off every test's clock; the timings are kept so
+/// <see cref="ReportHostHttpTests.HostStartup_IsReportedForTheCiLogAsync"/> can put them into the test log
+/// where the CI artifact keeps them.
 /// </summary>
 public sealed class ReportHostHttpFixture : IAsyncLifetime
 {
@@ -45,6 +46,12 @@ public sealed class ReportHostHttpFixture : IAsyncLifetime
 
     /// <summary>Milliseconds <c>StartAsync</c> took (Kestrel bind + host start).</summary>
     public long StartMs { get; private set; }
+
+    /// <summary>Milliseconds the process's first HTTP request took (made by the fixture, see class remarks).</summary>
+    public long WarmupMs { get; private set; }
+
+    /// <summary>Status of that warm-up request (200 when the host answered a well-formed poll).</summary>
+    public int WarmupStatus { get; private set; }
 
     public async Task InitializeAsync()
     {
@@ -72,6 +79,16 @@ public sealed class ReportHostHttpFixture : IAsyncLifetime
         StartMs = sw.ElapsedMilliseconds;
 
         Client = new HttpClient { BaseAddress = new Uri(_app.Urls.First()) };
+
+        // The process's first HTTP request is the suspect for the 34–134 s a CI run spent inside one test
+        // (#1362): make it here, off every test's clock, and keep its time for the probe test's log line.
+        sw.Restart();
+        using var warmup = new HttpRequestMessage(HttpMethod.Get, "/api/replies?key=" + FeedbackReplyKey.Derive("fixture-warm-up"));
+        warmup.Headers.Add("x-bugreport-key", WriteKey);
+        warmup.Headers.Add("X-Forwarded-For", "10.0.0.0");
+        using var response = await Client.SendAsync(warmup);
+        WarmupMs = sw.ElapsedMilliseconds;
+        WarmupStatus = (int)response.StatusCode;
     }
 
     public async Task DisposeAsync()
@@ -115,9 +132,24 @@ public sealed class ReportHostHttpTests : IClassFixture<ReportHostHttpFixture>
         _output = output;
     }
 
-    private HttpClient Client => _host.Client;
-
     private ReportStore Store => _host.Store;
+
+    private static int _processRequests;
+
+    /// <summary>Every request of the class goes through here (#1362): a CI run spent 34–134 s inside one
+    /// test whose two requests are plain 403s while the host start proved fast — so each request is timed
+    /// and written to the test output with its process-wide sequence number (the first request a process
+    /// makes is a suspect of its own), and anything over a second is flagged <c>SLOW</c>.</summary>
+    private async Task<HttpResponseMessage> TimedSendAsync(HttpRequestMessage request)
+    {
+        int seq = Interlocked.Increment(ref _processRequests);
+        var sw = Stopwatch.StartNew();
+        var response = await _host.Client.SendAsync(request);
+        sw.Stop();
+        string flag = sw.ElapsedMilliseconds >= 1000 ? "SLOW " : string.Empty;
+        _output.WriteLine($"{flag}request #{seq}: {request.Method} {request.RequestUri} → {(int)response.StatusCode} in {sw.ElapsedMilliseconds} ms");
+        return response;
+    }
 
     // ---------------- helpers ----------------
 
@@ -157,13 +189,13 @@ public sealed class ReportHostHttpTests : IClassFixture<ReportHostHttpFixture>
 
     private async Task<HttpStatusCode> PollAsync(string key)
     {
-        using var response = await Client.SendAsync(Request(HttpMethod.Get, "/api/replies?key=" + key));
+        using var response = await TimedSendAsync(Request(HttpMethod.Get, "/api/replies?key=" + key));
         return response.StatusCode;
     }
 
     private async Task<(HttpStatusCode Status, JsonDocument? Body)> PostReportAsync(string playerId)
     {
-        using var response = await Client.SendAsync(Request(HttpMethod.Post, "/api/bugreport", FeedbackPayload(playerId)));
+        using var response = await TimedSendAsync(Request(HttpMethod.Post, "/api/bugreport", FeedbackPayload(playerId)));
         string text = await response.Content.ReadAsStringAsync();
         return (response.StatusCode, text.Length > 0 ? JsonDocument.Parse(text) : null);
     }
@@ -173,12 +205,11 @@ public sealed class ReportHostHttpTests : IClassFixture<ReportHostHttpFixture>
     [Fact]
     public async Task HostStartup_IsReportedForTheCiLogAsync()
     {
-        // No budget assertion — the point is the number in the log: the first Kestrel host of a test
-        // process takes 84–134 s on the Linux CI runners and under a second locally, and the cause is
-        // still open (#1362). One more request here so the first-request cost is on record too.
-        var sw = Stopwatch.StartNew();
+        // No budget assertion — the point is the number in the log: the process's first HTTP request has
+        // taken 34–134 s on the Linux CI runners and under a second locally, and the cause is still open
+        // (#1362). The fixture made that request; this line puts its cost on record next to the host's.
         Assert.Equal(HttpStatusCode.OK, await PollAsync(KeyFor("startup-probe")));
-        _output.WriteLine($"ReportHost host: Create {_host.CreateMs} ms, StartAsync {_host.StartMs} ms, first request {sw.ElapsedMilliseconds} ms");
+        _output.WriteLine($"ReportHost host: Create {_host.CreateMs} ms, StartAsync {_host.StartMs} ms, process-first request {_host.WarmupMs} ms → {_host.WarmupStatus}");
     }
 
     // ---------------- #1352: polling never spends the ingest budget ----------------
@@ -244,7 +275,7 @@ public sealed class ReportHostHttpTests : IClassFixture<ReportHostHttpFixture>
         string key = KeyFor("token-abc");
 
         // Nothing to show until a developer writes something.
-        using (var empty = await Client.SendAsync(Request(HttpMethod.Get, "/api/replies?key=" + key)))
+        using (var empty = await TimedSendAsync(Request(HttpMethod.Get, "/api/replies?key=" + key)))
         {
             Assert.Equal(HttpStatusCode.OK, empty.StatusCode);
             using var doc = JsonDocument.Parse(await empty.Content.ReadAsStringAsync());
@@ -254,7 +285,7 @@ public sealed class ReportHostHttpTests : IClassFixture<ReportHostHttpFixture>
         long replyId = Store.AddDevReply(reportId, "Does it happen always?", isQuestion: true, nowUnix: DateTimeOffset.UtcNow.ToUnixTimeSeconds());
 
         // The poll returns the thread with the unread developer entry…
-        using (var poll = await Client.SendAsync(Request(HttpMethod.Get, "/api/replies?key=" + key)))
+        using (var poll = await TimedSendAsync(Request(HttpMethod.Get, "/api/replies?key=" + key)))
         {
             Assert.Equal(HttpStatusCode.OK, poll.StatusCode);
             Assert.Equal("*", poll.Headers.GetValues("Access-Control-Allow-Origin").Single()); // WebGL client
@@ -267,14 +298,14 @@ public sealed class ReportHostHttpTests : IClassFixture<ReportHostHttpFixture>
 
         // …the ack marks it read, so the next poll is empty again…
         string ack = JsonSerializer.Serialize(new { key, replyIds = new[] { replyId } });
-        using (var acked = await Client.SendAsync(Request(HttpMethod.Post, "/api/replies/ack", ack)))
+        using (var acked = await TimedSendAsync(Request(HttpMethod.Post, "/api/replies/ack", ack)))
         {
             Assert.Equal(HttpStatusCode.OK, acked.StatusCode);
             using var doc = JsonDocument.Parse(await acked.Content.ReadAsStringAsync());
             Assert.Equal(1, doc.RootElement.GetProperty("acked").GetInt32());
         }
 
-        using (var again = await Client.SendAsync(Request(HttpMethod.Get, "/api/replies?key=" + key)))
+        using (var again = await TimedSendAsync(Request(HttpMethod.Get, "/api/replies?key=" + key)))
         {
             using var doc = JsonDocument.Parse(await again.Content.ReadAsStringAsync());
             Assert.Equal(0, doc.RootElement.GetProperty("items").GetArrayLength());
@@ -282,7 +313,7 @@ public sealed class ReportHostHttpTests : IClassFixture<ReportHostHttpFixture>
 
         // …and the player's answer lands in the thread and flips the status.
         string answer = JsonSerializer.Serialize(new { key, reportId, text = "Yes, every time." });
-        using (var answered = await Client.SendAsync(Request(HttpMethod.Post, "/api/replies", answer)))
+        using (var answered = await TimedSendAsync(Request(HttpMethod.Post, "/api/replies", answer)))
         {
             Assert.Equal(HttpStatusCode.Created, answered.StatusCode);
         }
@@ -291,7 +322,7 @@ public sealed class ReportHostHttpTests : IClassFixture<ReportHostHttpFixture>
         Assert.Equal(2, Store.ListReplies(reportId).Count);
 
         // Another install's key sees none of it.
-        using (var foreign = await Client.SendAsync(Request(HttpMethod.Get, "/api/replies?key=" + KeyFor("someone-else"))))
+        using (var foreign = await TimedSendAsync(Request(HttpMethod.Get, "/api/replies?key=" + KeyFor("someone-else"))))
         {
             using var doc = JsonDocument.Parse(await foreign.Content.ReadAsStringAsync());
             Assert.Equal(0, doc.RootElement.GetProperty("items").GetArrayLength());
@@ -302,10 +333,10 @@ public sealed class ReportHostHttpTests : IClassFixture<ReportHostHttpFixture>
     public async Task ReplyRoutes_StillRequireTheWriteKeyAsync()
     {
         string key = KeyFor("token-abc");
-        using var wrong = await Client.SendAsync(Request(HttpMethod.Get, "/api/replies?key=" + key, writeKey: "nope"));
+        using var wrong = await TimedSendAsync(Request(HttpMethod.Get, "/api/replies?key=" + key, writeKey: "nope"));
         Assert.Equal(HttpStatusCode.Forbidden, wrong.StatusCode);
 
-        using var missing = await Client.SendAsync(Request(HttpMethod.Post, "/api/replies/ack", "{}", writeKey: null));
+        using var missing = await TimedSendAsync(Request(HttpMethod.Post, "/api/replies/ack", "{}", writeKey: null));
         Assert.Equal(HttpStatusCode.Forbidden, missing.StatusCode);
     }
 }


### PR DESCRIPTION
Part of #1362 (kept open — the cause is still unknown).

The CI artifact of #1364 showed the host start is **fast** on the runner (Create 441 ms, StartAsync 49 ms) while `ReplyRoutes_StillRequireTheWriteKeyAsync` still took **34.7 s**. Locally that test runs first, so its first request is the **process's first HTTP request** — the new suspect.

## What changed
- The fixture makes the process's first request itself (a well-formed poll), off every test's clock, and keeps its duration/status; the probe test logs `Create / StartAsync / process-first request`.
- Every request of the class goes through `TimedSendAsync`: method, path, status, duration and process-wide sequence number go to the test output, anything ≥ 1 s is flagged `SLOW` — so the CI TRX artifact names the slow request.
- Comments updated to the corrected diagnosis.

## Verification
- `dotnet test --filter ReportHostHttpTests`: 5/5 locally (warm-up 336 ms, the former first request now 17 ms)
- 0 warnings; `dotnet format --verify-no-changes` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)