### PR TITLE
test(ci): the "80 s first HTTP request" is xunit's parallel queue, not the network (#1362)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -162,10 +162,14 @@ jobs:
 
       # Fast-tier duration guardrail (PRs only — the full run legitimately contains Slow tests): fail when
       # any non-Slow test exceeds the per-test budget, so the fast tier cannot silently decay again (it once
-      # crept from ~6 to ~15 min unnoticed). Offenders belong in the Slow tier or need a real fix. The
-      # budget is deliberately loose: trx durations are wall-clock, and parallel CPU-heavy tests inflate
-      # innocent awaiting tests via thread-pool contention (a 9 ms test has measured 37 s inside the full
-      # suite) — 120 s only trips on order-of-magnitude offenders, which is exactly the decay this guards.
+      # crept from ~6 to ~15 min unnoticed). Offenders belong in the Slow tier or need a real fix.
+      # The budget is deliberately loose because a trx duration is NOT the work a test did: xunit runs the
+      # assembly through ONE FIFO queue (MaxConcurrencySyncContext) that already holds every collection
+      # which has not started yet, so an await that really yields — any real I/O — resumes only once that
+      # queue has drained, and the test is billed for the wait (#1362: 134 s measured for two 1 ms
+      # requests; a 9 ms test has measured 454 s). 120 s only trips on order-of-magnitude offenders, which
+      # is exactly the decay this guards. An I/O test that keeps tripping it belongs in
+      # RealTimeSensitiveCollection (DisableParallelization), not in the Slow tier.
       - name: Check fast-tier test durations
         if: inputs.duration-guardrail
         run: python3 scripts/check-test-durations.py --max-seconds 120 TestResults/*.trx

--- a/TODO.md
+++ b/TODO.md
@@ -110,6 +110,21 @@ Per-item detail lives in the dated work log below. **Since 2026-07 versions are 
 #1144, #1146, #1147), all 28 sub-issues #1102–#1129 done. The whole package is UNRELEASED pending the big
 playtest; the post-epic implementation audit spawned the follow-up fix round #1149–#1156.
 
+### ★ The "80 s HTTP request" was xunit's parallel queue, not the network (#1362, 2026-08-29, branch fix/1362-xunit-queue-latency)
+A ReportHost HTTP test measured 34 s / 82 s / 134 s for a loopback request that takes a millisecond, and
+the 134 s failed the fast-tier duration guardrail. It was never HTTP: with `maxParallelThreads` set, xunit
+serves the whole assembly from one FIFO queue and posts every collection into it up front, so an `await`
+that really yields has its continuation queued behind every collection that has not started yet and only
+resumes once the queue drains — the test is billed for the wait. The shard-5 trx proves it: during the
+82.5 s "request" the runner finished 170 other tests at 4.0/4 average concurrency, so **no CI time was
+ever lost** (that shard: 131 s wall clock for 498 test-seconds = 3.8 average concurrency) — the damage was
+a false positive on the guardrail. The suite already had the cure — `RealTimeSensitiveCollection`
+(`DisableParallelization`, i.e. the runner's sequential phase where that queue is empty), used by three
+other I/O classes; `ReportHostHttpTests` simply never joined it. It does now, the fixture reports request
+time and queue wait as two numbers instead of one, and a threshold assertion fails if the class ever
+leaves the collection. The mechanism is written down where people meet it: the collection's own doc
+comment, docs/developer/SERVER_TESTING.md, the guardrail script and tests.yml.
+
 ### ★ Epic #1197 completeness audit — 17 follow-ups in one round (#1287–#1303, 2026-08-26, branch fix/1197-audit-followups)
 A read-only audit of all 28 merged package slices (one reviewer per area over the implementing commits,
 issue acceptance bullets, data cross-checks and the tests) found four real bugs, a handful of unmet acceptance

--- a/docs/developer/SERVER_TESTING.md
+++ b/docs/developer/SERVER_TESTING.md
@@ -100,3 +100,15 @@ first-PR traps:
   clean `dotnet build -warnaserror` (see AGENTS.md "Local verification after changes").
 - The suite pins `maxParallelThreads: 4` ([xunit.runner.json](../../tests/BlocksBeyondTheStars.Tests/xunit.runner.json))
   — heavy worldgen tests funnel through shared caches; don't "fix" a slow local run by raising it.
+- **A test that does real I/O belongs in `[Collection(RealTimeSensitiveCollection.Name)]`.** With
+  `maxParallelThreads` set, xunit serves the whole assembly from one FIFO queue and posts every
+  collection into it up front, so an `await` that actually yields (an HTTP round trip, a socket
+  read, a real-time server loop) has its continuation queued *behind every collection that has not
+  started yet*. It resumes when the queue drains — near the end of the shard — and the test is
+  billed for the wait, even though nothing is stuck and the runner stayed busy the whole time.
+  That is how a 1 ms loopback request came to be measured as 134 s and failed the duration
+  guardrail (#1362). The
+  [collection](../../tests/BlocksBeyondTheStars.Tests/RealTimeSensitiveCollection.cs) is declared
+  `DisableParallelization`, so its classes run in the runner's sequential phase where the queue is
+  empty; it costs a few seconds of serial window. Marking such a test `Slow` instead would hide
+  the symptom and drop the coverage from every PR.

--- a/scripts/check-test-durations.py
+++ b/scripts/check-test-durations.py
@@ -10,10 +10,13 @@ to be fast. A test that blows the budget belongs in the Slow tier ([Trait("Categ
 or needs a real fix — without this check the fast tier silently decays back to a slow one (it
 grew from ~6 to ~15 min once before anyone noticed).
 
-The budget is generous on purpose: trx durations are wall-clock, and parallel worldgen/sim tests
-inflate the measured time of perfectly fast async tests (thread-pool contention — a 9 ms test has
-measured 37 s inside the full suite), so borderline values are normal and only order-of-magnitude
-offenders should trip this.
+The budget is generous on purpose, because a trx duration is not the work the test did. xunit runs
+the assembly through ONE FIFO queue (MaxConcurrencySyncContext, maxParallelThreads: 4) into which
+every test collection is posted up front, so an await that really yields — any real I/O — has its
+continuation queued behind all collections that have not started yet and only resumes once the
+queue has drained. The test is billed for that wait: #1362 measured 134 s for two 1 ms HTTP
+requests, and a 9 ms test has measured 37 s. Borderline values are therefore normal and only
+order-of-magnitude offenders should trip this.
 
 Usage: check-test-durations.py --max-seconds 120 TestResults/*.trx
 """
@@ -55,6 +58,9 @@ def main() -> int:
             print(f"  {seconds:7.1f}s  {name}")
         print("Tag them [Trait(\"Category\", \"Slow\")] (full runs on main/release still cover them) "
               "or make them faster.")
+        print("If the test does real I/O and the time is not its own, it is waiting for xunit's parallel "
+              "queue (#1362): put it in [Collection(RealTimeSensitiveCollection.Name)] instead of "
+              "marking it Slow.")
         return 1
 
     print(f"All {total} tests within the {args.max_seconds:.0f}s fast-tier budget.")

--- a/tests/BlocksBeyondTheStars.Tests/RealTimeSensitiveCollection.cs
+++ b/tests/BlocksBeyondTheStars.Tests/RealTimeSensitiveCollection.cs
@@ -8,10 +8,22 @@ namespace BlocksBeyondTheStars.Tests;
 /// <summary>
 /// A sequential island for wall-clock-sensitive tests: classes in this collection run while NO other
 /// collection runs in parallel. Real-time server loops (<c>GameServer.Run</c>), HTTP round-trips and
-/// async hand-offs otherwise starve behind the CPU-bound worldgen/sim tests saturating the thread
-/// pool — a 9 ms cache test has measured 454 s of wall time inside the parallel suite, tripping the
-/// fast-tier duration guardrail (scripts/check-test-durations.py) with pure scheduling noise.
-/// These tests are fast in isolation, so the serial window costs only seconds.
+/// async hand-offs otherwise measure pure scheduling noise instead of their own work — a 9 ms cache test
+/// has measured 454 s of wall time inside the parallel suite, tripping the fast-tier duration guardrail
+/// (scripts/check-test-durations.py). These tests are fast in isolation, so the serial window costs only
+/// seconds.
+///
+/// <para>The mechanism, nailed down in #1362: with <c>maxParallelThreads: 4</c> xunit installs a
+/// <c>MaxConcurrencySyncContext</c> — ONE FIFO queue served by four worker threads — and
+/// <c>XunitTestAssemblyRunner</c> posts every test collection of the assembly into that queue up front.
+/// An <c>await</c> that really yields (any real I/O; a synchronously-completing one such as Kestrel's
+/// <c>StartAsync</c> does not) posts its continuation to the BACK of that queue, behind every collection
+/// that has not started yet, and so resumes only once the queue has drained — near the end of the shard.
+/// The test is billed for that wait. It is not thread-pool starvation and it is not the I/O: the shard-5
+/// trx of run #1366 shows the runner completing 170 other tests at 4.0-of-4 average concurrency during an
+/// "82.5 s" loopback request that itself took a millisecond. Nothing is stuck and no CI time is lost —
+/// the shard ran 498 test-seconds in 131 s of wall clock — which is exactly why the symptom is a bogus
+/// duration rather than a slow run, and why the cure is this collection and not the <c>Slow</c> trait.</para>
 /// </summary>
 [CollectionDefinition(Name, DisableParallelization = true)]
 public static class RealTimeSensitiveCollection

--- a/tests/BlocksBeyondTheStars.Tests/ReportHostHttpTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/ReportHostHttpTests.cs
@@ -21,13 +21,9 @@ using Xunit.Abstractions;
 namespace BlocksBeyondTheStars.Tests;
 
 /// <summary>
-/// One in-process ReportHost for the whole <see cref="ReportHostHttpTests"/> class (#1362). On the Linux
-/// CI runners the very first HTTP request a test process makes has taken 34–134 s (under a second
-/// locally) while the host's Create/StartAsync measured well under a second — with one host per test that
-/// cost landed on whichever test ran first and blew the 120 s fast-tier budget. So the host starts once
-/// per class and makes that first request itself, off every test's clock; the timings are kept so
-/// <see cref="ReportHostHttpTests.HostStartup_IsReportedForTheCiLogAsync"/> can put them into the test log
-/// where the CI artifact keeps them.
+/// One in-process ReportHost for the whole <see cref="ReportHostHttpTests"/> class — the host's
+/// <c>Create</c> is the one genuinely expensive step (~1 s on the runners: builder, DI container, route
+/// table, SQLite open), so it is paid once per class instead of once per test.
 /// </summary>
 public sealed class ReportHostHttpFixture : IAsyncLifetime
 {
@@ -47,11 +43,30 @@ public sealed class ReportHostHttpFixture : IAsyncLifetime
     /// <summary>Milliseconds <c>StartAsync</c> took (Kestrel bind + host start).</summary>
     public long StartMs { get; private set; }
 
-    /// <summary>Milliseconds the process's first HTTP request took (made by the fixture, see class remarks).</summary>
+    /// <summary>Milliseconds the process's first HTTP request itself took, measured off xunit's
+    /// synchronization context (see <see cref="SendMeasuredAsync"/>).</summary>
     public long WarmupMs { get; private set; }
+
+    /// <summary>Milliseconds that same request then waited to be let back onto an xunit worker thread.
+    /// This is the number that reached 82 s in #1362; with <see cref="RealTimeSensitiveCollection"/>
+    /// keeping the class out of the parallel queue it is ~0, and a regression shows up here first.</summary>
+    public long WarmupQueueWaitMs { get; private set; }
 
     /// <summary>Status of that warm-up request (200 when the host answered a well-formed poll).</summary>
     public int WarmupStatus { get; private set; }
+
+    /// <summary>
+    /// Sends a request and reports how long the REQUEST took, measured on the thread the response arrived
+    /// on. The <c>ConfigureAwait(false)</c> is the point: it stops the stopwatch before the continuation is
+    /// handed back to xunit's scheduler, so the caller can see the two costs apart (#1362 — while they were
+    /// one number, a 1 ms request looked like 82 s).
+    /// </summary>
+    public static async Task<(HttpResponseMessage Response, long RequestMs)> SendMeasuredAsync(HttpClient client, HttpRequestMessage request)
+    {
+        var sw = Stopwatch.StartNew();
+        var response = await client.SendAsync(request).ConfigureAwait(false);
+        return (response, sw.ElapsedMilliseconds);
+    }
 
     public async Task InitializeAsync()
     {
@@ -80,15 +95,20 @@ public sealed class ReportHostHttpFixture : IAsyncLifetime
 
         Client = new HttpClient { BaseAddress = new Uri(_app.Urls.First()) };
 
-        // The process's first HTTP request is the suspect for the 34–134 s a CI run spent inside one test
-        // (#1362): make it here, off every test's clock, and keep its time for the probe test's log line.
+        // The process's first request also warms the HTTP stack (JIT, socket engine, route table), so it is
+        // made here rather than on some test's clock. Its two costs — the request, and the wait for an
+        // xunit worker thread afterwards — are recorded apart for the CI log (#1362).
         sw.Restart();
         using var warmup = new HttpRequestMessage(HttpMethod.Get, "/api/replies?key=" + FeedbackReplyKey.Derive("fixture-warm-up"));
         warmup.Headers.Add("x-bugreport-key", WriteKey);
         warmup.Headers.Add("X-Forwarded-For", "10.0.0.0");
-        using var response = await Client.SendAsync(warmup);
-        WarmupMs = sw.ElapsedMilliseconds;
-        WarmupStatus = (int)response.StatusCode;
+        var (warmupResponse, requestMs) = await SendMeasuredAsync(Client, warmup);
+        using (warmupResponse)
+        {
+            WarmupMs = requestMs;
+            WarmupQueueWaitMs = Math.Max(0, sw.ElapsedMilliseconds - requestMs);
+            WarmupStatus = (int)warmupResponse.StatusCode;
+        }
     }
 
     public async Task DisposeAsync()
@@ -113,7 +133,14 @@ public sealed class ReportHostHttpFixture : IAsyncLifetime
 /// in-process on a loopback port. Covers the player reply routes end to end (issue #1327 had only
 /// store-level tests) and the limiter split of issue #1352 — polling for answers must never spend the
 /// per-IP budget a real F1 report from the same NAT needs.
+///
+/// <para>The class belongs in <see cref="RealTimeSensitiveCollection"/> and must stay there: #1362 was
+/// this class missing it. Its loopback round trips are 1 ms of work whose continuation, in the parallel
+/// suite, waits behind every collection that has not started yet — 34 s, 82 s and 134 s were measured,
+/// and the 134 s failed the fast-tier duration guardrail on a test whose two requests were plain
+/// 403s.</para>
 /// </summary>
+[Collection(RealTimeSensitiveCollection.Name)] // 1 ms loopback requests, billed at up to 134 s in the parallel queue (#1362)
 public sealed class ReportHostHttpTests : IClassFixture<ReportHostHttpFixture>
 {
     private const string WriteKey = ReportHostHttpFixture.WriteKey;
@@ -136,18 +163,17 @@ public sealed class ReportHostHttpTests : IClassFixture<ReportHostHttpFixture>
 
     private static int _processRequests;
 
-    /// <summary>Every request of the class goes through here (#1362): a CI run spent 34–134 s inside one
-    /// test whose two requests are plain 403s while the host start proved fast — so each request is timed
-    /// and written to the test output with its process-wide sequence number (the first request a process
-    /// makes is a suspect of its own), and anything over a second is flagged <c>SLOW</c>.</summary>
+    /// <summary>Every request of the class goes through here: it logs the request's own time and, next to
+    /// it, the time the continuation then waited for an xunit worker thread. Keeping the two apart is what
+    /// #1362 was missing — one stopwatch around <c>SendAsync</c> reported 82 s for a 1 ms request.</summary>
     private async Task<HttpResponseMessage> TimedSendAsync(HttpRequestMessage request)
     {
         int seq = Interlocked.Increment(ref _processRequests);
         var sw = Stopwatch.StartNew();
-        var response = await _host.Client.SendAsync(request);
-        sw.Stop();
-        string flag = sw.ElapsedMilliseconds >= 1000 ? "SLOW " : string.Empty;
-        _output.WriteLine($"{flag}request #{seq}: {request.Method} {request.RequestUri} → {(int)response.StatusCode} in {sw.ElapsedMilliseconds} ms");
+        var (response, requestMs) = await ReportHostHttpFixture.SendMeasuredAsync(_host.Client, request);
+        long queueMs = Math.Max(0, sw.ElapsedMilliseconds - requestMs);
+        string flag = requestMs >= 1000 || queueMs >= 1000 ? "SLOW " : string.Empty;
+        _output.WriteLine($"{flag}request #{seq}: {request.Method} {request.RequestUri} → {(int)response.StatusCode} in {requestMs} ms (+{queueMs} ms xunit queue)");
         return response;
     }
 
@@ -205,11 +231,18 @@ public sealed class ReportHostHttpTests : IClassFixture<ReportHostHttpFixture>
     [Fact]
     public async Task HostStartup_IsReportedForTheCiLogAsync()
     {
-        // No budget assertion — the point is the number in the log: the process's first HTTP request has
-        // taken 34–134 s on the Linux CI runners and under a second locally, and the cause is still open
-        // (#1362). The fixture made that request; this line puts its cost on record next to the host's.
         Assert.Equal(HttpStatusCode.OK, await PollAsync(KeyFor("startup-probe")));
-        _output.WriteLine($"ReportHost host: Create {_host.CreateMs} ms, StartAsync {_host.StartMs} ms, process-first request {_host.WarmupMs} ms → {_host.WarmupStatus}");
+        _output.WriteLine($"ReportHost host: Create {_host.CreateMs} ms, StartAsync {_host.StartMs} ms, "
+            + $"process-first request {_host.WarmupMs} ms → {_host.WarmupStatus}, xunit queue wait {_host.WarmupQueueWaitMs} ms");
+
+        // The regression guard for #1362: take this class out of RealTimeSensitiveCollection and the
+        // fixture's first request is posted behind every collection that has not started yet again, so
+        // this wait goes back to tens of seconds — which is how a 1 ms request once cost a test 134 s and
+        // failed the fast-tier guardrail. The threshold sits far above any real scheduling hiccup and far
+        // below the values the bug produced.
+        Assert.True(_host.WarmupQueueWaitMs < 20_000,
+            $"The fixture's first request waited {_host.WarmupQueueWaitMs} ms for an xunit worker thread — "
+            + $"this class must stay in the {RealTimeSensitiveCollection.Name} collection (#1362).");
     }
 
     // ---------------- #1352: polling never spends the ingest budget ----------------


### PR DESCRIPTION
Closes #1362.

## What it actually was

Not Linux, not Kestrel, not `SocketsHttpHandler`. **No HTTP request ever took 80 s.**

With `maxParallelThreads: 4` xunit installs a `MaxConcurrencySyncContext` — **one FIFO queue** served by four worker threads — and `XunitTestAssemblyRunner` posts **every test collection of the assembly into that queue up front**. An `await` that really yields (any real I/O) posts its continuation to the **back** of that queue, behind every collection that has not started yet, so it resumes only once the queue has drained — near the end of the shard. The stopwatch around `SendAsync` measures that wait, not the request.

That also explains the two numbers that made the bug look like a network problem: `Create` (1055 ms) is synchronous, and `StartAsync` (88 ms) completes synchronously and never yields, so neither pays the queue. Only the request did.

## Evidence

**CI, shard-5 trx of run #1366** (downloaded and reduced per test to `endTime - duration`):

| | |
|---|---|
| tests the runner completed *during* the 82.5 s "request" | **170**, at **4.0 of 4** average concurrency |
| when the wait ended | 11 s before the shard's last test |
| whole shard | 131 s wall clock for 498 test-seconds = **3.80 average concurrency** |

**Full local run on Windows** (2509 tests, `--filter Category!=Slow`):

```
ReportHost host: Create 206 ms, StartAsync 47 ms, process-first request 101750 ms → 200
run span 1875 s, 7282 test-seconds, avg concurrency 3.88 of 4
```

101.7 s on Windows for a request that takes a millisecond. Whoever runs the class filtered sees <1 s, which is how this read as a CI/Linux problem for three rounds.

## One correction to the issue

**No CI time was ever lost.** The wait was fully overlapped — the runner sat at 3.8–4.0 of 4 concurrency throughout. The issue's "~1.5 min per shard-3 run is real CI time" does not hold; the real damage was a **false positive** on the 120 s duration guardrail, which is what failed PR #1360.

## The fix

The cure already existed in this repo. `RealTimeSensitiveCollection` (`DisableParallelization` → the runner's sequential phase, where the queue is empty) has carried `MaintenanceAnnounceTests`, `ServerShutdownTests` and `WorldHostStatsTests` since the same symptom hit them — its own comment records *"a 9 ms cache test has measured 454 s"*. `ReportHostHttpTests`, new in #1352, simply never joined it.

- `ReportHostHttpTests` joins `RealTimeSensitiveCollection` — that is the fix, one attribute.
- The fixture and `TimedSendAsync` now report the **request** and the **queue wait** as two numbers instead of one (stopwatch stopped inside a `ConfigureAwait(false)` continuation), so a CI log can never blame HTTP for scheduling again.
- `HostStartup_IsReportedForTheCiLogAsync` fails if that queue wait exceeds 20 s — the regression guard for the class leaving the collection.
- The mechanism is written down where people meet it: the collection's doc comment, `docs/developer/SERVER_TESTING.md`, `check-test-durations.py` (whose failure message now points at the collection instead of only the `Slow` trait) and `tests.yml` — all three previously credited thread-pool contention.

I checked whether other I/O classes need the same treatment: across all six shards of run #1366 no other class doing HTTP/sockets exceeds 16 s, so the scope stays this one class.

## Verification

| | process-first request | queue wait |
|---|---|---|
| before | **101 750 ms** | not separated |
| after | **80 ms** | **1 ms** |

Same machine, same full local fast tier, **2509/2509 passing** in both. Clean Release build with `-warnaserror` (0 warnings), `dotnet format --verify-no-changes` clean.

Note on wall clock: the "after" run finished in 24m34s against the baseline's 31m14s, but the baseline shared the box with a second suite for half its run — that difference is **not** attributable to this change, and this PR claims no speed-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
