### PR TITLE
fix: low-priority leftovers from the 2026-08-29 audit — server physics, report inbox, Unity client (#1367 #1368 #1369)

### DIFF
--- a/.github/workflows/reports-image.yml
+++ b/.github/workflows/reports-image.yml
@@ -3,8 +3,9 @@
 # of game releases, and its image only needs rebuilding when the service itself changes.
 #
 # Two entry points:
-#   * push to main touching ReportHost files — builds AND publishes to GHCR as :latest + :sha-<short>,
-#     so a VPS deploy can `docker compose pull` the current state of main.
+#   * push to main touching ReportHost files (or the Shared library it references — the reply key
+#     formula lives there, #1369) — builds AND publishes to GHCR as :latest + :sha-<short>, so a VPS
+#     deploy can `docker compose pull` the current state of main.
 #   * workflow_dispatch — build it by hand from the Actions tab (build-validate by default; set `push`
 #     to publish, with a tag of your choice).
 
@@ -15,6 +16,7 @@ on:
     branches: [main]
     paths:
       - "src/BlocksBeyondTheStars.ReportHost/**"
+      - "src/BlocksBeyondTheStars.Shared/**"
       - "Dockerfile.reports"
       - ".github/workflows/reports-image.yml"
   workflow_dispatch:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,40 @@ the richer, screenshot-laden versions live there. `(#123)` references the pull r
 
 ## [Unreleased]
 
+### 🧹 Audit leftovers — reply window, browser name prompt, creature view, repair panel (#1368)
+
+- **The whole developer answer is readable.** The reply window used to cut a thread at 1,400 characters with no
+  scrollbar and no hint; it now scrolls, however long the conversation gets, and shows developer and player text
+  exactly as written (no stray `<b>` or `<color>` formatting from a tag someone typed). The HUD toast does the same.
+- **F1 and Esc in the same frame no longer leave a stuck dialog** that held the world with no key able to close it.
+- **Browser solo entry**: the "What's your name?" prompt and the menu's name field are one and the same — Cancel no
+  longer leaves the field empty while Singleplayer would have started with the name typed in the prompt; both cap at
+  the server's 24-character limit so the name you keep is the name you play as; the prompt waits its turn behind the
+  "What's new?" notes after an update instead of hiding under them; and the menu no longer re-reads the whole saved
+  world on every rebuild just to find your name (a visible hitch with a large world).
+- **Doors and torches are no longer offered on water or lava.** The server refused a door in any fluid cell and a torch
+  in water; the crosshair now skips those cells with such an item in hand instead of bouncing a reject toast.
+- **Creatures**: a winged giant no longer floats through its hop (the client uses the server's own ground-bird rule for
+  the glide instead of "has wings"); a perched bird whose perch is dug away falls with its wings out — the server reports
+  the fall as such — and the per-creature animator lookup that ran every frame is done once.
+- **Repair panel**: the missing hull cells are outlined on the parked ship in hologram blue while the panel shows
+  breaches, so you can walk straight to the holes; "1 Hüllenzelle fehlt" reads singular; the empty bar track no
+  longer sits behind the breach text when the hull itself is full.
+
+### 🧭 Compass wrap, stale ship blip, crouch edge, honest repair panel (#1307, #1308, #1309, #1313)
+
+- **The compass honours the world's wrap** (#1307): across a longitude/latitude seam every blip — ship, waypoint,
+  beacons, markers — flipped its bearing and the distance line jumped by a whole circumference (">3000 m" to a ship a
+  few blocks away). Every marker is now measured against the same nearest-copy position all other world objects use.
+- **No stale ship blip** (#1308): after leaving for a new world the compass kept pointing at the previous landing site,
+  because nothing ever cleared the old placement. A world change clears it; a real placement re-arrives right after.
+- **Crouching reaches the edge** (#1309): sneaking stopped half a block before a drop, in the middle of the last block
+  — building an outer wall face from its top needed scaffolding. The sneak probe is now a short look ahead plus this
+  frame's step, so the capsule overhangs the edge the way sneaking does in every voxel builder.
+- **An honest repair panel** (#1313): one missing hull cell on a full hull raised a "SHIP REPAIR" panel with a full
+  Hull 100/100 bar and no word about what was wrong. With the hull full the panel now leads with the breach count and
+  hides the bar; the bar and its numbers only appear while the hull itself is short.
+
 ### 📮 Report inbox leftovers — deleted reports are forgotten, the answer box stays, admin forms are guarded (#1369)
 
 - **A report the developers deleted is no longer polled for three months.** The game asks the inbox about the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,26 @@ the richer, screenshot-laden versions live there. `(#123)` references the pull r
 
 ## [Unreleased]
 
+### 🧹 Audit leftovers — sand, drop packets, pad touchdown and creature physics (#1367)
+
+- **Falling sand no longer rests on a tuft of grass, a torch or a flame** — it crushes the prop (its drop lands on top
+  of the settled block; a flame is put out) and falls on to the real ground. A doorway holds a falling block up like a
+  player does; an animal the block lands on steps aside instead of being buried.
+- **Weather snow that slid off a ledge still melts**, sand dropped on a thawing drift comes down with it, and a sand
+  block you placed keeps your name after it has fallen (grief reports).
+- **A kill over a meadow leaves the loot packet in the grass, on the ground** — not floating a cell above it — and
+  a quit/shutdown save writes every expiring packet's exact age (up to 30 s of ageing used to be lost).
+- **`/tp pad N` lands on top of a paved pad**, a months-old save no longer parks its ship on its own ghost hull for one
+  session, and the "dug out" rescue announces itself once per entombment instead of every second when the pad is walled
+  in too.
+- **Creatures**: a titan is no longer hauled onto a tree crown because of a tuft of grass in its column; nothing in view
+  pops out at the far leash (the 70/110-block prune respects your view distance); a bird whose perch is dug away falls
+  and takes off again; an animal never jumps into a low ceiling; falls have a terminal speed (no more 2.7-block snaps);
+  walkers no longer step down onto lava; a swimmer beside a cliff overhang keeps swimming instead of steering out of
+  its lake.
+- **Walled base areas**: the fence check works across the world's north–south seam, and the fill is refreshed when
+  something changes inside the base's box rather than on every spawn attempt.
+
 ### 📮 Report inbox — polling for answers never blocks a real report (#1352)
 
 - **A whole class behind one NAT can poll for developer answers and still send a bug report.** The reply poll

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,21 @@ the richer, screenshot-laden versions live there. `(#123)` references the pull r
 
 ## [Unreleased]
 
+### 📮 Report inbox leftovers — deleted reports are forgotten, the answer box stays, admin forms are guarded (#1369)
+
+- **A report the developers deleted is no longer polled for three months.** The game asks the inbox about the
+  reports it still remembers; the ones that are gone (deleted, expired, or filed by an older browser build under
+  a key the game cannot read) are forgotten on the spot, and the polling stops once none are left.
+- **The answer box no longer disappears when the developers re-file your report.** Whether you can answer now
+  follows the conversation itself — the newest entry is a developer question you have not answered — instead of
+  the report's status label, which an operator may change by hand.
+- **Operators**: the admin forms carry a CSRF token (403 without it) and the JSON admin routes require a JSON
+  content type; the detail page says "No in-game reply possible" for arcade reports filed before the reply
+  channel existed (their reply key cannot match — answer those through the old channel). The ReportHost image
+  also rebuilds when the shared reply-key code changes. Redeploy the ReportHost image.
+- **Tooling**: `gen_textures.py` now applies the documented Guardian-plating post-process itself, so the tile can
+  be regenerated reproducibly.
+
 ### 🧹 Audit leftovers — sand, drop packets, pad touchdown and creature physics (#1367)
 
 - **Falling sand no longer rests on a tuft of grass, a torch or a flame** — it crushes the prop (its drop lands on top

--- a/TODO.md
+++ b/TODO.md
@@ -9658,6 +9658,46 @@ is **pre-approved** (keys in `tools/ai-assets/.env`, run via `uv`).
 
 ---
 
+## ✅ Done (2026-08-29): low-priority audit leftovers — reply window, browser name prompt, creature view, repair panel, changelog (#1368)
+
+The low-severity Unity-client findings of the 2026-08-29 audit of #1307–#1345 that the medium/high fix PRs left out.
+One PR, local Unity build.
+
+* **Reply window (#1328/#1330)** — the world hold was already in place since #1339 (`ShowThread` → `WorldHold.Hold`,
+  `CloseReply` → `Release`, `Tick` in `Update`; F1 and the reply window are mutually exclusive menu owners) — verified,
+  nothing to add. The thread body is now a scrollable stack of `UiTextChunks` pieces (`BuildReplyBodyScroll` /
+  `SetReplyBody`, the credits/what's-new ScrollRect pattern) instead of a 1400-character `Shorten` + `Truncate`;
+  the body chunks, the report title and the HUD toast run with `supportRichText = false` (developer/player text is
+  shown verbatim). `OpenRoutine` bails out after `WaitForEndOfFrame` when `Close()` already ran (hotkey + Esc in one
+  frame used to show the dialog with `_open == false`, holding the world with no way to close it).
+* **Browser solo entry (#1321/#1322)** — the name prompt mirrors every keystroke into the menu field
+  (`SetTextWithoutNotify`), so Cancel leaves the field showing the name Singleplayer would use; every name field
+  (`UiMainMenu`: menu, prompt, connect dialog, reserved-name prompt) caps at the new shared
+  `Protocol.MaxPlayerNameLength` (24 — the server's join cap now reads the same constant). The prompt defers while
+  the What's-new modal is open (`AppShell.WhatsNewOpen`; the flag stays pending and `AppShell.Update` rebuilds the
+  menu once the modal closes; an auto-opening modal over an already-showing prompt re-arms it via
+  `BrowserNamePromptShowing`). `BrowserLocalServer.PeekSavedPlayerName` goes through the new
+  `BlobPeekCache` (Client.Core; stamp = path + length + last-write ticks; a missing blob is never cached; `ResetLocalWorld`
+  invalidates) — `BlobPeekCacheTests` (6). `PlayerController.PlaceFluidAim` mirrors `HandlePlace`'s fluid-cell
+  refusals from the block data: a `door`-category block is never aimed at a fluid, a torch not at water (lava stays).
+* **Creature view (#1332/#1333)** — `NetCreature.Glides` (additive) carries the server's `CreatureMotion.Glides`
+  predicate; `CreatureView` uses it (× `VerticalMotion.GlideGravityScale`) instead of `HasWings`, so a winged giant no
+  longer extrapolates at 0.4 g. A perched flier whose perch went (#1367 fall) is reported by `ToNetCreature` from the
+  actual vertical state (`Airborne = true, Perched = false, VertVel`); the client also unfolds on `Perched && VertVel < 0`
+  for older servers. `CreatureAnimator` is cached on the entry. Tests: `NetCreature_GlidesFlag_RoundTrips…`,
+  `Flier_WhosePerchGoes_Falls_ThenTakesOffAgain` now pins the wire flags (`NetCreatureForTest` hook).
+* **Repair panel (#1313)** — `ShipRepairStatus` carries `StructureId` + `MissingX/Y/Z` (additive, ≤ 256 cells;
+  `BuildShipRepairStatus` on the server, `ShipRepairStatusForTest` hook, `ShipRepairStatus_ListsTheBreachCells…` +
+  codec round-trip). New `HullBreachView` (WorldRig) draws one inset hologram box per cell on the parked ship
+  (placement-ghost look, Cloud shader, one mesh rebuilt only when a new readout arrives, follows the ship's nearest
+  world copy; the space scene is left alone). `ui.shiprepair.cells_missing_one` (EN+DE) picked for a count of 1; the
+  bar track hides with the bar. `AuditLowLeftoversTests` guard the locale pair, the name caps and the verbatim texts.
+* **Docs** — CHANGELOG Unreleased gained the missing #1307/#1308/#1309/#1313 section and the #1368 section.
+* **Playtest**: the breach outlines on a carved starter ship (on foot, at the pad); a long developer answer scrolling;
+  browser name prompt after an update (What's-new first, then the prompt).
+
+---
+
 ## ✅ Done (2026-08-29): low-priority audit leftovers — reports that vanish are forgotten, the answer box follows the thread, admin CSRF, image filter, texture tool (#1369)
 
 The low-severity ReportHost / workflow / tooling findings of the 2026-08-29 audit that #1361 left out:

--- a/TODO.md
+++ b/TODO.md
@@ -9658,6 +9658,37 @@ is **pre-approved** (keys in `tools/ai-assets/.env`, run via `uv`).
 
 ---
 
+## ✅ Done (2026-08-29): low-priority audit leftovers — reports that vanish are forgotten, the answer box follows the thread, admin CSRF, image filter, texture tool (#1369)
+
+The low-severity ReportHost / workflow / tooling findings of the 2026-08-29 audit that #1361 left out:
+
+* **`gone` marker (#1327/#1328)** — `GET /api/replies` takes `ids=` (the report ids the client's `sent.json` still
+  holds, ≤ 50) and answers `gone: […]` for the ones the key can no longer read (`ReportStore.MissingReports`: deleted,
+  pruned, or stored under another key); `FeedbackReplyClient.Fetch(key, since, knownIds)` / `ParseGone` carry it and
+  `FeedbackUi.OnPollFinished` calls `SentReportsLog.Forget` — the previously dead method — so a deleted report is no
+  longer polled 6×/h for 90 days. Only named ids are ever reported (nothing enumerable).
+* **Answer box follows the thread** — `FeedbackReplyThread.AwaitsAnswer` = the newest entry is a developer question
+  (no player entry after it), no longer `Status == "waiting_for_player"`; an operator flipping the status by hand to
+  `triaged` no longer hides the box (the inbox accepts the answer in any status).
+* **Admin CSRF** — `AdminCsrf`: one random per-process token, hidden `csrf` field in every detail-page form, fixed-time
+  check on `/admin/report/{id}/reply|status|delete` → 403 on mismatch; the JSON admin routes (`PATCH /api/reports/{id}`,
+  `POST /api/reports/{id}/replies`) require `application/json` (415) so a `text/plain` form cannot smuggle a body.
+* **Pre-#1327 arcade reports** — not repairable (the inbox never learns the Glitch install id); documented in
+  REPORT_HOST.md, and the detail page says "No in-game reply possible" for a `WebGLPlayer` report whose key was
+  derived from the player id (`ReportHostPages.KeyOrigin`), a softer hint for old desktop rows.
+* **`reports-image.yml`** now also triggers on `src/BlocksBeyondTheStars.Shared/**` (the reply-key formula lives
+  there); `worldhost-image.yml` already had the path.
+* **`gen_textures.py`** — the Guardian plating post-process (desaturate 70 %, lift `v' = 1 − (1 − v)·0.76`) is
+  `guardian_plating()` in a `POST_PROCESS` table applied to the 64 px tile before it is written, so `--only enemy_robot`
+  + `bundle_textures.py --from-out` reproduce the committed tile. No texture regenerated.
+* Tests: `ReportHostReplyLifecycleTests` (gone over HTTP on the shared host) + `ReportHostAdminCsrfTests` (own host
+  with admin on: token in every form, 403 without it, 415 for text/plain JSON), `ReportHostTests` (+2: store
+  `MissingReports` incl. prune + cap, page hints + CSRF field), `FeedbackReplyTests` (+2: ids/gone round trip +
+  `Forget`, `AwaitsAnswer` by thread). ⚠ Needs a ReportHost image redeploy (`reports-image.yml`); the client half
+  ships with the next release.
+
+---
+
 ## ✅ Done (2026-08-29): low-priority audit leftovers — granular landings, drop packets, pad touchdown, creature physics (#1367)
 
 The small server findings of the 2026-08-29 audit of #1310–#1345 that the medium/high PRs left out, shipped together:

--- a/TODO.md
+++ b/TODO.md
@@ -7,7 +7,7 @@ plans live under [docs/](docs/) (committed); the long-range direction is the str
 keep it current when controls/features change. Last consolidated 2026-06-04.
 
 **Build:** `scripts/build-client.ps1` (Windows) or `scripts/build-client.sh` (Linux) — publishes shared libs + bundled server + Unity player.
-**Test:** `./scripts/run-tests.sh` — currently **2545 server (non-Slow tier) + 448 client passing** (2026-08-29). Locale parity (en/de) is enforced by a test.
+**Test:** `./scripts/run-tests.sh` — currently **2567 server (non-Slow tier) + 448 client passing** (2026-08-29). Locale parity (en/de) is enforced by a test.
 CI runs two tiers: PRs skip the tests marked `[Trait("Category", "Slow")]`; pushes to `main` and the release workflow run the full suite. CI builds/runs
 tests in Release, and a per-test duration guardrail (`scripts/check-test-durations.py`, PRs only) fails the gate when a non-Slow test exceeds 120 s.
 The server suite is sharded across a 6-runner matrix (`scripts/partition-tests.py` + checked-in weights; `Tests passed` is the required fan-in check) — PR gate ~4:30. The weights decay as test classes are added, so
@@ -9655,6 +9655,36 @@ is **pre-approved** (keys in `tools/ai-assets/.env`, run via `uv`).
    footprint so nothing seeps up. Leave landing at the seabed (so it *can* land underwater) unless the user
    prefers dry-land preference (see questions). Tests: collider excludes fluids; fluid won't enter a stamped
    ship interior; ship interior is water-free after landing in a sea.
+
+---
+
+## ✅ Done (2026-08-29): low-priority audit leftovers — granular landings, drop packets, pad touchdown, creature physics (#1367)
+
+The small server findings of the 2026-08-29 audit of #1310–#1345 that the medium/high PRs left out, shipped together:
+
+* **Granular blocks** — the landing follows the colliding rule (`GranularPassable` = `!IsCollidingBlock`): a falling
+  block crushes small flora / torch / lantern / ladder on the way (drops spilled on top of the settled block, a flame put
+  out) and falls on; a doorway cell, an NPC and a player hold it up; a creature it lands on gets `NudgeCreatureBodyChecks`
+  and steps aside. Snow melt calls `OnSupportRemoved` (sand on a thawing drift comes down); a weather-snow deposit that
+  falls carries its melt entry (`MoveWeatherDeposit`); the settled block keeps its `#490` owner (`GetBlockAttribution`).
+* **Drop packets** — `Fall`/`SettleDropCell` use the colliding rule (a kill over grass leaves the bundle in the grass, not a
+  cell above); `SaveAll` checkpoints every expiring packet on every resident world (`CheckpointLootPackets`); the
+  checkpoint counter is per world (`LoadedWorld.SinceLootCheckpoint`).
+* **Pad touchdown** — `/tp pad N` targets `PadSurfaceY`; `PlaceLandedShip` runs `CleanLegacyStampResidueOnce` on a
+  median-based origin BEFORE reading the raised surface; the entombment rescue fires once per episode
+  (`PlayerSession.EntombedRescueSpot`) instead of every second into the same walled-in pad spot.
+* **Creatures** — `StandableAt`/`IsSupportCell` use the colliding rule (props pass, canopy solid); the far prune is
+  `Max(70|110, MaxStreamRadiusBlocks)`; a perched flier whose perch went falls and then `TakingOff`; a jump/climb needs a
+  clear body column at the landing height (`riseBlocked`); `VerticalMotion.TerminalSpeed` = 25 b/s; lava under the next
+  feet cell is a wall for non-lava species (`LavaUnderFeet`); the swimmer gate reads its own column at its own feet;
+  `PreviewStep` hands `nextFeet` through `StepBlocked` → `StepBlockedByTerrain` and `ResolveVertical` (one probe per
+  column change instead of three).
+* **Wall fill (#1315/#1347)** — cached levels are invalidated by `ServerWorld.BlockSet` (new event) and hand-operated door
+  toggles inside the box (`MarkBaseWallsDirty`), backed by an 8 s interval instead of 1.5 s; the reach test wraps Z like X
+  (`WrapAbsZ`).
+* Skipped on purpose: the client-side `PlaceFluidAim` gate for door/torch in hand belongs to the client issue's PR.
+* Tests: `GranularBlockTests` (+6), `DropLootTests` (+2), `PadSpawnTests` (+3), `CreatureMotionArenaTests` (+5),
+  `CreatureBuildRespectTests` (+3), `BaseWalledYardTests` (+2), `VerticalMotionTests` (+1).
 
 ---
 

--- a/client/Assets/BlocksBeyondTheStars/Scripts/AppShell.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/AppShell.cs
@@ -253,8 +253,14 @@ namespace BlocksBeyondTheStars.Client
         private bool _autoSingleplayerWhenReady;
 
         /// <summary>Set when a deep-linked singleplayer start still needs a name; the WebGL menu consumes it
-        /// and opens the name prompt on top of itself (#1322).</summary>
+        /// and opens the name prompt on top of itself (#1322) — unless the What's-new modal is up, in which
+        /// case it stays set and <see cref="Update"/> rebuilds the menu once that modal closes (#1368).</summary>
         public bool BrowserNamePromptPending;
+
+        /// <summary>True while the WebGL menu shows the name prompt (#1368): if the one-shot What's-new modal
+        /// wants to open meanwhile, the prompt is re-armed and the menu rebuilt so it comes back AFTER the
+        /// modal instead of sitting buried under it.</summary>
+        public bool BrowserNamePromptShowing;
 
         /// <summary><c>?singleplayer=1</c> arrived without a name — none in the URL, the settings or an
         /// arcade session (#1322). The name IS the player id, so before asking we look at the world we are
@@ -1144,6 +1150,9 @@ namespace BlocksBeyondTheStars.Client
 
         /// <summary>Closes the "What's new?" dialog (its Back button).</summary>
         public void CloseWhatsNew() => _whatsNewOpen = false;
+
+        /// <summary>Whether the "What's new?" dialog is (about to be) shown — the WebGL name prompt defers to it (#1368).</summary>
+        public bool WhatsNewOpen => _whatsNewOpen;
         private GameObject _uiSettings;
         private GameObject _uiCredits;
         private GameObject _uiEditors;
@@ -1476,6 +1485,7 @@ namespace BlocksBeyondTheStars.Client
             {
                 Destroy(_uiMenu);
                 _uiMenu = null;
+                BrowserNamePromptShowing = false; // the prompt went with the menu (#1368)
             }
 
             // Startup update notice (#543): once the menu is up and the quiet check found a version,
@@ -1507,6 +1517,16 @@ namespace BlocksBeyondTheStars.Client
                     Settings.Save();
                     if (seen.Length > 0 && WhatsNew.Entries.Count > 0)
                     {
+                        if (BrowserNamePromptShowing && _uiMenu != null)
+                        {
+                            // The name prompt is already up (#1368): re-arm it and rebuild the menu, so it
+                            // returns once the release notes are closed instead of hiding under them.
+                            BrowserNamePromptShowing = false;
+                            BrowserNamePromptPending = true;
+                            Destroy(_uiMenu);
+                            _uiMenu = null;
+                        }
+
                         OpenWhatsNew();
                     }
                 }
@@ -1520,6 +1540,15 @@ namespace BlocksBeyondTheStars.Client
             {
                 Destroy(_uiWhatsNew);
                 _uiWhatsNew = null;
+            }
+
+            // A deferred name prompt (#1368): the menu was built while the What's-new modal was up and skipped
+            // the prompt (the flag stayed set). Now that the modal is closed, rebuild the menu — the new build
+            // consumes the flag and asks.
+            if (Phase == ShellPhase.MainMenu && BrowserNamePromptPending && !_whatsNewOpen && _uiMenu != null)
+            {
+                Destroy(_uiMenu);
+                _uiMenu = null;
             }
 
             if (Phase == ShellPhase.Loading && _uiLoading == null)

--- a/client/Assets/BlocksBeyondTheStars/Scripts/BrowserLocalServer.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/BrowserLocalServer.cs
@@ -85,8 +85,12 @@ namespace BlocksBeyondTheStars.Client
         /// <summary>The name of the one player saved in this browser's local world, or null (no world,
         /// unreadable, or not exactly one player). The menu prefills its name field from this when the
         /// settings hold no name (#1322): the name IS the player id, so nothing else gets a returning
-        /// player back into their own world.</summary>
-        public static string PeekSavedPlayerName() => MemoryWorldSnapshotPeek.SolePlayerId(LoadLocalBlob());
+        /// player back into their own world. Cached per blob version (#1368) — the menu asks on every build,
+        /// and reading + gunzipping a multi-MB blob each time was a visible hitch.</summary>
+        public static string PeekSavedPlayerName()
+            => _peekCache.Get(SaveBlobPath, () => MemoryWorldSnapshotPeek.SolePlayerId(LoadLocalBlob()));
+
+        private static readonly BlobPeekCache _peekCache = new BlobPeekCache();
 
         /// <summary>"New world" (#1181): deletes the world saved in this browser and arms the reset marker
         /// that keeps the deployment migration (#1177) and the cloud fetch from bringing the old world back
@@ -96,6 +100,7 @@ namespace BlocksBeyondTheStars.Client
         public static bool ResetLocalWorld()
         {
             bool deleted = BrowserWorldReset.Reset(SaveDirectory, BlobFile);
+            _peekCache.Invalidate(); // the blob is gone — the saved-name peek must not answer from memory
             WebGlStorage.Sync(); // the delete + marker must be durable before the fresh world boots
             Debug.Log(deleted
                 ? "[BrowserSP] Local world deleted on request — starting over."

--- a/client/Assets/BlocksBeyondTheStars/Scripts/CreatureView.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/CreatureView.cs
@@ -51,6 +51,7 @@ namespace BlocksBeyondTheStars.Client
             public TextMesh NameText;    // the label's text component (updated on rename)
             public GameObject Zzz;       // floating "z z z" shown above a sleeping (off-phase) creature
             public TextMesh ZzzText;     // the sleep label's text component
+            public CreatureAnimator Animator; // the rig's animator, looked up once at build (#1368) — not per frame
         }
 
         private readonly Dictionary<string, Entry> _creatures = new Dictionary<string, Entry>();
@@ -119,6 +120,7 @@ namespace BlocksBeyondTheStars.Client
                         PrevHostile = c.Hostile,
                         PrevAlerting = c.Alerting,
                         PrevHull = c.Hull,
+                        Animator = root.GetComponent<CreatureAnimator>(),
                     };
                     _creatures[c.Id] = entry;
                 }
@@ -144,9 +146,10 @@ namespace BlocksBeyondTheStars.Client
                     // A jump arc lasts ~0.7 s — barely one position update — so linear extrapolation would
                     // smear every hop into a bump. Integrate the server's launch velocity under the world's
                     // gravity instead (#1333; the micro-fauna hop already does this locally): a ground bird
-                    // glides under reduced gravity like the server's model.
+                    // glides under reduced gravity like the server's model — by the server's own predicate on
+                    // the wire (#1368), so a winged giant (which never glides there) is not floated here.
                     float g = 20f * Mathf.Max(0.3f, Game.Environment != null ? Game.Environment.GravityFactor : 1f);
-                    if (c.HasWings) g *= 0.4f;
+                    if (c.Glides) g *= VerticalMotion.GlideGravityScale;
                     float t = Mathf.Min(since, 0.6f);
                     predicted.y = entry.Target.y + c.VertVel * t - 0.5f * g * t * t;
                 }
@@ -212,10 +215,13 @@ namespace BlocksBeyondTheStars.Client
                 // Motion class + vertical state for the animator (#1333): wings only beat in the air, legs tuck
                 // mid-jump, a perched flier folds up, crawlers undulate. Cheap per-frame set; the animator
                 // detects the transitions itself (landing squash).
-                var animator = entry.Root.GetComponent<CreatureAnimator>();
-                if (animator != null)
+                if (entry.Animator != null)
                 {
-                    animator.SetMotion(c.Motion, c.Airborne, c.Perched);
+                    // A perched flier whose perch was dug away is falling (#1368): a current server already reports
+                    // it airborne; an older one still says "perched" but sends the fall velocity — either way the
+                    // wings unfold for the drop instead of a folded bird sliding down.
+                    bool airborne = c.Airborne || (c.Perched && c.VertVel < -0.01f);
+                    entry.Animator.SetMotion(c.Motion, airborne, c.Perched && !airborne);
                 }
 
                 SetStasis(entry, c.Frozen, c.Size); // icy-blue shell while held in stasis (item 36)

--- a/client/Assets/BlocksBeyondTheStars/Scripts/FeedbackUi.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/FeedbackUi.cs
@@ -576,15 +576,25 @@ namespace BlocksBeyondTheStars.Client
                 return; // nothing sent recently → no request at all (no phone-home without a reason)
             }
 
+            // The ids we still remember ride along (#1369): the inbox names the ones it no longer has for
+            // our key as `gone`, and OnPollFinished forgets them — otherwise a deleted or pruned report
+            // would be polled for up to 90 days.
+            var known = new List<string>();
+            foreach (var sent in _sentLog.List(NowUnix()))
+            {
+                known.Add(sent.Id);
+            }
+
             _polling = true;
 #if UNITY_WEBGL && !UNITY_EDITOR
-            StartCoroutine(FeedbackWebGlTransport.Request(_replies.FetchUrl(_replyKey, 0), "GET", null, (res, body) =>
+            StartCoroutine(FeedbackWebGlTransport.Request(_replies.FetchUrl(_replyKey, 0, known), "GET", null, (res, body) =>
             {
                 _polling = false;
                 var result = new FeedbackReplyResult { Ok = res.Ok, StatusCode = res.StatusCode, Error = res.Error };
                 if (res.Ok)
                 {
                     result.Threads.AddRange(FeedbackReplyClient.ParseThreads(body));
+                    result.Gone.AddRange(FeedbackReplyClient.ParseGone(body));
                 }
 
                 OnPollFinished(result);
@@ -592,7 +602,7 @@ namespace BlocksBeyondTheStars.Client
 #else
             var replies = _replies;
             string key = _replyKey;
-            _pollTask = Task.Run(() => replies.Fetch(key, 0));
+            _pollTask = Task.Run(() => replies.Fetch(key, 0, known));
 #endif
         }
 
@@ -606,6 +616,13 @@ namespace BlocksBeyondTheStars.Client
                 }
 
                 return;
+            }
+
+            // Reports the inbox no longer has for our key are forgotten, so the poll gate closes once the
+            // last remembered report is gone (#1369).
+            foreach (string goneId in result.Gone)
+            {
+                _sentLog?.Forget(goneId);
             }
 
             FeedbackReplyThread first = null;

--- a/client/Assets/BlocksBeyondTheStars/Scripts/FeedbackUi.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/FeedbackUi.cs
@@ -96,10 +96,18 @@ namespace BlocksBeyondTheStars.Client
         private readonly FeedbackReplyTracker _inboxTracker = new FeedbackReplyTracker(); // by reply id (#1351)
         private readonly object _replyOwner = new object(); // its own menu owner — independent of the F1 dialog
 
-        // Reply window (built lazily).
+        // Reply window (built lazily). The thread body is a scrollable stack of UiTextChunks pieces (#1368):
+        // developer answers and the player's own replies are unbounded data-driven text, and one uGUI Text
+        // silently drops its mesh past ~16k glyphs (#1097) — the old 1400-character cut + Truncate hid the
+        // rest of a long thread with no hint that there was more.
         private Canvas _replyCanvas;
         private GameObject _replyOverlay;
-        private Text _replyTitle, _replyBody, _replyStatus, _answerLabel;
+        private Text _replyTitle, _replyStatus, _answerLabel;
+        private ScrollRect _replyBodyScroll;
+        private RectTransform _replyBodyContent;
+        private readonly List<Text> _replyBodyChunks = new List<Text>();
+        private float _replyBodyW; // viewport width the chunk Texts wrap at (set when the scroll is built)
+        private const float ReplyBodyH = 296f, ReplyBodyScrollbarW = 12f, ReplyBodyGutter = 8f;
         private InputField _answerInput;
         private Button _replyOkBtn, _replyAnswerBtn;
         private FeedbackReplyThread _shown;
@@ -211,6 +219,14 @@ namespace BlocksBeyondTheStars.Client
             // Capture at end of frame, before the dialog is shown and before MenuOpen hides the HUD: the shot
             // is the full frame WITH the HUD but WITHOUT this dialog (the requested look).
             yield return new WaitForEndOfFrame();
+            if (!_open)
+            {
+                // Closed in the very frame it was opened (the hotkey and Esc together): Close() already ran, so
+                // building the dialog now would show it with _open == false — holding the world with no Esc
+                // able to close it (#1368). Nothing to show, nothing to hold.
+                yield break;
+            }
+
             _shotJpg = TryCaptureJpg();
 
             EnsureDialog();
@@ -659,7 +675,6 @@ namespace BlocksBeyondTheStars.Client
             _answering = false;
 
             _replyTitle.text = string.Format(L("ui.feedback.reply.report"), thread.Title.Length > 0 ? thread.Title : "…");
-            _replyBody.text = ThreadText(thread);
             _replyStatus.text = string.Empty;
             _replyStatus.color = UiKit.CyanDim;
             _answerInput.text = string.Empty;
@@ -672,11 +687,46 @@ namespace BlocksBeyondTheStars.Client
             _replyAnswerBtn.interactable = true;
 
             _replyOverlay.SetActive(true);
+            SetReplyBody(ThreadText(thread)); // after activation — the chunk heights are measured against live rects
             WorldHold.Hold(Time.realtimeSinceStartup); // reading/answering holds the world like the F1 dialog (#1330)
             Game.SetMenuOwner(_replyOwner, true);
         }
 
-        /// <summary>The thread as one readable block: who said what, oldest first, plus the "fixed in" line.</summary>
+        /// <summary>Fills the scrollable body with the thread text: one plain (non-rich) Text per
+        /// <see cref="UiTextChunks"/> piece, stacked top-down, the content sized to the sum so the viewport can
+        /// scroll to the very end; the scroll starts at the top (#1368).</summary>
+        private void SetReplyBody(string text)
+        {
+            foreach (var old in _replyBodyChunks)
+            {
+                if (old != null)
+                {
+                    Destroy(old.gameObject);
+                }
+            }
+
+            _replyBodyChunks.Clear();
+
+            float textW = _replyBodyW - ReplyBodyScrollbarW - ReplyBodyGutter;
+            float y = 0f;
+            foreach (var chunk in UiTextChunks.Split(text))
+            {
+                var t = UiKit.AddText(_replyBodyContent, 0f, y, textW, 20f, chunk, 16, UiKit.TextCol, TextAnchor.UpperLeft);
+                t.horizontalOverflow = HorizontalWrapMode.Wrap;
+                t.verticalOverflow = VerticalWrapMode.Overflow;
+                t.supportRichText = false; // developer/player text is shown verbatim — no <color>/<b> interpretation
+                float h = Mathf.Ceil(t.preferredHeight) + 2f;
+                t.rectTransform.sizeDelta = new Vector2(textW, h);
+                y += h;
+                _replyBodyChunks.Add(t);
+            }
+
+            _replyBodyContent.sizeDelta = new Vector2(0f, Mathf.Max(ReplyBodyH, y + 8f));
+            _replyBodyScroll.verticalNormalizedPosition = 1f;
+        }
+
+        /// <summary>The thread as one readable block: who said what, oldest first, plus the "fixed in" line.
+        /// Unbounded — the body renders it chunked and scrollable (#1368).</summary>
         private string ThreadText(FeedbackReplyThread thread)
         {
             var sb = new StringBuilder();
@@ -693,7 +743,7 @@ namespace BlocksBeyondTheStars.Client
                 sb.Append(string.Format(L("ui.feedback.reply.fixed_in"), thread.FixedInVersion));
             }
 
-            return Shorten(sb.ToString().TrimEnd(), 1400);
+            return sb.ToString().TrimEnd();
         }
 
         private void EnsureReplyDialog()
@@ -716,10 +766,9 @@ namespace BlocksBeyondTheStars.Client
             _replyTitle = UiKit.AddText(panel, m, 66, innerW, 26, string.Empty, 17, UiKit.TextCol, TextAnchor.MiddleLeft, FontStyle.Bold);
             _replyTitle.horizontalOverflow = HorizontalWrapMode.Wrap;
             _replyTitle.verticalOverflow = VerticalWrapMode.Truncate;
+            _replyTitle.supportRichText = false; // the report title is player text (#1368)
 
-            _replyBody = UiKit.AddText(panel, m, 100, innerW, 296, string.Empty, 16, UiKit.TextCol, TextAnchor.UpperLeft);
-            _replyBody.horizontalOverflow = HorizontalWrapMode.Wrap;
-            _replyBody.verticalOverflow = VerticalWrapMode.Truncate;
+            BuildReplyBodyScroll(panel, m, 100f, innerW, ReplyBodyH);
 
             _answerLabel = UiKit.AddText(panel, m, 404, innerW, 20, L("ui.feedback.reply.answer_label"), 15, UiKit.TextCol, TextAnchor.MiddleLeft);
             _answerInput = UiKit.AddInput(panel, m, 426, innerW, 110, string.Empty, null, L("ui.feedback.reply.answer_placeholder"), 1500);
@@ -732,6 +781,42 @@ namespace BlocksBeyondTheStars.Client
             _replyAnswerBtn = UiKit.AddButton(panel, m + 428, 582, 400, 56, L("ui.feedback.reply.send"), OnAnswerClicked, "btn_feedback");
 
             _replyOverlay.SetActive(false);
+        }
+
+        /// <summary>The thread body's vertical ScrollRect (the credits/what's-new pattern): a masked viewport
+        /// with a near-transparent hit surface for the wheel, a top-anchored content rect the chunk Texts stack
+        /// on, and a permanent scrollbar along the right edge (#1368).</summary>
+        private void BuildReplyBodyScroll(Transform panel, float x, float y, float w, float h)
+        {
+            var viewGo = new GameObject("ReplyBodyScroll", typeof(RectTransform));
+            viewGo.transform.SetParent(panel, false);
+            UiKit.Place(viewGo, x, y, w, h);
+            _replyBodyW = w;
+
+            _replyBodyScroll = viewGo.AddComponent<ScrollRect>();
+            _replyBodyScroll.horizontal = false;
+            _replyBodyScroll.vertical = true;
+            _replyBodyScroll.movementType = ScrollRect.MovementType.Clamped;
+            _replyBodyScroll.scrollSensitivity = 28f;
+            viewGo.AddComponent<RectMask2D>();
+
+            var hit = viewGo.AddComponent<Image>();
+            hit.sprite = UiKit.SolidSprite;
+            hit.color = new Color(0f, 0f, 0f, 0.001f);
+
+            var contentGo = new GameObject("Content", typeof(RectTransform));
+            _replyBodyContent = (RectTransform)contentGo.transform;
+            _replyBodyContent.SetParent(viewGo.transform, false);
+            _replyBodyContent.anchorMin = new Vector2(0f, 1f);
+            _replyBodyContent.anchorMax = new Vector2(1f, 1f);
+            _replyBodyContent.pivot = new Vector2(0.5f, 1f);
+            _replyBodyContent.anchoredPosition = Vector2.zero;
+            _replyBodyContent.sizeDelta = new Vector2(0f, h);
+
+            _replyBodyScroll.viewport = (RectTransform)viewGo.transform;
+            _replyBodyScroll.content = _replyBodyContent;
+
+            UiKit.AddVerticalScrollbar(panel, _replyBodyScroll, x + w - ReplyBodyScrollbarW, y, ReplyBodyScrollbarW, h);
         }
 
         /// <summary>OK / Esc: the entries were shown, so acknowledge them (fire-and-forget) and close.</summary>

--- a/client/Assets/BlocksBeyondTheStars/Scripts/HudUi.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/HudUi.cs
@@ -105,7 +105,7 @@ namespace BlocksBeyondTheStars.Client
         private GameObject _speederPanel;
         private Image _speederHull, _speederFuel, _speederFuelBg;
         private Text _speederTitle, _speederSpeed, _speederHullLabel, _speederFuelLabel, _speederHint;
-        private Image _wreckBar, _shipRepairBar;
+        private Image _wreckBar, _shipRepairBar, _shipRepairTrack;
         private Button _wreckClaim, _shipRepairBtn;
 
         // Damage feedback (B21): a red screen flash + a cause label when health drops.
@@ -543,6 +543,7 @@ namespace BlocksBeyondTheStars.Client
 
             // Toast / indicators / prompts / hint.
             _toast = UiKit.AddText(root, 14, 268, W - 28, 22, string.Empty, 15, UiKit.Cyan, TextAnchor.MiddleLeft, FontStyle.Bold);
+            _toast.supportRichText = false; // carries developer/player text (reply toasts, chat echoes) — shown verbatim (#1368)
             _inSpace = UiKit.AddText(root, W / 2f - 100, 8, 200, 22, string.Empty, 16, UiKit.Cyan, TextAnchor.MiddleCenter, FontStyle.Bold);
 
             // Observer badge (issue #487). Top centre, always-on while the mode is active: an admin who forgets
@@ -611,7 +612,7 @@ namespace BlocksBeyondTheStars.Client
             // back + refill EVA-carved hull cells with one click, paid in metal (docs/developer/SHIP_REPAIR.md).
             _shipRepairPanel = Panel(root, W - 260f, 300, 250, 120).gameObject;
             _shipRepairTitle = UiKit.AddText(_shipRepairPanel.transform, 10, 6, 230, 18, string.Empty, 14, UiKit.Cyan, TextAnchor.MiddleLeft, FontStyle.Bold);
-            UiKit.AddImage(_shipRepairPanel.transform, 10, 30, 230, 14, UiKit.SolidSprite, new Color(0.03f, 0.07f, 0.13f));
+            _shipRepairTrack = UiKit.AddImage(_shipRepairPanel.transform, 10, 30, 230, 14, UiKit.SolidSprite, new Color(0.03f, 0.07f, 0.13f));
             _shipRepairBar = UiKit.AddImage(_shipRepairPanel.transform, 10, 30, 230, 14, UiKit.SolidSprite, UiKit.Cyan);
             _shipRepairBar.type = Image.Type.Filled;
             _shipRepairBar.fillMethod = Image.FillMethod.Horizontal;
@@ -1821,9 +1822,10 @@ namespace BlocksBeyondTheStars.Client
             // case; the hull bar and its numbers only appear while the hull itself is short.
             bool hullShort = sr.HullMax > 0f && sr.Hull < sr.HullMax;
             _shipRepairBar.gameObject.SetActive(hullShort);
+            _shipRepairTrack.gameObject.SetActive(hullShort); // the empty track sat behind the breach text (#1368)
             _shipRepairProg.text = hullShort
                 ? $"{loc.Get("ui.shiprepair.hull")}  {(int)sr.Hull}/{(int)sr.HullMax}"
-                : string.Format(loc.Get("ui.shiprepair.cells_missing"), sr.MissingCells);
+                : string.Format(loc.Get(sr.MissingCells == 1 ? "ui.shiprepair.cells_missing_one" : "ui.shiprepair.cells_missing"), sr.MissingCells); // singular for one ("1 Hüllenzelle fehlt", #1368)
             if (hullShort)
             {
                 _shipRepairBar.fillAmount = Mathf.Clamp01(sr.Hull / sr.HullMax);

--- a/client/Assets/BlocksBeyondTheStars/Scripts/HullBreachView.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/HullBreachView.cs
@@ -1,0 +1,148 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using System.Collections.Generic;
+using BlocksBeyondTheStars.Networking.Messages;
+using UnityEngine;
+
+namespace BlocksBeyondTheStars.Client
+{
+    /// <summary>
+    /// Shows WHERE the ship is breached (#1368): while the repair panel reports missing design hull cells
+    /// (<see cref="GameBootstrap.ShipRepair"/>, <c>MissingCells &gt; 0</c>), every listed cell of the parked ship
+    /// gets a translucent hologram box in the world — the placement ghost's look — so the player can walk to
+    /// the holes instead of hunting for them along the hull. The cells arrive structure-local with the
+    /// readout and are mapped through the parked ship's origin (<see cref="LandedShipModel"/>); the space
+    /// scene (EVA) renders its own ship and is left alone.
+    ///
+    /// Cheap: one mesh for all cells, rebuilt only when a NEW readout arrives (the reference changes), moved
+    /// with the ship's nearest world copy every frame like <see cref="LandedShipView"/> does.
+    /// </summary>
+    public sealed class HullBreachView : MonoBehaviour
+    {
+        public GameBootstrap Game;
+
+        // The placement ghost's hologram blue — a breach reads as "a block belongs here", not as damage FX.
+        private static readonly Color BreachColor = new Color(0.55f, 0.85f, 1f, 0.35f);
+
+        // Faces sit a hair inside the cell so they never z-fight with the intact hull faces around the hole.
+        private const float Inset = 0.04f;
+
+        private GameObject _go;
+        private Mesh _mesh;
+        private ShipRepairStatus _built;
+        private readonly List<Vector3> _verts = new List<Vector3>();
+        private readonly List<int> _tris = new List<int>();
+
+        private void Update()
+        {
+            var sr = Game != null ? Game.ShipRepair : null;
+            LandedShipModel ship = null;
+            bool show = sr != null && sr.MissingCells > 0 && sr.MissingX != null && sr.MissingX.Length > 0
+                && !Game.SpaceViewActive
+                && Game.LandedShips.TryGetValue(sr.StructureId ?? string.Empty, out ship);
+            if (!show)
+            {
+                _built = null;
+                if (_go != null && _go.activeSelf)
+                {
+                    _go.SetActive(false);
+                }
+
+                return;
+            }
+
+            if (_go == null)
+            {
+                Create();
+            }
+
+            if (!ReferenceEquals(sr, _built))
+            {
+                _built = sr;
+                BuildMesh(sr);
+            }
+
+            // Round worlds: the parked ship is drawn at the copy nearest the player — follow it.
+            _go.transform.position = new Vector3(Game.SceneX(ship.Origin.X), ship.Origin.Y, Game.SceneZ(ship.Origin.Z));
+            if (!_go.activeSelf)
+            {
+                _go.SetActive(true);
+            }
+        }
+
+        private void OnDestroy()
+        {
+            if (_mesh != null)
+            {
+                Destroy(_mesh);
+                _mesh = null;
+            }
+
+            if (_go != null)
+            {
+                Destroy(_go);
+                _go = null;
+            }
+        }
+
+        private void Create()
+        {
+            _go = new GameObject("HullBreaches");
+            _go.transform.SetParent(transform, true); // under the game root — torn down with the world
+            var filter = _go.AddComponent<MeshFilter>();
+            var renderer = _go.AddComponent<MeshRenderer>();
+            renderer.shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.Off;
+            renderer.receiveShadows = false;
+
+            // The project's translucent-runtime-mesh pattern (PlacementGhost, BaseShieldView): the Cloud shader
+            // is in Always-Included Shaders, so Shader.Find survives build stripping.
+            var shader = Shader.Find("BlocksBeyondTheStars/Cloud") ?? Shader.Find("Unlit/Transparent");
+            var mat = new Material(shader);
+            mat.SetColor(Shader.PropertyToID("_Color"), ShaderColor.Srgb(BreachColor));
+            mat.renderQueue = 3001; // over the world, so a breach on the far side still shows through nothing
+            renderer.sharedMaterial = mat;
+
+            _mesh = new Mesh { name = "HullBreaches" };
+            filter.sharedMesh = _mesh;
+        }
+
+        /// <summary>One inset unit box per listed cell (structure-local offsets; the object sits at the origin).</summary>
+        private void BuildMesh(ShipRepairStatus sr)
+        {
+            _verts.Clear();
+            _tris.Clear();
+            int n = Mathf.Min(sr.MissingX.Length, Mathf.Min(sr.MissingY?.Length ?? 0, sr.MissingZ?.Length ?? 0));
+            for (int i = 0; i < n; i++)
+            {
+                Box(new Vector3(sr.MissingX[i], sr.MissingY[i], sr.MissingZ[i]));
+            }
+
+            _mesh.Clear();
+            _mesh.SetVertices(_verts);
+            _mesh.SetTriangles(_tris, 0);
+            _mesh.RecalculateNormals();
+            _mesh.RecalculateBounds();
+        }
+
+        /// <summary>Six outward-wound quads of the cell at <paramref name="o"/>, inset by <see cref="Inset"/>.</summary>
+        private void Box(Vector3 o)
+        {
+            float a = Inset, b = 1f - Inset;
+            void Quad(Vector3 p, Vector3 q, Vector3 r, Vector3 s)
+            {
+                int i = _verts.Count;
+                _verts.Add(o + p); _verts.Add(o + q); _verts.Add(o + r); _verts.Add(o + s);
+                _tris.Add(i); _tris.Add(i + 1); _tris.Add(i + 2);
+                _tris.Add(i); _tris.Add(i + 2); _tris.Add(i + 3);
+            }
+
+            Quad(new Vector3(a, b, a), new Vector3(a, b, b), new Vector3(b, b, b), new Vector3(b, b, a)); // +Y
+            Quad(new Vector3(a, a, b), new Vector3(a, a, a), new Vector3(b, a, a), new Vector3(b, a, b)); // -Y
+            Quad(new Vector3(b, a, a), new Vector3(b, b, a), new Vector3(b, b, b), new Vector3(b, a, b)); // +X
+            Quad(new Vector3(a, a, b), new Vector3(a, b, b), new Vector3(a, b, a), new Vector3(a, a, a)); // -X
+            Quad(new Vector3(b, a, b), new Vector3(b, b, b), new Vector3(a, b, b), new Vector3(a, a, b)); // +Z
+            Quad(new Vector3(a, a, a), new Vector3(a, b, a), new Vector3(b, b, a), new Vector3(b, a, a)); // -Z
+        }
+    }
+}

--- a/client/Assets/BlocksBeyondTheStars/Scripts/HullBreachView.cs.meta
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/HullBreachView.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1f6c2ba605791c3408edd4f98ec4a569

--- a/client/Assets/BlocksBeyondTheStars/Scripts/PlayerController.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/PlayerController.cs
@@ -1245,8 +1245,28 @@ namespace BlocksBeyondTheStars.Client
             BlocksBeyondTheStars.Shared.Definitions.BlockDefinition fluid)
             => fluid != null && fluid.Mineable && tool.Kind == fluid.RequiredTool && tool.Tier >= fluid.MinToolTier;
 
-        /// <summary>Both fluids when the held item places a block (the block displaces either, #851), else none.</summary>
-        private FluidAim PlaceFluidAim() => HeldItemPlacesBlock() ? FluidAim.Both : FluidAim.None;
+        /// <summary>Both fluids when the held item places a block (the block displaces either, #851) — minus what
+        /// the server refuses in a fluid cell (#1368, mirroring <c>HandlePlace</c>): a door is an entity that
+        /// needs an air cell (never offered over water or lava — the block data's <c>door</c> category), and a
+        /// torch is an open flame (not offered over water; lava is accepted). Without the gate the client
+        /// aimed the door/torch at the fluid, the server rejected, and the player got a reject toast.</summary>
+        private FluidAim PlaceFluidAim()
+        {
+            string held = Game.ItemInSlot(Game.SelectedHotbarSlot);
+            string placesKey = string.IsNullOrEmpty(held) ? null : Game.Content?.GetItem(held)?.PlacesBlock;
+            if (string.IsNullOrEmpty(placesKey))
+            {
+                return FluidAim.None;
+            }
+
+            var block = Game.Content.GetBlock(placesKey);
+            if (block != null && string.Equals(block.Category, "door", System.StringComparison.OrdinalIgnoreCase))
+            {
+                return FluidAim.None;
+            }
+
+            return block != null && block.Key == "torch" ? FluidAim.Lava : FluidAim.Both;
+        }
 
         /// <summary>The cell the selection outline belongs on (#1353): the very target the next click would take
         /// — mine with the held tool (including the fluids it can mine) or place the held block (into a fluid) —

--- a/client/Assets/BlocksBeyondTheStars/Scripts/UiMainMenu.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/UiMainMenu.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using BlocksBeyondTheStars.Client.Portal;
+using BlocksBeyondTheStars.Networking;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -87,7 +88,9 @@ namespace BlocksBeyondTheStars.Client
             // with the button column, content inset — see the native branch below.
             UiKit.AddPanel(root, bx, by - 10f, bw, 100f, new Color(0.12f, 0.45f, 0.62f, 0.22f));
             UiKit.AddText(root, bx + 16f, by, bw - 32f, 24f, shell.L("ui.menu.connect_name"), 17, UiKit.Cyan, TextAnchor.MiddleLeft, FontStyle.Bold);
-            UiKit.AddInput(root, bx + 16f, by + 30f, bw - 32f, 46f, webName[0], v => webName[0] = v);
+            // Capped at the server's join limit (#1368): a longer name was truncated server-side, so the settings
+            // remembered a name that was not the player's actual id.
+            var webNameInput = UiKit.AddInput(root, bx + 16f, by + 30f, bw - 32f, 46f, webName[0], v => webName[0] = v, maxLength: Protocol.MaxPlayerNameLength);
             var webWarn = UiKit.AddText(root, bx, by + 80f, bw, 22f, "", 14,
                 new Color(1f, 0.55f, 0.4f), TextAnchor.MiddleLeft, FontStyle.Bold);
             float wby = by + 112f;
@@ -246,15 +249,24 @@ namespace BlocksBeyondTheStars.Client
             // (URL, settings, saved world). One field, one button, shown once; replaces the old silent
             // "Explorer" fallback that baked a placeholder identity into the browser's one world. Built
             // last so it draws above everything; the shell's flag is consumed here so a later menu rebuild
-            // (settings → back) does not re-open it.
-            if (shell.BrowserNamePromptPending)
+            // (settings → back) does not re-open it. While the What's-new modal is up the prompt waits (#1368):
+            // the flag stays set and the shell rebuilds the menu — prompt included — once that modal closes,
+            // instead of both opening in the same menu frame with the prompt buried underneath.
+            if (shell.BrowserNamePromptPending && !shell.WhatsNewOpen)
             {
                 shell.BrowserNamePromptPending = false;
+                shell.BrowserNamePromptShowing = true;
                 var (nameOverlay, namePanel) = UiKit.AddModalOverlay(root, 660f, 340f, 600f, 360f);
                 UiKit.AddText(namePanel, 30f, 24f, 540f, 36f, shell.L("ui.webgl.name_prompt_title"), 24, UiKit.Cyan, TextAnchor.MiddleCenter, FontStyle.Bold);
                 var nameBody = UiKit.AddText(namePanel, 30f, 72f, 540f, 90f, shell.L("ui.webgl.name_prompt_body"), 16, UiKit.TextCol, TextAnchor.UpperLeft);
                 nameBody.horizontalOverflow = HorizontalWrapMode.Wrap;
-                var nameInput = UiKit.AddInput(namePanel, 30f, 170f, 540f, 46f, webName[0], v => webName[0] = v, shell.L("ui.menu.connect_name"));
+                // The prompt edits the SAME name the menu field shows (#1368): every keystroke is mirrored into the
+                // field, so Cancel leaves the menu showing exactly the name Singleplayer would start with.
+                var nameInput = UiKit.AddInput(namePanel, 30f, 170f, 540f, 46f, webName[0], v =>
+                {
+                    webName[0] = v;
+                    webNameInput.SetTextWithoutNotify(v);
+                }, shell.L("ui.menu.connect_name"), maxLength: Protocol.MaxPlayerNameLength);
                 var nameWarn = UiKit.AddText(namePanel, 30f, 222f, 540f, 22f, "", 14,
                     new Color(1f, 0.55f, 0.4f), TextAnchor.MiddleLeft, FontStyle.Bold);
                 UiKit.AddButton(namePanel, 30f, 270f, 260f, 56f, shell.L("ui.webgl.name_prompt_go"), () =>
@@ -268,10 +280,15 @@ namespace BlocksBeyondTheStars.Client
                     shell.PlayerName = webName[0].Trim();
                     shell.Settings.PlayerName = shell.PlayerName;
                     shell.Settings.Save();
+                    shell.BrowserNamePromptShowing = false;
                     nameOverlay.SetActive(false);
                     shell.StartBrowserSingleplayer();
                 }, "btn_singleplayer");
-                UiKit.AddButton(namePanel, 310f, 270f, 260f, 56f, shell.L("ui.action.cancel"), () => nameOverlay.SetActive(false), "btn_settings");
+                UiKit.AddButton(namePanel, 310f, 270f, 260f, 56f, shell.L("ui.action.cancel"), () =>
+                {
+                    shell.BrowserNamePromptShowing = false;
+                    nameOverlay.SetActive(false);
+                }, "btn_settings");
                 nameInput.ActivateInputField();
             }
 #else
@@ -284,7 +301,7 @@ namespace BlocksBeyondTheStars.Client
             // The panel's outer edges sit exactly on the button column (bx..bx+bw); content insets instead.
             UiKit.AddPanel(root, bx, by - 10f, bw, 100f, new Color(0.12f, 0.45f, 0.62f, 0.22f));
             UiKit.AddText(root, bx + 16f, by, bw - 32f, 24f, shell.L("ui.menu.connect_name"), 17, UiKit.Cyan, TextAnchor.MiddleLeft, FontStyle.Bold);
-            UiKit.AddInput(root, bx + 16f, by + 30f, bw - 32f, 46f, natName[0], v => natName[0] = v);
+            UiKit.AddInput(root, bx + 16f, by + 30f, bw - 32f, 46f, natName[0], v => natName[0] = v, maxLength: Protocol.MaxPlayerNameLength); // the server's join cap (#1368)
             var natWarn = UiKit.AddText(root, bx, by + 80f, bw, 22f, "", 14,
                 new Color(1f, 0.55f, 0.4f), TextAnchor.MiddleLeft, FontStyle.Bold);
             float nby = by + 112f;
@@ -365,7 +382,7 @@ namespace BlocksBeyondTheStars.Client
             connect = connectOverlay;
             UiKit.AddText(dlg, 30f, 24f, 540f, 30f, shell.L("ui.menu.connect_title"), 22, UiKit.Cyan, TextAnchor.MiddleCenter, FontStyle.Bold);
             UiKit.AddText(dlg, 30f, 80f, 540f, 22f, shell.L("ui.menu.connect_name"), 15, UiKit.TextCol, TextAnchor.MiddleLeft);
-            dlgName = UiKit.AddInput(dlg, 30f, 106f, 540f, 38f, name[0], v => name[0] = v);
+            dlgName = UiKit.AddInput(dlg, 30f, 106f, 540f, 38f, name[0], v => name[0] = v, maxLength: Protocol.MaxPlayerNameLength);
             UiKit.AddText(dlg, 30f, 160f, 540f, 22f, shell.L("ui.menu.connect_host"), 15, UiKit.TextCol, TextAnchor.MiddleLeft);
             UiKit.AddInput(dlg, 30f, 186f, 540f, 38f, host[0], v => host[0] = v);
             UiKit.AddText(dlg, 30f, 240f, 540f, 22f, shell.L("ui.menu.connect_port"), 15, UiKit.TextCol, TextAnchor.MiddleLeft);
@@ -1682,7 +1699,7 @@ namespace BlocksBeyondTheStars.Client
                 hint.horizontalOverflow = HorizontalWrapMode.Wrap;
 
                 string[] nm = { string.Empty };
-                UiKit.AddInput(dlg, 30f, 132f, 640f, 40f, nm[0], v => nm[0] = v);
+                UiKit.AddInput(dlg, 30f, 132f, 640f, 40f, nm[0], v => nm[0] = v, maxLength: Protocol.MaxPlayerNameLength);
                 UiKit.AddButton(dlg, 30f, 192f, 320f, 54f, shell.L("ui.portal.play"), () =>
                 {
                     if (string.IsNullOrWhiteSpace(nm[0]))

--- a/client/Assets/BlocksBeyondTheStars/Scripts/WorldRig.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/WorldRig.cs
@@ -515,6 +515,10 @@ namespace BlocksBeyondTheStars.Client
             miningFx.Camera = cam;
             miningFx.Player = pc; // the outline asks the player rig for the very cell a click would take (#1353)
 
+            // Missing hull cells of the parked ship, outlined in the world while the repair panel is up (#1368).
+            var hullBreach = root.AddComponent<HullBreachView>();
+            hullBreach.Game = boot;
+
             // Flora spawn/regrow cue: a growing sprout marks a harvested cell while its plant regrows.
             var floraGrowthFx = root.AddComponent<FloraGrowthFx>();
             floraGrowthFx.Game = boot;

--- a/data/locales/de.json
+++ b/data/locales/de.json
@@ -2313,6 +2313,7 @@
   "ui.shiprepair.hint": "Am Cockpit. Benötigt:",
   "ui.shiprepair.cells": "Hüllenzellen",
   "ui.shiprepair.cells_missing": "{0} Hüllenzellen fehlen",
+  "ui.shiprepair.cells_missing_one": "1 Hüllenzelle fehlt",
   "ui.hud.loot": "G: plündern",
   "ui.loot.out_of_reach": "Der Vorrat ist außer Reichweite — geh näher heran.",
   "ui.dock.title": "Andock-Anfrage",

--- a/data/locales/en.json
+++ b/data/locales/en.json
@@ -2313,6 +2313,7 @@
   "ui.shiprepair.hint": "At the cockpit. Needs:",
   "ui.shiprepair.cells": "hull cells",
   "ui.shiprepair.cells_missing": "{0} hull cells missing",
+  "ui.shiprepair.cells_missing_one": "1 hull cell missing",
   "ui.hud.loot": "G: loot",
   "ui.loot.out_of_reach": "The cache is out of reach — move closer.",
   "ui.dock.title": "Docking request",

--- a/docs/developer/PLAYER_FEEDBACK.md
+++ b/docs/developer/PLAYER_FEEDBACK.md
@@ -68,8 +68,14 @@ world loads ──► FeedbackUi.Start: replyKey = SHA256("bbs-reply:" + secret)
   previous glitch.fun deployment like the settings file.
 - **Display**: `FeedbackUi` owns a second modal (own menu owner, so it never fights the F1 dialog): title,
   the thread as "Developers: … / Developers ask: … / You answered: …", the fixed-in line; **OK** acknowledges
-  the shown ids (fire-and-forget) and the next queued thread follows. When the newest developer entry is a
-  question (`waiting_for_player`), an answer box + **Send answer** appear; the answer posts, acks, closes.
+  the shown ids (fire-and-forget) and the next queued thread follows. When the newest entry of the thread is a
+  developer question (no player answer after it — derived from the thread, not from the report's status, so an
+  operator who flips the status by hand does not hide the box, #1369), an answer box + **Send answer** appear;
+  the answer posts, acks, closes.
+- **Forgetting**: every poll names the report ids `sent.json` still holds (`ids=`), and the inbox answers with
+  the ones this key can no longer read (deleted, pruned, or stored under a different key) as `gone`; those
+  leave `sent.json` at once (`SentReportsLog.Forget`), so a deleted report is not polled for up to 90 days
+  (#1369).
   Threads are queued while another menu/chat/death prompt owns the screen. Strings: `ui.feedback.reply.*`.
 - Failures are silent (one log line); a 4xx never retries the same request. A `429` on a poll is the reply
   key's **own** per-minute budget (`BBS_REPORTS_REPLY_PER_MINUTE`, 30 by default) — never the network's report

--- a/docs/developer/REPORT_HOST.md
+++ b/docs/developer/REPORT_HOST.md
@@ -24,13 +24,14 @@ game server (crash flush) ──┘    (x-bugreport-key)    + files    └──
 | `GET /api/reports?since=&status=&category=&source=&limit=&cursor=` | header `x-report-read-key` | Delta-sync list: `{ items, nextCursor, hasMore }`, ascending `createdAt` |
 | `GET /api/reports/{id}` | read key | One report (full, incl. parsed `reportJson`) |
 | `GET /api/reports/{id}/screenshot` | read key | The screenshot image |
-| `PATCH /api/reports/{id}` `{"status":"new\|triaged\|waiting_for_player\|player_replied\|done"}` | admin Basic Auth | Triage from scripts/CI |
+| `PATCH /api/reports/{id}` `{"status":"new\|triaged\|waiting_for_player\|player_replied\|done"}` | admin Basic Auth, JSON content type | Triage from scripts/CI |
 | `DELETE /api/reports/{id}` | admin Basic Auth | Permanent delete (incl. screenshot + reply thread) |
-| `POST /api/reports/{id}/replies` `{"text","question":bool,"fixedInVersion"?}` | admin Basic Auth | Developer answer / follow-up question (#1327) — scriptable twin of the detail-page form |
-| `GET /api/replies?key=&since=` | header `x-bugreport-key` | **Client poll**: threads of this reply key with unread developer entries (CORS on) |
+| `POST /api/reports/{id}/replies` `{"text","question":bool,"fixedInVersion"?}` | admin Basic Auth, JSON content type | Developer answer / follow-up question (#1327) — scriptable twin of the detail-page form |
+| `GET /api/replies?key=&since=&ids=` | header `x-bugreport-key` | **Client poll**: threads of this reply key with unread developer entries, plus `gone` for the remembered `ids` the key can no longer read (CORS on) |
 | `POST /api/replies/ack` `{"key","replyIds":[]}` | header `x-bugreport-key` | Client marks shown developer entries read |
 | `POST /api/replies` `{"key","reportId","text"}` | header `x-bugreport-key` | The player's in-game answer to a question (max 3 per report) |
 | `GET /admin`, `/admin/report/{id}` | admin Basic Auth | Server-rendered admin UI: list, filters, detail, screenshot, status buttons, reply thread + form, delete |
+| `POST /admin/report/{id}/reply`, `/status`, `/delete` | admin Basic Auth + `csrf` form field | The detail page's forms (see *Admin CSRF guard* below) |
 | `GET /admin/export?status=&category=` | admin Basic Auth | One-click JSON file download of everything matching the filters (the UI's "Download JSON" button) |
 | `GET /healthz` | none | Liveness |
 
@@ -99,9 +100,13 @@ report to `waiting_for_player`. `POST /api/reports/{id}/replies` is the JSON twi
 
 **Player side (all gated by the write key + a per-reply-key limiter — `BBS_REPORTS_REPLY_PER_MINUTE`, *not* the
 per-IP ingest limiter, see #1352 — CORS-enabled for browser builds):**
-`GET /api/replies?key=…&since=…` returns
-`{ items: [ { reportId, title, status, fixedInVersion, createdUnix, replies: [ { id, author, text, isQuestion, createdUnix, seen } ], unseenIds: [] } ] }`
-— only threads with an unread developer entry (created after `since`, unix seconds, optional).
+`GET /api/replies?key=…&since=…&ids=…` returns
+`{ items: [ { reportId, title, status, fixedInVersion, createdUnix, replies: [ { id, author, text, isQuestion, createdUnix, seen } ], unseenIds: [] } ], gone: [] }`
+— only threads with an unread developer entry (created after `since`, unix seconds, optional). `ids` (optional,
+comma-separated, at most 50) are the report ids the client still remembers in its `sent.json`; `gone` lists the
+ones among them this key can no longer read — deleted, pruned by retention, or stored under a different key —
+and the client forgets them on the spot (`SentReportsLog.Forget`, #1369), so a deleted report is not polled for
+up to 90 days. Only ids the client named are ever reported, so nothing is enumerable.
 `POST /api/replies/ack` marks those ids read (scoped to the key — foreign ids are ignored). `POST /api/replies`
 appends the player's answer: requires the key to own the report, at least one developer entry to answer
 (no unsolicited threads), and at most **3** player answers per report (`409 reply_limit`); it flips the status
@@ -110,6 +115,35 @@ and HTML-encoded on render — it is hostile input like everything else a player
 
 **Read API.** `GET /api/reports/{id}` now includes `fixedInVersion` and `replies` (the key itself is never
 exposed). Delete and retention pruning remove threads with their report.
+
+**Arcade reports filed before the reply channel cannot be answered in-game.** The glitch.fun arcade client
+hashes its *Glitch install id* into the reply key (the browser-local `PlayerToken` there resets with every
+deployment, #1177), but such a report's stored `playerId` IS that browser-local token — so the key the inbox
+back-filled from it is one the arcade install never polls with. That is not repairable after the fact (the
+inbox never learns the install id). The detail page recognises the case — a `WebGLPlayer` report whose key was
+derived from the player id rather than sent by the client (`ReportHostPages.KeyOrigin`) — and says **"No
+in-game reply possible"**: answer those reporters through the old channel (the e-mail on the report, the
+portal, itch/Discord). Desktop reports from before the channel are fine: there the player id is the same
+token the client hashes. A play.* browser report from that era would match too, but the page cannot tell
+the two browser origins apart and errs on the side of the warning.
+
+## Admin CSRF guard (#1369)
+
+The admin UI sits behind Basic Auth, and a browser re-sends Basic credentials on **any** request to the
+origin — including a form auto-submitted by a page the operator happens to have open elsewhere. Since #1327 a
+form POST can put text in front of a player, so every admin form carries a token a foreign page cannot know:
+
+- `AdminCsrf` draws **one random 32-byte token per process** at start-up. `ReportHostPages.Detail` renders it
+  as a hidden `csrf` field in every form (reply, each status button, delete).
+- `POST /admin/report/{id}/reply`, `/status` and `/delete` compare the submitted field with the token
+  (fixed-time, `BasicAuth.TokenEquals`) **after** the Basic-Auth check and answer **403** on a mismatch — the
+  token is a second factor, never a substitute for the credentials.
+- The scriptable JSON routes (`PATCH /api/reports/{id}`, `POST /api/reports/{id}/replies`) instead require an
+  `application/json` content type (**415** otherwise): an HTML form can only send urlencoded, multipart or
+  `text/plain` bodies, so a forged form cannot reach them. Scripts already send JSON; nothing changes for them.
+- No cookie, no per-session table on purpose: the inbox is one process for one operator. A container restart
+  merely makes an already-open detail page's next submit fail with 403 — reload the page and try again. Running
+  several replicas behind one hostname would need a shared token (not supported; the inbox is a single container).
 
 ## Running it
 
@@ -199,8 +233,8 @@ names.
 | Payload parsing/validation | `src/BlocksBeyondTheStars.ReportHost/ReportIngest.cs` |
 | SQLite + screenshot store | `src/BlocksBeyondTheStars.ReportHost/ReportStore.cs` |
 | Admin pages (server-rendered) | `src/BlocksBeyondTheStars.ReportHost/ReportHostPages.cs` |
-| Rate limiter / Basic Auth | `IngestRateLimiter.cs` / `BasicAuth.cs` |
-| Tests | `tests/BlocksBeyondTheStars.Tests/ReportHostTests.cs` (store, parsing, pages) · `ReportHostHttpTests.cs` (the real app over HTTP on a loopback port: reply routes, limiter split) |
+| Rate limiter / Basic Auth / admin CSRF token | `IngestRateLimiter.cs` / `BasicAuth.cs` / `AdminCsrf.cs` |
+| Tests | `tests/BlocksBeyondTheStars.Tests/ReportHostTests.cs` (store, parsing, pages) · `ReportHostHttpTests.cs` (the real app over HTTP on a loopback port: reply routes, limiter split) · `ReportHostReplyLifecycleTests.cs` (`gone` marker; admin CSRF + JSON gate on a second host with the admin UI on) |
 | Image / compose | `Dockerfile.reports` / `docker-compose.reports.yml` |
 
 The admin pages HTML-encode every stored string — report content is hostile input rendered in the

--- a/src/BlocksBeyondTheStars.Client.Core/BlobPeekCache.cs
+++ b/src/BlocksBeyondTheStars.Client.Core/BlobPeekCache.cs
@@ -1,0 +1,94 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+
+using System;
+using System.IO;
+
+namespace BlocksBeyondTheStars.Client
+{
+    /// <summary>
+    /// Remembers the result of an expensive look into a file (the browser save blob's sole player name, #1322)
+    /// for as long as the file is unchanged. The menu asked for that name on EVERY build while the settings
+    /// held none — each ask read and gunzipped the whole blob synchronously, a visible hitch once a world's
+    /// blob reached a few megabytes (#1368). The stamp is (path, length, last write time): a save rewrites
+    /// the blob and bumps both, so a fresh answer follows the next save without any explicit invalidation.
+    /// A missing file is never cached — the loader may adopt a blob from an older deployment on that call.
+    /// Pure file-system bookkeeping, no Unity — unit-tested headless.
+    /// </summary>
+    public sealed class BlobPeekCache
+    {
+        private string? _path;
+        private long _length;
+        private long _writeTicks;
+        private string? _value;
+        private bool _valid;
+
+        /// <summary>How many times <see cref="Get"/> had to run the computation (diagnostics / tests).</summary>
+        public int Misses { get; private set; }
+
+        /// <summary>The cached value while the file at <paramref name="blobPath"/> still has the stamp it had when
+        /// the value was computed; otherwise runs <paramref name="compute"/> and remembers its result.</summary>
+        public string? Get(string blobPath, Func<string?> compute)
+        {
+            if (compute is null)
+            {
+                throw new ArgumentNullException(nameof(compute));
+            }
+
+            bool stamped = TryStamp(blobPath, out long length, out long writeTicks);
+            if (_valid && stamped && string.Equals(_path, blobPath, StringComparison.Ordinal)
+                && length == _length && writeTicks == _writeTicks)
+            {
+                return _value;
+            }
+
+            Misses++;
+            string? value = compute();
+            if (stamped)
+            {
+                _path = blobPath;
+                _length = length;
+                _writeTicks = writeTicks;
+                _value = value;
+                _valid = true;
+            }
+            else
+            {
+                _valid = false; // no file to stamp → ask again next time (it may appear or be adopted)
+            }
+
+            return value;
+        }
+
+        /// <summary>Forgets the remembered value (a "New world" reset deletes the blob; harmless otherwise).</summary>
+        public void Invalidate() => _valid = false;
+
+        private static bool TryStamp(string path, out long length, out long writeTicks)
+        {
+            length = 0;
+            writeTicks = 0;
+            if (string.IsNullOrEmpty(path))
+            {
+                return false;
+            }
+
+            try
+            {
+                var info = new FileInfo(path);
+                if (!info.Exists)
+                {
+                    return false;
+                }
+
+                length = info.Length;
+                writeTicks = info.LastWriteTimeUtc.Ticks;
+                return true;
+            }
+            catch (Exception)
+            {
+                return false; // unreadable metadata → treat as unstamped (compute, don't cache)
+            }
+        }
+    }
+}

--- a/src/BlocksBeyondTheStars.Client.Core/Feedback/FeedbackReplyClient.cs
+++ b/src/BlocksBeyondTheStars.Client.Core/Feedback/FeedbackReplyClient.cs
@@ -37,21 +37,22 @@ namespace BlocksBeyondTheStars.Client.Feedback
         /// <summary>The developer entries the client must acknowledge once it showed them.</summary>
         public List<long> UnseenIds { get; } = new List<long>();
 
-        /// <summary>True when the newest developer entry is a question the player can answer from the game
-        /// (the inbox's <c>waiting_for_player</c> state).</summary>
+        /// <summary>True when the player can answer from the game: the newest entry of the thread is a
+        /// developer question (nothing from the player after it). Derived from the thread alone, NOT from
+        /// <see cref="Status"/> (#1369): an operator who flips the status by hand to <c>triaged</c> while the
+        /// question is still open used to make the answer box vanish — and the inbox accepts an answer in
+        /// any status as long as a developer entry exists.</summary>
         public bool AwaitsAnswer
         {
             get
             {
-                for (int i = Replies.Count - 1; i >= 0; i--)
+                if (Replies.Count == 0)
                 {
-                    if (Replies[i].IsDev)
-                    {
-                        return Replies[i].IsQuestion && Status == "waiting_for_player";
-                    }
+                    return false;
                 }
 
-                return false;
+                var last = Replies[Replies.Count - 1];
+                return last.IsDev && last.IsQuestion; // a player entry after the question means it was answered
             }
         }
     }
@@ -65,6 +66,10 @@ namespace BlocksBeyondTheStars.Client.Feedback
 
         /// <summary>Threads returned by <see cref="FeedbackReplyClient.Fetch"/> (empty for the other calls).</summary>
         public List<FeedbackReplyThread> Threads { get; } = new List<FeedbackReplyThread>();
+
+        /// <summary>Of the report ids the poll asked about, the ones the inbox no longer has for this key
+        /// (deleted, pruned, or never readable with it) — the caller forgets them (#1369).</summary>
+        public List<string> Gone { get; } = new List<string>();
     }
 
     /// <summary>
@@ -114,9 +119,37 @@ namespace BlocksBeyondTheStars.Client.Feedback
 
         // ---------------- Wire helpers (shared with the WebGL transport) ----------------
 
-        /// <summary>The poll URL for a key: <c>{endpoint}?key=…&amp;since=…</c>.</summary>
-        public string FetchUrl(string replyKey, long sinceUnix)
-            => $"{_endpoint}?key={Uri.EscapeDataString(replyKey ?? string.Empty)}&since={Math.Max(0, sinceUnix)}";
+        /// <summary>Upper bound on the remembered ids one poll names — matches the inbox's cap.</summary>
+        public const int MaxKnownIds = 50;
+
+        /// <summary>The poll URL for a key: <c>{endpoint}?key=…&amp;since=…</c>, plus <c>&amp;ids=a,b,c</c> when the
+        /// caller names the report ids it still remembers (#1369) — the inbox answers with the ones it no
+        /// longer has for this key as <c>gone</c>.</summary>
+        public string FetchUrl(string replyKey, long sinceUnix, IEnumerable<string>? knownReportIds = null)
+        {
+            var sb = new StringBuilder(_endpoint)
+                .Append("?key=").Append(Uri.EscapeDataString(replyKey ?? string.Empty))
+                .Append("&since=").Append(Math.Max(0, sinceUnix));
+
+            if (knownReportIds != null)
+            {
+                var ids = new List<string>();
+                foreach (string id in knownReportIds)
+                {
+                    if (!string.IsNullOrEmpty(id) && !ids.Contains(id) && ids.Count < MaxKnownIds)
+                    {
+                        ids.Add(id);
+                    }
+                }
+
+                if (ids.Count > 0)
+                {
+                    sb.Append("&ids=").Append(Uri.EscapeDataString(string.Join(",", ids)));
+                }
+            }
+
+            return sb.ToString();
+        }
 
         public string AckUrl => _endpoint + "/ack";
 
@@ -218,10 +251,48 @@ namespace BlocksBeyondTheStars.Client.Feedback
             return threads;
         }
 
+        /// <summary>Parses the poll response's <c>gone</c> list (#1369) — the report ids the inbox no longer
+        /// has for this key. Tolerant like <see cref="ParseThreads"/>: anything malformed yields an empty
+        /// list, so an older inbox without the field forgets nothing.</summary>
+        public static List<string> ParseGone(string? json)
+        {
+            var gone = new List<string>();
+            if (string.IsNullOrWhiteSpace(json))
+            {
+                return gone;
+            }
+
+            try
+            {
+                using var doc = JsonDocument.Parse(json);
+                if (doc.RootElement.ValueKind != JsonValueKind.Object ||
+                    !doc.RootElement.TryGetProperty("gone", out var items) || items.ValueKind != JsonValueKind.Array)
+                {
+                    return gone;
+                }
+
+                foreach (var item in items.EnumerateArray())
+                {
+                    if (item.ValueKind == JsonValueKind.String && !string.IsNullOrEmpty(item.GetString()))
+                    {
+                        gone.Add(item.GetString()!);
+                    }
+                }
+            }
+            catch
+            {
+                // malformed body — nothing is gone
+            }
+
+            return gone;
+        }
+
         // ---------------- Blocking calls (desktop; run on a background task) ----------------
 
-        /// <summary>Asks for threads with unread developer entries. Blocking; never throws.</summary>
-        public FeedbackReplyResult Fetch(string replyKey, long sinceUnix = 0)
+        /// <summary>Asks for threads with unread developer entries; <paramref name="knownReportIds"/> (the
+        /// reports this install still remembers) come back as <see cref="FeedbackReplyResult.Gone"/> when the
+        /// inbox no longer has them. Blocking; never throws.</summary>
+        public FeedbackReplyResult Fetch(string replyKey, long sinceUnix = 0, IEnumerable<string>? knownReportIds = null)
         {
             var result = new FeedbackReplyResult();
             if (!Preflight(result, replyKey))
@@ -229,7 +300,11 @@ namespace BlocksBeyondTheStars.Client.Feedback
                 return result;
             }
 
-            Send(result, HttpMethod.Get, FetchUrl(replyKey, sinceUnix), null, body => result.Threads.AddRange(ParseThreads(body)));
+            Send(result, HttpMethod.Get, FetchUrl(replyKey, sinceUnix, knownReportIds), null, body =>
+            {
+                result.Threads.AddRange(ParseThreads(body));
+                result.Gone.AddRange(ParseGone(body));
+            });
             return result;
         }
 

--- a/src/BlocksBeyondTheStars.GameServer/GameServer.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServer.cs
@@ -30,7 +30,7 @@ public sealed partial class GameServer
     private const string ShipId = "default";
     private const float MaxReach = 8f;
     private const int HotbarSlots = 9;
-    private const int MaxPlayerNameLength = 24; // client-supplied names are capped to this on join
+    private const int MaxPlayerNameLength = Protocol.MaxPlayerNameLength; // client-supplied names are capped to this on join (the client fields cap at the same, #1368)
 
     // Vertical build band: client-driven block edits and chunk streaming are clamped to this Y range so a
     // spoofed position can't make the server generate/persist chunks at arbitrary heights — otherwise a cheat

--- a/src/BlocksBeyondTheStars.GameServer/GameServer.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServer.cs
@@ -570,6 +570,8 @@ public sealed partial class GameServer
         InitFlora();
         LoadFloraRegrow(); // restore persisted harvest regrowths so a restart doesn't strand bare cells
         LoadWeatherDeposits(); // #900: restore settled snow so a restart doesn't strand cells that can never melt
+        var resident = world.World;
+        resident.BlockSet += cell => MarkBaseWallsDirty(resident, cell); // #1367: a build inside a base's box refreshes its wall fill
 
         // A void world (an orbital station) has no terrain, so it gets none of the OTHER planet-surface
         // content — no fauna/fluids, no settlements/wrecks/landing zones. Only its stamped structure lives

--- a/src/BlocksBeyondTheStars.GameServer/GameServer.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServer.cs
@@ -5464,6 +5464,7 @@ public sealed partial class GameServer
                 _repo.SavePlayer(session.State);
             }
 
+            CheckpointLootPackets(); // #1367: expiring drop packets carry their exact age across a shutdown
             _repo.SaveMetadata(_meta);
         });
     }

--- a/src/BlocksBeyondTheStars.GameServer/GameServerAdminTeleport.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerAdminTeleport.cs
@@ -82,8 +82,10 @@ public sealed partial class GameServer
         for (int i = 0; i < _landingPads.Count; i++)
         {
             var pad = _landingPads[i];
+            // #1367: the real ground over the pad (a paved yard raises it), never the generated median alone —
+            // "/tp pad 1" used to drop the admin into their own concrete and leave the rescue to dig them out.
             list.Add(new TeleportTarget("pad", i + 1, $"pad{i + 1}",
-                new Vector3f(pad.CenterX + 0.5f, pad.CenterY + 2f, pad.CenterZ + 0.5f)));
+                new Vector3f(pad.CenterX + 0.5f, PadSurfaceY(pad.CenterX, pad.CenterZ) + 2f, pad.CenterZ + 0.5f)));
         }
 
         // Settlements split into two numbering series, because "village" and "ruin" are different places to

--- a/src/BlocksBeyondTheStars.GameServer/GameServerBaseWalls.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerBaseWalls.cs
@@ -26,7 +26,8 @@ namespace BlocksBeyondTheStars.GameServer;
 /// "fenced in" and no land animal spawned in it. The query's own level additionally passes through any
 /// non-colliding cell (the original rule, kept): the boundary is 48 blocks out and rarely on the yard's
 /// level, so the fill needs to cross lower ground to get there at all.</item>
-/// <item>Cached per (base, feet level) like <c>_baseAir</c>: the same recompute interval, a bounded budget,
+/// <item>Cached per (base, feet level) like <c>_baseAir</c>: invalidated by a block set or a gate toggled inside
+/// the box (#1367, with <see cref="WalledRecomputeInterval"/> as the backstop), a bounded budget,
 /// <see cref="ServerWorld.GetBlockIfLoaded"/> so an idle base never drags chunk generation. <b>Fail-open</b>:
 /// an unloaded column reads as air, the fill leaks in, the spawn is allowed — the same direction the air
 /// system fails; a fill that runs out of budget answers "open" for everything at that level as well.</item>
@@ -51,16 +52,61 @@ public sealed partial class GameServer
     /// <summary>Levels cached per base before the stalest are dropped (a hilly base is queried at a few dozen feet levels).</summary>
     private const int WalledLevelsPerBase = 24;
 
+    /// <summary>Seconds a level's fill is trusted without a change inside its box (#1367). The air system's
+    /// 1.5 s was shorter than the 1.5–4 s between spawn attempts, so nearly every attempt recomputed; a block
+    /// set or a gate toggled inside the box marks the level dirty instead, so the interval only backs that up.</summary>
+    private const double WalledRecomputeInterval = 8.0;
+
     /// <summary>One base's reachable-from-outside set at one feet level (everything else in the box is enclosed).</summary>
     private sealed class WalledLevel
     {
         public string Body = string.Empty;
+        public Vector3i Center;   // the base core — the fill's box is the reach cube around it
+        public int FeetY;
         public HashSet<Vector3i> Reachable = new();
         public bool FailOpen; // the fill ran out of budget — nothing at this level reads as enclosed
+        public bool Dirty = true; // a block changed / a gate toggled inside the box since the last fill
         public double ComputedAt = double.NegativeInfinity;
+        public int Computes; // fills run for this level (test seam)
     }
 
     private readonly Dictionary<(int BaseId, int FeetY), WalledLevel> _baseWalls = new();
+
+    /// <summary>Fills computed so far (test seam for the cache behaviour, #1367).</summary>
+    public int WalledFillComputesForTest { get; private set; }
+
+    /// <summary>Marks every cached level whose fill box holds <paramref name="cell"/> for recomputation (#1367):
+    /// called for every block set on a resident world and for every hand-operated gate toggled. A level's box is
+    /// the base's reach cube, clipped to the walking band around its feet level (plus the one-row margins).</summary>
+    private void MarkBaseWallsDirty(ServerWorld world, Vector3i cell)
+    {
+        if (_baseWalls.Count == 0)
+        {
+            return;
+        }
+
+        int circ = world.Circumference;
+        var canonical = WorldConstants.CanonicalBlock(cell, circ);
+        foreach (var level in _baseWalls.Values)
+        {
+            if (level.Dirty || level.Body != world.LocationId)
+            {
+                continue;
+            }
+
+            if (System.Math.Abs(WorldConstants.WrapDeltaX(canonical.X - level.Center.X, circ)) <= SealedRoomMaxReach
+                && System.Math.Abs(WorldConstants.WrapDeltaZ(canonical.Z - level.Center.Z, circ)) <= SealedRoomMaxReach
+                && System.Math.Abs(canonical.Y - level.FeetY) <= WalledFillBand + 1
+                && System.Math.Abs(canonical.Y - level.Center.Y) <= SealedRoomMaxReach + 1)
+            {
+                level.Dirty = true;
+            }
+        }
+    }
+
+    /// <summary>Shortest absolute latitude distance across the north–south seam (#1367: the reach test wrapped
+    /// X only, so a base near the seam got a truncated box and its yards failed open).</summary>
+    private int WrapAbsZ(int dz) => System.Math.Abs(WorldConstants.WrapDeltaZ(dz, _world.Circumference));
 
     /// <summary>Scratch classification of the fill's box (one byte per cell, reused across fills).</summary>
     private byte[]? _wallScratch;
@@ -79,7 +125,7 @@ public sealed partial class GameServer
             if (b.Planet != body
                 || WrapAbs(canonical.X - b.Cell.X) > SealedRoomMaxReach
                 || System.Math.Abs(canonical.Y - b.Cell.Y) > SealedRoomMaxReach
-                || System.Math.Abs(canonical.Z - b.Cell.Z) > SealedRoomMaxReach)
+                || WrapAbsZ(canonical.Z - b.Cell.Z) > SealedRoomMaxReach)
             {
                 continue;
             }
@@ -110,15 +156,38 @@ public sealed partial class GameServer
             _baseWalls[key] = level = new WalledLevel();
         }
 
-        if (level.Body != body || _uptime - level.ComputedAt >= SealedRoomRecomputeInterval)
+        if (level.Body != body || level.Dirty || level.Center != b.Cell || _uptime - level.ComputedAt >= WalledRecomputeInterval)
         {
             level.Body = body;
+            level.Center = b.Cell;
+            level.FeetY = feetY;
             level.ComputedAt = _uptime;
             level.Reachable = ComputeReachableFromOutside(b, feetY, out bool failOpen);
             level.FailOpen = failOpen;
+            level.Dirty = false;
+            level.Computes++;
+            WalledFillComputesForTest++;
         }
 
         return level;
+    }
+
+    /// <summary>Test seam (#1367): how many times the fill for the level a cell lies on has been computed for
+    /// the first base in reach — WITHOUT refreshing it. 0 when no level is cached there.</summary>
+    public int WalledLevelComputesForTest(int x, int y, int z)
+    {
+        var canonical = WorldConstants.CanonicalBlock(new Vector3i(x, y, z), _world.Circumference);
+        foreach (var b in _bases)
+        {
+            if (b.Planet == _world.LocationId && WrapAbs(canonical.X - b.Cell.X) <= SealedRoomMaxReach
+                && System.Math.Abs(canonical.Y - b.Cell.Y) <= SealedRoomMaxReach
+                && WrapAbsZ(canonical.Z - b.Cell.Z) <= SealedRoomMaxReach)
+            {
+                return _baseWalls.TryGetValue((b.Id, canonical.Y), out var level) ? level.Computes : 0;
+            }
+        }
+
+        return 0;
     }
 
     // Scratch cell classes: bits 0–1 = free (unknown / free / solid), bits 2–3 = carries feet (unknown / yes / no).
@@ -328,7 +397,7 @@ public sealed partial class GameServer
         {
             if (b.Planet == _world.LocationId && WrapAbs(canonical.X - b.Cell.X) <= SealedRoomMaxReach
                 && System.Math.Abs(canonical.Y - b.Cell.Y) <= SealedRoomMaxReach
-                && System.Math.Abs(canonical.Z - b.Cell.Z) <= SealedRoomMaxReach)
+                && WrapAbsZ(canonical.Z - b.Cell.Z) <= SealedRoomMaxReach)
             {
                 var level = RefreshBaseWalls(b, canonical.Y);
                 return (level.Reachable.Count, level.FailOpen);

--- a/src/BlocksBeyondTheStars.GameServer/GameServerCreatures.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerCreatures.cs
@@ -962,9 +962,10 @@ public sealed partial class GameServer
 
         // A flier coming down onto a perch or sitting on one does not walk (#1332).
         bool hold = motion == MotionClass.Flier && c.Vert.Flight is FlightPhase.Landing or FlightPhase.Perched;
+        int? groundHint = null; // the accepted target column's feet cell, when PreviewStep already found it (#1367)
         if (!hold)
         {
-            var cand = PreviewStep(sp, motion, cur, stepped, out bool needsRise, out int riseFeet);
+            var cand = PreviewStep(sp, motion, cur, stepped, out bool needsRise, out int riseFeet, out int? nextFeet);
 
             // #1348: a ground mover never STARTS a jump or a climb for a rise past its step-up limit. Wild
             // fauna is already walled by the terrain gate; a companion keeps its freedom from that gate
@@ -973,7 +974,13 @@ public sealed partial class GameServer
             // pet levitated straight up the wall (BeginClimb to the cliff top). Blocked, it waits at the
             // base like any animal; the leash teleport remains the fallback.
             bool riseTooHigh = needsRise && riseFeet - (int)System.Math.Floor(cur.Y) > CreatureMotion.StepUpLimit(motion);
-            if (riseTooHigh || StepBlocked(c, sp, motion, cur, cand, needsRise, terrainGates))
+            // #1367: nor does it start one without head clearance — the swept step samples only the cells
+            // AHEAD at the raised height, so under a low ceiling (a 2-high tunnel with a 1-block step) the
+            // animal launched in its own column and sat with its head in the roof for half a second. The
+            // body column at the landing height, right where it stands, must be clear first; otherwise the
+            // rise is a wall like any other.
+            bool riseBlocked = needsRise && !riseTooHigh && CreatureBodyBlocked(sp, new Vector3f(cur.X, riseFeet, cur.Z));
+            if (riseTooHigh || riseBlocked || StepBlocked(c, sp, motion, cur, cand, needsRise, terrainGates, nextFeet))
             {
                 // Creatures don't walk into the player's ship — hold position at the hull. Energy fences pen
                 // them in the same way, and terrain gates (#648) reuse the exact same mechanic. Instead of only
@@ -1014,11 +1021,12 @@ public sealed partial class GameServer
                 c.Vert.ClimbTargetY = 0f; // no rise ahead any more (heading changed) — don't finish a pointless haul
                 targetX = cand.X;
                 targetZ = cand.Z;
+                groundHint = nextFeet; // the step is taken as previewed — the probe need not run a third time
             }
         }
 
         c.Position = ResolveVertical(c, sp, motion, new Vector3f(targetX, cur.Y, targetZ), vertWave, prof, dt,
-            asleep: false, intent, moving);
+            asleep: false, intent, moving, groundHint);
     }
 
     /// <summary>Every barrier a step must pass (#1331): ship hull, energy fence, the terrain gate (wild fauna;
@@ -1026,14 +1034,14 @@ public sealed partial class GameServer
     /// RAISED height when the step is a ledge the animal will have climbed first, so the ledge's own block
     /// doesn't read as a wall the way it used to.</summary>
     private bool StepBlocked(CombatEntity c, CreatureSpecies sp, MotionClass motion, Vector3f cur, Vector3f cand,
-        bool needsRise, bool terrainGates)
+        bool needsRise, bool terrainGates, int? nextFeet = null)
     {
         if (EntityBlockedByShip(cand, CreatureShipMargin(sp)) || BlockedByEnergyFence(cur, cand))
         {
             return true; // body-aware hull guard for large species (#1320)
         }
 
-        if (terrainGates && StepBlockedByTerrain(sp, motion, cur, cand))
+        if (terrainGates && StepBlockedByTerrain(sp, motion, cur, cand, nextFeet))
         {
             return true;
         }
@@ -1210,8 +1218,8 @@ public sealed partial class GameServer
                     c.Position.X + (float)System.Math.Cos(h) * len,
                     c.Position.Y,
                     c.Position.Z + (float)System.Math.Sin(h) * len);
-                var cand = PreviewStep(sp, motion, c.Position, swung, out bool needsRise, out _);
-                if (!needsRise && !StepBlocked(c, sp, motion, c.Position, cand, false, terrainGates))
+                var cand = PreviewStep(sp, motion, c.Position, swung, out bool needsRise, out _, out int? nextFeet);
+                if (!needsRise && !StepBlocked(c, sp, motion, c.Position, cand, false, terrainGates, nextFeet))
                 {
                     detour = cand;
                     heading = h;
@@ -1228,12 +1236,15 @@ public sealed partial class GameServer
     /// into a higher column that is the ledge's feet cell (it will have jumped or climbed before it steps
     /// over — <paramref name="needsRise"/> tells the caller the feet are still below it); otherwise the
     /// current Y (fliers, hoverers and swimmers ease in place; a drop is taken by falling after the step).
+    /// <paramref name="nextFeet"/> hands the target column's feet cell on to the gate and the vertical resolve
+    /// (#1367) so one column change probes the ground once, not three times; null when nothing was probed.
     /// </summary>
     private Vector3f PreviewStep(CreatureSpecies sp, MotionClass motion, Vector3f cur, Vector3f stepped,
-        out bool needsRise, out int riseFeet)
+        out bool needsRise, out int riseFeet, out int? nextFeet)
     {
         needsRise = false;
         riseFeet = 0;
+        nextFeet = null;
         if (!CreatureMotion.IsGroundBound(motion))
         {
             return new Vector3f(stepped.X, cur.Y, stepped.Z);
@@ -1247,12 +1258,13 @@ public sealed partial class GameServer
         }
 
         int refY = (int)System.Math.Floor(cur.Y);
-        int nextFeet = GroundFeetFor(sp, nx, nz, refY);
-        if (nextFeet > cur.Y)
+        int feet = GroundFeetFor(sp, nx, nz, refY);
+        nextFeet = feet;
+        if (feet > cur.Y)
         {
-            riseFeet = nextFeet;
-            needsRise = VerticalMotion.IsBelow(cur.Y, nextFeet);
-            return new Vector3f(stepped.X, nextFeet, stepped.Z);
+            riseFeet = feet;
+            needsRise = VerticalMotion.IsBelow(cur.Y, feet);
+            return new Vector3f(stepped.X, feet, stepped.Z);
         }
 
         return new Vector3f(stepped.X, cur.Y, stepped.Z);
@@ -1262,8 +1274,9 @@ public sealed partial class GameServer
     /// <see cref="CreatureBehaviour.TerrainStepBlocked"/> gate (#648, per motion class since #1331). Only
     /// consulted when the step actually crosses a column boundary, and only for the classes the gate cares
     /// about — so the extra world queries stay off the common same-column tick. Ground heights come from
-    /// REAL blocks (#650), so player-built walls read as impassable steps and dug ramps as walkable ones.</summary>
-    private bool StepBlockedByTerrain(CreatureSpecies sp, MotionClass motion, Vector3f cur, Vector3f next)
+    /// REAL blocks (#650), so player-built walls read as impassable steps and dug ramps as walkable ones.
+    /// <paramref name="knownNextFeet"/> is the target column's probe when the caller already ran it (#1367).</summary>
+    private bool StepBlockedByTerrain(CreatureSpecies sp, MotionClass motion, Vector3f cur, Vector3f next, int? knownNextFeet = null)
     {
         if (!CreatureMotion.IsGroundBound(motion) && motion != MotionClass.Swimmer)
         {
@@ -1279,7 +1292,7 @@ public sealed partial class GameServer
 
         int refY = (int)System.Math.Floor(cur.Y);
         int curFeet = GroundFeetFor(sp, cx, cz, refY);
-        int nextFeet = GroundFeetFor(sp, nx, nz, refY);
+        int nextFeet = knownNextFeet ?? GroundFeetFor(sp, nx, nz, refY);
 
         // A large body treats a filled column as a wall (#750): ground-height deltas alone made ruin
         // walls invisible to fauna (NPCs have PathBlockedByWorld; creatures had nothing), so titans
@@ -1291,11 +1304,38 @@ public sealed partial class GameServer
             return true;
         }
 
-        int curDepth = WaterDepthAtFeet(cx, cz, curFeet);
+        // #1367: only water was gated — a walker stepped down (≤ 3 blocks) onto the crust of a lava column
+        // like onto any floor. The melt is a wall for everything that does not live in it.
+        if (CreatureMotion.IsGroundBound(motion) && sp.Habitat != CreatureHabitat.Lava && LavaUnderFeet(nx, nextFeet, nz))
+        {
+            return true;
+        }
+
+        // The creature's OWN column is read at its own feet (#1367), not at the probe's answer: in a water
+        // column under an overhang the probe finds the ledge above the surface, which reads as dry ground
+        // (depth 0) and let a swimmer steer out of its lake instead of along the shore.
+        int curDepth = WaterDepthAtFeet(cx, cz, refY);
         int nextDepth = WaterDepthAtFeet(nx, nz, nextFeet);
         return CreatureBehaviour.TerrainStepBlocked(motion, CreatureMotion.IsGiant(sp), CreatureMotion.IsAmphibious(sp),
             curFeet, nextFeet, curDepth, nextDepth);
     }
+
+    /// <summary>Whether feet at <paramref name="feetY"/> in a column would rest on lava (real block, no-load read).</summary>
+    private bool LavaUnderFeet(int x, int feetY, int z)
+        => _creatureLavaId != 0 && _world.GetBlockIfLoaded(new Vector3i(x, feetY - 1, z)).Value == _creatureLavaId;
+
+    /// <summary>Test seam (#1367): the terrain gate's verdict for a creature stepping to <paramref name="next"/>
+    /// from where it stands, in its current motion class.</summary>
+    public bool TerrainStepBlockedForTest(string creatureId, Vector3f next)
+    {
+        var c = _creatures.First(x => x.Id == creatureId);
+        var sp = _speciesById[c.SpeciesId];
+        return StepBlockedByTerrain(sp, EffectiveMotion(c, sp), c.Position, next);
+    }
+
+    /// <summary>Test seam: the generator's water body in a column of the active world (surface top, bed), or null.</summary>
+    public (int Top, int Bed)? WaterSurfaceForTest(int x, int z)
+        => _generator.TryGetWaterSurface(_world.Planet, x, z, out int top, out int bed) ? (top, bed) : null;
 
     /// <summary>The generator's water depth in a column, but only when that water actually reaches the
     /// creature's feet: a real floor built ABOVE a pond (a bridge, a floating platform, a filled-in shore)
@@ -1497,17 +1537,21 @@ public sealed partial class GameServer
         return false;
     }
 
-    /// <summary>Whether a cell carries feet: anything but air and water (lava included — a lava dweller's
-    /// column is handled before the probe). No-load read.</summary>
+    /// <summary>Whether a cell carries feet: a colliding block or lava (a lava dweller's column is handled
+    /// before the probe) — not air, not water, and since #1367 not a walk-through prop either (a tuft of grass
+    /// carries nobody; the same rule <see cref="CreatureBodyBlocked"/> and the wall fill read). Canopy counts:
+    /// a bird sits on a crown. No-load read.</summary>
     private bool IsSupportCell(int x, int y, int z)
     {
         var id = _world.GetBlockIfLoaded(new Vector3i(x, y, z));
-        return !id.IsAir && id.Value != _creatureWaterId;
+        return id.Value != _creatureWaterId && IsCollidingBlock(id, fluidsPass: false, foliagePasses: false);
     }
 
     /// <summary>Whether feet placed at <paramref name="y"/> stand on something real: solid (non-water)
-    /// support below, air from the feet up through <paramref name="headroom"/> cells. Uses the no-load
-    /// block read.</summary>
+    /// support below, and nothing a body collides with from the feet up through <paramref name="headroom"/>
+    /// cells (#1367: small flora, a torch or a ladder in the column passes — a titan's eight-cell headroom
+    /// used to fail on one tuft of grass, and the wide scan then hauled it onto the nearest tree crown; a
+    /// canopy or a fluid still blocks). Uses the no-load block read.</summary>
     private bool StandableAt(int x, int y, int z, int headroom = CreatureBodyMinHeight)
     {
         if (!IsSupportCell(x, y - 1, z))
@@ -1517,7 +1561,7 @@ public sealed partial class GameServer
 
         for (int dy = 0; dy < headroom; dy++)
         {
-            if (!_world.GetBlockIfLoaded(new Vector3i(x, y + dy, z)).IsAir)
+            if (IsCollidingBlock(_world.GetBlockIfLoaded(new Vector3i(x, y + dy, z)), fluidsPass: false, foliagePasses: false))
             {
                 return false;
             }
@@ -1720,7 +1764,7 @@ public sealed partial class GameServer
     /// Mutates the creature's <see cref="CombatEntity.Vert"/> state.
     /// </summary>
     private Vector3f ResolveVertical(CombatEntity c, CreatureSpecies sp, MotionClass motion, Vector3f p, float vertWave,
-        in LocomotionProfile prof, double dt, bool asleep, MoveMode intent, bool moving)
+        in LocomotionProfile prof, double dt, bool asleep, MoveMode intent, bool moving, int? groundHint = null)
     {
         int x = (int)System.Math.Floor(p.X), z = (int)System.Math.Floor(p.Z);
         int surface = _generator.SurfaceHeight(_world.Planet, x, z);
@@ -1757,7 +1801,7 @@ public sealed partial class GameServer
                     }
 
                     float g = VerticalMotion.Gravity(_gravityFactor);
-                    int groundY = GroundFeetFor(sp, x, z, (int)System.Math.Floor(p.Y));
+                    int groundY = groundHint ?? GroundFeetFor(sp, x, z, (int)System.Math.Floor(p.Y)); // #1367: reuse the step's probe
                     if (!asleep && moving && !c.Vert.Airborne && c.Vert.ClimbTargetY <= 0f)
                     {
                         if (sp.LocoStyle == LocomotionStyle.Hopper && CreatureMotion.CanJump(sp)
@@ -1830,9 +1874,18 @@ public sealed partial class GameServer
                     goto case FlightPhase.TakingOff;
                 }
 
-                // Sitting: plain gravity — if the perch is dug away it falls to the next floor and sits there.
-                return VerticalMotion.Ground(ref v, p.Y, GroundFeetYAt(x, z, (int)System.Math.Floor(p.Y)),
+                // Sitting: plain gravity — if the perch is dug away it falls to the next floor, and once it has
+                // landed there it takes off again (#1332 as decided, #1367): a bird whose branch went does not
+                // simply sit on the ground below; it flushes and looks for a perch afresh.
+                bool wasAirborne = v.Airborne;
+                float sit = VerticalMotion.Ground(ref v, p.Y, GroundFeetYAt(x, z, (int)System.Math.Floor(p.Y)),
                     VerticalMotion.Gravity(_gravityFactor), dt);
+                if (wasAirborne && !v.Airborne)
+                {
+                    v.Flight = FlightPhase.TakingOff;
+                }
+
+                return sit;
 
             case FlightPhase.TakingOff:
                 v.Airborne = false;
@@ -1970,8 +2023,13 @@ public sealed partial class GameServer
     /// if any were removed (caller re-broadcasts).</summary>
     private bool PruneFarCreatures(List<PlayerSession> targets, int cap)
     {
-        float maxSq = CreatureDespawnRange * CreatureDespawnRange;
-        float titanSq = TitanDespawnRange * TitanDespawnRange;
+        // #1367 (decided): the far leash is view-aware like the crowding pass (#1356) — at the 8-chunk view
+        // distance a herd 90 blocks out is on screen, and the unconditional 70-block prune popped it out.
+        float stream = MaxStreamRadiusBlocks(targets);
+        float maxRange = System.Math.Max(CreatureDespawnRange, stream);
+        float titanRange = System.Math.Max(TitanDespawnRange, stream);
+        float maxSq = maxRange * maxRange;
+        float titanSq = titanRange * titanRange;
         int removed = _creatures.RemoveAll(c =>
         {
             if (c.IsCompanion)

--- a/src/BlocksBeyondTheStars.GameServer/GameServerCreatures.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerCreatures.cs
@@ -1680,6 +1680,10 @@ public sealed partial class GameServer
     /// <summary>Runs the placement-time eviction sweep directly (no tick) so a test can isolate it.</summary>
     public void EvictWildlifeFromShipsForTest() => EvictWildlifeFromShips();
 
+    /// <summary>Test-only: the creature exactly as the next creature broadcast would carry it — lets a test
+    /// pin the wire's motion flags (airborne / perched / glide) to the simulated state (#1368).</summary>
+    public NetCreature NetCreatureForTest(string id) => ToNetCreature(_creatures.First(x => x.Id == id));
+
     /// <summary>Test-only: puts a creature's locomotion controller into a roam PAUSE for <paramref name="seconds"/>
     /// (as if it had rolled one), so a test can trigger the behaviour a pause drives — a flier landing to
     /// rest (#1332) — without waiting for the seeded roll.</summary>
@@ -2122,9 +2126,13 @@ public sealed partial class GameServer
         // its velocity so the client can integrate the arc between updates), a flier is airborne unless perched,
         // a hoverer always is; swimmers never.
         var motion = sp is null ? MotionClass.Walker : CreatureMotion.EffectiveClass(sp, e.Vert.InWater);
+        // A perched flier whose perch was dug away is falling under plain gravity (#1367): its phase is still
+        // Perched, but the wire reports the ACTUAL vertical state — airborne with its fall velocity — so the
+        // client unfolds the wings and integrates the drop instead of drawing a folded bird sliding down (#1368).
+        bool perchedFalling = motion == MotionClass.Flier && e.Vert.Flight == FlightPhase.Perched && e.Vert.Airborne;
         bool airborne = motion switch
         {
-            MotionClass.Flier => e.Vert.Flight != FlightPhase.Perched,
+            MotionClass.Flier => e.Vert.Flight != FlightPhase.Perched || perchedFalling,
             MotionClass.Hoverer => true,
             MotionClass.Swimmer => false,
             _ => e.Vert.Airborne,
@@ -2133,8 +2141,9 @@ public sealed partial class GameServer
         {
             Motion = CreatureMotion.Key(motion),
             Airborne = airborne,
-            Perched = motion == MotionClass.Flier && e.Vert.Flight == FlightPhase.Perched,
-            VertVel = CreatureMotion.IsGroundBound(motion) && e.Vert.Airborne ? e.Vert.VertVel : 0f,
+            Perched = motion == MotionClass.Flier && e.Vert.Flight == FlightPhase.Perched && !perchedFalling,
+            VertVel = (CreatureMotion.IsGroundBound(motion) || perchedFalling) && e.Vert.Airborne ? e.Vert.VertVel : 0f,
+            Glides = sp is not null && CreatureMotion.Glides(sp), // the client's glide factor follows the server's rule (#1368)
 
             Id = e.Id,
             SpeciesId = e.SpeciesId,

--- a/src/BlocksBeyondTheStars.GameServer/GameServerDoors.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerDoors.cs
@@ -294,6 +294,7 @@ public sealed partial class GameServer
         }
 
         door.Open = !door.Open;
+        MarkBaseWallsDirty(_world, door.Pos.ToBlock()); // #1367: a shut gate is a wall to the fill, an open one a gap
         BroadcastDoors();
     }
 

--- a/src/BlocksBeyondTheStars.GameServer/GameServerDropPackets.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerDropPackets.cs
@@ -70,7 +70,9 @@ public sealed partial class GameServer
     /// leave the bundle hanging at the flier's altitude.</summary>
     private const int DropFallScan = 32;
 
-    private double _sinceLootCheckpoint;
+    // Per world (#1367): a server-global counter let one world's checkpoint tick reset another's, so a packet
+    // could go a whole lifetime between writes.
+    private double _sinceLootCheckpoint { get => _worlds.Active.SinceLootCheckpoint; set => _worlds.Active.SinceLootCheckpoint = value; }
 
     /// <summary>A creature-loot packet (expires) vs. a mining/other packet (never does). The two kinds never
     /// merge, so a loot spill can never drag mining overflow to its grave.</summary>
@@ -230,7 +232,9 @@ public sealed partial class GameServer
     /// entombed). Falls back to the origin — a packet is collected by proximity, not by line of sight.
     /// A free cell then FALLS (#1311): down through air to the first cell with something under it — solid or
     /// fluid, so a kill over a lake leaves the bundle on the surface, not on the seabed. An air kill used to
-    /// leave the packet hanging at the flier's altitude ("Blöcke hängen überall im Himmel").</summary>
+    /// leave the packet hanging at the flier's altitude ("Blöcke hängen überall im Himmel"). "Free" and
+    /// "something under it" follow the colliding rule (#1367): grass, a torch or a ladder is neither a wall nor
+    /// a floor, so a kill over a meadow leaves the bundle IN the grass on the ground, not a cell above it.</summary>
     private Vector3i SettleDropCell(Vector3i origin)
     {
         for (int dy = 0; dy <= 2; dy++)
@@ -241,7 +245,7 @@ public sealed partial class GameServer
                 break;
             }
 
-            if (_world.GetBlock(cell).IsAir)
+            if (DropCellFree(cell))
             {
                 return Fall(cell);
             }
@@ -250,15 +254,19 @@ public sealed partial class GameServer
         return origin;
     }
 
-    /// <summary>The lowest air cell in the column at or below <paramref name="cell"/> within
-    /// <see cref="DropFallScan"/> whose cell below is not air (solid or fluid). Runs out of scan → stays.</summary>
+    /// <summary>A cell a packet may lie in: air or a walk-through prop (small flora, torch, lantern, ladder);
+    /// fluids and real blocks are not (<see cref="IsCollidingBlock"/>, the walking body's rule).</summary>
+    private bool DropCellFree(Vector3i cell) => !IsCollidingBlock(_world.GetBlock(cell), fluidsPass: false, foliagePasses: false);
+
+    /// <summary>The lowest free cell in the column at or below <paramref name="cell"/> within
+    /// <see cref="DropFallScan"/> whose cell below is a real block or a fluid. Runs out of scan → stays.</summary>
     private Vector3i Fall(Vector3i cell)
     {
         var at = cell;
         for (int i = 0; i < DropFallScan; i++)
         {
             var below = new Vector3i(at.X, at.Y - 1, at.Z);
-            if (!WithinBuildHeight(below.Y) || !_world.GetBlock(below).IsAir)
+            if (!WithinBuildHeight(below.Y) || !DropCellFree(below))
             {
                 return at;
             }
@@ -403,6 +411,23 @@ public sealed partial class GameServer
         }
 
         return removed;
+    }
+
+    /// <summary>Writes every creature-loot packet's remaining lifetime on every resident world (#1367) — the
+    /// shutdown/checkpoint save used to leave up to one <see cref="LootLifetimeCheckpoint"/> of ageing behind.
+    /// Called inside <c>SaveAll</c>'s transaction.</summary>
+    private void CheckpointLootPackets()
+    {
+        foreach (var world in _worlds.Loaded)
+        {
+            foreach (var packet in world.Containers)
+            {
+                if (packet.Kind == DropPacketKind && IsLootPacket(packet))
+                {
+                    _repo.SaveContainer(packet);
+                }
+            }
+        }
     }
 
     private static NetDropPacket ToNetDropPacket(StoredContainer c)

--- a/src/BlocksBeyondTheStars.GameServer/GameServerGranular.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerGranular.cs
@@ -225,8 +225,9 @@ public sealed partial class GameServer
     /// is displaced like a placed block displaces it (#851). Wakes what depended on the vacated cell — the
     /// granular column above (cascade) and any fluid around it — and keeps the landed block active so it can
     /// keep sinking when it came to rest on fluid. The block's owner (#490) and a weather-snow deposit's melt
-    /// entry travel with it; the props it fell through (<paramref name="crushed"/>) are destroyed first, and a
-    /// creature standing in the landing cell is told to step aside (#1357).</summary>
+    /// entry travel with it; the props it fell through (<paramref name="crushed"/>) are destroyed once it has
+    /// landed (their drops settle on top of it), and a creature standing in the landing cell is told to step
+    /// aside (#1357).</summary>
     private void SettleGranular(Vector3i from, Vector3i to, BlockId id, List<Vector3i> crushed)
     {
         var (tint, glow) = _world.GetModifier(from);

--- a/src/BlocksBeyondTheStars.GameServer/GameServerGranular.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerGranular.cs
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
 using System.Collections.Generic;
+using System.Linq;
 using BlocksBeyondTheStars.Networking.Messages;
+using BlocksBeyondTheStars.Shared.Definitions;
 using BlocksBeyondTheStars.Shared.Geometry;
 using BlocksBeyondTheStars.Shared.Primitives;
 using BlocksBeyondTheStars.Shared.World;
@@ -26,6 +28,11 @@ namespace BlocksBeyondTheStars.GameServer;
 /// <item>A <b>carved</b> form of a granular block is a built thing and stays; dye/glow/paint travel with the
 /// fall; a parked ship's interior is never entered and never disturbed; a player standing in the landing cell
 /// makes the block wait.</item>
+/// <item><b>Landing follows the colliding rule</b> (#1367): a walk-through prop on the way — small flora, a
+/// torch, a lantern, a ladder, a flame — is crushed (dropped as items where it has a drop, put out when it is
+/// fire) and the block falls on; a doorway cell, an NPC and a player all hold the block up like a player does;
+/// a creature the block lands in is nudged to step aside on its next tick (#1357). The settled block keeps its
+/// owner (grief attribution, #490) and, when it is weather snow, its melt-tracking entry.</item>
 /// </list>
 /// </summary>
 public sealed partial class GameServer
@@ -76,6 +83,8 @@ public sealed partial class GameServer
         var todo = new List<Vector3i>(_activeGranular);
         _activeGranular.Clear();
         int budget = GranularUpdatesPerStep;
+        HashSet<Vector3i>? doorways = null; // the doorway cells of this world, built once per step and only when needed
+        var crushed = new List<Vector3i>();
 
         foreach (var pos in todo)
         {
@@ -99,22 +108,25 @@ public sealed partial class GameServer
 
             var belowId = _world.GetBlock(below);
             Vector3i target;
-            if (belowId.IsAir)
+            if (GranularPassable(belowId))
             {
-                if (!TryLandingCell(pos, out target))
+                doorways ??= _doors.Count > 0 ? DoorCellsWhere(_ => true) : new HashSet<Vector3i>();
+                crushed.Clear();
+                if (!TryLandingCell(pos, doorways, crushed, out target))
                 {
-                    _activeGranular.Add(pos); // a player stands in the way — wait for them to move
+                    _activeGranular.Add(pos); // a player / NPC / doorway is in the way — wait for it to clear
                     continue;
                 }
             }
             else if (IsFluid(belowId.Value))
             {
-                if (CellOccupiedByPlayer(below))
+                if (CellOccupiedByPlayer(below) || CellOccupiedByNpc(below))
                 {
                     _activeGranular.Add(pos);
                     continue;
                 }
 
+                crushed.Clear();
                 target = below; // one cell per step through water/lava
             }
             else
@@ -122,27 +134,45 @@ public sealed partial class GameServer
                 continue; // supported
             }
 
-            SettleGranular(pos, target, id);
+            SettleGranular(pos, target, id, crushed);
         }
     }
 
-    /// <summary>The cell a block at <paramref name="pos"/> lands in: straight down through air until the next
-    /// cell is not air (solid or fluid), the build floor, or a ship interior. False when a player occupies a
-    /// cell on the way — the block waits rather than landing on someone's head.</summary>
-    private bool TryLandingCell(Vector3i pos, out Vector3i landing)
+    /// <summary>Whether a falling block passes through a cell (#1367): air, or a block with no collider — the
+    /// same rule a walking body uses (<see cref="IsCollidingBlock"/>): small flora, torch, lantern, ladder, a
+    /// flame. Fluids and every real block stop it (a canopy too — sand rests on a tree crown).</summary>
+    private bool GranularPassable(BlockId id) => !IsCollidingBlock(id, fluidsPass: false, foliagePasses: false);
+
+    /// <summary>The cell a block at <paramref name="pos"/> lands in: straight down through air and walk-through
+    /// props (collected in <paramref name="crushed"/> — they are destroyed when the block settles) until the next
+    /// cell is a real block or a fluid, the build floor, or a ship interior. False when a player, an NPC or a
+    /// doorway occupies a cell on the way — the block waits rather than landing on someone's head or in a gate.</summary>
+    private bool TryLandingCell(Vector3i pos, HashSet<Vector3i> doorways, List<Vector3i> crushed, out Vector3i landing)
     {
         landing = pos;
         for (int i = 0; i < GranularFallScan; i++)
         {
             var next = new Vector3i(landing.X, landing.Y - 1, landing.Z);
-            if (!WithinBuildHeight(next.Y) || !_world.GetBlock(next).IsAir || InShipInterior(next))
+            if (!WithinBuildHeight(next.Y) || InShipInterior(next))
             {
                 break;
             }
 
-            if (CellOccupiedByPlayer(next))
+            var id = _world.GetBlock(next);
+            if (!GranularPassable(id))
+            {
+                break;
+            }
+
+            if (CellOccupiedByPlayer(next) || CellOccupiedByNpc(next)
+                || doorways.Contains(WorldConstants.CanonicalBlock(next, _world.Circumference)))
             {
                 return false;
+            }
+
+            if (!id.IsAir)
+            {
+                crushed.Add(next);
             }
 
             landing = next;
@@ -151,24 +181,80 @@ public sealed partial class GameServer
         return true;
     }
 
+    /// <summary>Destroys a walk-through prop a settling block fell through (#1367): a flame is put out, anything
+    /// else is cleared and its drops (if any) spill onto the ground — the same yield mining it would give, minus
+    /// the regrow. <paramref name="overwritten"/> skips the clear for the landing cell itself, which the settled
+    /// block has already replaced (<paramref name="id"/> is what stood there). Runs AFTER the block has landed,
+    /// so the spill settles on top of it rather than inside it.</summary>
+    private void CrushProp(Vector3i cell, BlockId id, bool overwritten)
+    {
+        if (id.IsAir)
+        {
+            return;
+        }
+
+        if (id.Value == _fireId)
+        {
+            if (overwritten)
+            {
+                UntrackFire(cell);
+            }
+            else
+            {
+                Extinguish(cell);
+            }
+
+            return;
+        }
+
+        var def = _world.Definition(id);
+        if (!overwritten)
+        {
+            _world.SetBlock(cell, BlockId.Air);
+            BroadcastToWorld(new BlockChanged { X = cell.X, Y = cell.Y, Z = cell.Z, Block = BlockId.AirValue });
+        }
+
+        if (def is { Drops.Count: > 0 })
+        {
+            SpillToGround(cell, def.Drops.Select(d => new ItemAmount(d.Item, d.Count)));
+        }
+    }
+
     /// <summary>Moves a granular block from <paramref name="from"/> to <paramref name="to"/>, carrying its dye,
     /// glow and paint design (read before clearing — the <c>BreakBlockAt</c> pattern). A fluid at the target
     /// is displaced like a placed block displaces it (#851). Wakes what depended on the vacated cell — the
     /// granular column above (cascade) and any fluid around it — and keeps the landed block active so it can
-    /// keep sinking when it came to rest on fluid.</summary>
-    private void SettleGranular(Vector3i from, Vector3i to, BlockId id)
+    /// keep sinking when it came to rest on fluid. The block's owner (#490) and a weather-snow deposit's melt
+    /// entry travel with it; the props it fell through (<paramref name="crushed"/>) are destroyed first, and a
+    /// creature standing in the landing cell is told to step aside (#1357).</summary>
+    private void SettleGranular(Vector3i from, Vector3i to, BlockId id, List<Vector3i> crushed)
     {
         var (tint, glow) = _world.GetModifier(from);
         int design = ShapeCode.DesignOf(_world.GetShape(from));
         int shape = design != 0 ? ShapeCode.WithDesign(0, design) : 0;
         bool intoFluid = IsFluid(_world.GetBlock(to).Value);
+        // #1367: a painted/built sand block stays attributed to its builder after the fall — the grief report
+        // must still name whoever put it there, not "the server".
+        string owner = _repo.GetBlockAttribution(_world.LocationId, WorldConstants.CanonicalBlock(from, _world.Circumference))?.Owner ?? string.Empty;
 
         _world.SetBlock(from, BlockId.Air);
         _miningProgress.Remove(from);
         BroadcastToWorld(new BlockChanged { X = from.X, Y = from.Y, Z = from.Z, Block = BlockId.AirValue });
 
-        _world.SetBlock(to, id, tint, glow, shape);
+        var crushedIds = new List<(Vector3i Cell, BlockId Id)>(crushed.Count);
+        foreach (var cell in crushed)
+        {
+            crushedIds.Add((cell, _world.GetBlock(cell))); // read before the landing cell is overwritten
+        }
+
+        _world.SetBlock(to, id, tint, glow, shape, owner);
         BroadcastToWorld(new BlockChanged { X = to.X, Y = to.Y, Z = to.Z, Block = id.Value, Tint = tint, Glow = glow, Shape = shape });
+        NudgeCreatureBodyChecks(to); // #1357/#1367: an animal the block landed on steps aside on its next tick
+        MoveWeatherDeposit(from, to, id.Value); // fallen weather snow still melts (#1367)
+        foreach (var (cell, crushedId) in crushedIds)
+        {
+            CrushProp(cell, crushedId, overwritten: cell == to);
+        }
 
         if (intoFluid)
         {
@@ -191,6 +277,22 @@ public sealed partial class GameServer
         foreach (var s in JoinedInActiveWorld())
         {
             var feet = s.State.Position.ToBlock();
+            if (feet == cell || new Vector3i(feet.X, feet.Y + 1, feet.Z) == cell)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>True if a settlement / trader / camp NPC on this world stands in the cell (feet or head). NPCs
+    /// have no displacement of their own (#1367), so they hold a falling block up exactly like a player.</summary>
+    private bool CellOccupiedByNpc(Vector3i cell)
+    {
+        foreach (var n in _npcs)
+        {
+            var feet = n.Pos.ToBlock();
             if (feet == cell || new Vector3i(feet.X, feet.Y + 1, feet.Z) == cell)
             {
                 return true;

--- a/src/BlocksBeyondTheStars.GameServer/GameServerShipRepair.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerShipRepair.cs
@@ -146,12 +146,16 @@ public sealed partial class GameServer
     }
 
     /// <summary>Pushes the current own-ship repair readout so the client can offer "Repair ship".</summary>
-    private void SendShipRepairStatus(PlayerSession session)
+    private void SendShipRepairStatus(PlayerSession session) => Send(session, BuildShipRepairStatus(session));
+
+    /// <summary>The own-ship repair readout: hull, breach count + the breach cells themselves (structure-local,
+    /// capped — the client outlines them in the world while the panel is up, #1368), affordability and the
+    /// material summary. Also clears the downed flag once a lost ship is whole again.</summary>
+    private ShipRepairStatus BuildShipRepairStatus(PlayerSession session)
     {
         if (!TryGetOwnShipStructure(session.State.PlayerId, out var live, out _))
         {
-            Send(session, new ShipRepairStatus { Hull = _ship.Hull, HullMax = _shipHullMax, NeedsRepair = false });
-            return;
+            return new ShipRepairStatus { Hull = _ship.Hull, HullMax = _shipHullMax, NeedsRepair = false };
         }
 
         var design = OwnShipDesignReference(session.State.PlayerId);
@@ -167,7 +171,10 @@ public sealed partial class GameServer
             Send(session, new ServerMessage { Text = "@srv.repair.done" });
         }
 
-        Send(session, new ShipRepairStatus
+        // The breach cells, in the same order the repair walks them; bounded so a gutted custom hull can't
+        // turn the readout into a multi-KB message (the count above stays honest).
+        var listed = EnumerateShipRepairCells(live, design).Take(ShipRepairStatus.MaxListedMissingCells).Select(c => c.Cell).ToList();
+        return new ShipRepairStatus
         {
             Hull = _ship.Hull,
             HullMax = _shipHullMax,
@@ -175,7 +182,11 @@ public sealed partial class GameServer
             NeedsRepair = missing > 0 || _ship.Hull < _shipHullMax,
             CanAfford = free || pool.Has(cost),
             Needs = string.Join(",", cost.OrderByDescending(c => c.Count).Select(c => $"{c.Item}:{c.Count}")),
-        });
+            StructureId = live.Id,
+            MissingX = listed.Select(c => c.X).ToArray(),
+            MissingY = listed.Select(c => c.Y).ToArray(),
+            MissingZ = listed.Select(c => c.Z).ToArray(),
+        };
     }
 
     private void HandleRepairShip(PlayerSession session, RepairShipIntent intent)
@@ -377,6 +388,20 @@ public sealed partial class GameServer
 
         Serve(session);
         _ship.Hull = System.Math.Max(0f, System.Math.Min(_shipHullMax, hull));
+    }
+
+    /// <summary>Test hook: the repair readout exactly as the cockpit would receive it (null when the player
+    /// is unknown) — pins the listed breach cells to the live structure (#1368).</summary>
+    public ShipRepairStatus? ShipRepairStatusForTest(string playerId)
+    {
+        var session = FindSessionByPlayerId(playerId);
+        if (session is null)
+        {
+            return null;
+        }
+
+        Serve(session);
+        return BuildShipRepairStatus(session);
     }
 
     /// <summary>Test hook: number of missing design cells on the player's live ship structure (-1 if none here).</summary>

--- a/src/BlocksBeyondTheStars.GameServer/GameServerShipStructure.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerShipStructure.cs
@@ -51,7 +51,6 @@ public sealed partial class GameServer
         var rec = CurLanded;
 
         var pad = PlayerPad(_current);
-        int y0 = PadSurfaceY(pad.CenterX, pad.CenterZ); // median, raised over whatever the player built on the pad (#1318)
 
         var s = BuildShipStructure(playerId);
         if (s.Cells.Count == 0)
@@ -62,11 +61,18 @@ public sealed partial class GameServer
         }
 
         rec.Structure = s;
+
+        // Pre-object saves carry the old stamped hull as world block edits — on the generated median, where the
+        // stamp always sat. Clean that up BEFORE reading the raised surface (#1367): the residue is exactly the
+        // kind of "built over the pad" block PadSurfaceY honours, and reading it first lifted a months-old save's
+        // ship onto its own ghost hull for one session.
+        rec.Origin = new Vector3i(pad.CenterX - s.Width / 2, PadGroundY(pad.CenterX, pad.CenterZ) + 1, pad.CenterZ - s.Length / 2);
+        CleanLegacyStampResidueOnce(rec, pad);
+
+        int y0 = PadSurfaceY(pad.CenterX, pad.CenterZ); // median, raised over whatever the player built on the pad (#1318)
         // The structure sits ON the levelled pad surface (origin.y = first cell layer above the ground).
         rec.Origin = new Vector3i(pad.CenterX - s.Width / 2, y0 + 1, pad.CenterZ - s.Length / 2);
         DeriveLandedAnchors(rec);
-
-        CleanLegacyStampResidueOnce(rec, pad); // pre-object saves carry the old stamped hull as world block edits
 
         rec.Placed = true;
         _log.Info($"Ship parked at ({rec.Origin.X}, {rec.Origin.Y}, {rec.Origin.Z}) — {s.Cells.Count} cells, {rec.Stations.Count} stations.");

--- a/src/BlocksBeyondTheStars.GameServer/GameServerSpawnSafety.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerSpawnSafety.cs
@@ -256,6 +256,17 @@ public sealed partial class GameServer
             if (IsEntombed(p.Position))
             {
                 var freed = DigOutUpwards(p.Position) ?? SafeSpawnPoint(p.PlayerId);
+                // #1367: when the pad fallback is walled in as well (a build higher than the touchdown scan over
+                // the pad), the rescue used to fire every second — teleport, toast and chat line — into the same
+                // blocked spot for as long as the player stayed sealed in. One rescue per entombment episode: a
+                // destination that is itself entombed and the same as last time is left alone until the player
+                // (or the world) changes something; a new destination is a new rescue.
+                if (s.EntombedRescueSpot is { } last && last.ToBlock() == freed.ToBlock() && IsEntombed(freed))
+                {
+                    continue;
+                }
+
+                s.EntombedRescueSpot = freed;
                 p.Position = freed;
                 s.AwaitingSpawnAdopt = true; // #865: the client's stale stream must not drag them back in
                 _log.Warn($"Player '{p.Name}' was sealed inside blocks; moved to {freed}.");
@@ -266,6 +277,8 @@ public sealed partial class GameServer
                 SendPlayerState(s);
                 continue;
             }
+
+            s.EntombedRescueSpot = null; // out in the open again — the episode is over
 
             if (!IsInVoid(p.Position))
             {

--- a/src/BlocksBeyondTheStars.GameServer/GameServerWeatherEvents.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerWeatherEvents.cs
@@ -270,15 +270,38 @@ public sealed partial class GameServer
                     continue;
                 }
 
-                _world.SetBlock(cell, new BlockId(_weatherSnowId));
-                // Weather-placed blocks are still block edits, so clients MUST be told or they'd only
-                // see the snow after a chunk reload.
-                BroadcastToWorld(new BlockChanged { X = cell.X, Y = cell.Y, Z = cell.Z, Block = _weatherSnowId });
-                deposits[cell] = DepositMeltSeconds;
-                _repo.SaveWeatherDeposit(_world.LocationId, cell, _weatherSnowId, DepositMeltSeconds);
+                DepositSnowAt(cell, deposits);
                 placed++;
             }
         }
+    }
+
+    /// <summary>Lays one weather-snow block and tracks it for the melt pass (memory + save row).</summary>
+    private void DepositSnowAt(Vector3i cell, Dictionary<Vector3i, double> deposits)
+    {
+        _world.SetBlock(cell, new BlockId(_weatherSnowId));
+        // Weather-placed blocks are still block edits, so clients MUST be told or they'd only
+        // see the snow after a chunk reload.
+        BroadcastToWorld(new BlockChanged { X = cell.X, Y = cell.Y, Z = cell.Z, Block = _weatherSnowId });
+        deposits[cell] = DepositMeltSeconds;
+        _repo.SaveWeatherDeposit(_world.LocationId, cell, _weatherSnowId, DepositMeltSeconds);
+    }
+
+    /// <summary>Carries a weather-snow deposit's melt entry along with the block when it settles (#1367): snow is
+    /// granular now, and a deposit that fell off a ledge used to lose its entry (the melt pass looked for snow at
+    /// the OLD cell, found none, and dropped the row) — fallen snow never melted. No-op for anything that is not
+    /// a tracked deposit.</summary>
+    private void MoveWeatherDeposit(Vector3i from, Vector3i to, ushort block)
+    {
+        var deposits = _worlds.Active.WeatherDeposits;
+        if (!deposits.Remove(from, out double timer))
+        {
+            return;
+        }
+
+        deposits[to] = timer;
+        _repo.DeleteWeatherDeposit(_world.LocationId, from);
+        _repo.SaveWeatherDeposit(_world.LocationId, to, block, timer);
     }
 
     /// <summary>Finds the air cell resting on the first solid block below the player's level in this
@@ -316,7 +339,7 @@ public sealed partial class GameServer
     /// <summary>Melts weather snow once the air turns warm (or the world stopped snowing long enough),
     /// bounded to the same per-pass budget. Only cells in the deposit table are ever removed, so a
     /// player's own snow blocks are untouchable here.</summary>
-    private void MeltSnow(Dictionary<Vector3i, double> deposits)
+    private void MeltSnow(Dictionary<Vector3i, double> deposits, bool force = false)
     {
         if (deposits.Count == 0)
         {
@@ -324,7 +347,7 @@ public sealed partial class GameServer
         }
 
         bool warm = CurrentTemperature(_weatherState, _dayFraction) > 2f;
-        bool overCap = deposits.Count > MaxDepositsPerWorld;
+        bool overCap = deposits.Count > MaxDepositsPerWorld || force;
         if (!warm && !overCap)
         {
             return; // still freezing and within budget — the snow stays
@@ -355,9 +378,24 @@ public sealed partial class GameServer
             {
                 _world.SetBlock(cell, new BlockId(0));
                 BroadcastToWorld(new BlockChanged { X = cell.X, Y = cell.Y, Z = cell.Z, Block = 0 });
+                OnSupportRemoved(cell); // #1367: sand someone dropped on the drift comes down with the thaw
             }
         }
     }
+
+    /// <summary>Test seam: lays a tracked weather-snow block at a cell exactly as a blizzard would.</summary>
+    public void DepositWeatherSnowForTest(int x, int y, int z)
+    {
+        _weatherIdsResolved = true;
+        _weatherSnowId = _content.GetBlock("snow")?.NumericId.Value ?? 0;
+        DepositSnowAt(new Vector3i(x, y, z), _worlds.Active.WeatherDeposits);
+    }
+
+    /// <summary>Test seam: one melt pass with the thaw forced (every tracked deposit within the pass budget goes).</summary>
+    public void MeltWeatherSnowForTest() => MeltSnow(_worlds.Active.WeatherDeposits, force: true);
+
+    /// <summary>Test seam: the cells the melt pass currently tracks on the active world.</summary>
+    public IReadOnlyCollection<Vector3i> WeatherDepositCellsForTest => _worlds.Active.WeatherDeposits.Keys;
 
     // ---------------- Forecast (the weather scanner gadget) ----------------
 

--- a/src/BlocksBeyondTheStars.GameServer/PlayerSession.cs
+++ b/src/BlocksBeyondTheStars.GameServer/PlayerSession.cs
@@ -123,6 +123,11 @@ public sealed class PlayerSession
     /// mining can overflow on every block of a burst; one warning per few seconds says it just as well.</summary>
     public double NextInventoryFullHintAt { get; set; }
 
+    /// <summary>Where the entombment rescue last moved this player during the CURRENT episode of being sealed
+    /// in (#1367), or null when they are out in the open. A rescue whose destination is the same blocked spot
+    /// as last time is skipped instead of re-teleporting and re-announcing every second.</summary>
+    public Shared.Geometry.Vector3f? EntombedRescueSpot { get; set; }
+
     /// <summary>Loot banked from asteroids / salvage drops that has not been announced yet (#1317): item key +
     /// how much went to the backpack and to the cargo hold. Flushed as ONE "+n … → hold" toast per cooldown.</summary>
     public List<(string Item, int ToBackpack, int ToCargo)> PendingLootToast { get; } = new();

--- a/src/BlocksBeyondTheStars.GameServer/ServerWorld.cs
+++ b/src/BlocksBeyondTheStars.GameServer/ServerWorld.cs
@@ -65,6 +65,10 @@ public sealed class ServerWorld
 
     public int LoadedChunkCount => _loaded.Count;
 
+    /// <summary>Raised after every <see cref="SetBlock"/> with the canonical cell (#1367) — the hook for caches
+    /// that key on the block grid (the walled-base fill invalidates the levels whose box the cell lies in).</summary>
+    public event System.Action<Vector3i>? BlockSet;
+
     /// <summary>Whether a chunk is currently resident in the cache (canonicalized like the cache keys). For
     /// tests/diagnostics — e.g. asserting far-chunk eviction by <see cref="UnloadFarChunks"/>.</summary>
     public bool IsChunkLoaded(ChunkCoord coord) => _loaded.ContainsKey(WorldConstants.CanonicalChunk(coord, Circumference));
@@ -143,6 +147,7 @@ public sealed class ServerWorld
         chunk.SetModifier(local.X, local.Y, local.Z, tint, glow);
         chunk.SetShape(local.X, local.Y, local.Z, shape);
         _repo.SetBlock(LocationId, world, block.Value, tint, glow, shape, owner);
+        BlockSet?.Invoke(world);
         return previous;
     }
 

--- a/src/BlocksBeyondTheStars.GameServer/WorldManager.cs
+++ b/src/BlocksBeyondTheStars.GameServer/WorldManager.cs
@@ -254,6 +254,9 @@ internal sealed class LoadedWorld
     /// <summary>Throttle for the snow accumulation/melt pass.</summary>
     public double SinceWeatherDeposit { get; set; }
 
+    /// <summary>Seconds since this world's expiring drop packets were last checkpointed to the store (#1312, per world since #1367).</summary>
+    public double SinceLootCheckpoint { get; set; }
+
     /// <summary>This body's size class (asteroid/moon/planet), set on load — seeds the per-world gravity band.</summary>
     public WorldConstants.WorldSizeClass SizeClass { get; set; } = WorldConstants.WorldSizeClass.Planet;
 

--- a/src/BlocksBeyondTheStars.Networking/Messages.cs
+++ b/src/BlocksBeyondTheStars.Networking/Messages.cs
@@ -507,6 +507,20 @@ public sealed class ShipRepairStatus
 
     /// <summary>Compact "item:count,item:count" summary of the full repair cost (for the HUD hint).</summary>
     public string Needs { get; set; } = string.Empty;
+
+    /// <summary>The live structure the missing cells below belong to ("ship:&lt;playerId&gt;") — the client maps
+    /// them into the world through that structure's origin. Additive (#1368); empty from an older server.</summary>
+    public string StructureId { get; set; } = string.Empty;
+
+    /// <summary>Structure-local coordinates of the missing design hull cells (parallel arrays, at most
+    /// <see cref="MaxListedMissingCells"/> of them — <see cref="MissingCells"/> stays the true count) so the
+    /// client can outline every breach in the world while the repair panel is up (#1368). Additive.</summary>
+    public int[] MissingX { get; set; } = System.Array.Empty<int>();
+    public int[] MissingY { get; set; } = System.Array.Empty<int>();
+    public int[] MissingZ { get; set; } = System.Array.Empty<int>();
+
+    /// <summary>Upper bound on the listed breach cells — a fully wrecked custom hull can have thousands.</summary>
+    public const int MaxListedMissingCells = 256;
 }
 
 /// <summary>Client scans a subject with the handheld scanner (creature species id / block key).</summary>
@@ -1690,9 +1704,16 @@ public sealed class NetCreature
     /// <summary>A flier sitting on the ground (#1332) — wings folded, legs down. Additive.</summary>
     public bool Perched { get; set; }
 
-    /// <summary>Vertical velocity (blocks/s, +up) while a ground class is airborne, so the client can integrate
-    /// the jump arc between the ~2 Hz position updates instead of smearing it. 0 otherwise. Additive.</summary>
+    /// <summary>Vertical velocity (blocks/s, +up) while airborne — a ground class mid-jump/fall, or a perched
+    /// flier whose perch went (#1368) — so the client can integrate the arc between the ~2 Hz position updates
+    /// instead of smearing it. 0 otherwise. Additive.</summary>
     public float VertVel { get; set; }
+
+    /// <summary>The server's ground-bird predicate (<c>CreatureMotion.Glides</c>: wings ∧ land ∧ can jump — no
+    /// giants, no air species): this walker falls under reduced gravity while airborne, so the client's local
+    /// arc integration uses the same glide factor the server does (#1368). Additive; a legacy server sends
+    /// false, which is also what it simulates.</summary>
+    public bool Glides { get; set; }
 }
 
 /// <summary>Snapshot of live creatures (fauna) near the player on the planet surface.</summary>

--- a/src/BlocksBeyondTheStars.Networking/Protocol.cs
+++ b/src/BlocksBeyondTheStars.Networking/Protocol.cs
@@ -16,6 +16,11 @@ public static class Protocol
 
     public const int DefaultGameplayPort = 31415;
     public const int DefaultAdminPort = 31416;
+
+    /// <summary>Longest player name the server keeps on join (anything longer is truncated, control characters
+    /// stripped). Client name fields cap their input at this so the name a player typed — and stored in the
+    /// settings — is the identity the server actually uses (#1368).</summary>
+    public const int MaxPlayerNameLength = 24;
 }
 
 /// <summary>Network delivery guarantees, mapped onto transport channels.</summary>

--- a/src/BlocksBeyondTheStars.ReportHost/AdminCsrf.cs
+++ b/src/BlocksBeyondTheStars.ReportHost/AdminCsrf.cs
@@ -1,0 +1,42 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using System.Security.Cryptography;
+
+namespace BlocksBeyondTheStars.ReportHost;
+
+/// <summary>
+/// Cross-site request forgery guard for the admin forms (#1369). The admin UI sits behind Basic Auth, and a
+/// browser re-sends Basic credentials on ANY request to the origin — including a form auto-submitted by a
+/// page the operator opened elsewhere. Since #1327 a form POST can send text to a player, so every admin
+/// form now carries a token the foreign page cannot know: one random value per process, rendered as a
+/// hidden field (<see cref="FieldName"/>) and checked with a fixed-time compare on every admin POST.
+/// Deliberately the simplest robust shape — no cookie, no per-session table: the inbox is one process
+/// behind one operator, and a restart merely makes an already-open page's next submit fail with 403 until
+/// it is reloaded.
+/// </summary>
+public sealed class AdminCsrf
+{
+    /// <summary>Name of the hidden form field (and of the form key the check reads).</summary>
+    public const string FieldName = "csrf";
+
+    /// <summary>The token pages render — 32 random bytes as lowercase hex, fixed for the process lifetime.</summary>
+    public string Token { get; }
+
+    public AdminCsrf()
+        : this(Convert.ToHexString(RandomNumberGenerator.GetBytes(32)).ToLowerInvariant())
+    {
+    }
+
+    /// <summary>Test seam: a fixed token.</summary>
+    public AdminCsrf(string token)
+    {
+        Token = token;
+    }
+
+    /// <summary>The hidden input every admin form must contain.</summary>
+    public string HiddenField() => $"<input type='hidden' name='{FieldName}' value='{Token}'>";
+
+    /// <summary>True when the submitted value is this process's token (fixed-time compare; empty never matches).</summary>
+    public bool IsValid(string? presented) => BasicAuth.TokenEquals(presented, Token);
+}

--- a/src/BlocksBeyondTheStars.ReportHost/ReportHostApp.cs
+++ b/src/BlocksBeyondTheStars.ReportHost/ReportHostApp.cs
@@ -23,6 +23,11 @@ public static class ReportHostApp
         var limiter = new IngestRateLimiter(config.IngestPerMinute);
         var replyLimiter = new IngestRateLimiter(config.ReplyPerMinute);
 
+        // One random token per process, rendered into every admin form and required on every admin form
+        // POST (#1369): Basic credentials ride along on any cross-site request the browser makes, and since
+        // #1327 a forged form submit could put text in front of a player.
+        var csrf = new AdminCsrf();
+
         var builder = WebApplication.CreateBuilder(args);
         builder.Logging.ClearProviders();
         builder.Logging.AddConsole();
@@ -106,6 +111,25 @@ public static class ReportHostApp
 
             ctx.Response.Headers.WWWAuthenticate = "Basic realm=\"BBS ReportHost\", charset=\"UTF-8\"";
             return Results.Text("Unauthorized.\n", statusCode: StatusCodes.Status401Unauthorized);
+        }
+
+        // Admin FORM gate (#1369): the submitted hidden field must be this process's CSRF token. Null = OK.
+        IResult? GuardAdminForm(IFormCollection form)
+        {
+            return csrf.IsValid(form[AdminCsrf.FieldName].ToString())
+                ? null
+                : Results.Text("Forbidden — the form's CSRF token does not match this inbox (reload the page and try again).\n",
+                    statusCode: StatusCodes.Status403Forbidden);
+        }
+
+        // Admin JSON gate (#1369): the scriptable routes only take a real JSON body. An HTML form can post
+        // urlencoded, multipart or text/plain — never application/json — so a forged <form> cannot reach
+        // them even though the browser attaches the Basic credentials. Null = OK.
+        static IResult? GuardAdminJson(HttpContext ctx)
+        {
+            return ctx.Request.HasJsonContentType()
+                ? null
+                : Results.Json(new { error = "json_body_required" }, statusCode: StatusCodes.Status415UnsupportedMediaType);
         }
 
         // One reply-thread entry as JSON (shared by the read API and the client's poll).
@@ -353,6 +377,11 @@ public static class ReportHostApp
                 return denied;
             }
 
+            if (GuardAdminJson(ctx) is { } notJson)
+            {
+                return notJson;
+            }
+
             string status;
             try
             {
@@ -387,6 +416,9 @@ public static class ReportHostApp
 
         // The client's poll: every thread of this key with an unread developer entry. `since` (unix seconds,
         // optional) narrows to entries created after that point — the client passes its last poll time.
+        // `ids` (comma-separated, optional, #1369) are the report ids the client still remembers; the ones
+        // this key can no longer read (deleted, pruned, or never its own) come back as `gone`, so the
+        // client forgets them instead of polling for up to 90 days for a report that no longer exists.
         app.MapGet("/api/replies", (HttpContext ctx) =>
         {
             if (GuardPlayerRoute(ctx) is { } denied)
@@ -402,7 +434,12 @@ public static class ReportHostApp
 
             long since = long.TryParse(ctx.Request.Query["since"], out var s) ? s : 0;
             var threads = store.UnreadThreads(key, since);
-            return Results.Json(new { items = threads.Select(t => ThreadJson(t)).ToArray() });
+            string[] asked = ctx.Request.Query["ids"].ToString()
+                .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Where(id => id.Length <= 64)
+                .ToArray();
+            var gone = asked.Length > 0 ? store.MissingReports(key, asked) : new List<string>();
+            return Results.Json(new { items = threads.Select(t => ThreadJson(t)).ToArray(), gone });
         });
 
         // Marks developer entries as read once the client showed them. Scoped to the key inside the store.
@@ -512,6 +549,11 @@ public static class ReportHostApp
                 return denied;
             }
 
+            if (GuardAdminJson(ctx) is { } notJson)
+            {
+                return notJson;
+            }
+
             string text;
             bool question;
             string? fixedIn;
@@ -591,7 +633,7 @@ public static class ReportHostApp
             }
 
             return store.Get(id) is { } record
-                ? Results.Content(ReportHostPages.Detail(record, store.ListReplies(id)), "text/html; charset=utf-8")
+                ? Results.Content(ReportHostPages.Detail(record, store.ListReplies(id), csrf), "text/html; charset=utf-8")
                 : Results.NotFound();
         });
 
@@ -605,6 +647,11 @@ public static class ReportHostApp
             }
 
             var form = await ctx.Request.ReadFormAsync();
+            if (GuardAdminForm(form) is { } forged)
+            {
+                return forged;
+            }
+
             string text = form["text"].ToString().Trim();
             bool question = form["question"].ToString() == "1";
             string fixedIn = form["fixed_in_version"].ToString().Trim();
@@ -645,6 +692,11 @@ public static class ReportHostApp
             }
 
             var form = await ctx.Request.ReadFormAsync();
+            if (GuardAdminForm(form) is { } forged)
+            {
+                return forged;
+            }
+
             string status = form["status"].ToString();
             if (!BugReportStatus.IsValid(status) || !store.SetStatus(id, status))
             {
@@ -654,11 +706,17 @@ public static class ReportHostApp
             return Results.Redirect($"/admin/report/{id}");
         });
 
-        app.MapPost("/admin/report/{id}/delete", (HttpContext ctx, string id) =>
+        app.MapPost("/admin/report/{id}/delete", async (HttpContext ctx, string id) =>
         {
             if (GuardAdmin(ctx) is { } denied)
             {
                 return denied;
+            }
+
+            var form = await ctx.Request.ReadFormAsync();
+            if (GuardAdminForm(form) is { } forged)
+            {
+                return forged;
             }
 
             store.Delete(id);

--- a/src/BlocksBeyondTheStars.ReportHost/ReportHostPages.cs
+++ b/src/BlocksBeyondTheStars.ReportHost/ReportHostPages.cs
@@ -194,9 +194,59 @@ public static class ReportHostPages
     /// <summary>Collapses whitespace so the two wordings compare cleanly.</summary>
     private static string Normalize(string s) => string.Join(' ', s.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries));
 
-    public static string Detail(BugReportRecord r, IReadOnlyList<ReplyRecord>? replies = null)
+    /// <summary>Where a report's reply key came from — decides what the detail page promises about reaching
+    /// the player (#1369).</summary>
+    public enum ReplyKeyOrigin
+    {
+        /// <summary>No key: nothing written here can reach anyone.</summary>
+        None,
+
+        /// <summary>The client sent the key with the report — the key it polls with.</summary>
+        SentByClient,
+
+        /// <summary>Derived from the stored player id at ingest/back-fill (report filed before the reply
+        /// channel). A desktop / play.* install polls with the same value; a glitch.fun arcade install does
+        /// NOT (it hashes its Glitch install id, the player id there was the browser-local token).</summary>
+        DerivedFromPlayerId,
+    }
+
+    /// <summary>Classifies <paramref name="r"/>'s reply key. "Sent by the client" means the stored payload
+    /// carries a <c>replyKey</c> node — the only way a key other than the player-id derivation gets in.</summary>
+    public static ReplyKeyOrigin KeyOrigin(BugReportRecord r)
+    {
+        if (r.ReplyKey.Length == 0)
+        {
+            return ReplyKeyOrigin.None;
+        }
+
+        try
+        {
+            using var doc = JsonDocument.Parse(r.ReportJson);
+            if (doc.RootElement.ValueKind == JsonValueKind.Object
+                && doc.RootElement.TryGetProperty("replyKey", out var sent)
+                && sent.ValueKind == JsonValueKind.String
+                && sent.GetString() == r.ReplyKey)
+            {
+                return ReplyKeyOrigin.SentByClient;
+            }
+        }
+        catch (JsonException)
+        {
+            // unreadable payload — fall through to the derivation check
+        }
+
+        return r.ReplyKey == BlocksBeyondTheStars.Shared.Feedback.FeedbackReplyKey.Derive(r.PlayerId)
+            ? ReplyKeyOrigin.DerivedFromPlayerId
+            : ReplyKeyOrigin.SentByClient; // passed through a /bump forward (#1359) — the client's own key
+    }
+
+    /// <summary>The Unity platform string of every browser build (play.* and the glitch.fun arcade alike).</summary>
+    private const string WebGlPlatform = "WebGLPlayer";
+
+    public static string Detail(BugReportRecord r, IReadOnlyList<ReplyRecord>? replies = null, AdminCsrf? csrf = null)
     {
         replies ??= Array.Empty<ReplyRecord>();
+        string csrfField = csrf?.HiddenField() ?? string.Empty;
         var sb = new StringBuilder();
         string when = DateTimeOffset.FromUnixTimeSeconds(r.CreatedUnix).ToString("yyyy-MM-dd HH:mm:ss");
         sb.Append($"<p><a href='/admin'>&larr; back to list</a></p>");
@@ -225,11 +275,27 @@ public static class ReportHostPages
         // Reply thread (#1327): what the player sees in the game, plus the form to add to it. Only reports
         // that carry a reply key can reach a player (server crash reports have none).
         sb.Append("<div class='card'><h2>Conversation with the player</h2>");
-        if (r.ReplyKey.Length == 0)
+        var origin = KeyOrigin(r);
+        if (origin == ReplyKeyOrigin.None)
         {
             sb.Append("<p class='hint'>This report carries no reply key (no player id) — nothing you write here can reach a player.</p>");
         }
-        else if (replies.Count == 0)
+        else if (origin == ReplyKeyOrigin.DerivedFromPlayerId && r.Platform == WebGlPlatform)
+        {
+            // A browser report from before the reply channel: the key was derived from the browser-local
+            // token, which the glitch.fun arcade never polls with (#1369) — only a play.* install would.
+            sb.Append("<p class='hint'><b>No in-game reply possible (probably).</b> This browser report was filed before the reply channel " +
+                      "existed, so its reply key was derived from the browser-local player id. A glitch.fun arcade install polls with a " +
+                      "different key (its Glitch install id) and will never see an answer written here — reach the reporter through the " +
+                      "old channel instead. Only a play.* install would match this key.</p>");
+        }
+        else if (origin == ReplyKeyOrigin.DerivedFromPlayerId)
+        {
+            sb.Append("<p class='hint'>Reply key derived from the player id (report filed before the reply channel). A desktop install " +
+                      "matches it once the player runs a build with the in-game reply inbox; if the answer never turns <i>read</i>, use the old channel.</p>");
+        }
+
+        if (origin != ReplyKeyOrigin.None && replies.Count == 0)
         {
             sb.Append("<p class='hint'>No replies yet. An answer shows up in the player's game on their next start (or within ~10 minutes while playing); " +
                       "a <b>question</b> also lets them answer from inside the game.</p>");
@@ -248,7 +314,7 @@ public static class ReportHostPages
             sb.Append($"<p class='sub'>Fixed in version: <b>{E(r.FixedInVersion)}</b> (shown to the player with the thread)</p>");
         }
 
-        sb.Append($"<form method='post' action='/admin/report/{r.Id}/reply' class='replyform'>");
+        sb.Append($"<form method='post' action='/admin/report/{r.Id}/reply' class='replyform'>{csrfField}");
         sb.Append("<textarea name='text' rows='4' maxlength='5000' placeholder='Answer, or a follow-up question. Never ask for personal data — the audience includes children.'></textarea>");
         sb.Append("<label><input type='checkbox' name='question' value='1'> this is a question (status → waiting_for_player; the player can answer in-game)</label>");
         sb.Append($"<label>fixed in version <input type='text' name='fixed_in_version' value='{E(r.FixedInVersion)}' placeholder='e.g. 2026.8.23' size='14'></label>");
@@ -257,10 +323,10 @@ public static class ReportHostPages
         sb.Append("<div class='card actions'>");
         foreach (var s in BugReportStatus.All)
         {
-            sb.Append($"<form method='post' action='/admin/report/{r.Id}/status'><input type='hidden' name='status' value='{s}'><button{(s == r.Status ? " disabled" : "")}>mark {s}</button></form>");
+            sb.Append($"<form method='post' action='/admin/report/{r.Id}/status'>{csrfField}<input type='hidden' name='status' value='{s}'><button{(s == r.Status ? " disabled" : "")}>mark {s}</button></form>");
         }
 
-        sb.Append($"<form method='post' action='/admin/report/{r.Id}/delete' onsubmit=\"return confirm('Delete this report permanently?')\"><button class='danger'>delete</button></form>");
+        sb.Append($"<form method='post' action='/admin/report/{r.Id}/delete' onsubmit=\"return confirm('Delete this report permanently?')\">{csrfField}<button class='danger'>delete</button></form>");
         sb.Append("</div>");
 
         return Shell($"Report {r.Id[..8]} — Blocks Beyond the Stars", sb.ToString());

--- a/src/BlocksBeyondTheStars.ReportHost/ReportStore.cs
+++ b/src/BlocksBeyondTheStars.ReportHost/ReportStore.cs
@@ -505,6 +505,32 @@ public sealed class ReportStore : IDisposable
         }
     }
 
+    /// <summary>Upper bound on the ids one poll may ask about (the client remembers at most 50 sent reports).</summary>
+    public const int MaxGoneQueryIds = 50;
+
+    /// <summary>The "gone" half of the client's poll (#1369): of the report ids the client still remembers,
+    /// the ones that are NOT a report this key can read — deleted, pruned by retention, or stored under
+    /// a different key (an arcade report filed before the reply channel). The client forgets those and
+    /// stops polling for them. Only ids the caller named are ever reported, so nothing is enumerable;
+    /// a malformed key makes every id gone (it can read nothing). Capped at <see cref="MaxGoneQueryIds"/>.</summary>
+    public List<string> MissingReports(string replyKey, IEnumerable<string> reportIds)
+    {
+        var gone = new List<string>();
+        bool keyOk = FeedbackReplyKey.IsWellFormed(replyKey);
+        lock (_gate)
+        {
+            foreach (string id in reportIds.Where(i => !string.IsNullOrEmpty(i)).Distinct().Take(MaxGoneQueryIds))
+            {
+                if (!keyOk || !OwnsLocked(replyKey, id))
+                {
+                    gone.Add(id);
+                }
+            }
+        }
+
+        return gone;
+    }
+
     /// <summary>Marks developer entries as read. Scoped to the key: ids belonging to other players' reports
     /// are silently ignored (reply ids are guessable integers). Returns how many rows changed.</summary>
     public int AckReplies(string replyKey, IEnumerable<long> replyIds, long nowUnix)

--- a/src/BlocksBeyondTheStars.Shared/Definitions/VerticalMotion.cs
+++ b/src/BlocksBeyondTheStars.Shared/Definitions/VerticalMotion.cs
@@ -60,6 +60,11 @@ public static class VerticalMotion
     /// <summary>Seconds between voluntary bounds (startled ground birds, flee hops).</summary>
     public const float BoundCooldown = 1.2f;
 
+    /// <summary>Terminal fall speed (blocks/s, #1367). Unclamped, a fall that ran to the 2 s timeout reached ~40
+    /// blocks/s and its last step was ~2.7 blocks — a visible snap at the 15 Hz creature tick. 25 blocks/s is
+    /// reached after ~1.25 s at base gravity and keeps every step under two blocks.</summary>
+    public const float TerminalSpeed = 25f;
+
     /// <summary>Effective gravity for a world: the base constant scaled by its gravity factor (asteroids ~0.4,
     /// heavy worlds up to 1.6), clamped so a degenerate factor can't stall or slam anything.</summary>
     public static float Gravity(float gravityFactor)
@@ -118,7 +123,7 @@ public static class VerticalMotion
             // peak by ~v·dt/2 and a 1.25-block jump could fall a hair short of a 1-block ledge at 15 Hz.
             float ga = g * gravityScale;
             float y = curY + s.VertVel * ft - 0.5f * ga * ft * ft;
-            s.VertVel -= ga * ft;
+            s.VertVel = System.Math.Max(-TerminalSpeed, s.VertVel - ga * ft); // drag caps the fall (#1367)
             if (s.VertVel <= 0f && y <= groundY)
             {
                 Land(ref s);

--- a/tests/BlocksBeyondTheStars.Client.Tests/AuditLowLeftoversTests.cs
+++ b/tests/BlocksBeyondTheStars.Client.Tests/AuditLowLeftoversTests.cs
@@ -1,0 +1,86 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using System.IO;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using BlocksBeyondTheStars.Networking;
+using Xunit;
+
+namespace BlocksBeyondTheStars.Client.Tests;
+
+/// <summary>
+/// The testable pieces of the 2026-08-29 low-priority client leftovers (#1368): the repair panel's
+/// singular/plural pair exists in both mandatory locales, every player-name field caps at the server's
+/// join limit, and the Texts that show developer/player text render it verbatim (no rich-text tags).
+/// The Unity sources are read as text (the UI layout guards' pattern) — they cannot be loaded headless.
+/// </summary>
+public sealed class AuditLowLeftoversTests
+{
+    private static string Scripts(string file)
+        => Path.Combine(ClientTestPaths.RepoRoot(), "client", "Assets", "BlocksBeyondTheStars", "Scripts", file);
+
+    private static JsonElement Locale(string code)
+    {
+        using var doc = JsonDocument.Parse(File.ReadAllText(Path.Combine(ClientTestPaths.DataDir(), "locales", code + ".json")));
+        return doc.RootElement.Clone();
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("de")]
+    public void RepairPanel_HasASingularAndAPluralBreachLine(string code)
+    {
+        var loc = Locale(code);
+        Assert.True(loc.TryGetProperty("ui.shiprepair.cells_missing", out var many), $"{code}: plural key missing");
+        Assert.True(loc.TryGetProperty("ui.shiprepair.cells_missing_one", out var one), $"{code}: singular key missing");
+
+        // The plural takes the count; the singular is a fixed line (no "1 Hüllenzellen fehlen").
+        Assert.Contains("{0}", many.GetString());
+        Assert.DoesNotContain("{0}", one.GetString());
+        Assert.NotEqual(string.Format(many.GetString()!, 1), one.GetString());
+    }
+
+    [Fact]
+    public void PlayerNameFields_CapAtTheServersJoinLimit()
+    {
+        // The server truncates a join name to Protocol.MaxPlayerNameLength; every menu/prompt field that
+        // edits the player's name must cap at the same, or the stored PlayerName differs from the real id.
+        Assert.Equal(24, Protocol.MaxPlayerNameLength);
+
+        string src = File.ReadAllText(Scripts("UiMainMenu.cs"));
+        var nameFields = Regex.Matches(src, @"AddInput\([^;]*?\b(?:webName|natName|name|nm)\[0\] = v", RegexOptions.ExplicitCapture, System.TimeSpan.FromSeconds(5));
+        Assert.True(nameFields.Count >= 5, $"expected the name fields (menu, prompt, connect dialog, reserved-name prompt), found {nameFields.Count}");
+        foreach (Match m in nameFields)
+        {
+            // The cap must sit in the same AddInput call — i.e. before the next UiKit builder call.
+            int end = src.IndexOf("UiKit.Add", m.Index + 8, System.StringComparison.Ordinal);
+            string call = src.Substring(m.Index, (end < 0 ? src.Length : end) - m.Index);
+            Assert.Contains("maxLength: Protocol.MaxPlayerNameLength", call);
+        }
+    }
+
+    [Fact]
+    public void DeveloperAndPlayerText_IsShownVerbatim()
+    {
+        string feedback = File.ReadAllText(Scripts("FeedbackUi.cs"));
+        Assert.Contains("_replyTitle.supportRichText = false", feedback);
+        Assert.Contains("t.supportRichText = false", feedback); // every thread-body chunk
+        Assert.DoesNotContain("Shorten(sb.ToString()", feedback); // the old 1400-character cut is gone
+        Assert.Contains("UiTextChunks.Split(", feedback); // unbounded thread text goes through the splitter
+
+        string hud = File.ReadAllText(Scripts("HudUi.cs"));
+        Assert.Contains("_toast.supportRichText = false", hud);
+    }
+
+    [Fact]
+    public void FeedbackDialog_BailsOutWhenClosedBeforeItsFrameEnds()
+    {
+        // Hotkey + Esc in one frame: Close() runs before OpenRoutine resumes — the routine must not build/hold.
+        string feedback = File.ReadAllText(Scripts("FeedbackUi.cs"));
+        int wait = feedback.IndexOf("yield return new WaitForEndOfFrame();", System.StringComparison.Ordinal);
+        int bail = feedback.IndexOf("if (!_open)", wait, System.StringComparison.Ordinal);
+        int capture = feedback.IndexOf("_shotJpg = TryCaptureJpg();", wait, System.StringComparison.Ordinal);
+        Assert.True(wait >= 0 && bail > wait && bail < capture, "OpenRoutine must check _open right after WaitForEndOfFrame, before capturing/building");
+    }
+}

--- a/tests/BlocksBeyondTheStars.Client.Tests/BlobPeekCacheTests.cs
+++ b/tests/BlocksBeyondTheStars.Client.Tests/BlobPeekCacheTests.cs
@@ -1,0 +1,109 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using System;
+using System.IO;
+using Xunit;
+
+namespace BlocksBeyondTheStars.Client.Tests;
+
+/// <summary>
+/// The saved-name peek cache (#1368): the browser menu's look into the save blob runs once per blob version,
+/// not once per menu build — and never caches a blob that is not there yet.
+/// </summary>
+public sealed class BlobPeekCacheTests : IDisposable
+{
+    private readonly string _dir = Path.Combine(Path.GetTempPath(), "bbts_peekcache_" + Guid.NewGuid().ToString("N"));
+
+    public BlobPeekCacheTests() => Directory.CreateDirectory(_dir);
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { /* best effort */ }
+    }
+
+    [Fact]
+    public void UnchangedBlob_IsComputedOnce()
+    {
+        string blob = Path.Combine(_dir, "world.blob");
+        File.WriteAllBytes(blob, new byte[] { 1, 2, 3 });
+        var cache = new BlobPeekCache();
+        int computed = 0;
+        string? Compute() { computed++; return "Justus"; }
+
+        Assert.Equal("Justus", cache.Get(blob, Compute));
+        Assert.Equal("Justus", cache.Get(blob, Compute));
+        Assert.Equal("Justus", cache.Get(blob, Compute));
+
+        Assert.Equal(1, computed);
+        Assert.Equal(1, cache.Misses);
+    }
+
+    [Fact]
+    public void RewrittenBlob_IsComputedAgain()
+    {
+        string blob = Path.Combine(_dir, "world.blob");
+        File.WriteAllBytes(blob, new byte[] { 1, 2, 3 });
+        var cache = new BlobPeekCache();
+        Assert.Equal("first", cache.Get(blob, () => "first"));
+
+        // A save rewrites the blob: different length AND a later write time — either alone invalidates.
+        File.WriteAllBytes(blob, new byte[] { 1, 2, 3, 4 });
+        File.SetLastWriteTimeUtc(blob, DateTime.UtcNow.AddSeconds(5));
+        Assert.Equal("second", cache.Get(blob, () => "second"));
+        Assert.Equal("second", cache.Get(blob, () => "third")); // …and the new answer sticks
+        Assert.Equal(2, cache.Misses);
+    }
+
+    [Fact]
+    public void SameLength_NewerWriteTime_IsComputedAgain()
+    {
+        string blob = Path.Combine(_dir, "world.blob");
+        File.WriteAllBytes(blob, new byte[] { 9, 9 });
+        var cache = new BlobPeekCache();
+        Assert.Equal("a", cache.Get(blob, () => "a"));
+
+        File.SetLastWriteTimeUtc(blob, File.GetLastWriteTimeUtc(blob).AddMinutes(1));
+        Assert.Equal("b", cache.Get(blob, () => "b"));
+    }
+
+    [Fact]
+    public void MissingBlob_IsNeverCached()
+    {
+        string blob = Path.Combine(_dir, "absent.blob");
+        var cache = new BlobPeekCache();
+        int computed = 0;
+        string? Compute() { computed++; return null; }
+
+        Assert.Null(cache.Get(blob, Compute));
+        Assert.Null(cache.Get(blob, Compute));
+        Assert.Equal(2, computed); // no stamp → ask again (the loader may adopt one from an older deployment)
+
+        // Once the blob exists the answer is cached from then on.
+        File.WriteAllBytes(blob, new byte[] { 7 });
+        Assert.Equal("Marcel", cache.Get(blob, () => "Marcel"));
+        Assert.Equal("Marcel", cache.Get(blob, () => "nope"));
+    }
+
+    [Fact]
+    public void Invalidate_ForcesTheNextGetToCompute()
+    {
+        string blob = Path.Combine(_dir, "world.blob");
+        File.WriteAllBytes(blob, new byte[] { 1 });
+        var cache = new BlobPeekCache();
+        Assert.Equal("x", cache.Get(blob, () => "x"));
+        cache.Invalidate();
+        Assert.Equal("y", cache.Get(blob, () => "y"));
+        Assert.Equal(2, cache.Misses);
+    }
+
+    [Fact]
+    public void NullOrEmptyPath_Computes_WithoutCaching()
+    {
+        var cache = new BlobPeekCache();
+        int computed = 0;
+        Assert.Null(cache.Get(string.Empty, () => { computed++; return null; }));
+        Assert.Null(cache.Get(string.Empty, () => { computed++; return null; }));
+        Assert.Equal(2, computed);
+    }
+}

--- a/tests/BlocksBeyondTheStars.Client.Tests/FeedbackReplyTests.cs
+++ b/tests/BlocksBeyondTheStars.Client.Tests/FeedbackReplyTests.cs
@@ -311,6 +311,86 @@ public sealed class FeedbackReplyTests : IDisposable
         Assert.Equal(4, tracker.ShownCount);
     }
 
+    // ---------------- #1369: gone marker + the answer box follows the thread ----------------
+
+    [Fact]
+    public void Fetch_NamesTheRememberedReports_AndForgetsTheOnesTheInboxCallsGone()
+    {
+        string key = FeedbackReplyKey.Derive("token-abc");
+        _responseJson = "{\"items\":[],\"gone\":[\"r2\",\"r3\",\"\",7]}";
+        var client = new FeedbackReplyClient(Endpoint, "test-key");
+
+        // Duplicates and blanks are dropped from the query; the inbox's answer is parsed as-is (strings only).
+        var result = client.Fetch(key, 0, new[] { "r1", "r2", "", "r3", "r2" });
+        Assert.True(result.Ok);
+        Assert.Contains("&ids=" + Uri.EscapeDataString("r1,r2,r3"), _lastPathAndQuery);
+        Assert.Equal(new List<string> { "r2", "r3" }, result.Gone);
+
+        // No remembered ids → no ids parameter at all; an inbox without the field (older build) retires nothing.
+        _responseJson = "{\"items\":[]}";
+        result = client.Fetch(key, 0, Array.Empty<string>());
+        Assert.DoesNotContain("ids=", _lastPathAndQuery);
+        Assert.Empty(result.Gone);
+        Assert.Empty(FeedbackReplyClient.ParseGone("{\"gone\":\"nope\"}"));
+        Assert.Empty(FeedbackReplyClient.ParseGone("{not json"));
+        Assert.Empty(FeedbackReplyClient.ParseGone(null));
+
+        // The client never names more than the inbox looks at.
+        var many = new List<string>();
+        for (int i = 0; i < FeedbackReplyClient.MaxKnownIds + 10; i++)
+        {
+            many.Add("id" + i);
+        }
+
+        string url = client.FetchUrl(key, 0, many);
+        Assert.Contains("id" + (FeedbackReplyClient.MaxKnownIds - 1), url);
+        Assert.DoesNotContain("id" + FeedbackReplyClient.MaxKnownIds + "%2C", url);
+        Assert.DoesNotContain("id" + (FeedbackReplyClient.MaxKnownIds + 9), url);
+
+        // What FeedbackUi does with the answer: the gone reports leave the sent log, and once the last one
+        // is gone the poll gate closes — persistently.
+        string path = Path.Combine(_tempDir, "feedback", "sent.json");
+        var log = new SentReportsLog(path);
+        const long now = 1_800_000_000;
+        log.Record("r1", "one", now);
+        log.Record("r2", "two", now);
+        foreach (string gone in new[] { "r2", "never-known" })
+        {
+            log.Forget(gone);
+        }
+
+        Assert.Equal("r1", Assert.Single(log.List(now)).Id);
+        log.Forget("r1");
+        Assert.False(log.ShouldPoll(now));
+        Assert.False(new SentReportsLog(path).ShouldPoll(now));
+    }
+
+    [Fact]
+    public void AwaitsAnswer_FollowsTheThread_NotTheStatus()
+    {
+        static FeedbackReplyEntry Dev(long id, bool question) => new FeedbackReplyEntry { Id = id, Author = "dev", Text = "…", IsQuestion = question };
+        static FeedbackReplyEntry Player(long id) => new FeedbackReplyEntry { Id = id, Author = "player", Text = "…" };
+
+        // The operator flipped the status by hand while the question is still open — the box stays.
+        var thread = new FeedbackReplyThread { ReportId = "r1", Status = "triaged" };
+        thread.Replies.Add(Dev(1, question: true));
+        Assert.True(thread.AwaitsAnswer);
+
+        // Answered → nothing to answer, whatever the status says.
+        thread.Replies.Add(Player(2));
+        thread.Status = "waiting_for_player";
+        Assert.False(thread.AwaitsAnswer);
+
+        // A follow-up question after the answer re-opens it; a plain answer after it closes it again.
+        thread.Replies.Add(Dev(3, question: true));
+        Assert.True(thread.AwaitsAnswer);
+        thread.Replies.Add(Dev(4, question: false));
+        Assert.False(thread.AwaitsAnswer);
+
+        // An empty thread never asks for anything.
+        Assert.False(new FeedbackReplyThread { Status = "waiting_for_player" }.AwaitsAnswer);
+    }
+
     public void Dispose()
     {
         _running = false;

--- a/tests/BlocksBeyondTheStars.Tests/BaseWalledYardTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/BaseWalledYardTests.cs
@@ -358,6 +358,71 @@ public sealed class BaseWalledYardTests : IDisposable
         }
     }
 
+    // ---------------- #1367: the fill is cached until something changes; the box wraps north–south too ----------------
+
+    [Fact]
+    public void TheWallFill_IsReused_UntilSomethingChangesInsideTheBox()
+    {
+        var server = Started(out var repo, "wallcache");
+        using (repo)
+        {
+            var (_, padY) = Yard(server);
+            int feet = padY + 1;
+            Assert.True(server.InWalledBaseAreaForTest(Cx + 2, feet, Cz));
+            int fills = server.WalledLevelComputesForTest(Cx + 2, feet, Cz);
+            Assert.Equal(1, fills);
+
+            Settle(server); // 2 s — past the old 1.5 s interval, at which every spawn attempt used to recompute
+            Assert.True(server.InWalledBaseAreaForTest(Cx + 2, feet, Cz));
+            Assert.Equal(fills, server.WalledLevelComputesForTest(Cx + 2, feet, Cz)); // nothing changed — the fill is reused
+
+            server.RemoveBlockForTest(Cx + Ring, padY + 1, Cz); // a block inside the box changes → refreshed at once
+            server.RemoveBlockForTest(Cx + Ring, padY + 2, Cz);
+            Assert.False(server.InWalledBaseAreaForTest(Cx + 2, feet, Cz), "the gap is seen without waiting for any interval");
+            Assert.Equal(fills + 1, server.WalledLevelComputesForTest(Cx + 2, feet, Cz));
+        }
+    }
+
+    [Fact]
+    public void AYardAcrossTheLatitudeSeam_IsStillFencedIn()
+    {
+        var server = Started(out var repo, "seamyard");
+        using (repo)
+        {
+            int half = BlocksBeyondTheStars.Shared.World.WorldConstants.LatitudePeriodFor(server.World.Circumference) / 2;
+            int cx = 40, cz = half - 2; // the core two blocks south of the seam; the ring straddles it
+            var stone = _content.GetBlock("stone")!.NumericId;
+            int padY = MaxTopY(server, cx, cz, 12) + 8;
+            for (int dx = -10; dx <= 10; dx++)
+                for (int dz = -10; dz <= 10; dz++)
+                {
+                    server.World.SetBlock(new Vector3i(cx + dx, padY, cz + dz), stone);
+                }
+
+            for (int dx = -Ring; dx <= Ring; dx++)
+                for (int dz = -Ring; dz <= Ring; dz++)
+                {
+                    if (System.Math.Abs(dx) == Ring || System.Math.Abs(dz) == Ring)
+                    {
+                        server.World.SetBlock(new Vector3i(cx + dx, padY + 1, cz + dz), stone);
+                        server.World.SetBlock(new Vector3i(cx + dx, padY + 2, cz + dz), stone);
+                    }
+                }
+
+            var p = server.AddLocalPlayer("Builder");
+            p.State.AboardShip = false;
+            p.State.Position = new Vector3f(cx - 1.5f, padY + 1, cz + 0.5f);
+            p.State.Inventory.Add("base_core", 2, 16);
+            server.PlaceBlock("Builder", cx, padY + 1, cz, "base_core");
+            Assert.Single(server.BaseSnapshots);
+
+            int feet = padY + 1;
+            Assert.True(server.InWalledBaseAreaForTest(cx + 2, feet, cz + 4), "across the seam, still inside the ring: fenced in (#1367)");
+            Assert.True(server.InWalledBaseAreaForTest(cx - 3, feet, cz - 2), "the near side too");
+            Assert.False(server.InWalledBaseAreaForTest(cx + 9, feet, cz + 3), "outside the ring across the seam is open");
+        }
+    }
+
     public void Dispose()
     {
         try

--- a/tests/BlocksBeyondTheStars.Tests/CreatureBuildRespectTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/CreatureBuildRespectTests.cs
@@ -583,6 +583,89 @@ public sealed class CreatureBuildRespectTests : IDisposable
         }
     }
 
+    // ---------------- #1367: the far leash is view-aware; a falling block nudges the animal it buries ----------------
+
+    /// <summary>A sleeper on a pad 100 blocks from the player: past the fixed 70-block leash, inside an 8-chunk
+    /// view (#1367). Returns its id.</summary>
+    private string FarSleeper(SvGameServer server, int viewChunks)
+    {
+        var p = server.AddLocalPlayer("Watcher");
+        p.State.AboardShip = false;
+        p.ViewDistance = viewChunks;
+        Force(server, 0, titan: false, nocturnal: true);
+        server.SetDayFractionForTest(0.5);
+
+        const int cx = -100, cz = 100;
+        int padY = System.Math.Max(MaxTopY(server, cx, cz, 6), MaxTopY(server, cx + 100, cz, 6)) + 8;
+        BuildPad(server, cx, cz, 4, padY);
+        BuildPad(server, cx + 100, cz, 4, padY);
+        p.State.Position = new Vector3f(cx + 0.5f, padY + 1, cz + 0.5f);
+        return server.SpawnCreatureAtForTest(new Vector3f(cx + 100.5f, padY + 1, cz + 0.5f));
+    }
+
+    [Fact]
+    public void TheFarPrune_KeepsAnAnimalThePlayerCanSee()
+    {
+        var server = Started("farview", out var repo);
+        using (repo)
+        {
+            string id = FarSleeper(server, viewChunks: 8); // 288 blocks streamed: the far pad is on screen
+            Ticks(server, 3);
+            Assert.Contains(server.Creatures, c => c.Id == id);
+        }
+    }
+
+    [Fact]
+    public void TheFarPrune_StillShedsAnAnimalBeyondTheView()
+    {
+        var server = Started("farblind", out var repo);
+        using (repo)
+        {
+            string id = FarSleeper(server, viewChunks: 1); // 64 blocks streamed: 100 out is neither in view nor within the leash
+            Ticks(server, 3);
+            Assert.DoesNotContain(server.Creatures, c => c.Id == id);
+        }
+    }
+
+    [Fact]
+    public void AFallingBlock_NudgesTheAnimalItLandsOn_ToStepAside()
+    {
+        var server = Started("sandfall", out var repo);
+        using (repo)
+        {
+            var p = server.AddLocalPlayer("Digger");
+            p.State.AboardShip = false;
+            Force(server, 0, titan: false, nocturnal: false);
+            server.SetDayFractionForTest(0.5);
+
+            const int cx = -80, cz = -80;
+            int padY = MaxTopY(server, cx, cz, 10) + 8;
+            BuildPad(server, cx, cz, 8, padY);
+            p.State.Position = new Vector3f(cx + 6.5f, padY + 1, cz + 0.5f);
+
+            var planted = new Vector3f(cx + 0.5f, padY + 1, cz + 0.5f);
+            string id = server.SpawnCreatureAtForTest(planted);
+            server.PauseCreatureForTest(id, 30f);
+            Ticks(server, 2);
+            Assert.Equal(planted.X, server.Creatures.Single(c => c.Id == id).Position.X);
+
+            // Sand woken eight cells over its head: only players, NPCs and doorways hold a block up — an animal is
+            // buried and told to re-check its body at once (#1357 via #1367).
+            var sand = _content.GetBlock("sand")!.NumericId;
+            server.World.SetBlock(new Vector3i(cx, padY + 9, cz), sand);
+            server.WakeGranularForTest(cx, padY + 9, cz);
+            Ticks(server, 2, 0.3); // one settle step
+            Assert.Equal(sand.Value, server.World.GetBlock(new Vector3i(cx, padY + 1, cz)).Value);
+
+            Ticks(server, 5); // one second
+            var live = server.Creatures.Single(c => c.Id == id);
+            Assert.True(ColumnClear(server, live.Position, 2),
+                $"the animal must step out of the sand (at {live.Position.X:F1}/{live.Position.Y:F1}/{live.Position.Z:F1})");
+            Assert.True(System.Math.Abs(live.Position.X - planted.X) >= 0.9f || System.Math.Abs(live.Position.Z - planted.Z) >= 0.9f,
+                "it must have stepped ASIDE, not been hopped onto the sand");
+        }
+    }
+
     public void Dispose()
     {
         try

--- a/tests/BlocksBeyondTheStars.Tests/CreatureMotionArenaTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/CreatureMotionArenaTests.cs
@@ -465,4 +465,201 @@ public sealed class CreatureMotionArenaTests : IDisposable
             Assert.Equal(padY + 5, c.Position.Y, 2); // on the upper floor
         }
     }
+
+    // ---------------- #1367: creature physics leftovers ----------------
+
+    [Fact]
+    public void Flier_WhosePerchGoes_Falls_ThenTakesOffAgain()
+    {
+        var server = Started(out var repo);
+        using (repo)
+        {
+            var p = server.AddLocalPlayer("Birder");
+            p.State.AboardShip = false;
+            Force(server, CreatureHabitat.Air, legs: 2, LocomotionStyle.Glider, CreatureTemperament.Passive, wings: true, hover: 4f);
+
+            const int cx = -180, cz = 180;
+            int padY = MaxTopY(server, cx, cz, 8) + 12;
+            for (int y = padY - 8; y <= padY - 5; y++)
+            {
+                BuildPad(server, cx, cz, 6, y); // a thick floor under the perch (the probe must find IT, not the terrain)
+            }
+
+            BuildPad(server, cx, cz, 6, padY); // the perch
+            p.State.Position = new Vector3f(cx + 20, padY + 1, cz);
+            string id = server.SpawnCreatureAtForTest(new Vector3f(cx + 0.5f, padY + 5, cz + 0.5f));
+            server.TickForTest(0.1);
+            server.PauseCreatureForTest(id, 30f);
+            var c = server.Creatures.First(x => x.Id == id);
+            for (int i = 0; i < 60 && c.Vert.Flight != FlightPhase.Perched; i++)
+            {
+                server.TickForTest(0.1);
+                c = server.Creatures.First(x => x.Id == id);
+            }
+
+            Assert.Equal(FlightPhase.Perched, c.Vert.Flight);
+
+            // The perch is dug away under it.
+            server.World.SetBlock(new Vector3i((int)Math.Floor(c.Position.X), padY, (int)Math.Floor(c.Position.Z)), BlockId.Air);
+            bool fell = false, tookOff = false;
+            float highestAfterTakeOff = float.MinValue;
+            for (int i = 0; i < 60; i++)
+            {
+                server.TickForTest(0.1);
+                c = server.Creatures.First(x => x.Id == id);
+                fell |= c.Vert.Airborne;
+                tookOff |= c.Vert.Flight == FlightPhase.TakingOff;
+                if (tookOff)
+                {
+                    highestAfterTakeOff = Math.Max(highestAfterTakeOff, c.Position.Y);
+                }
+            }
+
+            Assert.True(fell, "it must fall when the perch goes");
+            Assert.True(tookOff, "…and take off once it has landed (#1332 as decided), not sit on the floor below");
+            Assert.True(highestAfterTakeOff >= padY - 4 + 1.5f, $"it must have climbed off the lower floor (highest {highestAfterTakeOff:F2}, lower feet {padY - 4})");
+        }
+    }
+
+    [Fact]
+    public void Walker_NeverJumpsALedge_UnderALowCeiling()
+    {
+        var server = Started(out var repo);
+        using (repo)
+        {
+            Force(server, CreatureHabitat.Land, legs: 4, LocomotionStyle.Strider, CreatureTemperament.Aggressive);
+            var p = server.AddLocalPlayer("Bait");
+            p.State.AboardShip = false;
+            const int cx = 60, cz = -120;
+            int padY = MaxTopY(server, cx, cz, 10) + 8;
+            BuildPad(server, cx, cz, 8, padY);
+            BuildLedge(server, cx, cz, 8, padY, fromDx: 1, height: 1);
+            var stone = _content.GetBlock("stone")!.NumericId;
+            for (int dx = -8; dx <= 8; dx++)
+            {
+                for (int dz = -8; dz <= 8; dz++)
+                {
+                    // A 2-high tunnel whose roof follows the floor up one block past the step: the swept step
+                    // check sees clear cells AHEAD at the raised height, only the roof right over the animal is low.
+                    server.World.SetBlock(new Vector3i(cx + dx, padY + (dx <= 0 ? 3 : 4), cz + dz), stone);
+                }
+            }
+
+            p.State.Position = new Vector3f(cx + 5.5f, padY + 2, cz + 0.5f);
+            string id = server.SpawnCreatureAtForTest(new Vector3f(cx - 1.5f, padY + 1, cz + 0.5f));
+            for (int i = 0; i < 100; i++)
+            {
+                server.TickForTest(0.1);
+                var c = server.Creatures.First(x => x.Id == id);
+                Assert.False(c.Vert.Airborne, $"it must not launch into the roof (tick {i})");
+                Assert.True(c.Position.Y <= padY + 1.01f, $"its head must stay out of the roof (Y {c.Position.Y:F2} at tick {i})");
+            }
+        }
+    }
+
+    [Fact]
+    public void Walker_NeverStepsOntoLava()
+    {
+        var server = Started(out var repo);
+        using (repo)
+        {
+            Force(server, CreatureHabitat.Land, legs: 4, LocomotionStyle.Strider, CreatureTemperament.Aggressive);
+            var p = server.AddLocalPlayer("Bait");
+            p.State.AboardShip = false;
+            const int cx = -60, cz = -120;
+            int padY = MaxTopY(server, cx, cz, 10) + 8;
+            BuildPad(server, cx, cz, 8, padY);
+            var lava = _content.GetBlock("lava")!.NumericId;
+            for (int dx = 1; dx <= 8; dx++)
+            {
+                for (int dz = -8; dz <= 8; dz++)
+                {
+                    server.World.SetBlock(new Vector3i(cx + dx, padY, cz + dz), lava); // the +X half of the pad is a melt, flush with the floor
+                }
+            }
+
+            server.World.SetBlock(new Vector3i(cx + 5, padY, cz), _content.GetBlock("stone")!.NumericId); // the bait's own island
+            p.State.Position = new Vector3f(cx + 5.5f, padY + 1, cz + 0.5f);
+            string id = server.SpawnCreatureAtForTest(new Vector3f(cx - 1.5f, padY + 1, cz + 0.5f));
+            for (int i = 0; i < 100; i++)
+            {
+                server.TickForTest(0.1);
+                var c = server.Creatures.First(x => x.Id == id);
+                Assert.True(c.Position.X < cx + 1f, $"a walker must not step onto lava (X {c.Position.X:F2} at tick {i})");
+            }
+        }
+    }
+
+    [Fact]
+    public void Titan_StandsAmongGrassTufts_InsteadOfBeingHauledOntoThem()
+    {
+        var server = Started(out var repo);
+        using (repo)
+        {
+            var p = server.AddLocalPlayer("Watcher");
+            p.State.AboardShip = false;
+            Force(server, CreatureHabitat.Land, legs: 4, LocomotionStyle.Grazer, size: 4f, plan: CreatureBodyPlan.Titan);
+
+            const int cx = 240, cz = -240;
+            int padY = MaxTopY(server, cx, cz, 10) + 8;
+            BuildPad(server, cx, cz, 8, padY);
+            var fern = _content.GetBlock("flora_fern")!.NumericId;
+            server.World.SetBlock(new Vector3i(cx, padY + 2, cz), fern); // tufts inside the titan's eight-cell headroom
+            server.World.SetBlock(new Vector3i(cx, padY + 5, cz), fern);
+            p.State.Position = new Vector3f(cx + 14, padY + 1, cz);
+            string id = server.SpawnCreatureAtForTest(new Vector3f(cx + 0.5f, padY + 1, cz + 0.5f));
+            server.PauseCreatureForTest(id, 30f);
+
+            for (int i = 0; i < 20; i++)
+            {
+                server.TickForTest(0.1);
+            }
+
+            var c = Assert.Single(server.Creatures, x => x.Id == id);
+            Assert.Equal(padY + 1, c.Position.Y, 2); // on the floor — the old probe read the tufts as a wall and lifted it onto the upper one
+            Assert.False(c.Vert.Airborne);
+        }
+    }
+
+    [Fact]
+    public void ASwimmerUnderAnOverhang_StillReadsItsOwnColumnAsWater()
+    {
+        var server = Started(out var repo);
+        using (repo)
+        {
+            Force(server, CreatureHabitat.Water, legs: 0, LocomotionStyle.Schooler);
+
+            // A generated water column at least three deep, and a dry column anywhere (the gate compares depths only).
+            (int X, int Z, int Top, int Bed)? wet = null;
+            (int X, int Z)? dry = null;
+            for (int x = -800; x < 800 && (wet is null || dry is null); x += 16)
+            {
+                for (int z = -400; z < 400 && (wet is null || dry is null); z += 16)
+                {
+                    var w = server.WaterSurfaceForTest(x, z);
+                    if (w is { } s && s.Top - s.Bed >= 3 && wet is null)
+                    {
+                        wet = (x, z, s.Top, s.Bed);
+                    }
+
+                    if (w is null && dry is null)
+                    {
+                        dry = (x, z);
+                    }
+                }
+            }
+
+            Assert.NotNull(wet);
+            Assert.NotNull(dry);
+            var (wx, wz, top, _) = wet!.Value;
+            var stone = _content.GetBlock("stone")!.NumericId;
+            server.World.SetBlock(new Vector3i(wx, top + 3, wz), stone); // a ledge over the water — the probe's "nearest standable cell"
+            server.World.SetBlock(new Vector3i(wx, top + 4, wz), BlockId.Air);
+            server.World.SetBlock(new Vector3i(wx, top + 5, wz), BlockId.Air);
+            string id = server.SpawnCreatureAtForTest(new Vector3f(wx + 0.5f, top - 1, wz + 0.5f));
+
+            Assert.True(server.TerrainStepBlockedForTest(id, new Vector3f(dry!.Value.X + 0.5f, top - 1, dry.Value.Z + 0.5f)),
+                "a swimmer must never leave its water body — the old gate read the ledge above as its dry feet (#1367)");
+        }
+    }
 }

--- a/tests/BlocksBeyondTheStars.Tests/CreatureMotionArenaTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/CreatureMotionArenaTests.cs
@@ -508,6 +508,16 @@ public sealed class CreatureMotionArenaTests : IDisposable
                 server.TickForTest(0.1);
                 c = server.Creatures.First(x => x.Id == id);
                 fell |= c.Vert.Airborne;
+                if (c.Vert.Airborne && c.Vert.Flight == FlightPhase.Perched)
+                {
+                    // The wire reports the ACTUAL state while it drops (#1368): airborne with its fall velocity,
+                    // not "perched" — the client would otherwise draw a folded bird sliding down.
+                    var wire = server.NetCreatureForTest(id);
+                    Assert.True(wire.Airborne, "a falling perched flier must read as airborne on the wire");
+                    Assert.False(wire.Perched, "…and not as perched");
+                    Assert.Equal(c.Vert.VertVel, wire.VertVel, 3);
+                }
+
                 tookOff |= c.Vert.Flight == FlightPhase.TakingOff;
                 if (tookOff)
                 {

--- a/tests/BlocksBeyondTheStars.Tests/DropLootTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/DropLootTests.cs
@@ -349,6 +349,52 @@ public sealed class DropLootTests : IDisposable
         }
     }
 
+    // ---------------- #1367: the colliding rule + the shutdown checkpoint ----------------
+
+    [Fact]
+    public void AKillOverGrass_LeavesThePacketInTheGrass_NotACellAboveIt()
+    {
+        var server = Started(out var repo, "grass");
+        using (repo)
+        {
+            server.AddLocalPlayer("Hunter").State.AboardShip = false;
+            const int x = 12, z = 12;
+            int top = SurfaceTopY(server, x, z);
+            server.World.SetBlock(new Vector3i(x, top + 1, z), _content.GetBlock("flora_fern")!.NumericId); // a meadow tuft on the ground
+
+            server.SpillToGroundForTest(new Vector3i(x, top + 8, z), "iron_ore", 2, creatureLoot: true);
+
+            var packet = Assert.Single(server.DropPackets);
+            Assert.Equal(top + 1, packet.Position.Y); // in the grass, on the ground — the old rule stopped on the tuft
+        }
+    }
+
+    [Fact]
+    public void TheShutdownSave_WritesALootPacketsExactAge()
+    {
+        const string world = "shutdown";
+        var server = Started(out var repo, world);
+        using (repo)
+        {
+            var p = server.AddLocalPlayer("Settler");
+            p.State.AboardShip = false;
+            p.State.Position = new Vector3f(0.5f, SurfaceTopY(server, 0, 0) + 1, 0.5f);
+            int top = SurfaceTopY(server, 30, 30);
+            server.SpillToGroundForTest(new Vector3i(30, top + 1, 30), "iron_ore", 3, creatureLoot: true);
+
+            server.Tick(10.0); // ten seconds of ageing — well short of the 30 s checkpoint
+            Assert.InRange(Assert.Single(server.DropPackets).LifetimeLeft, 289.0, 291.0);
+            server.SaveAllForTest(); // the shutdown / checkpoint save
+        }
+
+        var reloaded = Started(out var repo2, world);
+        using (repo2)
+        {
+            reloaded.AddLocalPlayer("Settler").State.AboardShip = false;
+            Assert.InRange(Assert.Single(reloaded.DropPackets).LifetimeLeft, 280.0, 291.0); // not the 300 the spill wrote
+        }
+    }
+
     public void Dispose()
     {
         try

--- a/tests/BlocksBeyondTheStars.Tests/GranularBlockTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/GranularBlockTests.cs
@@ -283,6 +283,133 @@ public sealed class GranularBlockTests : IDisposable
         return reach;
     }
 
+    // ---------------- #1367: the landing follows the colliding rule ----------------
+
+    [Fact]
+    public void SandFallingOntoFlora_CrushesIt_DropsItsYield_AndLandsOnTheGround()
+    {
+        var server = Started(out var repo, "crushflora");
+        using (repo)
+        {
+            Floor(server, 120);
+            server.World.SetBlock(new Vector3i(0, 121, 0), Id("flora_fern")); // a fern on the floor — no collider
+            server.World.SetBlock(new Vector3i(0, 126, 0), Id("sand"));
+            server.WakeGranularForTest(0, 126, 0);
+            Steps(server, 2);
+
+            Assert.Equal(Id("sand").Value, server.World.GetBlock(new Vector3i(0, 121, 0)).Value); // on the floor, not a cell above it
+            Assert.True(server.World.GetBlock(new Vector3i(0, 126, 0)).IsAir);
+            var packet = Assert.Single(server.DropPackets);
+            Assert.Contains(packet.Items, s => s.Item == "plant_fiber" && s.Count == 2); // the fern's own drop
+            Assert.Equal(122, packet.Position.Y); // lying on top of the settled sand
+        }
+    }
+
+    [Fact]
+    public void SandFallingThroughAFlame_PutsItOut_AndFallsOn()
+    {
+        var server = Started(out var repo, "crushfire");
+        using (repo)
+        {
+            Floor(server, 120);
+            server.World.SetBlock(new Vector3i(0, 123, 0), Id("fire"));
+            server.World.SetBlock(new Vector3i(0, 127, 0), Id("sand"));
+            server.WakeGranularForTest(0, 127, 0);
+            Steps(server, 2);
+
+            Assert.Equal(Id("sand").Value, server.World.GetBlock(new Vector3i(0, 121, 0)).Value);
+            Assert.True(server.World.GetBlock(new Vector3i(0, 123, 0)).IsAir, "the flame is put out on the way down");
+            Assert.Empty(server.DropPackets); // fire drops nothing
+        }
+    }
+
+    [Fact]
+    public void AFallingBlock_WaitsAboveADoorway_InsteadOfLandingInTheGate()
+    {
+        var server = Started(out var repo, "doorway");
+        using (repo)
+        {
+            Floor(server, 120);
+            var p = server.AddLocalPlayer("Builder");
+            p.State.AboardShip = false;
+            p.State.Position = new Vector3f(2.5f, 121f, 0.5f);
+            p.State.Inventory.Add("door_wood", 2, 16);
+            server.PlaceBlock("Builder", 0, 121, 0, "door_wood");
+            Assert.Contains(server.DoorSnapshots, d => d.Kind == "wood"); // the settlements bring their own doors
+
+            server.World.SetBlock(new Vector3i(0, 127, 0), Id("sand"));
+            server.WakeGranularForTest(0, 127, 0);
+            Steps(server, 3);
+
+            Assert.Equal(Id("sand").Value, server.World.GetBlock(new Vector3i(0, 127, 0)).Value); // held up — the doorway is occupied
+            for (int y = 121; y <= 126; y++)
+            {
+                Assert.True(server.World.GetBlock(new Vector3i(0, y, 0)).IsAir, $"y={y} must stay clear");
+            }
+        }
+    }
+
+    [Fact]
+    public void ASettledBlock_KeepsItsBuildersAttribution()
+    {
+        var server = Started(out var repo, "owner");
+        using (repo)
+        {
+            Floor(server, 120);
+            var p = server.AddLocalPlayer("Builder");
+            p.State.AboardShip = false;
+            p.State.Position = new Vector3f(0.5f, 132f, 0.5f);
+            p.State.Inventory.Add("sand", 4, 64);
+            server.PlaceBlock("Builder", 0, 130, 0, "sand");
+            Steps(server, 2);
+
+            var landed = new Vector3i(0, 121, 0);
+            Assert.Equal(Id("sand").Value, server.World.GetBlock(landed).Value);
+            Assert.Equal(p.State.PlayerId, repo.GetBlockAttribution(server.World.LocationId, landed)?.Owner); // #490 survives the fall
+        }
+    }
+
+    [Fact]
+    public void WeatherSnowThatFalls_KeepsItsMeltEntry_AndStillMelts()
+    {
+        var server = Started(out var repo, "snowfall");
+        using (repo)
+        {
+            Floor(server, 120);
+            server.World.SetBlock(new Vector3i(0, 125, 0), Id("stone")); // a ledge
+            server.DepositWeatherSnowForTest(0, 126, 0);                 // a blizzard's drift on it
+            Assert.Contains(new Vector3i(0, 126, 0), server.WeatherDepositCellsForTest);
+
+            server.RemoveBlockForTest(0, 125, 0); // the ledge is mined away — the drift comes down
+            Steps(server, 2);
+            Assert.Equal(Id("snow").Value, server.World.GetBlock(new Vector3i(0, 121, 0)).Value);
+            Assert.Contains(new Vector3i(0, 121, 0), server.WeatherDepositCellsForTest);
+            Assert.DoesNotContain(new Vector3i(0, 126, 0), server.WeatherDepositCellsForTest);
+
+            server.MeltWeatherSnowForTest();
+            Assert.True(server.World.GetBlock(new Vector3i(0, 121, 0)).IsAir, "the fallen drift still thaws");
+            Assert.Empty(server.WeatherDepositCellsForTest);
+        }
+    }
+
+    [Fact]
+    public void SandOnAMeltingDrift_ComesDownWithTheThaw()
+    {
+        var server = Started(out var repo, "thaw");
+        using (repo)
+        {
+            Floor(server, 120);
+            server.DepositWeatherSnowForTest(0, 121, 0);
+            server.World.SetBlock(new Vector3i(0, 122, 0), Id("sand")); // dropped on the drift, at rest
+
+            server.MeltWeatherSnowForTest();
+            Steps(server, 2);
+
+            Assert.Equal(Id("sand").Value, server.World.GetBlock(new Vector3i(0, 121, 0)).Value);
+            Assert.True(server.World.GetBlock(new Vector3i(0, 122, 0)).IsAir);
+        }
+    }
+
     public void Dispose()
     {
         try

--- a/tests/BlocksBeyondTheStars.Tests/NetCodecTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/NetCodecTests.cs
@@ -358,6 +358,57 @@ public sealed class NetCodecTests
     }
 
     [Fact]
+    public void NetCreature_GlidesFlag_RoundTrips_AndDefaultsToFalse()
+    {
+        // #1368: the server's ground-bird predicate rides along as an ADDITIVE flag so the client's local arc
+        // integration uses the same glide factor — a legacy creature reads as a non-glider.
+        Assert.False(new NetCreature().Glides);
+
+        var list = new CreatureList
+        {
+            Creatures = new[]
+            {
+                new NetCreature { Id = "bird", Motion = "walker", HasWings = true, Glides = true, Airborne = true, VertVel = 5f },
+                new NetCreature { Id = "titan", Motion = "walker", HasWings = true, Glides = false },
+            },
+        };
+        var decoded = Assert.IsType<CreatureList>(NetCodec.Decode(NetCodec.Encode(list)));
+        Assert.True(decoded.Creatures[0].Glides);
+        Assert.False(decoded.Creatures[1].Glides);
+        Assert.True(decoded.Creatures[1].HasWings); // wings alone no longer imply the glide
+    }
+
+    [Fact]
+    public void ShipRepairStatus_MissingCellList_RoundTrips_AndDefaultsToEmpty()
+    {
+        // #1368: the breach cells are ADDITIVE parallel arrays on the repair readout — a legacy status carries
+        // none (the client then highlights nothing), a populated one survives the trip with its structure id.
+        var legacy = new ShipRepairStatus();
+        Assert.Equal(string.Empty, legacy.StructureId);
+        Assert.Empty(legacy.MissingX);
+        Assert.Empty(legacy.MissingY);
+        Assert.Empty(legacy.MissingZ);
+
+        var status = new ShipRepairStatus
+        {
+            Hull = 100f,
+            HullMax = 100f,
+            MissingCells = 2,
+            NeedsRepair = true,
+            StructureId = "ship:Host",
+            MissingX = new[] { 1, 4 },
+            MissingY = new[] { 0, 2 },
+            MissingZ = new[] { 7, 3 },
+        };
+        var decoded = Assert.IsType<ShipRepairStatus>(NetCodec.Decode(NetCodec.Encode(status)));
+        Assert.Equal("ship:Host", decoded.StructureId);
+        Assert.Equal(new[] { 1, 4 }, decoded.MissingX);
+        Assert.Equal(new[] { 0, 2 }, decoded.MissingY);
+        Assert.Equal(new[] { 7, 3 }, decoded.MissingZ);
+        Assert.Equal(2, decoded.MissingCells);
+    }
+
+    [Fact]
     public void JoinRequest_PreservesFieldsThroughMessagePackRoundTrip()
     {
         var original = new JoinRequest

--- a/tests/BlocksBeyondTheStars.Tests/PadSpawnTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/PadSpawnTests.cs
@@ -149,6 +149,102 @@ public sealed class PadSpawnTests : IDisposable
         }
     }
 
+    [Fact]
+    public void TpPad_LandsOnTopOfThePaving()
+    {
+        var server = Started(out var repo, "tppad", ship: false);
+        using (repo)
+        {
+            var (px, py, pz) = server.LandingPadForTest(0);
+            var concrete = _content.GetBlock("concrete")!.NumericId;
+            for (int y = py + 1; y <= py + 3; y++)
+            {
+                server.World.SetBlock(new Vector3i(px, y, pz), concrete);
+            }
+
+            var p = server.AddLocalPlayer("Admin");
+            var pad = server.TeleportTargetsForTest(p.State.PlayerId).First(t => t.Kind == "pad" && t.Number == 1);
+            Assert.Equal(py + 3 + 2, (int)Math.Floor(pad.Position.Y)); // the old target was median + 2 = inside the concrete (#1367)
+            Assert.False(Entombed(server, pad.Position));
+        }
+    }
+
+    [Fact]
+    public void ALegacyStampedHull_IsCleanedBeforeTheTouchdownHeightIsRead()
+    {
+        // Where the ship parks and what the pad's median is are deterministic from the seed — probe them.
+        int px, py, pz;
+        string location;
+        var probe = Started(out var probeRepo, "residueprobe", ship: true);
+        using (probeRepo)
+        {
+            (px, py, pz) = probe.LandingPadForTest(0);
+            location = probe.World.LocationId;
+            probe.AddLocalPlayer("Pilot");
+            var (origin, _) = probe.LandedShipBoundsForTest("Pilot");
+            Assert.Equal(py + 1, origin.Y);
+        }
+
+        // A pre-ship-as-object save: born without the clean flag, with the old stamped hull persisted as a world
+        // block edit two cells over the pad's median — inside today's ship volume AND inside the touchdown scan.
+        var setup = Started(out var setupRepo, "residuelegacy", ship: true);
+        setup.Stop();
+        using (setupRepo)
+        {
+            var meta = setupRepo.LoadMetadata()!;
+            meta.CreatedWithShipObjects = false;
+            setupRepo.SaveMetadata(meta);
+            setupRepo.SetBlock(location, new Vector3i(px, py + 2, pz), _content.GetBlock("iron_wall")!.NumericId.Value);
+        }
+
+        var legacy = Started(out var repo, "residuelegacy", ship: true);
+        using (repo)
+        {
+            legacy.AddLocalPlayer("Pilot");
+            var (origin, _) = legacy.LandedShipBoundsForTest("Pilot");
+            Assert.Equal(py + 1, origin.Y); // on the median — the ghost hull was cleaned BEFORE the raised surface was read (#1367)
+            Assert.True(legacy.World.GetBlock(new Vector3i(px, py + 2, pz)).IsAir);
+        }
+    }
+
+    [Fact]
+    public void TheRescue_FiresOncePerEntombment_WhenThePadFallbackIsWalledInToo()
+    {
+        var transport = new RecordingTransport();
+        var server = Started(out var repo, "entombedpad", ship: false, transport);
+        using (repo)
+        {
+            var (px, py, pz) = server.LandingPadForTest(0);
+            var concrete = _content.GetBlock("concrete")!.NumericId;
+            for (int y = py + 1; y <= py + 270; y++)
+            {
+                server.World.SetBlock(new Vector3i(px, y, pz), concrete); // a tower over the pad taller than the dig-out ever looks
+            }
+
+            var p = server.AddLocalPlayer("Buried");
+            p.State.AboardShip = false;
+            p.State.Position = new Vector3f(px + 0.5f, py - 6, pz + 0.5f); // sealed in the rock under the pad, the tower above
+            Assert.True(Entombed(server, p.State.Position));
+
+            for (int i = 0; i < 4; i++)
+            {
+                server.RunVoidRescueForTest(); // four seconds of rescue ticks
+            }
+
+            int Rescues() => transport.Sent.OfType<RespawnNotice>().Count(n => n.Reason == "@srv.misc.dug_out");
+            Assert.Equal(1, Rescues()); // one rescue per episode (#1367) — not one per second into the same blocked spot
+            Assert.Equal(py + 8 + 2, (int)Math.Floor(p.State.Position.Y)); // the pad fallback, itself inside the tower
+            Assert.True(Entombed(server, p.State.Position));
+
+            // The player digs themselves out: the episode ends, and nothing more is announced.
+            server.World.SetBlock(new Vector3i(px, py + 10, pz), BlocksBeyondTheStars.Shared.Primitives.BlockId.Air);
+            server.World.SetBlock(new Vector3i(px, py + 11, pz), BlocksBeyondTheStars.Shared.Primitives.BlockId.Air);
+            server.RunVoidRescueForTest();
+            Assert.False(Entombed(server, p.State.Position));
+            Assert.Equal(1, Rescues());
+        }
+    }
+
     public void Dispose()
     {
         try

--- a/tests/BlocksBeyondTheStars.Tests/ReportHostReplyLifecycleTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/ReportHostReplyLifecycleTests.cs
@@ -24,6 +24,7 @@ namespace BlocksBeyondTheStars.Tests;
 /// longer read (deleted, pruned, never its own) so the client forgets them instead of polling for up to
 /// 90 days for a report that no longer exists.
 /// </summary>
+[Collection(RealTimeSensitiveCollection.Name)] // loopback requests are billed the parallel queue wait otherwise (#1362)
 public sealed class ReportHostReplyLifecycleTests : IClassFixture<ReportHostHttpFixture>
 {
     private static int _nextClientIp;
@@ -185,6 +186,7 @@ public sealed class ReportHostAdminHttpFixture : IAsyncLifetime
 /// browser send the Basic credentials, but not the token. The scriptable JSON routes refuse anything a
 /// browser form could send (they need a JSON content type).
 /// </summary>
+[Collection(RealTimeSensitiveCollection.Name)] // loopback requests are billed the parallel queue wait otherwise (#1362)
 public sealed class ReportHostAdminCsrfTests : IClassFixture<ReportHostAdminHttpFixture>
 {
     private readonly ReportHostAdminHttpFixture _host;

--- a/tests/BlocksBeyondTheStars.Tests/ReportHostReplyLifecycleTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/ReportHostReplyLifecycleTests.cs
@@ -1,0 +1,305 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using BlocksBeyondTheStars.ReportHost;
+using BlocksBeyondTheStars.Shared.Feedback;
+using BlocksBeyondTheStars.Shared.Notifications;
+using Microsoft.AspNetCore.Builder;
+using Xunit;
+
+namespace BlocksBeyondTheStars.Tests;
+
+/// <summary>
+/// The poll's "gone" half (#1369) over real HTTP, on the shared <see cref="ReportHostHttpFixture"/> host:
+/// a client names the report ids it still remembers, and the inbox returns the ones this key can no
+/// longer read (deleted, pruned, never its own) so the client forgets them instead of polling for up to
+/// 90 days for a report that no longer exists.
+/// </summary>
+public sealed class ReportHostReplyLifecycleTests : IClassFixture<ReportHostHttpFixture>
+{
+    private static int _nextClientIp;
+
+    private readonly ReportHostHttpFixture _host;
+    private readonly string _clientIp = "10.0.1." + Interlocked.Increment(ref _nextClientIp); // own NAT address, own ingest budget
+
+    public ReportHostReplyLifecycleTests(ReportHostHttpFixture host)
+    {
+        _host = host;
+    }
+
+    private static string KeyFor(string secret) => FeedbackReplyKey.Derive(secret);
+
+    private string AddReport(string playerId)
+    {
+        var parsed = ReportIngest.Parse(ReportHostTestPayloads.Feedback(playerId), new ReportHostConfig(), out string error);
+        Assert.NotNull(parsed);
+        Assert.Equal(string.Empty, error);
+        return _host.Store.Add(parsed!, DateTimeOffset.UtcNow.ToUnixTimeSeconds());
+    }
+
+    private async Task<JsonDocument> PollAsync(string key, IEnumerable<string>? ids = null)
+    {
+        string url = "/api/replies?key=" + key;
+        if (ids != null)
+        {
+            url += "&ids=" + Uri.EscapeDataString(string.Join(",", ids));
+        }
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, url);
+        request.Headers.Add("X-Forwarded-For", _clientIp);
+        request.Headers.Add("x-bugreport-key", ReportHostHttpFixture.WriteKey);
+        using var response = await _host.Client.SendAsync(request);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        return JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+    }
+
+    private static string[] Gone(JsonDocument doc)
+        => doc.RootElement.GetProperty("gone").EnumerateArray().Select(e => e.GetString()!).ToArray();
+
+    [Fact]
+    public async Task Poll_NamesTheRememberedReportsTheKeyCanNoLongerRead_AsGoneAsync()
+    {
+        string key = KeyFor("lifecycle-owner");
+        string owned = AddReport("lifecycle-owner");
+        string foreign = AddReport("lifecycle-someone-else");
+        string deleted = AddReport("lifecycle-owner");
+        Assert.True(_host.Store.Delete(deleted));
+
+        // The client asks about everything it remembers: its live report stays, the deleted one, a report
+        // stored under another key and an id that never existed are gone.
+        using (var doc = await PollAsync(key, new[] { owned, deleted, foreign, "never-existed" }))
+        {
+            Assert.Equal(0, doc.RootElement.GetProperty("items").GetArrayLength());
+            string[] gone = Gone(doc);
+            Assert.DoesNotContain(owned, gone);
+            Assert.Contains(deleted, gone);
+            Assert.Contains(foreign, gone);
+            Assert.Contains("never-existed", gone);
+        }
+
+        // Without ids the field is present and empty — nothing is ever reported unasked.
+        using (var doc = await PollAsync(key))
+        {
+            Assert.Empty(Gone(doc));
+        }
+
+        // The operator deletes the live report → the next poll retires it as well.
+        Assert.True(_host.Store.Delete(owned));
+        using (var doc = await PollAsync(key, new[] { owned }))
+        {
+            Assert.Equal(new[] { owned }, Gone(doc));
+        }
+    }
+}
+
+/// <summary>Payloads shared by the reply-lifecycle and admin-CSRF classes (the game's camelCase FeedbackReport).</summary>
+internal static class ReportHostTestPayloads
+{
+    public static string Feedback(string playerId, string platform = "WindowsPlayer", string? replyKey = null)
+    {
+        var body = new Dictionary<string, object?>
+        {
+            ["title"] = "Hat eaten by door",
+            ["description"] = "The door on my ship eats my hat.",
+            ["email"] = "",
+            ["gameVersion"] = "2026.8.22",
+            ["playerId"] = playerId,
+            ["playerName"] = "Justus",
+            ["platform"] = platform,
+            ["clientTimestamp"] = "2026-08-29T12:00:00Z",
+            ["reportJson"] = new Dictionary<string, object?> { ["scene"] = "planet" },
+        };
+        if (replyKey != null)
+        {
+            body["replyKey"] = replyKey;
+        }
+
+        return JsonSerializer.Serialize(body);
+    }
+}
+
+/// <summary>
+/// A second in-process host with the admin UI switched ON (the shared fixture leaves it off) for the
+/// CSRF guard of #1369. Redirects are not followed so a form POST's own status is observable.
+/// </summary>
+public sealed class ReportHostAdminHttpFixture : IAsyncLifetime
+{
+    public const string WriteKey = "write-key-for-admin-tests";
+    public const string AdminUser = "admin";
+    public const string AdminPassword = "pw-123";
+
+    private readonly string _root = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "bbts_rha_" + Guid.NewGuid().ToString("N"));
+    private WebApplication _app = null!;
+
+    public ReportStore Store { get; private set; } = null!;
+    public HttpClient Client { get; private set; } = null!;
+
+    public async Task InitializeAsync()
+    {
+        System.IO.Directory.CreateDirectory(_root);
+        var config = new ReportHostConfig
+        {
+            BindAddress = "127.0.0.1",
+            Port = 0,
+            DataDir = _root,
+            WriteKey = WriteKey,
+            AdminUser = AdminUser,
+            AdminPassword = AdminPassword,
+            TrustProxy = true,
+        };
+        Store = new ReportStore(config, System.IO.Path.Combine(_root, "reports.db"));
+        _app = ReportHostApp.Create(config, Store, new AdminNotifier(string.Empty, "reports"), Array.Empty<string>());
+        await _app.StartAsync();
+        Client = new HttpClient(new HttpClientHandler { AllowAutoRedirect = false }) { BaseAddress = new Uri(_app.Urls.First()) };
+    }
+
+    public async Task DisposeAsync()
+    {
+        Client.Dispose();
+        await _app.StopAsync();
+        await _app.DisposeAsync();
+        Store.Dispose();
+        try
+        {
+            System.IO.Directory.Delete(_root, recursive: true);
+        }
+        catch (System.IO.IOException)
+        {
+            // Windows can hold SQLite WAL handles briefly; temp cleanup is best-effort.
+        }
+    }
+}
+
+/// <summary>
+/// The admin forms' CSRF guard (#1369): every form on the detail page carries the process token, and the
+/// three form routes (reply, status, delete) refuse a POST without it — a page elsewhere can make the
+/// browser send the Basic credentials, but not the token. The scriptable JSON routes refuse anything a
+/// browser form could send (they need a JSON content type).
+/// </summary>
+public sealed class ReportHostAdminCsrfTests : IClassFixture<ReportHostAdminHttpFixture>
+{
+    private readonly ReportHostAdminHttpFixture _host;
+
+    public ReportHostAdminCsrfTests(ReportHostAdminHttpFixture host)
+    {
+        _host = host;
+    }
+
+    private static readonly string Basic = "Basic " + Convert.ToBase64String(Encoding.UTF8.GetBytes(
+        ReportHostAdminHttpFixture.AdminUser + ":" + ReportHostAdminHttpFixture.AdminPassword));
+
+    private string AddReport()
+    {
+        var parsed = ReportIngest.Parse(ReportHostTestPayloads.Feedback("csrf-player"), new ReportHostConfig(), out _);
+        return _host.Store.Add(parsed!, DateTimeOffset.UtcNow.ToUnixTimeSeconds());
+    }
+
+    private HttpRequestMessage Request(HttpMethod method, string path, bool authorized = true)
+    {
+        var request = new HttpRequestMessage(method, path);
+        request.Headers.Add("X-Forwarded-For", "10.0.2.1");
+        if (authorized)
+        {
+            request.Headers.TryAddWithoutValidation("Authorization", Basic);
+        }
+
+        return request;
+    }
+
+    private async Task<HttpStatusCode> PostFormAsync(string path, Dictionary<string, string> fields)
+    {
+        using var request = Request(HttpMethod.Post, path);
+        request.Content = new FormUrlEncodedContent(fields);
+        using var response = await _host.Client.SendAsync(request);
+        return response.StatusCode;
+    }
+
+    private async Task<string> TokenFromDetailPageAsync(string id)
+    {
+        using var request = Request(HttpMethod.Get, "/admin/report/" + id);
+        using var response = await _host.Client.SendAsync(request);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        string html = await response.Content.ReadAsStringAsync();
+        const string Marker = "name='csrf' value='";
+        var tokens = html.Split(Marker).Skip(1).Select(rest => rest.Substring(0, rest.IndexOf('\''))).ToArray();
+        Assert.Equal(1 + BugReportStatus.All.Length + 1, tokens.Length); // reply + status buttons + delete
+        Assert.Single(tokens.Distinct()); // one process token, in every form
+        Assert.Matches("^[0-9a-f]{64}$", tokens[0]);
+        return tokens[0];
+    }
+
+    [Fact]
+    public async Task AdminForms_CarryTheToken_AndAPostWithoutItIsRefusedAsync()
+    {
+        string id = AddReport();
+        string token = await TokenFromDetailPageAsync(id);
+
+        // Status: no token / a wrong token → 403 and nothing changes; the page's token → redirect + change.
+        Assert.Equal(HttpStatusCode.Forbidden, await PostFormAsync($"/admin/report/{id}/status", new() { ["status"] = "done" }));
+        Assert.Equal(HttpStatusCode.Forbidden, await PostFormAsync($"/admin/report/{id}/status", new() { ["status"] = "done", ["csrf"] = new string('0', 64) }));
+        Assert.Equal(BugReportStatus.New, _host.Store.Get(id)!.Status);
+        Assert.Equal(HttpStatusCode.Found, await PostFormAsync($"/admin/report/{id}/status", new() { ["status"] = "done", ["csrf"] = token }));
+        Assert.Equal(BugReportStatus.Done, _host.Store.Get(id)!.Status);
+
+        // Reply: the route that can put text in front of a player.
+        Assert.Equal(HttpStatusCode.Forbidden, await PostFormAsync($"/admin/report/{id}/reply", new() { ["text"] = "forged" }));
+        Assert.Empty(_host.Store.ListReplies(id));
+        Assert.Equal(HttpStatusCode.Found, await PostFormAsync($"/admin/report/{id}/reply", new() { ["text"] = "genuine", ["csrf"] = token }));
+        Assert.Equal("genuine", _host.Store.ListReplies(id).Single().Text);
+
+        // Delete.
+        Assert.Equal(HttpStatusCode.Forbidden, await PostFormAsync($"/admin/report/{id}/delete", new()));
+        Assert.NotNull(_host.Store.Get(id));
+        Assert.Equal(HttpStatusCode.Found, await PostFormAsync($"/admin/report/{id}/delete", new() { ["csrf"] = token }));
+        Assert.Null(_host.Store.Get(id));
+
+        // The token is a second factor, never a substitute for the credentials.
+        using var anonymous = Request(HttpMethod.Post, $"/admin/report/{id}/status", authorized: false);
+        anonymous.Content = new FormUrlEncodedContent(new Dictionary<string, string> { ["status"] = "done", ["csrf"] = token });
+        using var refused = await _host.Client.SendAsync(anonymous);
+        Assert.Equal(HttpStatusCode.Unauthorized, refused.StatusCode);
+    }
+
+    [Fact]
+    public async Task AdminJsonRoutes_RefuseWhatABrowserFormCouldSendAsync()
+    {
+        string id = AddReport();
+
+        // text/plain is the one encoding a <form> can use to smuggle a JSON-shaped body — 415, untouched.
+        using (var forged = Request(HttpMethod.Patch, "/api/reports/" + id))
+        {
+            forged.Content = new StringContent("{\"status\":\"done\"}", Encoding.UTF8, "text/plain");
+            using var response = await _host.Client.SendAsync(forged);
+            Assert.Equal(HttpStatusCode.UnsupportedMediaType, response.StatusCode);
+        }
+
+        using (var forged = Request(HttpMethod.Post, $"/api/reports/{id}/replies"))
+        {
+            forged.Content = new StringContent("{\"text\":\"forged\"}", Encoding.UTF8, "text/plain");
+            using var response = await _host.Client.SendAsync(forged);
+            Assert.Equal(HttpStatusCode.UnsupportedMediaType, response.StatusCode);
+        }
+
+        Assert.Equal(BugReportStatus.New, _host.Store.Get(id)!.Status);
+        Assert.Empty(_host.Store.ListReplies(id));
+
+        // A real script sends application/json and is served as before.
+        using (var genuine = Request(HttpMethod.Patch, "/api/reports/" + id))
+        {
+            genuine.Content = new StringContent("{\"status\":\"triaged\"}", Encoding.UTF8, "application/json");
+            using var response = await _host.Client.SendAsync(genuine);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+
+        Assert.Equal(BugReportStatus.Triaged, _host.Store.Get(id)!.Status);
+    }
+}

--- a/tests/BlocksBeyondTheStars.Tests/ReportHostTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/ReportHostTests.cs
@@ -628,6 +628,99 @@ public sealed class ReportHostTests : IDisposable
         Assert.False(BasicAuth.IsAuthorized(Header("admin", ""), "admin", ""));
     }
 
+    // ---------------- #1369: gone marker, derived-key hint, CSRF field ----------------
+
+    private static string PayloadFor(string playerId, string platform, string? replyKey = null)
+    {
+        var body = new Dictionary<string, object?>
+        {
+            ["title"] = "Hat eaten by door",
+            ["description"] = "The door on my ship eats my hat.",
+            ["gameVersion"] = "2026.8.22",
+            ["playerId"] = playerId,
+            ["playerName"] = "Justus",
+            ["platform"] = platform,
+            ["reportJson"] = new Dictionary<string, object?> { ["scene"] = "planet" },
+        };
+        if (replyKey != null)
+        {
+            body["replyKey"] = replyKey;
+        }
+
+        return JsonSerializer.Serialize(body);
+    }
+
+    [Fact]
+    public void MissingReports_NamesForeignDeletedAndUnknownIds_NeverTheKeysOwn_AndCapsTheQuery()
+    {
+        var store = NewStore();
+        string key = KeyFor("token-abc");
+        string owned = store.Add(ReportIngest.Parse(PayloadFor("token-abc", "WindowsPlayer"), new ReportHostConfig(), out _)!, nowUnix: 1);
+        string foreign = store.Add(ReportIngest.Parse(PayloadFor("token-xyz", "WindowsPlayer"), new ReportHostConfig(), out _)!, nowUnix: 2);
+        string deleted = store.Add(ReportIngest.Parse(PayloadFor("token-abc", "WindowsPlayer"), new ReportHostConfig(), out _)!, nowUnix: 3);
+        Assert.True(store.Delete(deleted));
+
+        var gone = store.MissingReports(key, new[] { owned, foreign, deleted, "unknown", "", owned });
+        Assert.Equal(new[] { foreign, deleted, "unknown" }, gone);
+
+        // A key that cannot read anything sees everything gone; a retention prune retires a report the same way.
+        Assert.Equal(new[] { owned }, store.MissingReports("not-a-key", new[] { owned }));
+        Assert.Equal(2, store.Prune(retentionDays: 1, nowUnix: 1 + 2 * 86400)); // owned + foreign
+        Assert.Equal(new[] { owned }, store.MissingReports(key, new[] { owned }));
+
+        // At most 50 ids per poll are looked at — the client remembers no more than that.
+        var many = Enumerable.Range(0, ReportStore.MaxGoneQueryIds + 10).Select(i => "id" + i).ToArray();
+        Assert.Equal(ReportStore.MaxGoneQueryIds, store.MissingReports(key, many).Count);
+    }
+
+    [Fact]
+    public void DetailPage_SaysNoInGameReplyForOldArcadeReports_AndEveryFormCarriesTheCsrfToken()
+    {
+        var store = NewStore();
+        var csrf = new AdminCsrf("tok-for-the-test");
+
+        // A browser report filed before the reply channel: key derived from the browser-local player id —
+        // the glitch.fun arcade never polls with it.
+        string oldArcade = store.Add(ReportIngest.Parse(PayloadFor("browser-token", "WebGLPlayer"), new ReportHostConfig(), out _)!, nowUnix: 1);
+        Assert.Equal(ReportHostPages.ReplyKeyOrigin.DerivedFromPlayerId, ReportHostPages.KeyOrigin(store.Get(oldArcade)!));
+        string html = ReportHostPages.Detail(store.Get(oldArcade)!, store.ListReplies(oldArcade), csrf);
+        Assert.Contains("No in-game reply possible", html);
+
+        // An old desktop report: the same derivation, but a desktop install DOES poll with it — a softer hint.
+        string oldDesktop = store.Add(ReportIngest.Parse(PayloadFor("token-abc", "WindowsPlayer"), new ReportHostConfig(), out _)!, nowUnix: 2);
+        html = ReportHostPages.Detail(store.Get(oldDesktop)!, store.ListReplies(oldDesktop), csrf);
+        Assert.DoesNotContain("No in-game reply possible", html);
+        Assert.Contains("Reply key derived from the player id", html);
+
+        // A report that carried its key (any platform): no caveat at all.
+        string current = store.Add(ReportIngest.Parse(PayloadFor("browser-token", "WebGLPlayer", KeyFor("glitch-install-id")), new ReportHostConfig(), out _)!, nowUnix: 3);
+        Assert.Equal(ReportHostPages.ReplyKeyOrigin.SentByClient, ReportHostPages.KeyOrigin(store.Get(current)!));
+        html = ReportHostPages.Detail(store.Get(current)!, store.ListReplies(current), csrf);
+        Assert.DoesNotContain("No in-game reply possible", html);
+        Assert.DoesNotContain("derived from the player id", html);
+        Assert.Contains("No replies yet", html);
+
+        // No key at all (a crash from a server): the existing wording.
+        string crash = store.Add(ReportIngest.Parse(CrashPayload(), new ReportHostConfig(), out _)!, nowUnix: 4);
+        Assert.Equal(ReportHostPages.ReplyKeyOrigin.None, ReportHostPages.KeyOrigin(store.Get(crash)!));
+        Assert.Contains("no reply key", ReportHostPages.Detail(store.Get(crash)!, store.ListReplies(crash), csrf));
+
+        // Every form on the page — reply, one per status button, delete — carries the token; without a
+        // guard instance (older callers, tests) no field is rendered.
+        int forms = html.Split("<form method='post'").Length - 1;
+        Assert.Equal(1 + BugReportStatus.All.Length + 1, forms);
+        Assert.Equal(forms, html.Split(csrf.HiddenField()).Length - 1);
+        Assert.DoesNotContain("name='csrf'", ReportHostPages.Detail(store.Get(current)!, store.ListReplies(current)));
+
+        // The guard itself: fixed-time compare, nothing empty ever matches, a fresh instance is 64 hex chars.
+        Assert.True(csrf.IsValid("tok-for-the-test"));
+        Assert.False(csrf.IsValid("tok-for-the-tesT"));
+        Assert.False(csrf.IsValid(""));
+        Assert.False(csrf.IsValid(null));
+        Assert.Matches("^[0-9a-f]{64}$", new AdminCsrf().Token);
+        Assert.NotEqual(new AdminCsrf().Token, new AdminCsrf().Token);
+    }
+
     public void Dispose()
     {
         foreach (var store in _stores)

--- a/tests/BlocksBeyondTheStars.Tests/ShipRepairTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/ShipRepairTests.cs
@@ -101,6 +101,38 @@ public sealed class ShipRepairTests : IDisposable
     }
 
     [Fact]
+    public void ShipRepairStatus_ListsTheBreachCells_AndClearsThemOnceRepaired()
+    {
+        // #1368: the readout carries the missing design cells (structure-local) so the client can outline every
+        // breach in the world while the panel is up — the same cells the per-cell repair accepts.
+        var server = Started(out var repo);
+        using (repo)
+        {
+            var player = server.AddLocalPlayer("Host");
+            var hole = server.CarveFirstShipCellForTest("Host");
+
+            var status = server.ShipRepairStatusForTest("Host");
+            Assert.NotNull(status);
+            Assert.True(status!.NeedsRepair);
+            Assert.Equal(1, status.MissingCells);
+            Assert.Equal("ship:Host", status.StructureId);
+            Assert.Equal(new[] { hole.X }, status.MissingX);
+            Assert.Equal(new[] { hole.Y }, status.MissingY);
+            Assert.Equal(new[] { hole.Z }, status.MissingZ);
+
+            player.State.Inventory.Add(hole.Item, 1, 99);
+            Assert.True(server.RepairShipForTest("Host", new RepairShipIntent { Mode = "cell", X = hole.X, Y = hole.Y, Z = hole.Z }));
+
+            var after = server.ShipRepairStatusForTest("Host");
+            Assert.NotNull(after);
+            Assert.Equal(0, after!.MissingCells);
+            Assert.Empty(after.MissingX);
+            Assert.Empty(after.MissingY);
+            Assert.Empty(after.MissingZ);
+        }
+    }
+
+    [Fact]
     public void RepairShipAll_RefillsCarvedHull_AndHull_Together()
     {
         var server = Started(out var repo);

--- a/tests/BlocksBeyondTheStars.Tests/VerticalMotionTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/VerticalMotionTests.cs
@@ -142,4 +142,22 @@ public sealed class VerticalMotionTests
 
         Assert.True(Ticks(gGlide) > Ticks(gFull) * 1.3f, "the glide arc must last noticeably longer");
     }
+
+    [Fact]
+    public void Fall_IsCappedAtTerminalSpeed()
+    {
+        // #1367: unclamped, a fall that ran to the 2 s timeout reached ~40 b/s — a 2.7-block last step at 15 Hz.
+        var s = new VerticalState();
+        float y = 1000f, maxStep = 0f;
+        for (int i = 0; i < 28; i++) // 1.87 s: just short of the never-stuck timeout
+        {
+            float before = y;
+            y = VerticalMotion.Ground(ref s, y, 0f, G, Dt);
+            maxStep = System.Math.Max(maxStep, before - y);
+        }
+
+        Assert.True(s.Airborne);
+        Assert.Equal(-VerticalMotion.TerminalSpeed, s.VertVel, 3);
+        Assert.True(maxStep <= VerticalMotion.TerminalSpeed * (float)Dt + 0.05f, $"the largest step was {maxStep:F2} blocks");
+    }
 }

--- a/tools/ai-assets/gen_textures.py
+++ b/tools/ai-assets/gen_textures.py
@@ -19,8 +19,10 @@ import base64
 import os
 import sys
 import time
+from collections.abc import Callable
 from io import BytesIO
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from dotenv import load_dotenv
 
@@ -198,10 +200,38 @@ TEXTURES = [
     ("factory_terminal", "a sci-fi factory production terminal, a dark metal console with a glowing cyan holographic screen showing production graphs, buttons and a status light, front view"),
     # Guardian machines (#1338): the plating tile WorldEntities/SpaceView load for the robot, scan-drone,
     # space drone, UFO and cruiser hulls — grey circuit-board armour, no lights (the red eyes are separate).
-    # Post-processed before bundling (the entity loaders do NOT brighten tiles like CreatureBuilder does):
-    # desaturated 70 % and lifted v' = 1 - (1 - v) * 0.76 so the plates sit at ~0.40 mean grey.
+    # Post-processed by `guardian_plating` (see POST_PROCESS) before the tile is written, since the entity
+    # loaders do NOT brighten tiles like CreatureBuilder does: desaturated 70 % and lifted
+    # v' = 1 - (1 - v) * 0.76 so the plates sit at ~0.40 mean grey.
     ("enemy_robot", "dark grey armoured sci-fi robot plating with bolted panel seams and etched light-grey circuit-board traces and solder pads, matte metal, coarse large panels, no lights, no glow, no colour"),
 ]
+
+if TYPE_CHECKING:
+    from PIL import Image
+
+
+def guardian_plating(img: Image.Image) -> Image.Image:
+    """The Guardian plating post-process (#1338, made reproducible in #1369).
+
+    Desaturates by 70 % (blend towards the luminance with weight 0.7) and lifts every RGB channel
+    towards white with v' = 1 - (1 - v) * 0.76, alpha untouched. Applied to the 64 px tile right after
+    the resize, so out/textures/enemy_robot.png — and therefore `bundle_textures.py --from-out` — carries
+    the processed plates that the committed .bytes tile shows.
+    """
+    from PIL import ImageEnhance
+
+    rgba = img.convert("RGBA")
+    rgb = ImageEnhance.Color(rgba.convert("RGB")).enhance(1.0 - 0.70)
+    lifted = rgb.point(lambda v: round(255 - (255 - v) * 0.76))
+    lifted.putalpha(rgba.getchannel("A"))
+    return lifted
+
+
+# Per-tile post-processing applied to the generated 64 px tile before it is saved (key -> function).
+# Anything not listed here is written as generated.
+POST_PROCESS: dict[str, Callable[[Image.Image], Image.Image]] = {
+    "enemy_robot": guardian_plating,
+}
 
 
 def main() -> None:
@@ -219,7 +249,8 @@ def main() -> None:
     print(f"[tex] {len(textures)} textures")
     if args.dry_run:
         for i, (key, desc) in enumerate(textures, 1):
-            print(f"  {i:2d}. {key:16s} {desc}")
+            post = f"  [post: {POST_PROCESS[key].__name__}]" if key in POST_PROCESS else ""
+            print(f"  {i:2d}. {key:16s} {desc}{post}")
         return
 
     load_dotenv()
@@ -252,6 +283,8 @@ def main() -> None:
                     model="gpt-image-1-mini", prompt=prompt, size="1024x1024", quality="low", n=1)
                 raw = base64.b64decode(resp.data[0].b64_json)
                 img = Image.open(BytesIO(raw)).convert("RGBA").resize((64, 64), Image.NEAREST)
+                if block in POST_PROCESS:
+                    img = POST_PROCESS[block](img)
                 img.save(out)
                 done += 1
                 ok = True


### PR DESCRIPTION
The low-severity leftovers from the 2026-08-29 audit of the day's merges, bundled into three checklist issues and worked in order on one branch (server → web/tooling → client), rebased onto main after #1370.

closes #1367
closes #1368
closes #1369

## #1367 — server (granular blocks, drop packets, pad touchdown, creature physics)
- Falling blocks follow the colliding rule: walk-through props are crushed (drops spill on top, fire is put out), doorway cells / NPCs / players hold the block, the settled block keeps its builder attribution and a weather-snow deposit keeps its melt entry; snow melt calls `OnSupportRemoved`; a landing block nudges the animal underneath aside (#1357 body check).
- Drop packets fall through grass; `SaveAll` checkpoints loot-packet age per world.
- `/tp pad N` lands on `PadSurfaceY`; legacy stamp residue is cleaned before the touchdown height is read; the entombed rescue fires once per episode instead of every second.
- Creatures: standable columns by the colliding rule (titans no longer pulled onto canopies), **view-aware far prune** (`Max(70|110, stream radius)`, decided), a perched flier whose perch is removed falls and **takes off** (decided), head clearance before a jump/climb, terminal fall speed (25 b/s), lava gate for non-lava walkers, own-column water depth for swimmers, `GroundFeetFor` computed once per column change.
- Wall fill (#1347): cached until a block changes / a hand door toggles inside the box (`ServerWorld.BlockSet`, 8 s backstop), reach box wraps north–south.

## #1369 — ReportHost / workflows / tooling
- `/api/replies?ids=…` answers `gone: […]` for remembered reports the key can no longer read; the client calls `SentReportsLog.Forget` (no more 90-day polling of deleted reports).
- The answer box follows the thread (last entry is a developer question) instead of the status.
- Admin forms carry a per-process CSRF token (403 on mismatch); admin JSON routes require `application/json` (415) so a forged form cannot reach them. Documented in `REPORT_HOST.md`.
- Pre-#1327 arcade reports cannot be answered in-game (documented; the admin page says so per report).
- `reports-image.yml` also triggers on `Shared/**`.
- `gen_textures.py` applies the Guardian plating post-process itself (no texture regenerated).
- First HTTP-level tests for the reply lifecycle and the CSRF guard (`RealTimeSensitive` collection per #1370).

## #1368 — Unity client
- Reply window: whole thread as plain, chunked (`UiTextChunks`), scrollable text; rich text off for reply/toast bodies; the F1-hotkey + Esc same-frame race no longer leaves a held, unclosable dialog. (World hold for the reply window was already in place since #1339 — verified, unchanged.)
- Browser name prompt mirrors into the menu field, both capped at `Protocol.MaxPlayerNameLength` (24, shared with the server), deferred while the What's-new modal is open; the save-blob name peek is cached per blob.
- Doors skip fluid cells, torches only water (mirrors the server's `HandlePlace` rejections).
- Creature view glides by the server's rule (`NetCreature.Glides`, additive), a falling perched flier unfolds its wings (server sets the wire flags from the real state), `CreatureAnimator` cached per entry.
- **Missing hull cells are highlighted** on the parked ship (decided): `ShipRepairStatus` carries the breach cells (additive), `HullBreachView` draws placement-ghost boxes; singular/plural line (`ui.shiprepair.cells_missing_one`, DE + EN); the bar track hides with the bar.
- CHANGELOG entries for #1307 / #1308 / #1309 / #1313 added.

## Verification
- Server: full non-Slow suite on the branch before the web/client parts: 2531 passed, 0 failed; afterwards targeted suites (ReportHost/Portal 172, Feedback 24, NetCodec/ShipRepair/CreatureMotionArena 51, Client.Tests 461) — all green; the PR CI is the full-suite gate (the machine was shared with another worktree's run).
- Clean rebuild after the rebase onto main (#1370): 0 warnings, 0 errors; `dotnet format --verify-no-changes` clean; `ruff` clean.
- Local Unity build: `Build Finished, Result: Success.`, fresh `BlocksBeyondTheStars.Client.dll` (2026-08-29 20:35); #1370 touched no client code, so no rebuild after the rebase.
- TODO.md + CHANGELOG (Unreleased) + REPORT_HOST.md + PLAYER_FEEDBACK.md updated.

## Deploy / playtest
- **ReportHost image** redeploy (`gone`, CSRF, JSON gate, admin hint).
- Playtest: breach boxes on a drilled parked ship; a > 1400-char developer reply scrolls; WebGL `?singleplayer=1` after an update: What's-new first, then the name prompt; sand onto a flower / a door / an animal; `/tp pad` on a paved pad; a flier whose branch is mined; titans next to trees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
