### PR TITLE
fix(client): WebGL report transport parses JSON with JsonUtility — System.Text.Json is not in Unity's runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -334,6 +334,9 @@ channel, and the WorldHost image for the portal's solo entry.
 - The report-host test fixture no longer looks like an 80-second network stall. It was xunit's parallel queue,
   not I/O: one in-process ReportHost per test class, every request timed, and the loopback HTTP tests moved into
   a real-time-sensitive collection so the slow first Kestrel start stays off the fast-tier clock.
+- **The browser build compiles again.** The WebGL report transport (#1339) parsed the inbox answer with
+  `System.Text.Json`, which Unity's runtime does not ship; only the release-tag WebGL build compiles that file, so no
+  PR build caught it. It reads the one field it needs with `JsonUtility` now (#1377).
 
 ## [2026.8.22] — 2026-08-26
 

--- a/client/Assets/BlocksBeyondTheStars/Scripts/FeedbackWebGlTransport.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/FeedbackWebGlTransport.cs
@@ -5,9 +5,9 @@
 using System;
 using System.Collections;
 using System.Text;
-using System.Text.Json;
 using BlocksBeyondTheStars.Build;
 using BlocksBeyondTheStars.Client.Feedback;
+using UnityEngine;
 using UnityEngine.Networking;
 
 namespace BlocksBeyondTheStars.Client
@@ -78,19 +78,24 @@ namespace BlocksBeyondTheStars.Client
                 return string.Empty;
             }
 
+            // System.Text.Json is not part of Unity's runtime (the WebGL build is the only one that compiles
+            // this file, so the desktop players never noticed) — JsonUtility reads the one field we need.
             try
             {
-                using var doc = JsonDocument.Parse(body);
-                return doc.RootElement.ValueKind == JsonValueKind.Object
-                       && doc.RootElement.TryGetProperty("bugReportId", out var id)
-                       && id.ValueKind == JsonValueKind.String
-                    ? id.GetString() ?? string.Empty
-                    : string.Empty;
+                var dto = JsonUtility.FromJson<IngestResponse>(body);
+                return dto?.bugReportId ?? string.Empty;
             }
             catch
             {
                 return string.Empty;
             }
+        }
+
+        [Serializable]
+        private sealed class IngestResponse
+        {
+            // Field name = the inbox's JSON property (JsonUtility maps by name, no attributes).
+            public string bugReportId;
         }
     }
 }


### PR DESCRIPTION
The v2026.8.23 release run (33273930351) failed its WebGL job:

```
FeedbackWebGlTransport.cs(8,19): error CS0234: The type or namespace name 'Json' does not exist in the namespace 'System.Text'
```

`System.Text.Json` is not part of Unity's runtime. The file is `#if UNITY_WEBGL && !UNITY_EDITOR`, so only the release-tag WebGL build compiles it — desktop players and PR CI never saw it. Replaces the `JsonDocument` parse with `JsonUtility.FromJson` on a one-field DTO; no new dependency, same never-throws contract.

The partial release + tag were deleted; `v2026.8.23` is re-tagged on this merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
