### PR TITLE
fix(reports): the screenshot half of a report pair shows the pair's conversation; replies land on the keyed half (#1378)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ the richer, screenshot-laden versions live there. `(#123)` references the pull r
 
 ## [Unreleased]
 
+### 📬 Report inbox — the screenshot half of a pair shows the pair's conversation (#1378)
+
+- **Opening a report from the admin list showed an empty conversation** although the developers had answered.
+  The list links each pair to its richer half — the server's `/bump` row with the screenshot — and for reports
+  filed before the reply channel that half carries no reply key (the #1359 repair blanks name-derived keys on
+  purpose), so its page said "no in-game reply possible" while the answers sat on the client row behind the
+  small `+1` link. Whichever half you open now, the page shows the pair's one thread and says where it lives;
+  the reply form, `POST /admin/report/{id}/reply` and `POST /api/reports/{id}/replies` all write to the half
+  that carries the key (the API answer names it as `reportId`), so an answer is never stored where no game
+  can read it. Operators: redeploy the ReportHost image.
+
 ## [2026.8.23] — 2026-08-29
 
 The menagerie release. Animals stopped sliding along the ground and started **moving like animals**:

--- a/TODO.md
+++ b/TODO.md
@@ -110,6 +110,14 @@ Per-item detail lives in the dated work log below. **Since 2026-07 versions are 
 #1144, #1146, #1147), all 28 sub-issues #1102–#1129 done. The whole package is UNRELEASED pending the big
 playtest; the post-epic implementation audit spawned the follow-up fix round #1149–#1156.
 
+### ★ Report inbox: the screenshot half of a pair shows the pair's conversation (#1378, 2026-08-30, branch fix/reporthost-pair-thread)
+After answering Lyxette's 11 reports through the API, the admin list showed no answer on any of them: it links each
+pair to the `/bump` half (screenshot), whose reply key is blank for pre-8.23 reports (#1359 repair), so its detail
+page rendered an empty thread while the replies sat on the client row. `ReportHostPages.ThreadOwner` resolves the
+keyed half through the existing pairing rule (`ReportStore.Around` supplies the candidates); the detail page renders
+the owner's thread + "fixed in" with a hand-over hint, and both reply routes write to the owner. Test:
+`PairedScreenshotRow_ShowsTheClientHalfsThread_AndReceivesRepliesThere`. ReportHost image redeploy needed.
+
 ### ★ The "80 s HTTP request" was xunit's parallel queue, not the network (#1362, 2026-08-29, branch fix/1362-xunit-queue-latency)
 A ReportHost HTTP test measured 34 s / 82 s / 134 s for a loopback request that takes a millisecond, and
 the 134 s failed the fast-tier duration guardrail. It was never HTTP: with `maxParallelThreads` set, xunit

--- a/src/BlocksBeyondTheStars.ReportHost/ReportHostApp.cs
+++ b/src/BlocksBeyondTheStars.ReportHost/ReportHostApp.cs
@@ -39,6 +39,10 @@ public static class ReportHostApp
 
         long NowUnix() => DateTimeOffset.UtcNow.ToUnixTimeSeconds();
 
+        // The half of a report pair that owns the conversation (#1378) — see ReportHostPages.ThreadOwner.
+        BugReportRecord ThreadOwnerOf(BugReportRecord r)
+            => ReportHostPages.ThreadOwner(r, store.Around(r.CreatedUnix, ReportHostPages.DuplicateWindowSeconds));
+
         int prunedAtStart = store.Prune(config.RetentionDays, NowUnix());
         // Reports stored before the reply channel (#1327) get their reply key derived from the player id they
         // already carry, so their reporters can be answered too. Idempotent — a no-op after the first start.
@@ -575,7 +579,15 @@ public static class ReportHostApp
                 return Results.BadRequest(new { error = "empty_text" });
             }
 
-            long replyId = store.AddDevReply(id, text, question, NowUnix());
+            // The thread lives on the keyed half of the pair (#1378) — answering the screenshot row of an old
+            // report must not store the text where no game can read it.
+            if (store.Get(id) is not { } target)
+            {
+                return Results.NotFound();
+            }
+
+            var owner = ThreadOwnerOf(target);
+            long replyId = store.AddDevReply(owner.Id, text, question, NowUnix());
             if (replyId < 0)
             {
                 return Results.NotFound();
@@ -583,10 +595,10 @@ public static class ReportHostApp
 
             if (fixedIn != null)
             {
-                store.SetFixedInVersion(id, fixedIn);
+                store.SetFixedInVersion(owner.Id, fixedIn);
             }
 
-            return Results.Json(new { ok = true, replyId }, statusCode: StatusCodes.Status201Created);
+            return Results.Json(new { ok = true, replyId, reportId = owner.Id }, statusCode: StatusCodes.Status201Created);
         });
 
         // ---------------- Admin UI (Basic Auth; server-rendered, no script) ----------------
@@ -632,9 +644,13 @@ public static class ReportHostApp
                 return denied;
             }
 
-            return store.Get(id) is { } record
-                ? Results.Content(ReportHostPages.Detail(record, store.ListReplies(id), csrf), "text/html; charset=utf-8")
-                : Results.NotFound();
+            if (store.Get(id) is not { } record)
+            {
+                return Results.NotFound();
+            }
+
+            var owner = ThreadOwnerOf(record);
+            return Results.Content(ReportHostPages.Detail(record, store.ListReplies(owner.Id), csrf, owner), "text/html; charset=utf-8");
         });
 
         // The reply form on the detail page: an answer, or a follow-up question (flips the status to
@@ -656,14 +672,21 @@ public static class ReportHostApp
             bool question = form["question"].ToString() == "1";
             string fixedIn = form["fixed_in_version"].ToString().Trim();
 
-            if (text.Length > 0 && store.AddDevReply(id, text, question, NowUnix()) < 0)
+            if (store.Get(id) is not { } record)
             {
                 return Results.NotFound();
             }
 
-            if (store.Get(id) is { } record && fixedIn != record.FixedInVersion)
+            // Same resolution as the detail page (#1378): the reply goes to the half that carries the key.
+            var owner = ThreadOwnerOf(record);
+            if (text.Length > 0 && store.AddDevReply(owner.Id, text, question, NowUnix()) < 0)
             {
-                store.SetFixedInVersion(id, fixedIn);
+                return Results.NotFound();
+            }
+
+            if (fixedIn != owner.FixedInVersion)
+            {
+                store.SetFixedInVersion(owner.Id, fixedIn);
             }
 
             return Results.Redirect($"/admin/report/{id}");

--- a/src/BlocksBeyondTheStars.ReportHost/ReportHostPages.cs
+++ b/src/BlocksBeyondTheStars.ReportHost/ReportHostPages.cs
@@ -104,7 +104,42 @@ public static class ReportHostPages
 
     /// <summary>How far apart the two rows of one F1 report may be stamped. The client posts directly and the
     /// server forwards its /bump snapshot independently, so they land a moment apart — observed 0–2 s.</summary>
-    private const long DuplicateWindowSeconds = 8;
+    public const long DuplicateWindowSeconds = 8;
+
+    /// <summary>
+    /// The half of a report pair that owns its conversation (#1378): the row whose reply key the player's game
+    /// polls with. A row that carries a key owns its own thread. A key-less row (the server's /bump forward of a
+    /// report filed before the reply channel — #1359 blanked its name-derived key on purpose) hands over to its
+    /// paired half when that one has a key, so the detail page shows the pair's one thread whichever half the
+    /// operator opened, and an answer typed there is never stored where no game can read it. Without a keyed
+    /// partner the row stays its own owner (and the page says nothing can reach the player).
+    /// </summary>
+    /// <param name="candidates">Rows stamped within <see cref="DuplicateWindowSeconds"/> of <paramref name="r"/>
+    /// (see <c>ReportStore.Around</c>); <paramref name="r"/> itself may be among them.</param>
+    public static BugReportRecord ThreadOwner(BugReportRecord r, IReadOnlyList<BugReportRecord> candidates)
+    {
+        if (r.ReplyKey.Length > 0)
+        {
+            return r;
+        }
+
+        BugReportRecord? owner = null;
+        foreach (var c in candidates)
+        {
+            if (c.Id == r.Id || c.ReplyKey.Length == 0 || !IsSameReport(r, c))
+            {
+                continue;
+            }
+
+            // Prefer the client-direct half — the one that always carries the install's own key.
+            if (owner == null || (owner.Source.Length > 0 && c.Source.Length == 0))
+            {
+                owner = c;
+            }
+        }
+
+        return owner ?? r;
+    }
 
     /// <summary>
     /// Collapses the two database rows that one in-game F1 report produces into a single group.
@@ -243,9 +278,12 @@ public static class ReportHostPages
     /// <summary>The Unity platform string of every browser build (play.* and the glitch.fun arcade alike).</summary>
     private const string WebGlPlatform = "WebGLPlayer";
 
-    public static string Detail(BugReportRecord r, IReadOnlyList<ReplyRecord>? replies = null, AdminCsrf? csrf = null)
+    /// <param name="threadOwner">The half of the pair that owns the conversation (<see cref="ThreadOwner"/>);
+    /// <paramref name="replies"/> are ITS replies. Null or <paramref name="r"/> itself = the row owns its thread.</param>
+    public static string Detail(BugReportRecord r, IReadOnlyList<ReplyRecord>? replies = null, AdminCsrf? csrf = null, BugReportRecord? threadOwner = null)
     {
         replies ??= Array.Empty<ReplyRecord>();
+        threadOwner ??= r;
         string csrfField = csrf?.HiddenField() ?? string.Empty;
         var sb = new StringBuilder();
         string when = DateTimeOffset.FromUnixTimeSeconds(r.CreatedUnix).ToString("yyyy-MM-dd HH:mm:ss");
@@ -275,12 +313,22 @@ public static class ReportHostPages
         // Reply thread (#1327): what the player sees in the game, plus the form to add to it. Only reports
         // that carry a reply key can reach a player (server crash reports have none).
         sb.Append("<div class='card'><h2>Conversation with the player</h2>");
-        var origin = KeyOrigin(r);
+        bool viaPartner = threadOwner.Id != r.Id;
+        if (viaPartner)
+        {
+            // The screenshot half of a pre-reply-channel pair (#1378): its own key is blank, the thread lives
+            // on the client-direct row — say so, and let the form below write there.
+            sb.Append($"<p class='hint'>This row's own reply key is blank; the conversation lives on the paired " +
+                      $"<a href='/admin/report/{threadOwner.Id}'>{(threadOwner.Source.Length > 0 ? E(threadOwner.Source) : "client")} row</a> " +
+                      "— the half whose key the player's game polls with. What you write below is stored there.</p>");
+        }
+
+        var origin = KeyOrigin(threadOwner);
         if (origin == ReplyKeyOrigin.None)
         {
             sb.Append("<p class='hint'>This report carries no reply key (no player id) — nothing you write here can reach a player.</p>");
         }
-        else if (origin == ReplyKeyOrigin.DerivedFromPlayerId && r.Platform == WebGlPlatform)
+        else if (origin == ReplyKeyOrigin.DerivedFromPlayerId && threadOwner.Platform == WebGlPlatform)
         {
             // A browser report from before the reply channel: the key was derived from the browser-local
             // token, which the glitch.fun arcade never polls with (#1369) — only a play.* install would.
@@ -309,15 +357,17 @@ public static class ReportHostPages
             sb.Append($"<div class='reply reply-{E(reply.Author)}'><div class='sub'>{who} · {stamp} UTC{seen}</div><pre>{E(reply.Text)}</pre></div>");
         }
 
-        if (r.FixedInVersion.Length > 0)
+        if (threadOwner.FixedInVersion.Length > 0)
         {
-            sb.Append($"<p class='sub'>Fixed in version: <b>{E(r.FixedInVersion)}</b> (shown to the player with the thread)</p>");
+            sb.Append($"<p class='sub'>Fixed in version: <b>{E(threadOwner.FixedInVersion)}</b> (shown to the player with the thread)</p>");
         }
 
+        // The form posts to THIS row's route; the route resolves the owner the same way (#1378), so a reply
+        // typed on either half lands on the keyed one and the redirect returns here.
         sb.Append($"<form method='post' action='/admin/report/{r.Id}/reply' class='replyform'>{csrfField}");
         sb.Append("<textarea name='text' rows='4' maxlength='5000' placeholder='Answer, or a follow-up question. Never ask for personal data — the audience includes children.'></textarea>");
         sb.Append("<label><input type='checkbox' name='question' value='1'> this is a question (status → waiting_for_player; the player can answer in-game)</label>");
-        sb.Append($"<label>fixed in version <input type='text' name='fixed_in_version' value='{E(r.FixedInVersion)}' placeholder='e.g. 2026.8.23' size='14'></label>");
+        sb.Append($"<label>fixed in version <input type='text' name='fixed_in_version' value='{E(threadOwner.FixedInVersion)}' placeholder='e.g. 2026.8.23' size='14'></label>");
         sb.Append("<button>send to player</button></form></div>");
 
         sb.Append("<div class='card actions'>");

--- a/src/BlocksBeyondTheStars.ReportHost/ReportStore.cs
+++ b/src/BlocksBeyondTheStars.ReportHost/ReportStore.cs
@@ -362,6 +362,28 @@ public sealed class ReportStore : IDisposable
         }
     }
 
+    /// <summary>Every row stamped within <paramref name="windowSeconds"/> of <paramref name="createdUnix"/> —
+    /// the candidates for the other half of a report pair (#1378); the caller applies the pairing rule.</summary>
+    public List<BugReportRecord> Around(long createdUnix, long windowSeconds)
+    {
+        lock (_gate)
+        {
+            using var cmd = _db.CreateCommand();
+            cmd.CommandText = "SELECT * FROM bugreport WHERE created_unix BETWEEN $from AND $to ORDER BY created_unix, id;";
+            cmd.Parameters.AddWithValue("$from", createdUnix - windowSeconds);
+            cmd.Parameters.AddWithValue("$to", createdUnix + windowSeconds);
+
+            var items = new List<BugReportRecord>();
+            using var reader = cmd.ExecuteReader();
+            while (reader.Read())
+            {
+                items.Add(ReadRecord(reader));
+            }
+
+            return items;
+        }
+    }
+
     public bool SetStatus(string id, string status)
     {
         if (!BugReportStatus.IsValid(status))

--- a/tests/BlocksBeyondTheStars.Tests/ReportHostTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/ReportHostTests.cs
@@ -673,6 +673,76 @@ public sealed class ReportHostTests : IDisposable
         Assert.Equal(ReportStore.MaxGoneQueryIds, store.MissingReports(key, many).Count);
     }
 
+    /// <summary>The server's /bump forward of the same report, exactly as it lands in production: the player
+    /// id is the NAME, no reply key, the description wraps the player's wording, and the snapshot carries the
+    /// screenshot — which is why the admin list links to this half.</summary>
+    private static string ServerForwardPayloadFor(string playerName)
+    {
+        var body = new Dictionary<string, object?>
+        {
+            ["title"] = $"Bump [World]: [feedback] Hat eaten by door — The door on my ship eats my hat.",
+            ["description"] = "[feedback] Hat eaten by door — The door on my ship eats my hat.",
+            ["gameVersion"] = "2026.8.22",
+            ["playerId"] = playerName,
+            ["playerName"] = playerName,
+            ["platform"] = "WindowsPlayer",
+            ["reportJson"] = new Dictionary<string, object?> { ["source"] = "server", ["snapshot"] = new Dictionary<string, object?>() },
+            ["screenshot"] = new Dictionary<string, object?>
+            {
+                ["fileName"] = "bump.jpg",
+                ["mimeType"] = "image/jpeg",
+                ["base64"] = Convert.ToBase64String(new byte[] { 0xFF, 0xD8, 0xFF, 0xE0, 1, 2, 3 }),
+            },
+        };
+        return JsonSerializer.Serialize(body);
+    }
+
+    /// <summary>#1378: a report filed before the reply channel is a pair whose screenshot half carries no reply
+    /// key (the #1359 repair blanks name-derived keys on server rows). Opening THAT half must still show the
+    /// pair's thread, and an answer written on it must land on the keyed half — the only one a game polls.</summary>
+    [Fact]
+    public void PairedScreenshotRow_ShowsTheClientHalfsThread_AndReceivesRepliesThere()
+    {
+        var store = NewStore();
+        string client = store.Add(ReportIngest.Parse(PayloadFor("token-abc", "WindowsPlayer"), new ReportHostConfig(), out _)!, nowUnix: 100);
+        string server = store.Add(ReportIngest.Parse(ServerForwardPayloadFor("Justus"), new ReportHostConfig(), out _)!, nowUnix: 101);
+
+        var clientRow = store.Get(client)!;
+        var serverRow = store.Get(server)!;
+        Assert.NotEmpty(clientRow.ReplyKey);
+        Assert.Empty(serverRow.ReplyKey); // the production shape after #1359
+
+        // Resolution: the key-less half hands over to its keyed partner; the keyed half owns itself; an
+        // unrelated key-less row (another player, same minute) stays its own owner.
+        var around = store.Around(serverRow.CreatedUnix, ReportHostPages.DuplicateWindowSeconds);
+        Assert.Equal(client, ReportHostPages.ThreadOwner(serverRow, around).Id);
+        Assert.Equal(client, ReportHostPages.ThreadOwner(clientRow, around).Id);
+        string stranger = store.Add(ReportIngest.Parse(ServerForwardPayloadFor("Pilot"), new ReportHostConfig(), out _)!, nowUnix: 102);
+        var strangerRow = store.Get(stranger)!;
+        Assert.Equal(stranger, ReportHostPages.ThreadOwner(strangerRow, store.Around(102, ReportHostPages.DuplicateWindowSeconds)).Id);
+
+        // The answer is stored on the client half; the screenshot half's page renders it and says where it lives.
+        long replyId = store.AddDevReply(client, "Fixed — thanks for the hat.", isQuestion: false, nowUnix: 200);
+        Assert.True(replyId > 0);
+        store.SetFixedInVersion(client, "2026.8.23");
+        Assert.Empty(store.ListReplies(server));
+
+        // Re-resolve after the write — records are snapshots (the routes resolve per request anyway).
+        var owner = ReportHostPages.ThreadOwner(serverRow, store.Around(serverRow.CreatedUnix, ReportHostPages.DuplicateWindowSeconds));
+        string html = ReportHostPages.Detail(serverRow, store.ListReplies(owner.Id), null, owner);
+        Assert.Contains("Fixed — thanks for the hat.", html);
+        Assert.Contains("Fixed in version: <b>2026.8.23</b>", html);
+        Assert.Contains($"/admin/report/{client}'>client row</a>", html);
+        Assert.DoesNotContain("no reply key", html);
+        Assert.DoesNotContain("No replies yet", html);
+        Assert.Contains($"action='/admin/report/{server}/reply'", html); // the route resolves the owner again
+
+        // Opened on its own half nothing changes: no hand-over hint.
+        html = ReportHostPages.Detail(clientRow, store.ListReplies(client), null, owner);
+        Assert.DoesNotContain("conversation lives on the paired", html);
+        Assert.Contains("Fixed — thanks for the hat.", html);
+    }
+
     [Fact]
     public void DetailPage_SaysNoInGameReplyForOldArcadeReports_AndEveryFormCarriesTheCsrfToken()
     {


### PR DESCRIPTION
Closes #1378

After answering Lyxette's 11 reports through the API, opening any of them from the admin list showed **no conversation**: the list links each pair to the `/bump` half (the one with the screenshot), and for reports filed before the reply channel that half carries no reply key (the #1359 repair blanks name-derived keys on server rows on purpose). The answers sat on the client row behind the small `+1` link.

**Fix (ReportHost only)**
- `ReportHostPages.ThreadOwner(row, candidates)` — a key-less row hands over to its paired keyed half, using the existing pairing rule (`IsSameReport`); `ReportStore.Around` supplies the rows within the duplicate window. A keyed row owns itself; an unrelated key-less row stays its own owner.
- Detail page: renders the owner's thread and "fixed in", with a hint naming the row the conversation lives on. The reply form keeps posting to the opened row.
- `POST /admin/report/{id}/reply` and `POST /api/reports/{id}/replies` resolve the owner the same way, so an answer typed on the screenshot row is never stored where no game can read it. The API answer now also carries `reportId` (the row the reply was stored on).
- Test `PairedScreenshotRow_ShowsTheClientHalfsThread_AndReceivesRepliesThere` (production-shaped pair: client row with derived key, server row with blank key + screenshot).

Local: ReportHost test classes 44/44 green, `dotnet format --verify-no-changes` clean. **Needs a ReportHost image redeploy.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
