### PR TITLE
fix(reports): "mark done" and delete cover both rows of a report pair; reply flips mirrored (#1380)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ the richer, screenshot-laden versions live there. `(#123)` references the pull r
 
 ## [Unreleased]
 
+### 📬 Report inbox — "mark done" and delete cover both rows of a report (#1380)
+
+- **Marking a report done or deleting it always left one row behind.** The admin list shows the two rows
+  every in-game F1 report produces (client-direct + the server's `/bump` snapshot) as one report, but the
+  buttons acted on the one row you had opened: the other half stayed `new` — a lone row under the status
+  filter — or survived a delete under its `Bump [world]: …` title. Even without clicking, a follow-up
+  question or a player's answer moved only the keyed half. Status changes and deletes now cover the pair
+  (detail page and `PATCH` / `DELETE /api/reports/{id}` alike — the buttons say "both rows", the API answer
+  lists the `reportIds` changed), the reply-driven flips are mirrored onto the other half, and pairs left
+  triaged apart settle on their most advanced state once at startup. Operators: redeploy the ReportHost image.
+
 ### 📬 Report inbox — the screenshot half of a pair shows the pair's conversation (#1378)
 
 - **Opening a report from the admin list showed an empty conversation** although the developers had answered.

--- a/TODO.md
+++ b/TODO.md
@@ -110,6 +110,18 @@ Per-item detail lives in the dated work log below. **Since 2026-07 versions are 
 #1144, #1146, #1147), all 28 sub-issues #1102–#1129 done. The whole package is UNRELEASED pending the big
 playtest; the post-epic implementation audit spawned the follow-up fix round #1149–#1156.
 
+### ★ Report inbox: "mark done" and delete cover both rows of a report (#1380, 2026-08-30, branch fix/reporthost-pair-actions)
+Marcel: marking a stacked report done or deleting it always left one row behind. Pairing (#1359) is render-time only
+and every action hit the one row id — the admin forms, `PATCH`/`DELETE /api/reports/{id}`, and the reply-driven
+flips (`waiting_for_player`, `player_replied`) that land on the `ThreadOwner` only; `ReportStore.Latest` filters by
+status before grouping, so the untouched half showed as a lone row. New `ReportPairActions` (SetStatus / Delete /
+MirrorStatus) resolves the pair through `ReportStore.Around` + `ReportHostPages.PairOf` and applies the action to
+every member; the detail page says "(both rows)", names the partner and greys a status out only when both halves
+have it; `ReportStore.SyncPairStatuses` settles historical pairs on `BugReportStatus.MostAdvanced` once at startup.
+Tests: `PairActions_StatusDeleteAndReplyFlips_CoverBothHalves_AndLeaveAStrangerAlone`,
+`SyncPairStatuses_SettlesPairsTriagedApart_OnTheMostAdvancedState`, `DetailPage_SaysActionsCoverBothRows_OnlyForAPair`,
+`PairOf_ReturnsTheRowAndItsHalf_NeverAStranger`. ReportHost image redeploy needed; no client change.
+
 ### ★ Report inbox: the screenshot half of a pair shows the pair's conversation (#1378, 2026-08-30, branch fix/reporthost-pair-thread)
 After answering Lyxette's 11 reports through the API, the admin list showed no answer on any of them: it links each
 pair to the `/bump` half (screenshot), whose reply key is blank for pre-8.23 reports (#1359 repair), so its detail

--- a/docs/developer/REPORT_HOST.md
+++ b/docs/developer/REPORT_HOST.md
@@ -24,8 +24,8 @@ game server (crash flush) ──┘    (x-bugreport-key)    + files    └──
 | `GET /api/reports?since=&status=&category=&source=&limit=&cursor=` | header `x-report-read-key` | Delta-sync list: `{ items, nextCursor, hasMore }`, ascending `createdAt` |
 | `GET /api/reports/{id}` | read key | One report (full, incl. parsed `reportJson`) |
 | `GET /api/reports/{id}/screenshot` | read key | The screenshot image |
-| `PATCH /api/reports/{id}` `{"status":"new\|triaged\|waiting_for_player\|player_replied\|done"}` | admin Basic Auth, JSON content type | Triage from scripts/CI |
-| `DELETE /api/reports/{id}` | admin Basic Auth | Permanent delete (incl. screenshot + reply thread) |
+| `PATCH /api/reports/{id}` `{"status":"new\|triaged\|waiting_for_player\|player_replied\|done"}` | admin Basic Auth, JSON content type | Triage from scripts/CI — covers the whole report pair (#1380); the answer lists the rows changed as `reportIds` |
+| `DELETE /api/reports/{id}` | admin Basic Auth | Permanent delete of the report and its paired half (incl. screenshots + reply threads) |
 | `POST /api/reports/{id}/replies` `{"text","question":bool,"fixedInVersion"?}` | admin Basic Auth, JSON content type | Developer answer / follow-up question (#1327) — scriptable twin of the detail-page form |
 | `GET /api/replies?key=&since=&ids=` | header `x-bugreport-key` | **Client poll**: threads of this reply key with unread developer entries, plus `gone` for the remembered `ids` the key can no longer read (CORS on) |
 | `POST /api/replies/ack` `{"key","replyIds":[]}` | header `x-bugreport-key` | Client marks shown developer entries read |
@@ -197,7 +197,14 @@ reports.example.com {
   containing the other, and the **same reporter** — by reply key when both halves carry one, by player
   **name** otherwise. Not by `playerId`: the client row carries the install token, the server row the
   player name, so the two never agree (the original #618 check compared exactly that and never paired a
-  single report in production — #1359).
+  single report in production — #1359). **Operator actions cover the pair** (#1380): a status change or
+  delete on either half — the detail-page buttons, `PATCH` / `DELETE /api/reports/{id}` — applies to both
+  rows (`ReportPairActions`, resolving the pair through `ReportStore.Around` + `ReportHostPages.PairOf`),
+  the reply-driven flips (`waiting_for_player` on a question, `player_replied` on an answer) are mirrored
+  from the keyed half onto the other, and at startup `ReportStore.SyncPairStatuses` settles pairs that
+  were triaged apart before this on their most advanced state. Before, "mark done" on the list's row left
+  the other half `new` (a lone row under the status filter) and a delete left it behind under the server's
+  `Bump [world]: …` title.
 - **`/reportpaint` / `/reportshape` reports** (#938) — any server with a configured sink also forwards
   each in-game paint/shape report to the inbox, shaped like a `/bump` (no `reportJson.kind` → category
   *feedback*, `source: "server"`) with `reportJson.reportType: "paint-report"` / `"shape-report"` and

--- a/src/BlocksBeyondTheStars.ReportHost/ReportHostApp.cs
+++ b/src/BlocksBeyondTheStars.ReportHost/ReportHostApp.cs
@@ -60,6 +60,14 @@ public static class ReportHostApp
             log.LogInformation("Revoked name-derived reply keys on {Count} server-forwarded report(s).", revoked);
         }
 
+        // Pairs triaged apart before actions covered both halves (#1380) settle on their most advanced
+        // state. Idempotent — a no-op once repaired, and every action below keeps pairs in step from here on.
+        int synced = store.SyncPairStatuses(ReportHostPages.GroupDuplicates);
+        if (synced > 0)
+        {
+            log.LogInformation("Aligned the status of {Count} report row(s) with their paired half.", synced);
+        }
+
         log.LogInformation(
             "ReportHost on {Bind}:{Port} — ingest {Ingest}, read API {Read}, admin UI {Admin}, retention {Retention}, pruned {Pruned} at start.",
             config.BindAddress, config.Port,
@@ -403,7 +411,10 @@ public static class ReportHostApp
                 return Results.BadRequest(new { error = "invalid_status" });
             }
 
-            return store.SetStatus(id, status) ? Results.Json(new { ok = true, status }) : Results.NotFound();
+            // The whole pair (#1380) — `reportIds` names every row changed, the addressed one first.
+            return ReportPairActions.SetStatus(store, id, status) is { } reportIds
+                ? Results.Json(new { ok = true, status, reportIds })
+                : Results.NotFound();
         });
 
         app.MapDelete("/api/reports/{id}", (HttpContext ctx, string id) =>
@@ -413,7 +424,7 @@ public static class ReportHostApp
                 return denied;
             }
 
-            return store.Delete(id) ? Results.NoContent() : Results.NotFound();
+            return ReportPairActions.Delete(store, id) != null ? Results.NoContent() : Results.NotFound();
         });
 
         // ---------------- Reply threads (#1327): player pull + answer, operator post ----------------
@@ -537,6 +548,7 @@ public static class ReportHostApp
                     return Results.Json(new { error = "reply_limit" }, statusCode: StatusCodes.Status409Conflict);
             }
 
+            ReportPairActions.MirrorStatus(store, reportId); // player_replied on the screenshot half too (#1380)
             var report = store.Get(reportId);
             log.LogInformation("Player replied on report {Id} (reply {ReplyId}).", reportId, replyId);
             notifier.Post("Player replied",
@@ -598,6 +610,11 @@ public static class ReportHostApp
                 store.SetFixedInVersion(owner.Id, fixedIn);
             }
 
+            if (question)
+            {
+                ReportPairActions.MirrorStatus(store, owner.Id); // waiting_for_player on the screenshot half too (#1380)
+            }
+
             return Results.Json(new { ok = true, replyId, reportId = owner.Id }, statusCode: StatusCodes.Status201Created);
         });
 
@@ -650,7 +667,8 @@ public static class ReportHostApp
             }
 
             var owner = ThreadOwnerOf(record);
-            return Results.Content(ReportHostPages.Detail(record, store.ListReplies(owner.Id), csrf, owner), "text/html; charset=utf-8");
+            var pair = ReportPairActions.PairOf(store, record);
+            return Results.Content(ReportHostPages.Detail(record, store.ListReplies(owner.Id), csrf, owner, pair), "text/html; charset=utf-8");
         });
 
         // The reply form on the detail page: an answer, or a follow-up question (flips the status to
@@ -689,6 +707,11 @@ public static class ReportHostApp
                 store.SetFixedInVersion(owner.Id, fixedIn);
             }
 
+            if (text.Length > 0 && question)
+            {
+                ReportPairActions.MirrorStatus(store, owner.Id); // waiting_for_player on the screenshot half too (#1380)
+            }
+
             return Results.Redirect($"/admin/report/{id}");
         });
 
@@ -720,8 +743,10 @@ public static class ReportHostApp
                 return forged;
             }
 
+            // The whole pair (#1380): the list shows the two rows as one report, so "mark done" must not leave
+            // the other half new.
             string status = form["status"].ToString();
-            if (!BugReportStatus.IsValid(status) || !store.SetStatus(id, status))
+            if (ReportPairActions.SetStatus(store, id, status) == null)
             {
                 return Results.NotFound();
             }
@@ -742,7 +767,7 @@ public static class ReportHostApp
                 return forged;
             }
 
-            store.Delete(id);
+            ReportPairActions.Delete(store, id); // both halves, with screenshots and threads (#1380)
             return Results.Redirect("/admin");
         });
 

--- a/src/BlocksBeyondTheStars.ReportHost/ReportHostPages.cs
+++ b/src/BlocksBeyondTheStars.ReportHost/ReportHostPages.cs
@@ -142,6 +142,29 @@ public static class ReportHostPages
     }
 
     /// <summary>
+    /// Every row of the report pair <paramref name="r"/> belongs to — <paramref name="r"/> first, then each
+    /// candidate the pairing rule (<see cref="GroupDuplicates"/>) accepts. This is what an operator action
+    /// works on (#1380): status changes and deletes apply to the whole pair, because the list shows the pair
+    /// as ONE report and an action on one row would otherwise leave the other half behind as a lone row
+    /// (still <c>new</c>, or surviving a delete under the server's <c>Bump [world]: …</c> title).
+    /// </summary>
+    /// <param name="candidates">Rows stamped within <see cref="DuplicateWindowSeconds"/> of <paramref name="r"/>
+    /// (see <c>ReportStore.Around</c>); <paramref name="r"/> itself may be among them.</param>
+    public static List<BugReportRecord> PairOf(BugReportRecord r, IReadOnlyList<BugReportRecord> candidates)
+    {
+        var pair = new List<BugReportRecord> { r };
+        foreach (var c in candidates)
+        {
+            if (c.Id != r.Id && IsSameReport(r, c))
+            {
+                pair.Add(c);
+            }
+        }
+
+        return pair;
+    }
+
+    /// <summary>
     /// Collapses the two database rows that one in-game F1 report produces into a single group.
     /// <para>
     /// Pressing F1 fires two independent uploads by design (see the ReportHost docs): the client posts to
@@ -280,10 +303,13 @@ public static class ReportHostPages
 
     /// <param name="threadOwner">The half of the pair that owns the conversation (<see cref="ThreadOwner"/>);
     /// <paramref name="replies"/> are ITS replies. Null or <paramref name="r"/> itself = the row owns its thread.</param>
-    public static string Detail(BugReportRecord r, IReadOnlyList<ReplyRecord>? replies = null, AdminCsrf? csrf = null, BugReportRecord? threadOwner = null)
+    /// <param name="pair">The rows the status buttons and delete act on (<see cref="PairOf"/>, #1380) — the
+    /// page says so when there is more than one. Null = <paramref name="r"/> alone.</param>
+    public static string Detail(BugReportRecord r, IReadOnlyList<ReplyRecord>? replies = null, AdminCsrf? csrf = null, BugReportRecord? threadOwner = null, IReadOnlyList<BugReportRecord>? pair = null)
     {
         replies ??= Array.Empty<ReplyRecord>();
         threadOwner ??= r;
+        var partners = pair?.Where(p => p.Id != r.Id).ToList() ?? new List<BugReportRecord>();
         string csrfField = csrf?.HiddenField() ?? string.Empty;
         var sb = new StringBuilder();
         string when = DateTimeOffset.FromUnixTimeSeconds(r.CreatedUnix).ToString("yyyy-MM-dd HH:mm:ss");
@@ -301,6 +327,17 @@ public static class ReportHostPages
         AppendRow(sb, "Session", r.SessionId);
         AppendRow(sb, "Client time", r.ClientTimestamp);
         AppendRow(sb, "Report id", r.Id);
+        if (partners.Count > 0)
+        {
+            // The other half of the pair (#1380): the list shows the two as one report, and the buttons below
+            // act on both — name the partner so the operator can see what "both rows" means.
+            sb.Append("<tr><th>Paired row</th><td>");
+            sb.Append(string.Join(" · ", partners.Select(p =>
+                $"<a href='/admin/report/{p.Id}'>{(p.Source.Length > 0 ? E(p.Source) : "client")} row</a> " +
+                $"<span class='sub'>({E(p.Status)}{(p.ScreenshotFile.Length > 0 ? ", 📷" : "")})</span>")));
+            sb.Append("</td></tr>");
+        }
+
         sb.Append("</table></div>");
 
         if (r.ScreenshotFile.Length > 0)
@@ -370,13 +407,18 @@ public static class ReportHostPages
         sb.Append($"<label>fixed in version <input type='text' name='fixed_in_version' value='{E(threadOwner.FixedInVersion)}' placeholder='e.g. 2026.8.23' size='14'></label>");
         sb.Append("<button>send to player</button></form></div>");
 
+        // Status and delete act on the whole pair (#1380) — the buttons say so, and a status the partner
+        // already has still counts as "not yet set" when this row lacks it.
+        string bothRows = partners.Count > 0 ? " (both rows)" : string.Empty;
+        string confirmText = partners.Count > 0 ? "Delete this report and its paired row permanently?" : "Delete this report permanently?";
         sb.Append("<div class='card actions'>");
         foreach (var s in BugReportStatus.All)
         {
-            sb.Append($"<form method='post' action='/admin/report/{r.Id}/status'>{csrfField}<input type='hidden' name='status' value='{s}'><button{(s == r.Status ? " disabled" : "")}>mark {s}</button></form>");
+            bool already = s == r.Status && partners.All(p => p.Status == s);
+            sb.Append($"<form method='post' action='/admin/report/{r.Id}/status'>{csrfField}<input type='hidden' name='status' value='{s}'><button{(already ? " disabled" : "")}>mark {s}{bothRows}</button></form>");
         }
 
-        sb.Append($"<form method='post' action='/admin/report/{r.Id}/delete' onsubmit=\"return confirm('Delete this report permanently?')\">{csrfField}<button class='danger'>delete</button></form>");
+        sb.Append($"<form method='post' action='/admin/report/{r.Id}/delete' onsubmit=\"return confirm('{confirmText}')\">{csrfField}<button class='danger'>delete{bothRows}</button></form>");
         sb.Append("</div>");
 
         return Shell($"Report {r.Id[..8]} — Blocks Beyond the Stars", sb.ToString());

--- a/src/BlocksBeyondTheStars.ReportHost/ReportPairActions.cs
+++ b/src/BlocksBeyondTheStars.ReportHost/ReportPairActions.cs
@@ -1,0 +1,87 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+namespace BlocksBeyondTheStars.ReportHost;
+
+/// <summary>
+/// Operator actions that must cover the whole report pair (#1380). One in-game F1 report is two rows
+/// (client-direct + the server's /bump forward) that the admin list shows as ONE report; the rows stay
+/// separate records, so a status change or delete addressed to one id used to leave the other half behind —
+/// still <c>new</c> under the status filter, or surviving a delete as a lone row. Every route that mutates a
+/// report goes through here: the pair is resolved the way the list pairs (<see cref="ReportHostPages.PairOf"/>
+/// over <see cref="ReportStore.Around"/>) and the action applied to each member.
+/// </summary>
+public static class ReportPairActions
+{
+    /// <summary>The rows an action on <paramref name="r"/> covers — <paramref name="r"/> first.</summary>
+    public static List<BugReportRecord> PairOf(ReportStore store, BugReportRecord r)
+        => ReportHostPages.PairOf(r, store.Around(r.CreatedUnix, ReportHostPages.DuplicateWindowSeconds));
+
+    /// <summary>Sets <paramref name="status"/> on the report <paramref name="id"/> and its paired half. Returns
+    /// the ids changed (the addressed one first), or null when <paramref name="id"/> is unknown or the status
+    /// invalid.</summary>
+    public static List<string>? SetStatus(ReportStore store, string id, string status)
+    {
+        if (!BugReportStatus.IsValid(status) || store.Get(id) is not { } record)
+        {
+            return null;
+        }
+
+        var ids = new List<string>();
+        foreach (var member in PairOf(store, record))
+        {
+            if (store.SetStatus(member.Id, status))
+            {
+                ids.Add(member.Id);
+            }
+        }
+
+        return ids;
+    }
+
+    /// <summary>Deletes the report <paramref name="id"/> and its paired half — rows, screenshot files and reply
+    /// threads. Returns the ids removed (the addressed one first), or null when <paramref name="id"/> is unknown.</summary>
+    public static List<string>? Delete(ReportStore store, string id)
+    {
+        if (store.Get(id) is not { } record)
+        {
+            return null;
+        }
+
+        var ids = new List<string>();
+        foreach (var member in PairOf(store, record))
+        {
+            if (store.Delete(member.Id))
+            {
+                ids.Add(member.Id);
+            }
+        }
+
+        return ids;
+    }
+
+    /// <summary>
+    /// Copies the status of <paramref name="ownerId"/> onto its paired half. Called after a reply moved the
+    /// thread owner's status on its own — a developer question (<c>waiting_for_player</c>) or the player's
+    /// answer (<c>player_replied</c>) is recorded on the keyed half only (<see cref="ReportHostPages.ThreadOwner"/>),
+    /// and without this the screenshot half would stay <c>new</c> forever. Returns how many rows changed.
+    /// </summary>
+    public static int MirrorStatus(ReportStore store, string ownerId)
+    {
+        if (store.Get(ownerId) is not { } owner)
+        {
+            return 0;
+        }
+
+        int changed = 0;
+        foreach (var member in PairOf(store, owner))
+        {
+            if (member.Id != owner.Id && member.Status != owner.Status && store.SetStatus(member.Id, owner.Status))
+            {
+                changed++;
+            }
+        }
+
+        return changed;
+    }
+}

--- a/src/BlocksBeyondTheStars.ReportHost/ReportStore.cs
+++ b/src/BlocksBeyondTheStars.ReportHost/ReportStore.cs
@@ -64,10 +64,30 @@ public static class BugReportStatus
     public const string PlayerReplied = "player_replied";
     public const string Done = "done";
 
-    /// <summary>Every state, in the order the admin UI lists them.</summary>
+    /// <summary>Every state, in the order the admin UI lists them — which is also how far along the triage a
+    /// state is (<see cref="MostAdvanced"/>).</summary>
     public static readonly string[] All = { New, Triaged, WaitingForPlayer, PlayerReplied, Done };
 
     public static bool IsValid(string status) => status is New or Triaged or WaitingForPlayer or PlayerReplied or Done;
+
+    /// <summary>The state furthest along the triage among <paramref name="statuses"/> (order of <see cref="All"/>;
+    /// an unknown value ranks lowest). What a report pair left with differing halves settles on (#1380).</summary>
+    public static string MostAdvanced(IEnumerable<string> statuses)
+    {
+        string best = New;
+        int bestRank = -1;
+        foreach (string s in statuses)
+        {
+            int rank = Array.IndexOf(All, s);
+            if (rank > bestRank)
+            {
+                best = s;
+                bestRank = rank;
+            }
+        }
+
+        return best;
+    }
 }
 
 /// <summary>
@@ -266,6 +286,46 @@ public sealed class ReportStore : IDisposable
             }
 
             return derived.Count;
+        }
+    }
+
+    /// <summary>One-time repair for report pairs triaged apart (#1380): before status changes covered the whole
+    /// pair, "mark done" on the list's row left the other half <c>new</c>, and a developer question moved only
+    /// the keyed half. Every pair <paramref name="group"/> forms (the admin list's rule, passed in so the store
+    /// does not own it) settles on its most advanced state. Idempotent; returns how many rows changed. Called
+    /// at startup after <see cref="RevokeNameDerivedServerKeys"/>.</summary>
+    public int SyncPairStatuses(Func<IReadOnlyList<BugReportRecord>, List<List<BugReportRecord>>> group)
+    {
+        lock (_gate)
+        {
+            var rows = new List<BugReportRecord>();
+            using (var select = _db.CreateCommand())
+            {
+                select.CommandText = "SELECT * FROM bugreport ORDER BY created_unix, id;";
+                using var reader = select.ExecuteReader();
+                while (reader.Read())
+                {
+                    rows.Add(ReadRecord(reader));
+                }
+            }
+
+            int changed = 0;
+            foreach (var pair in group(rows))
+            {
+                if (pair.Count < 2)
+                {
+                    continue;
+                }
+
+                string target = BugReportStatus.MostAdvanced(pair.Select(r => r.Status));
+                foreach (var lagging in pair.Where(r => r.Status != target))
+                {
+                    SetStatusLocked(lagging.Id, target);
+                    changed++;
+                }
+            }
+
+            return changed;
         }
     }
 

--- a/tests/BlocksBeyondTheStars.Tests/ReportDuplicateGroupingTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/ReportDuplicateGroupingTests.cs
@@ -78,6 +78,33 @@ public sealed class ReportDuplicateGroupingTests
         Assert.Equal(2, groups[0].Count);
     }
 
+    /// <summary>#1380: the rows an operator action covers — the addressed row first, then its paired half; an
+    /// unrelated report inside the same window is never part of it.</summary>
+    [Fact]
+    public void PairOf_ReturnsTheRowAndItsHalf_NeverAStranger()
+    {
+        var client = Row("client1", "Treppen Winkel", "Ich will das Treppen in verschiedenen Winkeln platzierbar sind.", 1000);
+        var server = Row("server1", "Bump [Minecraft]: [feedback] Treppen Winkel — Ich will das Treppen in ver",
+            "[feedback] Treppen Winkel — Ich will das Treppen in verschiedenen Winkeln platzierbar sind.",
+            1001, source: "server", screenshot: "bump_1.jpg");
+        var stranger = Row("server2", "Bump [w]: [feedback] Lampe — geht aus.", "[feedback] Lampe — geht aus.", 1002, source: "server", playerName: "Justus");
+        var window = new[] { client, server, stranger };
+
+        var pair = ReportHostPages.PairOf(server, window);
+        Assert.Equal(2, pair.Count);
+        Assert.Equal("server1", pair[0].Id);
+        Assert.Equal("client1", pair[1].Id);
+
+        pair = ReportHostPages.PairOf(client, window);
+        Assert.Equal(2, pair.Count);
+        Assert.Equal("client1", pair[0].Id);
+        Assert.Equal("server1", pair[1].Id);
+
+        pair = ReportHostPages.PairOf(stranger, window);
+        Assert.Single(pair);
+        Assert.Equal("server2", pair[0].Id);
+    }
+
     /// <summary>A #1359 client passes its reply key through /bump, so both halves carry the same key — the
     /// exact identity, which wins over the name (here the player renamed between the two uploads).</summary>
     [Fact]

--- a/tests/BlocksBeyondTheStars.Tests/ReportHostTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/ReportHostTests.cs
@@ -791,6 +791,104 @@ public sealed class ReportHostTests : IDisposable
         Assert.NotEqual(new AdminCsrf().Token, new AdminCsrf().Token);
     }
 
+    /// <summary>#1380: the list shows the two rows of an F1 report as ONE report, so "mark done", delete and the
+    /// reply-driven status flips must cover both halves — before, the other row stayed <c>new</c> under the
+    /// status filter or survived a delete as a lone row. An unrelated report in the same window is untouched.</summary>
+    [Fact]
+    public void PairActions_StatusDeleteAndReplyFlips_CoverBothHalves_AndLeaveAStrangerAlone()
+    {
+        var store = NewStore();
+        string client = store.Add(ReportIngest.Parse(PayloadFor("token-abc", "WindowsPlayer"), new ReportHostConfig(), out _)!, nowUnix: 100);
+        string server = store.Add(ReportIngest.Parse(ServerForwardPayloadFor("Justus"), new ReportHostConfig(), out _)!, nowUnix: 101);
+        string stranger = store.Add(ReportIngest.Parse(ServerForwardPayloadFor("Pilot"), new ReportHostConfig(), out _)!, nowUnix: 102);
+
+        // The pair resolves from either half (the addressed row first); the stranger is a pair of one.
+        Assert.Equal(new[] { server, client }, ReportPairActions.PairOf(store, store.Get(server)!).Select(r => r.Id));
+        Assert.Equal(new[] { client, server }, ReportPairActions.PairOf(store, store.Get(client)!).Select(r => r.Id));
+        Assert.Equal(new[] { stranger }, ReportPairActions.PairOf(store, store.Get(stranger)!).Select(r => r.Id));
+
+        // "mark done" on the screenshot half — the row the list links — sets both; the stranger stays new.
+        Assert.Equal(new[] { server, client }, ReportPairActions.SetStatus(store, server, BugReportStatus.Done));
+        Assert.Equal(BugReportStatus.Done, store.Get(client)!.Status);
+        Assert.Equal(BugReportStatus.Done, store.Get(server)!.Status);
+        Assert.Equal(BugReportStatus.New, store.Get(stranger)!.Status);
+        Assert.Null(ReportPairActions.SetStatus(store, "no-such-id", BugReportStatus.Done));
+        Assert.Null(ReportPairActions.SetStatus(store, server, "bogus"));
+
+        // A developer question flips the thread owner (the keyed client half) on its own; the mirror carries
+        // it over to the screenshot half, and is a no-op once the two agree.
+        Assert.True(store.AddDevReply(client, "Which world was that?", isQuestion: true, nowUnix: 200) > 0);
+        Assert.Equal(BugReportStatus.WaitingForPlayer, store.Get(client)!.Status);
+        Assert.Equal(BugReportStatus.Done, store.Get(server)!.Status);
+        Assert.Equal(1, ReportPairActions.MirrorStatus(store, client));
+        Assert.Equal(BugReportStatus.WaitingForPlayer, store.Get(server)!.Status);
+        Assert.Equal(0, ReportPairActions.MirrorStatus(store, client));
+        Assert.Equal(0, ReportPairActions.MirrorStatus(store, "no-such-id"));
+
+        // Delete from the client half: both rows and the thread are gone, the stranger survives.
+        Assert.Equal(new[] { client, server }, ReportPairActions.Delete(store, client));
+        Assert.Null(store.Get(client));
+        Assert.Null(store.Get(server));
+        Assert.Empty(store.ListReplies(client));
+        Assert.NotNull(store.Get(stranger));
+        Assert.Null(ReportPairActions.Delete(store, client));
+    }
+
+    /// <summary>#1380: pairs triaged apart before actions covered both halves settle on the most advanced state
+    /// once, at startup — idempotent, and a lone row is never touched.</summary>
+    [Fact]
+    public void SyncPairStatuses_SettlesPairsTriagedApart_OnTheMostAdvancedState()
+    {
+        var store = NewStore();
+        string client = store.Add(ReportIngest.Parse(PayloadFor("token-abc", "WindowsPlayer"), new ReportHostConfig(), out _)!, nowUnix: 100);
+        string server = store.Add(ReportIngest.Parse(ServerForwardPayloadFor("Justus"), new ReportHostConfig(), out _)!, nowUnix: 101);
+        string stranger = store.Add(ReportIngest.Parse(ServerForwardPayloadFor("Pilot"), new ReportHostConfig(), out _)!, nowUnix: 102);
+
+        // The shape the old admin UI left behind: done on the list's row, new on the other.
+        Assert.True(store.SetStatus(server, BugReportStatus.Done));
+        Assert.Equal(1, store.SyncPairStatuses(ReportHostPages.GroupDuplicates));
+        Assert.Equal(BugReportStatus.Done, store.Get(client)!.Status);
+        Assert.Equal(BugReportStatus.Done, store.Get(server)!.Status);
+        Assert.Equal(BugReportStatus.New, store.Get(stranger)!.Status);
+        Assert.Equal(0, store.SyncPairStatuses(ReportHostPages.GroupDuplicates));
+
+        // The ranking is the admin UI's order; unknown values never win.
+        Assert.Equal(BugReportStatus.PlayerReplied, BugReportStatus.MostAdvanced(new[] { BugReportStatus.Triaged, BugReportStatus.PlayerReplied, BugReportStatus.WaitingForPlayer }));
+        Assert.Equal(BugReportStatus.Done, BugReportStatus.MostAdvanced(new[] { BugReportStatus.Done, "bogus", BugReportStatus.New }));
+        Assert.Equal(BugReportStatus.New, BugReportStatus.MostAdvanced(Array.Empty<string>()));
+    }
+
+    /// <summary>#1380: the detail page says when the buttons act on both rows, names the partner, and greys a
+    /// status out only while BOTH halves already have it. A row on its own keeps the old wording.</summary>
+    [Fact]
+    public void DetailPage_SaysActionsCoverBothRows_OnlyForAPair()
+    {
+        var store = NewStore();
+        string client = store.Add(ReportIngest.Parse(PayloadFor("token-abc", "WindowsPlayer"), new ReportHostConfig(), out _)!, nowUnix: 100);
+        string server = store.Add(ReportIngest.Parse(ServerForwardPayloadFor("Justus"), new ReportHostConfig(), out _)!, nowUnix: 101);
+        var serverRow = store.Get(server)!;
+
+        string html = ReportHostPages.Detail(serverRow, pair: ReportPairActions.PairOf(store, serverRow));
+        Assert.Contains("mark done (both rows)", html);
+        Assert.Contains(">delete (both rows)<", html);
+        Assert.Contains("Delete this report and its paired row permanently?", html);
+        Assert.Contains($"<th>Paired row</th><td><a href='/admin/report/{client}'>client row</a>", html);
+        Assert.Contains("value='new'><button disabled>mark new (both rows)", html);
+
+        // Triage the partner alone (the pre-#1380 shape): "mark new" is live again, because it would still change a row.
+        Assert.True(store.SetStatus(client, BugReportStatus.Triaged));
+        html = ReportHostPages.Detail(serverRow, pair: ReportPairActions.PairOf(store, serverRow));
+        Assert.Contains("value='new'><button>mark new (both rows)", html);
+
+        string stranger = store.Add(ReportIngest.Parse(ServerForwardPayloadFor("Pilot"), new ReportHostConfig(), out _)!, nowUnix: 102);
+        var strangerRow = store.Get(stranger)!;
+        html = ReportHostPages.Detail(strangerRow, pair: ReportPairActions.PairOf(store, strangerRow));
+        Assert.DoesNotContain("both rows", html);
+        Assert.DoesNotContain("Paired row", html);
+        Assert.Contains("Delete this report permanently?", html);
+        Assert.Contains("value='new'><button disabled>mark new</button>", html);
+    }
+
     public void Dispose()
     {
         foreach (var store in _stores)


### PR DESCRIPTION
## Problem
The admin list shows the two rows of an in-game F1 report (client-direct + the server's `/bump` snapshot, paired since #1359) as one report, but every action hit the one row id you had opened: the other half stayed `new` — a lone row under the status filter — or survived a delete under its `Bump [world]: …` title. Even without clicking, a developer question or a player's answer moved only the `ThreadOwner` (the keyed client half).

## Fix (ReportHost only, no client change)
- **`ReportPairActions`** (new): `SetStatus` / `Delete` / `MirrorStatus` resolve the pair through `ReportStore.Around` + `ReportHostPages.PairOf` (the list's own pairing rule) and apply the action to every member.
- Admin forms and `PATCH` / `DELETE /api/reports/{id}` go through it; the API answer lists the `reportIds` changed. The reply routes mirror `waiting_for_player` / `player_replied` onto the other half.
- Detail page: buttons say "(both rows)", the meta card names the paired row, a status is greyed out only while both halves already have it, the delete confirm names the pair.
- `ReportStore.SyncPairStatuses` + `BugReportStatus.MostAdvanced`: pairs triaged apart before this settle on their most advanced state once at startup (idempotent, logged).

## Tests
`PairActions_StatusDeleteAndReplyFlips_CoverBothHalves_AndLeaveAStrangerAlone`, `SyncPairStatuses_SettlesPairsTriagedApart_OnTheMostAdvancedState`, `DetailPage_SaysActionsCoverBothRows_OnlyForAPair`, `PairOf_ReturnsTheRowAndItsHalf_NeverAStranger` — ReportHost test classes 48/48 green locally, `dotnet format --verify-no-changes` clean.

## After merge
Redeploy the ReportHost image (`reports-image.yml`). The startup sync aligns the pairs Marcel already triaged apart.

Closes #1380

🤖 Generated with [Claude Code](https://claude.com/claude-code)