### PR TITLE
fix(client): build editors — palette rows, scrollbar, typing guard, orphaned menu planet, wheel zoom, visible grid (#1386 #1387 #1388 #1389 #1390 #1391)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -110,6 +110,24 @@ Per-item detail lives in the dated work log below. **Since 2026-07 versions are 
 #1144, #1146, #1147), all 28 sub-issues #1102–#1129 done. The whole package is UNRELEASED pending the big
 playtest; the post-epic implementation audit spawned the follow-up fix round #1149–#1156.
 
+### ★ Build editors: palette rows, scrollbar, typing guard, orphaned menu planet, wheel zoom, visible grid (#1386–#1391, 2026-08-30, branch fix/editor-ux)
+Marcel's settlement-editor screenshot: "no scrollbar or search on the left, a weird orb in the background, can't
+zoom, can't see the grid". Six causes, all in the shared editor bricks so ship/station/settlement got them at once.
+**Rows (#1386)**: `PaletteListUi` rows only set a `LayoutElement`, but `UiKit.ScrollList`'s layout group has
+`childControlHeight=false` → every row was the RectTransform default of 100 units tall (8 entries visible, three
+quarters empty) — rows/headers now set `sizeDelta`. **Scrollbar (#1387)**: `ScrollList` attaches
+`AddInlineScrollbar` itself (every list built with it — BeamPad, StoryReader, ContentEditor, trade — gets the
+auto-hide indicator; the trade dialog's own call removed). **Typing (#1388)**: both editors read WASD/Q/E/R
+regardless of a focused field — guarded by `UiKit.TextFieldFocused()`. **Orb (#1389)**:
+`MenuBackground.MakeSphere` was the one backdrop builder without `SetParent`, so the menu planet + moon
+survived `DestroyMenuBackground` and rose out of every editor's floor (and leaked per visit). **Zoom (#1390)**:
+new `EditorSceneKit.WheelDolly` (wheel = dolly along the view, Shift ×3, not over a panel), `Frame` for the
+opening view + the `F` key (30° down, whole build in view). **Grid (#1391)**: the 258 sub-pixel cube lines are
+replaced by one floor material with a mipmapped procedural grid texture (minor line per cell, major every 8) via
+`EditorSceneKit.BuildFloor`; the placement ghost moved into the shared `EditorPlacementGhost`, so the
+station/settlement editor finally shows where a click lands. Hint line (en/de) names wheel + F. No .NET tests
+(pure Unity); verified by local Unity build + in-game check.
+
 ### ★ Report inbox: "mark done" and delete cover both rows of a report (#1380, 2026-08-30, branch fix/reporthost-pair-actions)
 Marcel: marking a stacked report done or deleting it always left one row behind. Pairing (#1359) is render-time only
 and every action hit the one row id — the admin forms, `PATCH`/`DELETE /api/reports/{id}`, and the reply-driven

--- a/client/Assets/BlocksBeyondTheStars/Scripts/EditorPaletteKit.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/EditorPaletteKit.cs
@@ -218,12 +218,22 @@ namespace BlocksBeyondTheStars.Client
             }
         }
 
+        /// <summary>Row height under <see cref="UiKit.ScrollList"/>: its layout group has
+        /// <c>childControlHeight = false</c>, so it lays rows out by their OWN rect height and ignores a
+        /// LayoutElement — without an explicit sizeDelta every row was the RectTransform default of
+        /// 100 units tall, three-quarters empty (#1386).</summary>
+        private static void SetRowHeight(GameObject row, float height)
+        {
+            ((RectTransform)row.transform).sizeDelta = new Vector2(0f, height);
+            var le = row.AddComponent<LayoutElement>();
+            le.minHeight = le.preferredHeight = height;
+        }
+
         private void AddHeader(string title)
         {
             var row = new GameObject("Header", typeof(RectTransform));
             row.transform.SetParent(_parent, false);
-            var le = row.AddComponent<LayoutElement>();
-            le.minHeight = le.preferredHeight = 26f;
+            SetRowHeight(row, 26f);
             UiKit.AddText(row.transform, 6f, 4f, 250f, 22f, title, 13, UiKit.CyanDim, TextAnchor.LowerLeft, FontStyle.Bold);
         }
 
@@ -232,8 +242,7 @@ namespace BlocksBeyondTheStars.Client
             var e = _entries[entryIndex];
             var row = new GameObject("Row", typeof(RectTransform));
             row.transform.SetParent(_parent, false);
-            var le = row.AddComponent<LayoutElement>();
-            le.minHeight = le.preferredHeight = 36f;
+            SetRowHeight(row, 36f);
 
             var img = row.AddComponent<Image>();
             img.sprite = UiKit.ButtonSprite;

--- a/client/Assets/BlocksBeyondTheStars/Scripts/EditorSceneKit.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/EditorSceneKit.cs
@@ -1,0 +1,217 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using System.Collections.Generic;
+using BlocksBeyondTheStars.Shared.Geometry;
+using UnityEngine;
+
+namespace BlocksBeyondTheStars.Client
+{
+    /// <summary>
+    /// The shared 3D scene pieces of the standalone build editors (<see cref="ShipEditor"/>,
+    /// <see cref="StructureEditor"/>): the build floor with its grid, the fill light, the mouse-wheel
+    /// dolly + "frame the build" camera helpers. Keeping them here means both editors look and steer
+    /// the same, and a grid/camera tweak lands in both at once (#1390 #1391).
+    /// </summary>
+    internal static class EditorSceneKit
+    {
+        /// <summary>Cells per grid-texture tile: a brighter MAJOR line every this many cells.</summary>
+        private const int MajorEvery = 8;
+
+        /// <summary>Pixels per cell inside the tile — enough for a crisp 2-px line that mip-filters to a
+        /// soft but still visible line at distance (the old 0.03-unit cube lines fell below one pixel and
+        /// aliased away, #1391).</summary>
+        private const int PxPerCell = 32;
+
+        private static Texture2D _gridTex;
+
+        /// <summary>The build floor: a <paramref name="w"/>×<paramref name="l"/> slab whose top sits at
+        /// y = 0 (the raycast target for floor placements) carrying the procedural grid — a minor line
+        /// on every cell edge and a major line every <see cref="MajorEvery"/> cells, tiled so the lines
+        /// land exactly on the integer cell boundaries.</summary>
+        public static GameObject BuildFloor(Transform parent, int w, int l)
+        {
+            var floor = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            floor.name = "BuildFloor";
+            floor.transform.position = new Vector3(w / 2f, -0.5f, l / 2f);
+            floor.transform.localScale = new Vector3(w, 1f, l);
+            floor.transform.SetParent(parent, false);
+
+            var shader = Shader.Find("BlocksBeyondTheStars/LitColor") ?? Shader.Find("Unlit/Texture");
+            var mat = new Material(shader)
+            {
+                color = ShaderColor.Srgb(Color.white),
+                mainTexture = GridTexture(),
+                mainTextureScale = new Vector2(w / (float)MajorEvery, l / (float)MajorEvery),
+            };
+            floor.GetComponent<Renderer>().sharedMaterial = mat;
+            return floor;
+        }
+
+        /// <summary>The directional fill light that makes the lit cells read in 3D.</summary>
+        public static Light BuildSun(Transform parent)
+        {
+            var lightGo = new GameObject("EditorSun");
+            lightGo.transform.SetParent(parent, false);
+            var sun = lightGo.AddComponent<Light>();
+            sun.type = LightType.Directional;
+            sun.transform.rotation = Quaternion.Euler(45f, 35f, 0f);
+            sun.intensity = 1f;
+            return sun;
+        }
+
+        /// <summary>One <see cref="MajorEvery"/>-cell tile of the floor grid, built once and shared:
+        /// dark floor, a 2-px minor line on every cell edge, a 3-px brighter major line on the tile
+        /// edge. Mipmapped + trilinear + anisotropic so the lines stay visible at a grazing angle.</summary>
+        private static Texture2D GridTexture()
+        {
+            if (_gridTex != null)
+            {
+                return _gridTex;
+            }
+
+            const int size = MajorEvery * PxPerCell;
+            var floorCol = new Color(0.10f, 0.13f, 0.18f);
+            var minorCol = new Color(0.26f, 0.44f, 0.58f);
+            var majorCol = new Color(0.45f, 0.78f, 1.00f);
+
+            var tex = new Texture2D(size, size, TextureFormat.RGBA32, true)
+            {
+                name = "EditorGrid",
+                filterMode = FilterMode.Trilinear,
+                anisoLevel = 8,
+                wrapMode = TextureWrapMode.Repeat,
+            };
+            var px = new Color[size * size];
+            for (int y = 0; y < size; y++)
+            {
+                for (int x = 0; x < size; x++)
+                {
+                    bool major = x < 3 || y < 3;
+                    bool minor = x % PxPerCell < 2 || y % PxPerCell < 2;
+                    px[y * size + x] = major ? majorCol : minor ? minorCol : floorCol;
+                }
+            }
+
+            tex.SetPixels(px);
+            tex.Apply(true);
+            _gridTex = tex;
+            return tex;
+        }
+
+        /// <summary>Units the camera moves per wheel notch (Shift triples it).</summary>
+        private const float DollyPerNotch = 3f;
+
+        /// <summary>Mouse-wheel zoom: dollies the camera along its view direction (#1390). A fly-through
+        /// editor has no orbit pivot to zoom about, so moving the eye is the honest "zoom".</summary>
+        public static void WheelDolly(Transform cam, bool fast)
+        {
+            float notches = Input.mouseScrollDelta.y;
+            if (Mathf.Abs(notches) < 0.01f)
+            {
+                return;
+            }
+
+            cam.position += cam.forward * (notches * DollyPerNotch * (fast ? 3f : 1f));
+        }
+
+        /// <summary>Points the camera at the build (or, with nothing placed, at a starter patch in the
+        /// middle of the floor) from a comfortable three-quarter view: pitch 30° down, yaw kept, far
+        /// enough back that the whole bounds fit. Used for the opening view and the F hotkey (#1390).</summary>
+        public static void Frame(Transform cam, ref float pitch, float yaw, IReadOnlyCollection<Vector3i> cells, int w, int l)
+        {
+            var b = cells.Count == 0
+                ? new Bounds(new Vector3(w / 2f, 0f, l / 2f), new Vector3(16f, 0f, 16f))
+                : CellBounds(cells);
+
+            pitch = 30f;
+            var rot = Quaternion.Euler(pitch, yaw, 0f);
+            float dist = Mathf.Max(10f, b.extents.magnitude * 2.2f);
+            cam.rotation = rot;
+            cam.position = b.center - rot * Vector3.forward * dist;
+        }
+
+        private static Bounds CellBounds(IEnumerable<Vector3i> cells)
+        {
+            var b = new Bounds();
+            bool first = true;
+            foreach (var c in cells)
+            {
+                var p = new Vector3(c.X + 0.5f, c.Y + 0.5f, c.Z + 0.5f);
+                if (first)
+                {
+                    b = new Bounds(p, Vector3.one);
+                    first = false;
+                }
+                else
+                {
+                    b.Encapsulate(new Bounds(p, Vector3.one));
+                }
+            }
+
+            return b;
+        }
+    }
+
+    /// <summary>
+    /// The placement ghost of the build editors: a softly pulsing translucent cube at the cell a click
+    /// would fill — green when the placement is valid, red when the cell is occupied or out of bounds.
+    /// The ship editor had one, the station/settlement editor did not (#1391).
+    /// </summary>
+    internal sealed class EditorPlacementGhost
+    {
+        private readonly GameObject _go;
+        private readonly Renderer _renderer;
+        private readonly Material _valid, _invalid;
+
+        public EditorPlacementGhost(Transform parent)
+        {
+            _go = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            _go.name = "PlacementGhost";
+            Object.Destroy(_go.GetComponent<Collider>()); // must never block the picking ray
+            _go.transform.SetParent(parent, false);
+            _renderer = _go.GetComponent<Renderer>();
+
+            var shader = Shader.Find("BlocksBeyondTheStars/Cloud") ?? Shader.Find("Unlit/Transparent");
+            _valid = new Material(shader) { renderQueue = 3000 };
+            _valid.SetColor("_Color", ShaderColor.Srgb(new Color(0.30f, 1f, 0.60f, 0.30f)));
+            _invalid = new Material(shader) { renderQueue = 3000 };
+            _invalid.SetColor("_Color", ShaderColor.Srgb(new Color(1f, 0.25f, 0.20f, 0.30f)));
+            _go.SetActive(false);
+        }
+
+        /// <summary>Shows the ghost at <paramref name="cell"/> (or hides it when <paramref name="show"/> is false).</summary>
+        public void Update(bool show, Vector3i cell, bool valid)
+        {
+            if (_go == null)
+            {
+                return;
+            }
+
+            if (_go.activeSelf != show)
+            {
+                _go.SetActive(show);
+            }
+
+            if (!show)
+            {
+                return;
+            }
+
+            _go.transform.position = new Vector3(cell.X + 0.5f, cell.Y + 0.5f, cell.Z + 0.5f);
+            _go.transform.localScale = Vector3.one * (1.0f + 0.04f * Mathf.Sin(Time.unscaledTime * 5f));
+            _renderer.sharedMaterial = valid ? _valid : _invalid;
+        }
+
+        public void Dispose()
+        {
+            if (_go != null)
+            {
+                Object.Destroy(_go);
+            }
+
+            Object.Destroy(_valid);
+            Object.Destroy(_invalid);
+        }
+    }
+}

--- a/client/Assets/BlocksBeyondTheStars/Scripts/EditorSceneKit.cs.meta
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/EditorSceneKit.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c54aacab30eb5d3499a723188c4f6a34

--- a/client/Assets/BlocksBeyondTheStars/Scripts/MenuBackground.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/MenuBackground.cs
@@ -588,11 +588,16 @@ namespace BlocksBeyondTheStars.Client
             return tex;
         }
 
-        private static GameObject MakeSphere(string name, Vector3 pos, float scale, Material mat)
+        /// <summary>A sphere body parented under this backdrop — like every other backdrop object, so
+        /// destroying/parking the backdrop takes it along. The planet + moon used to be created at the
+        /// scene root and outlived <c>DestroyMenuBackground</c>: every editor showed a huge blue planet
+        /// rising out of its build floor, and each visit leaked another pair (#1389).</summary>
+        private GameObject MakeSphere(string name, Vector3 pos, float scale, Material mat)
         {
             var go = GameObject.CreatePrimitive(PrimitiveType.Sphere);
             go.name = name;
             StripCollider(go);
+            go.transform.SetParent(transform, false);
             go.transform.localPosition = pos;
             go.transform.localScale = Vector3.one * scale;
             go.GetComponent<Renderer>().sharedMaterial = mat;

--- a/client/Assets/BlocksBeyondTheStars/Scripts/PlayerInteractions.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/PlayerInteractions.cs
@@ -356,8 +356,7 @@ namespace BlocksBeyondTheStars.Client
 
             // Left column: my inventory as icon cards, each with the −/n/+ offer control.
             UiKit.AddText(panel, ColLeftX, 100f, ColLeftW, 24f, loc.Get("ui.trade.inventory"), 18, UiKit.TextCol, TextAnchor.MiddleLeft, FontStyle.Bold);
-            _invContent = UiKit.ScrollList(panel, ColLeftX, 130f, ColLeftW, DialogH - 130f - 96f, 4f);
-            UiKit.AddInlineScrollbar(_invContent.GetComponentInParent<ScrollRect>());
+            _invContent = UiKit.ScrollList(panel, ColLeftX, 130f, ColLeftW, DialogH - 130f - 96f, 4f); // ScrollList brings its own inline scrollbar (#1387)
             _invEmpty = UiKit.AddText(panel, ColLeftX + 12f, 140f, ColLeftW - 24f, 40f, loc.Get("ui.trade.inventory_empty"), 16, UiKit.CyanDim, TextAnchor.UpperLeft);
 
             // Right column, top: what I give (+ knowledge control) with my ready state.

--- a/client/Assets/BlocksBeyondTheStars/Scripts/ShipEditor.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/ShipEditor.cs
@@ -103,12 +103,11 @@ namespace BlocksBeyondTheStars.Client
             _cam.backgroundColor = new Color(0.02f, 0.03f, 0.06f);
             _cam.farClipPlane = 800f;
             camGo.AddComponent<AudioListener>();
-            _cam.transform.position = new Vector3(MaxW / 2f, 10f, -18f);
             _yaw = 0f;
-            _pitch = 15f;
-            _cam.transform.rotation = Quaternion.Euler(_pitch, _yaw, 0f);
+            EditorSceneKit.Frame(_cam.transform, ref _pitch, _yaw, _design.Keys, MaxW, MaxL); // opening view (#1390)
 
             _view = new EditorVoxelChunkView(transform);
+            _ghost = new EditorPlacementGhost(transform);
             BuildRoom();
             BuildUi();
         }
@@ -156,44 +155,9 @@ namespace BlocksBeyondTheStars.Client
 
         private void BuildRoom()
         {
-            // Build floor (raycast target + visual grid base).
-            _floor = GameObject.CreatePrimitive(PrimitiveType.Cube);
-            _floor.name = "BuildFloor";
-            _floor.transform.position = new Vector3(MaxW / 2f, -0.5f, MaxL / 2f);
-            _floor.transform.localScale = new Vector3(MaxW, 1f, MaxL);
-            _floor.transform.SetParent(transform, false);
-            _floor.GetComponent<Renderer>().sharedMaterial = Lit(new Color(0.10f, 0.13f, 0.18f), null);
-
-            // Faint grid lines on the floor.
-            var lineMat = Unlit(new Color(0.2f, 0.35f, 0.45f, 1f));
-            for (int x = 0; x <= MaxW; x++)
-            {
-                GridLine(new Vector3(x, 0.02f, MaxL / 2f), new Vector3(0.03f, 0.02f, MaxL), lineMat);
-            }
-
-            for (int z = 0; z <= MaxL; z++)
-            {
-                GridLine(new Vector3(MaxW / 2f, 0.02f, z), new Vector3(MaxW, 0.02f, 0.03f), lineMat);
-            }
-
-            // A directional fill light so the lit cubes read in 3D.
-            var lightGo = new GameObject("EditorSun");
-            lightGo.transform.SetParent(transform, false);
-            var sun = lightGo.AddComponent<Light>();
-            sun.type = LightType.Directional;
-            sun.transform.rotation = Quaternion.Euler(45f, 35f, 0f);
-            sun.intensity = 1f;
-        }
-
-        private void GridLine(Vector3 pos, Vector3 scale, Material mat)
-        {
-            var go = GameObject.CreatePrimitive(PrimitiveType.Cube);
-            go.name = "Grid";
-            Destroy(go.GetComponent<Collider>());
-            go.transform.SetParent(transform, false);
-            go.transform.position = pos;
-            go.transform.localScale = scale;
-            go.GetComponent<Renderer>().sharedMaterial = mat;
+            // Floor (raycast target) with the shared procedural grid + fill light (#1391).
+            _floor = EditorSceneKit.BuildFloor(transform, MaxW, MaxL);
+            EditorSceneKit.BuildSun(transform);
         }
 
         private void Update()
@@ -226,15 +190,26 @@ namespace BlocksBeyondTheStars.Client
                 _cam.transform.rotation = Quaternion.Euler(_pitch, _yaw, 0f);
             }
 
+            // Keystrokes belong to a focused text field (the palette search, the form inputs) — typing
+            // "sand" must not fly the camera away or turn the brush (#1388).
+            bool typing = UiKit.TextFieldFocused();
             bool fast = Input.GetKey(KeyCode.LeftShift) || (padViewport && InputMap.PadHeld(PadButton.L3));
             float speed = (fast ? 30f : 14f) * Time.deltaTime;
             var move = Vector3.zero;
-            if (Input.GetKey(KeyCode.W)) move += _cam.transform.forward;
-            if (Input.GetKey(KeyCode.S)) move -= _cam.transform.forward;
-            if (Input.GetKey(KeyCode.D)) move += _cam.transform.right;
-            if (Input.GetKey(KeyCode.A)) move -= _cam.transform.right;
-            if (Input.GetKey(KeyCode.E) || Input.GetKey(KeyCode.Space)) move += Vector3.up;
-            if (Input.GetKey(KeyCode.Q) || Input.GetKey(KeyCode.LeftControl)) move += Vector3.down;
+            if (!typing)
+            {
+                if (Input.GetKey(KeyCode.W)) move += _cam.transform.forward;
+                if (Input.GetKey(KeyCode.S)) move -= _cam.transform.forward;
+                if (Input.GetKey(KeyCode.D)) move += _cam.transform.right;
+                if (Input.GetKey(KeyCode.A)) move -= _cam.transform.right;
+                if (Input.GetKey(KeyCode.E) || Input.GetKey(KeyCode.Space)) move += Vector3.up;
+                if (Input.GetKey(KeyCode.Q) || Input.GetKey(KeyCode.LeftControl)) move += Vector3.down;
+                if (Input.GetKeyDown(KeyCode.F))
+                {
+                    EditorSceneKit.Frame(_cam.transform, ref _pitch, _yaw, _design.Keys, MaxW, MaxL);
+                }
+            }
+
             if (padViewport)
             {
                 move += _cam.transform.forward * InputMap.PadStickY();
@@ -248,6 +223,11 @@ namespace BlocksBeyondTheStars.Client
             // Place (LMB) / remove (MMB) when not flying and not over a uGUI panel. The pad has no pointer,
             // so in viewport mode the panels can never be 'under' the aim and the reticle always picks.
             _mouseOverUi = !padViewport && EventSystem.current != null && EventSystem.current.IsPointerOverGameObject();
+            if (!_mouseOverUi)
+            {
+                EditorSceneKit.WheelDolly(_cam.transform, fast); // wheel over a panel scrolls the panel (#1390)
+            }
+
             if (_blocksLabel != null && _lastPlaced != _design.Count)
             {
                 _lastPlaced = _design.Count;
@@ -281,7 +261,7 @@ namespace BlocksBeyondTheStars.Client
             }
 
             // Rotate the shape brush (matches the in-game place-orientation control); Y on the pad.
-            if ((!_mouseOverUi && Input.GetKeyDown(KeyCode.R)) || (padViewport && InputMap.PadDown(PadButton.Y)))
+            if ((!typing && !_mouseOverUi && Input.GetKeyDown(KeyCode.R)) || (padViewport && InputMap.PadDown(PadButton.Y)))
             {
                 _brushOrient = (_brushOrient + 1) & 3;
             }
@@ -401,42 +381,15 @@ namespace BlocksBeyondTheStars.Client
             return true;
         }
 
-        private GameObject _ghost;
-        private Material _ghostValid, _ghostInvalid;
+        private EditorPlacementGhost _ghost;
 
-        /// <summary>The placement ghost: a softly pulsing translucent cube at the target cell —
-        /// green when the placement is valid, red when out of bounds or occupied.</summary>
+        /// <summary>The placement ghost (shared <see cref="EditorPlacementGhost"/>): green when the
+        /// placement is valid, red when out of bounds or occupied.</summary>
         private void UpdateGhost(bool hidden)
         {
-            if (_ghost == null)
-            {
-                _ghost = GameObject.CreatePrimitive(PrimitiveType.Cube);
-                _ghost.name = "PlacementGhost";
-                Destroy(_ghost.GetComponent<Collider>()); // must never block the picking ray
-                _ghost.transform.SetParent(transform, false);
-                var shader = Shader.Find("BlocksBeyondTheStars/Cloud") ?? Shader.Find("Unlit/Transparent");
-                _ghostValid = new Material(shader) { renderQueue = 3000 };
-                _ghostValid.SetColor("_Color", ShaderColor.Srgb(new Color(0.30f, 1f, 0.60f, 0.30f)));
-                _ghostInvalid = new Material(shader) { renderQueue = 3000 };
-                _ghostInvalid.SetColor("_Color", ShaderColor.Srgb(new Color(1f, 0.25f, 0.20f, 0.30f)));
-            }
-
             Vector3i cell = default;
             bool show = !hidden && TryGetTargetCell(out cell);
-            if (_ghost.activeSelf != show)
-            {
-                _ghost.SetActive(show);
-            }
-
-            if (!show)
-            {
-                return;
-            }
-
-            bool valid = InBounds(cell) && !_design.ContainsKey(cell);
-            _ghost.transform.position = new Vector3(cell.X + 0.5f, cell.Y + 0.5f, cell.Z + 0.5f);
-            _ghost.transform.localScale = Vector3.one * (1.0f + 0.04f * Mathf.Sin(Time.unscaledTime * 5f));
-            _ghost.GetComponent<Renderer>().sharedMaterial = valid ? _ghostValid : _ghostInvalid;
+            _ghost?.Update(show, cell, show && InBounds(cell) && !_design.ContainsKey(cell));
         }
 
         private void TryPlace()
@@ -519,6 +472,7 @@ namespace BlocksBeyondTheStars.Client
         private void OnDestroy()
         {
             _view?.Dispose();
+            _ghost?.Dispose();
             _atlas?.Destroy(); // palette sprites reference this texture; the editor owns it (#423 lesson)
             _atlas = null;
             if (_canvas != null)
@@ -989,20 +943,6 @@ namespace BlocksBeyondTheStars.Client
             }
 
             return sb.ToString();
-        }
-
-        private static Material Lit(Color color, Texture2D tex)
-        {
-            var shader = Shader.Find("BlocksBeyondTheStars/LitColor") ?? Shader.Find("Unlit/Color");
-            var m = new Material(shader) { color = ShaderColor.Srgb(color) };
-            if (tex != null) m.mainTexture = tex;
-            return m;
-        }
-
-        private static Material Unlit(Color color)
-        {
-            var shader = Shader.Find("Unlit/Color") ?? Shader.Find("BlocksBeyondTheStars/VertexColorOpaque");
-            return new Material(shader) { color = ShaderColor.Srgb(color) };
         }
     }
 }

--- a/client/Assets/BlocksBeyondTheStars/Scripts/StructureEditor.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/StructureEditor.cs
@@ -85,11 +85,10 @@ namespace BlocksBeyondTheStars.Client
             _cam.backgroundColor = new Color(0.02f, 0.03f, 0.06f);
             _cam.farClipPlane = 1600f;
             camGo.AddComponent<AudioListener>();
-            _cam.transform.position = new Vector3(MaxW / 2f, 18f, -36f);
-            _pitch = 18f;
-            _cam.transform.rotation = Quaternion.Euler(_pitch, _yaw, 0f);
+            EditorSceneKit.Frame(_cam.transform, ref _pitch, _yaw, _design.Keys, MaxW, MaxL); // opening view (#1390)
 
             _view = new EditorVoxelChunkView(transform);
+            _ghost = new EditorPlacementGhost(transform);
             BuildRoom();
             BuildUi();
         }
@@ -135,41 +134,9 @@ namespace BlocksBeyondTheStars.Client
 
         private void BuildRoom()
         {
-            _floor = GameObject.CreatePrimitive(PrimitiveType.Cube);
-            _floor.name = "BuildFloor";
-            _floor.transform.position = new Vector3(MaxW / 2f, -0.5f, MaxL / 2f);
-            _floor.transform.localScale = new Vector3(MaxW, 1f, MaxL);
-            _floor.transform.SetParent(transform, false);
-            _floor.GetComponent<Renderer>().sharedMaterial = Lit(new Color(0.10f, 0.13f, 0.18f), null);
-
-            var lineMat = Unlit(new Color(0.2f, 0.35f, 0.45f, 1f));
-            for (int x = 0; x <= MaxW; x += 2)
-            {
-                GridLine(new Vector3(x, 0.02f, MaxL / 2f), new Vector3(0.03f, 0.02f, MaxL), lineMat);
-            }
-
-            for (int z = 0; z <= MaxL; z += 2)
-            {
-                GridLine(new Vector3(MaxW / 2f, 0.02f, z), new Vector3(MaxW, 0.02f, 0.03f), lineMat);
-            }
-
-            var lightGo = new GameObject("EditorSun");
-            lightGo.transform.SetParent(transform, false);
-            var sun = lightGo.AddComponent<Light>();
-            sun.type = LightType.Directional;
-            sun.transform.rotation = Quaternion.Euler(45f, 35f, 0f);
-            sun.intensity = 1f;
-        }
-
-        private void GridLine(Vector3 pos, Vector3 scale, Material mat)
-        {
-            var go = GameObject.CreatePrimitive(PrimitiveType.Cube);
-            go.name = "Grid";
-            Destroy(go.GetComponent<Collider>());
-            go.transform.SetParent(transform, false);
-            go.transform.position = pos;
-            go.transform.localScale = scale;
-            go.GetComponent<Renderer>().sharedMaterial = mat;
+            // Floor (raycast target) with the shared procedural grid + fill light (#1391).
+            _floor = EditorSceneKit.BuildFloor(transform, MaxW, MaxL);
+            EditorSceneKit.BuildSun(transform);
         }
 
         private void Update()
@@ -190,23 +157,41 @@ namespace BlocksBeyondTheStars.Client
                 _cam.transform.rotation = Quaternion.Euler(_pitch, _yaw, 0f);
             }
 
-            float speed = (Input.GetKey(KeyCode.LeftShift) ? 55f : 22f) * Time.deltaTime;
-            var move = Vector3.zero;
-            if (Input.GetKey(KeyCode.W)) move += _cam.transform.forward;
-            if (Input.GetKey(KeyCode.S)) move -= _cam.transform.forward;
-            if (Input.GetKey(KeyCode.D)) move += _cam.transform.right;
-            if (Input.GetKey(KeyCode.A)) move -= _cam.transform.right;
-            if (Input.GetKey(KeyCode.E) || Input.GetKey(KeyCode.Space)) move += Vector3.up;
-            if (Input.GetKey(KeyCode.Q) || Input.GetKey(KeyCode.LeftControl)) move += Vector3.down;
-            _cam.transform.position += move * speed;
+            // Keystrokes belong to a focused text field (the palette search, the key/name inputs) —
+            // typing "sand" must not fly the camera away or turn the brush (#1388).
+            bool typing = UiKit.TextFieldFocused();
+            bool fast = Input.GetKey(KeyCode.LeftShift);
+            if (!typing)
+            {
+                float speed = (fast ? 55f : 22f) * Time.deltaTime;
+                var move = Vector3.zero;
+                if (Input.GetKey(KeyCode.W)) move += _cam.transform.forward;
+                if (Input.GetKey(KeyCode.S)) move -= _cam.transform.forward;
+                if (Input.GetKey(KeyCode.D)) move += _cam.transform.right;
+                if (Input.GetKey(KeyCode.A)) move -= _cam.transform.right;
+                if (Input.GetKey(KeyCode.E) || Input.GetKey(KeyCode.Space)) move += Vector3.up;
+                if (Input.GetKey(KeyCode.Q) || Input.GetKey(KeyCode.LeftControl)) move += Vector3.down;
+                _cam.transform.position += move * speed;
+
+                if (Input.GetKeyDown(KeyCode.F))
+                {
+                    EditorSceneKit.Frame(_cam.transform, ref _pitch, _yaw, _design.Keys, MaxW, MaxL);
+                }
+            }
 
             _mouseOverUi = EventSystem.current != null && EventSystem.current.IsPointerOverGameObject();
+            if (!_mouseOverUi)
+            {
+                EditorSceneKit.WheelDolly(_cam.transform, fast); // wheel over a panel scrolls the panel
+            }
+
             if (_blocksLabel != null && _lastPlaced != _design.Count)
             {
                 _lastPlaced = _design.Count;
                 _blocksLabel.text = string.Format(L("ui.ed.placed"), _design.Count);
             }
 
+            UpdateGhost(flying || _mouseOverUi);
             if (!flying && !_mouseOverUi)
             {
                 if (Input.GetMouseButtonDown(0)) TryPlace();
@@ -214,13 +199,23 @@ namespace BlocksBeyondTheStars.Client
             }
 
             // Rotate the shape brush (matches the in-game place-orientation control).
-            if (!_mouseOverUi && Input.GetKeyDown(KeyCode.R))
+            if (!typing && !_mouseOverUi && Input.GetKeyDown(KeyCode.R))
             {
                 _brushOrient = (_brushOrient + 1) & 3;
                 if (_orientLabel != null) _orientLabel.text = (_brushOrient * 90) + "°";
             }
 
             _view.Flush(); // upload any chunk meshes touched by this frame's edits
+        }
+
+        private EditorPlacementGhost _ghost;
+
+        /// <summary>Shows where a click would land: green = free cell, red = occupied / out of bounds.</summary>
+        private void UpdateGhost(bool hidden)
+        {
+            Vector3i cell = default;
+            bool show = !hidden && TryGetTargetCell(out cell);
+            _ghost?.Update(show, cell, show && InBounds(cell) && !_design.ContainsKey(cell));
         }
 
         private void TryPlace()
@@ -533,20 +528,6 @@ namespace BlocksBeyondTheStars.Client
             return sb.ToString();
         }
 
-        private static Material Lit(Color color, Texture2D tex)
-        {
-            var shader = Shader.Find("BlocksBeyondTheStars/LitColor") ?? Shader.Find("Unlit/Color");
-            var m = new Material(shader) { color = ShaderColor.Srgb(color) };
-            if (tex != null) m.mainTexture = tex;
-            return m;
-        }
-
-        private static Material Unlit(Color color)
-        {
-            var shader = Shader.Find("Unlit/Color") ?? Shader.Find("BlocksBeyondTheStars/VertexColorOpaque");
-            return new Material(shader) { color = ShaderColor.Srgb(color) };
-        }
-
         // ----------------------------- UI (uGUI) -----------------------------
 
         private const float PanelH = 1048f;
@@ -564,6 +545,7 @@ namespace BlocksBeyondTheStars.Client
         private void OnDestroy()
         {
             _view?.Dispose();
+            _ghost?.Dispose();
             _atlas?.Destroy(); // palette sprites reference this texture; the editor owns it (#423 lesson)
             _atlas = null;
             if (_canvas != null)

--- a/client/Assets/BlocksBeyondTheStars/Scripts/UiKit.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/UiKit.cs
@@ -891,12 +891,17 @@ namespace BlocksBeyondTheStars.Client
             vlg.childForceExpandHeight = false;
             vlg.childControlHeight = false;
             vlg.spacing = spacing;
-            vlg.padding = new RectOffset(4, 4, 4, 4);
+            vlg.padding = new RectOffset(4, 12, 4, 4); // right: room for the inline scrollbar
             var fitter = contentGo.AddComponent<ContentSizeFitter>();
             fitter.verticalFit = ContentSizeFitter.FitMode.PreferredSize;
 
             scroll.viewport = viewGo.GetComponent<RectTransform>();
             scroll.content = content;
+
+            // A position indicator: the wheel scrolled but nothing SHOWED that a list continued below
+            // the viewport (the editor palettes looked like eight-entry lists, #1387). Auto-hides when
+            // the content fits, so short lists look unchanged.
+            AddInlineScrollbar(scroll);
             return content;
         }
 

--- a/data/locales/de.json
+++ b/data/locales/de.json
@@ -1586,7 +1586,7 @@
   "ui.struct.brush_none": "Keine",
   "ui.struct.save": "SPEICHERN / EXPORT",
   "ui.struct.load": "LADEN",
-  "ui.struct.hint": "RECHTE MAUS halten zum Umsehen · WASD + Q/E fliegen · Shift = schneller · LINKSKLICK setzen · MITTELKLICK entfernen · Esc = Menü",
+  "ui.struct.hint": "RECHTE MAUS halten zum Umsehen · WASD + Q/E fliegen · MAUSRAD = zoomen · Shift = schneller · F = Bau zentrieren · LINKSKLICK setzen · MITTELKLICK entfernen · Esc = Menü",
   "ui.struct.hint_pad": "Linker Stick fliegen · rechter Stick umsehen · LB/RB runter/hoch · A setzen · X entfernen · Y drehen · Steuerkreuz Palette · Start = Panels · B = zurück",
   "ui.struct.hint_pad_panel": "Stick geht durch die Panels · A wählt · Start = fliegen und bauen · B = Editor verlassen",
   "ui.tier.small": "Klein",

--- a/data/locales/en.json
+++ b/data/locales/en.json
@@ -1586,7 +1586,7 @@
   "ui.struct.brush_none": "None",
   "ui.struct.save": "SAVE / EXPORT",
   "ui.struct.load": "LOAD",
-  "ui.struct.hint": "Hold RIGHT-MOUSE to look · WASD + Q/E to fly · Shift = faster · LEFT-CLICK place · MIDDLE-CLICK remove · Esc = menu",
+  "ui.struct.hint": "Hold RIGHT-MOUSE to look · WASD + Q/E to fly · WHEEL = zoom · Shift = faster · F = frame build · LEFT-CLICK place · MIDDLE-CLICK remove · Esc = menu",
   "ui.struct.hint_pad": "Left stick fly · right stick look · LB/RB down/up · A place · X remove · Y turn · D-pad palette · Start = panels · B = back",
   "ui.struct.hint_pad_panel": "Stick walks the panels · A picks · Start = fly and build · B = leave the editor",
   "ui.tier.small": "Small",

--- a/docs/user/USER_MANUAL.md
+++ b/docs/user/USER_MANUAL.md
@@ -1254,7 +1254,11 @@ separate unlock; admins can still disable it through server world rules.
 All editors are menu tools that **export a JSON bundle**; a developer folds it into the game data with the
 matching Python merge tool (review the diff, translate locale placeholders, commit). Shared build-room
 controls (Ship/Station/Town/Material 3D editors): **hold Right-mouse** to look, **WASD** to fly, **Q/E**
-(or Space/Ctrl) up/down, **Shift** faster, **Left-click** place, **Middle-click** remove, **Esc** to exit.
+(or Space/Ctrl) up/down, **Mouse wheel** zoom (dolly along your view), **Shift** faster, **F** frame the
+build (or the floor centre when nothing is placed yet), **Left-click** place, **Middle-click** remove,
+**Esc** to exit. A translucent ghost cube shows where a click lands (green = free, red = occupied / out of
+bounds); the floor grid marks every cell with a brighter line every 8 cells. The palette on the left has a
+search box (typing there never moves the camera) and a scrollbar.
 
 | Editor | Designs | Export → merge tool |
 |---|---|---|


### PR DESCRIPTION
## Summary
Marcel's settlement-editor screenshot ("no scrollbar/search on the left, a weird orb in the background, can't zoom, can't see the grid") — six causes, fixed in the shared editor bricks so the ship, station and settlement editors get all of them at once.

- **#1386 Palette rows 100 units tall** — `PaletteListUi` rows only set a `LayoutElement`; `UiKit.ScrollList` lays out with `childControlHeight = false`, so rows kept the RectTransform default of 100×100. Rows/headers now set `sizeDelta`.
- **#1387 No scrollbar** — `UiKit.ScrollList` attaches `AddInlineScrollbar` itself (auto-hide, so short lists look unchanged); the trade dialog's own call is dropped to avoid a double bar.
- **#1388 Typing flies the camera** — both editors guard WASD/Q/E/Space/Ctrl/R/F with `UiKit.TextFieldFocused()`.
- **#1389 The "orb"** — `MenuBackground.MakeSphere` was the only backdrop builder without `SetParent`; the menu planet + moon survived `DestroyMenuBackground` and rose out of every editor's floor (leaking a pair per visit). Now parented.
- **#1390 No zoom** — new `EditorSceneKit.WheelDolly` (wheel = dolly along the view, Shift ×3, not over a panel) and `Frame` (opening view + `F` key: 30° down, whole build in view).
- **#1391 Invisible grid / no ghost** — one floor material with a mipmapped procedural grid texture (minor line per cell, major every 8) replaces 258 sub-pixel cube lines; the placement ghost moved into the shared `EditorPlacementGhost`, so the station/settlement editor finally shows where a click lands.

Hint line (en/de), USER_MANUAL and TODO.md updated. The other 11 locales keep the previous hint text (nothing missing, wheel/F just not mentioned yet).

closes #1386, closes #1387, closes #1388, closes #1389, closes #1390, closes #1391

## Verification
- Local Unity build: `Build Finished, Result: Success`, no new warnings; in-game check by Marcel (palette, search, no orb, wheel zoom, F, grid, ghost) ✅
- Locale guard tests (`scripts/locale-test-filter.py` set): 310/310 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)