### PR TITLE
fix(worldhost): stop leaking ~1 GB of anonymous Docker volumes per world wake (#1414)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ the richer, screenshot-laden versions live there. `(#123)` references the pull r
 
 ## [Unreleased]
 
+### Fixed
+
+- WorldHost leaked ~1 GB of anonymous Docker volumes per world wake — the image declared `/app/clients`
+  + `/app/webgl` as VOLUMEs, every start downloaded the client installers into one, and `docker rm`
+  ran without `-v`. Now `rm -v`, `BBS_FETCH_CLIENT=0` for hosted instances, and only saves + config
+  are VOLUMEs; the VPS was pruned from 121 GB to 18 GB and a weekly prune guards the host. (#1414)
+
 ## [2026.8.24] — 2026-08-30
 
 The drafting-table release. The three build editors — ship, station, town — stopped being empty

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,10 @@ ENV BBS_ADMIN_BIND=0.0.0.0
 EXPOSE 31415/udp 31415/tcp 31416/tcp
 
 # saves/ = SQLite world + backups + logs + /bump bug reports (<world>/bumps) · config/ = server.json · clients/ = published Windows Setup.exe + Linux AppImage + macOS zip · webgl/ = Unity WebGL browser build served at /play (mount a local Build/WebGL, or set BBS_FETCH_WEBGL=1)
-VOLUME ["/app/saves", "/app/config", "/app/clients", "/app/webgl"]
+# Only saves + config are VOLUMEs. clients/ and webgl/ deliberately are NOT: an undeclared path lives in the
+# container's own layer (or an explicit mount) — as VOLUMEs they became a fresh ~1 GB anonymous volume per
+# container start that outlived `docker rm` (#1414).
+VOLUME ["/app/saves", "/app/config"]
 
 # Health = the public admin dashboard root (cheap static HTML, never password-gated unlike /api/*).
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \

--- a/TODO.md
+++ b/TODO.md
@@ -110,6 +110,20 @@ Per-item detail lives in the dated work log below. **Since 2026-07 versions are 
 #1144, #1146, #1147), all 28 sub-issues #1102–#1129 done. The whole package is UNRELEASED pending the big
 playtest; the post-epic implementation audit spawned the follow-up fix round #1149–#1156.
 
+### ★ WorldHost: the VPS disk leak — 92 GB of orphaned anonymous volumes (#1414, 2026-08-30, branch fix/worldhost-volume-leak)
+Marcel: "what exactly eats so much disk on my VPS?" — 121 GB / 237 GB, and `docker system df` said 379 volumes,
+351 dangling, 92 GB reclaimable (+ 93 images, 82 unused, 17 GB). Four pieces: the `Dockerfile` declares
+`/app/saves /app/config /app/clients /app/webgl` as VOLUMEs; `DockerCliLauncher.BuildRunArgs` bind-mounts only
+saves, so every `docker run` minted THREE anonymous volumes; `entrypoint.sh` defaults `BBS_FETCH_CLIENT=1` and
+pulled Setup.exe + AppImage + macOS zip (~1 GB) into `/app/clients` on every start — for an instance whose admin
+port is never published; and `Start()`/`Remove()` ran `docker rm -f` without `-v`, orphaning them on every
+re-wake (6–18 per day since 2026-07-05). Fix: `rm -f -v` at both call sites (saves are a bind mount, untouched),
+`-e BBS_FETCH_CLIENT=0` per instance, Dockerfile VOLUME list = saves + config only. Ops (done by hand on the host):
+`docker volume prune` −92 GB, `docker image prune -a` −18 GB → **18 GB used**; `/etc/cron.weekly/bbs-docker-prune`
+(dangling volumes + images unused >30 d, never containers) as belt-and-braces. Test:
+`BuildRunArgs_SkipsClientInstallerFetch_AndMountsOnlySaves`. Docs: deploy/README § Disk hygiene (+ runbook step 4
+`rm -v`), HOSTED_WORLDS diagram, CHANGELOG.
+
 ### ★ Gamepad: the menus are actually navigable — search-box trap, pie ring, field focus, scroll-into-view, hint strip, LB/RB tabs, selection frame, scrollbars (#1404–#1411, 2026-08-30, branch fix/gamepad-menus)
 Marcel's pad test: "how do I enter a name, how do I navigate the Tab menu, the R3 pie can't be used." Three real
 bugs plus the missing guidance. **#1404** the crafting search box was the one `InputField` built by hand (no

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -85,7 +85,7 @@ dedicated-server image `ghcr.io/marceld23/blocks-beyond-the-stars-server:X.Y.Z` 
    check `worldhost-image.yml` runs). The `production` environment gate must be approved.
 4. **Recycle the keep-awake arcade pool worlds.** They never idle-exit
    (`BBS_WH_GLITCH_KEEP_AWAKE`), so unlike normal worlds they would keep the old image forever:
-   `docker rm -f bbs-world-<id>` per pool world — WorldHost re-wakes each on the new pin within
+   `docker rm -f -v bbs-world-<id>` per pool world — WorldHost re-wakes each on the new pin within
    ~20 s via the crash→re-wake path. Verify the image with `docker ps`.
    Normal hosted worlds need nothing: they pick up the new pin on their next wake.
 5. **Refresh `/play`** with the release's `webgl` zip — see the in-place snippet above.
@@ -95,6 +95,26 @@ dedicated-server image `ghcr.io/marceld23/blocks-beyond-the-stars-server:X.Y.Z` 
    does not fit.
 
 Rollback = restore the `.env` backup, redeploy `worldhost`, recycle the pool worlds again.
+
+## Disk hygiene (#1414)
+
+On 2026-08-30 the host sat at 121 GB / 237 GB: **92 GB of orphaned anonymous Docker volumes** plus
+17 GB of unused images. Every world wake had created three anonymous volumes (the image's
+`/app/config`, `/app/clients`, `/app/webgl` VOLUMEs — only `/app/saves` is bind-mounted) and the
+entrypoint filled `/app/clients` with the ~1 GB client installers; `docker rm -f` without `-v` then
+left them behind. Fixed in the launcher (`rm -v`, `BBS_FETCH_CLIENT=0`) and the Dockerfile (only
+saves + config are VOLUMEs).
+
+Belt-and-braces on the host: `/etc/cron.weekly/bbs-docker-prune` (hand-installed, not in the repo)
+
+```sh
+docker volume prune -f                          # dangling anonymous volumes only (named netdata/caddy stay)
+docker image prune -af --filter "until=720h"    # images unused for 30+ days
+logger -t bbs-docker-prune "weekly prune done: $(df -h / | awk 'NR==2{print $3" used, "$4" free"}')"
+```
+
+It never touches containers, so sleeping `bbs-world-*` objects keep their logs. Check it ran with
+`journalctl -t bbs-docker-prune`; the quick health check is `docker system df` (RECLAIMABLE should be ≈ 0).
 
 ## One-time host prerequisites (already done on bbs-host-1, 2026-07-04)
 

--- a/docs/developer/HOSTED_WORLDS.md
+++ b/docs/developer/HOSTED_WORLDS.md
@@ -28,7 +28,7 @@ The three hosting tiers, side by side:
                     │   docker CLI: one container per world                                     │
                     │                                                                           │
                     │ bbs-world-<id> containers (the normal dedicated-server image)             │
-                    │   volume bbs-world-<id>-saves:/app/saves                                  │
+                    │   bind mount worlds/<id>/saves:/app/saves (only mount; docker rm -v #1414)│
  native UDP ───────►│   host port 3200x → 31415/udp (gameplay), 127.0.0.1:3200x → /status probe │
                     └───────────────────────────────────────────────────────────────────────────┘
 ```

--- a/src/BlocksBeyondTheStars.WorldHost/InstanceLauncher.cs
+++ b/src/BlocksBeyondTheStars.WorldHost/InstanceLauncher.cs
@@ -45,7 +45,8 @@ public interface IInstanceLauncher
 /// registry (world ids are server-generated hex; the display name is passed only as an ENV VALUE).
 ///
 /// Container shape per world:
-///  - name <c>bbs-world-&lt;id&gt;</c>, volume <c>bbs-world-&lt;id&gt;-saves</c> mounted at /app/saves
+///  - name <c>bbs-world-&lt;id&gt;</c>, the host's <c>worlds/&lt;id&gt;/saves</c> BIND-mounted at /app/saves — the only
+///    mount; every other VOLUME the image declares would become an anonymous volume, hence <c>rm -v</c> (#1414)
 ///  - <c>--restart=no</c> — REQUIRED: the instance exits itself on idle (BBS_IDLE_SHUTDOWN_MINUTES);
 ///    an auto-restart policy would wake it right back up and defeat sleeping
 ///  - one stable host port published as udp (native gameplay) AND tcp (WS gateway; /status health probe)
@@ -67,7 +68,10 @@ public sealed class DockerCliLauncher : IInstanceLauncher
         // Instances exit on idle but their container OBJECT remains (we run without --rm so logs stay
         // inspectable while a world sleeps) — remove any stale one first or the re-wake's `docker run
         // --name bbs-world-<id>` fails with a name conflict. Best effort: "no such container" is fine.
-        Run(new List<string> { "rm", "-f", $"bbs-world-{world.Id}" });
+        // `-v` drops the container's ANONYMOUS volumes with it (the image declares VOLUMEs we do not mount);
+        // without it every wake leaked them — 92 GB of orphans on the VPS by 2026-08-30 (#1414). The saves
+        // are a bind mount, which `-v` never touches.
+        Run(new List<string> { "rm", "-f", "-v", $"bbs-world-{world.Id}" });
 
         var (exitCode, stdout, stderr) = Run(BuildRunArgs(_config, world, savesDir));
         if (exitCode != 0)
@@ -103,6 +107,9 @@ public sealed class DockerCliLauncher : IInstanceLauncher
             "-e", $"BBS_WORLD_OWNER={world.OwnerAccountId}",
             "-e", "BBS_ENABLE_WEBSOCKET=true",
             "-e", "BBS_WEBSOCKET_BIND=+",
+            // A hosted instance never publishes its admin port, so the entrypoint's best-effort download of the
+            // client installers (~1 GB per start, into /app/clients) could never be served — skip it (#1414).
+            "-e", "BBS_FETCH_CLIENT=0",
         };
 
         // Resource fences: a hard memory cap (same value as --memory-swap, so a capped world can't push
@@ -206,7 +213,7 @@ public sealed class DockerCliLauncher : IInstanceLauncher
 
         // By NAME, not container id: the registry row is about to disappear, and the name is the one
         // handle that survives a crashed/replaced container (Start() removes stale ones the same way).
-        Run(new List<string> { "rm", "-f", $"bbs-world-{worldId}" });
+        Run(new List<string> { "rm", "-f", "-v", $"bbs-world-{worldId}" });
     }
 
     public bool IsRunning(string containerId)

--- a/tests/BlocksBeyondTheStars.Tests/WorldHostTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/WorldHostTests.cs
@@ -651,6 +651,22 @@ public sealed class WorldHostTests : IDisposable
         Assert.Equal(config.ServerImage, args[^1]); // image stays the last argv entry
     }
 
+
+    [Fact]
+    public void BuildRunArgs_SkipsClientInstallerFetch_AndMountsOnlySaves()
+    {
+        // #1414: the image declares several VOLUMEs; anything we do not bind-mount becomes an anonymous volume
+        // per start (which `rm -v` must then drop), and the entrypoint's ~1 GB installer download can never be
+        // served from a hosted instance (admin port not published) — so it is switched off.
+        var config = new WorldHostConfig();
+        var world = new WorldRecord("abc123abc123", "acct", "My World", "secret", 32001, WorldStatus.Stopped, "", 0, 0);
+
+        var args = DockerCliLauncher.BuildRunArgs(config, world, "/opt/bbs/worldhost/worlds/abc123abc123/saves");
+
+        Assert.Contains("BBS_FETCH_CLIENT=0", args);
+        Assert.Equal(new[] { "/opt/bbs/worldhost/worlds/abc123abc123/saves:/app/saves" }, args.Where(a => a.Contains(":/app/")).ToArray());
+        Assert.DoesNotContain(args, a => a.Contains("bbs-world-abc123abc123-saves")); // bind mount, not a named volume
+    }
     [Fact]
     public void BuildRunArgs_OmitsFencesAndAi_WhenUnconfigured()
     {


### PR DESCRIPTION
## Why
The production VPS was at **121 GB / 237 GB**. `docker system df`: 379 volumes, **351 dangling (92 GB)**, plus 82 unused images (17 GB). Analysis in #1414.

## Root cause
1. `Dockerfile` declared `/app/saves /app/config /app/clients /app/webgl` as VOLUMEs.
2. `DockerCliLauncher.BuildRunArgs` bind-mounts only saves → every `docker run` created **three anonymous volumes**.
3. `entrypoint.sh` defaults `BBS_FETCH_CLIENT=1` → every start downloaded Setup.exe + AppImage + macOS zip (~1 GB) into `/app/clients` — for an instance whose admin port is never published.
4. `Start()` / `Remove()` ran `docker rm -f` **without `-v`** → orphaned on every re-wake (6–18/day since 2026-07-05).

## Fix
- `docker rm -f -v` at both launcher call sites (saves are a bind mount — `-v` never touches them)
- `-e BBS_FETCH_CLIENT=0` per hosted instance
- Dockerfile `VOLUME` = saves + config only (clients/webgl live in the container layer or an explicit mount)
- New test `BuildRunArgs_SkipsClientInstallerFetch_AndMountsOnlySaves`; stale "named saves volume" comments/diagram corrected
- Docs: `deploy/README.md` § Disk hygiene + runbook step 4 uses `rm -v`; `HOSTED_WORLDS.md`; CHANGELOG; TODO

## Ops (already done on the host, by hand)
`docker volume prune` −92 GB, `docker image prune -a` −18 GB → **18 GB used**; `/etc/cron.weekly/bbs-docker-prune` (dangling volumes + images unused >30 d, never containers) installed and test-run.

## Verification
- `dotnet build -c Release -warnaserror` → 0 warnings
- WorldHostTests + GlitchGatewayTests → all passed (6 `BuildRunArgs_*` incl. the new one)
- `dotnet format --verify-no-changes` → clean

closes #1414

🤖 Generated with [Claude Code](https://claude.com/claude-code)