### PR TITLE
docs(readme): localization row — ask for native-speaker polish instead of missing keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ entire test suite are plain C# and JSON, and everything our CI checks runs on th
 | --- | --- |
 | 🌱 [**Good first issues**](https://github.com/marceld23/BlocksBeyondTheStars/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) | Small and scoped, described end to end. Several are **pure JSON** — game balance, recipes, tech-tree wiring — with no C# at all. |
 | 🙌 [**Help wanted**](https://github.com/marceld23/BlocksBeyondTheStars/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) | Everything we'd be glad to hand over. |
-| 🌍 [**Localization**](https://github.com/marceld23/BlocksBeyondTheStars/issues?q=is%3Aissue+is%3Aopen+label%3Alocalization) | No code at all. 14 languages, and **partial translations are welcome** — every missing key falls back to English. |
+| 🌍 [**Localization**](https://github.com/marceld23/BlocksBeyondTheStars/issues?q=is%3Aissue+is%3Aopen+label%3Alocalization) | No code at all. All 14 languages are complete but mostly machine-assisted — **native-speaker polish is welcome**, and even a handful of improved lines makes a real difference. |
 | 🐛 [**All open issues**](https://github.com/marceld23/BlocksBeyondTheStars/issues) | The full list. |
 
 **Quickstart — clone, build, test (.NET 10 SDK, nothing else):**


### PR DESCRIPTION
The Localization row in **Where to start** still pitched "partial translations are welcome — every missing key falls back to English". That's outdated: all 14 locale files carry the full 3,914 keys, so there are no missing keys left to fill.

What contributors can actually help with now is wording quality — most languages are machine-assisted and need native-speaker review. The row now says exactly that and the evergreen issue #1417 gives them a place to start, so the `label:localization` link in this row no longer points at an empty list.

Refs #1417

🤖 Generated with [Claude Code](https://claude.com/claude-code)