### PR TITLE
feat(client): tablet-browser profile — audio modal, DPR/canvas guards, shell preset, touch from shell, auto quality calibration, mobile budgets

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -110,6 +110,26 @@ Per-item detail lives in the dated work log below. **Since 2026-07 versions are 
 #1144, #1146, #1147), all 28 sub-issues #1102–#1129 done. The whole package is UNRELEASED pending the big
 playtest; the post-epic implementation audit spawned the follow-up fix round #1149–#1156.
 
+### ★ WebGL on tablets: audio EncodingError modal + browser-mobile profile + auto quality calibration (#1419–#1425, 2026-08-31, branch feat/webgl-tablet-profile)
+Marcel's Galaxy Tab A8 test of browser singleplayer: heavy stutter from the intro on, sluggish controls, and a
+fatal-looking "EncodingError: unable to decode audio data" modal after leaving the ship. Delivery was verified
+clean on both hosts (VPS + glitch CDN: byte-identical `audio/mpeg`, real 404s) — the decode fails client-side
+under memory pressure, and the C# side already recovers (synth fallback), so **#1419** the WebGL template now
+swallows exactly that alert to the console. **#1420** `ApplyWindowMode` no longer calls `Screen.SetResolution`
+on WebGL (the template owns the canvas), and the template's DPR-1 cap also fires for multi-touch coarse-pointer
+devices (iPadOS desktop UA). **#1421** IntroCinematic/MenuBackground respect the player's preset (Medium+ keeps
+the High cinematic look) and shell cameras go through `ApplyCameraLook(camData)` — no more forced-High post +
+full-res SSAO on devices set to Low. **#1422** touch latches at AppShell level from frame one (`NoteTouch`) and
+rescales the live EventSystem's drag threshold, so menus get touch behavior pre-game. **#1423** `BrowserDevice`
+classifies phone/tablet browsers by GPU family (Mali/Adreno/PowerVR; "Apple GPU"+touch) as a start guess, and
+`AutoQualityCalibrator` measures shell frame times (~15 s, median/p90) and steps the auto-managed preset one
+notch per session (`PresetAuto`, cleared by a manual choice in settings). **#1424** WebGL Low is really low
+(renderScale 0.8, HDR off) and the mobile profile defaults to view distance 3 + Synth music with no 45-s
+prefetch (each decoded track is ~80 MB PCM). **#1425** browser-SP server budgets tighten on mobile
+(2 ticks/frame, 3 ms chunk-gen) and the prologue's `RequiredPull` raymarch burst is cached over 3 frames.
+Desktop behavior is unchanged except: the shell honors Low/Potato, and desktop-browser first runs now calibrate
+UP from Low instead of being stuck there. Needs an on-device playtest (Tab A8) after the next WebGL release.
+
 ### ★ WorldHost: the VPS disk leak — 92 GB of orphaned anonymous volumes (#1414, 2026-08-30, branch fix/worldhost-volume-leak)
 Marcel: "what exactly eats so much disk on my VPS?" — 121 GB / 237 GB, and `docker system df` said 379 volumes,
 351 dangling, 92 GB reclaimable (+ 93 images, 82 unused, 17 GB). Four pieces: the `Dockerfile` declares

--- a/client/Assets/BlocksBeyondTheStars/Scripts/AppShell.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/AppShell.cs
@@ -167,6 +167,19 @@ namespace BlocksBeyondTheStars.Client
             crashGo.AddComponent<CrashReporter>().Settings = Settings;
             InputMap.Use(Settings); // route remappable controls through the loaded bindings (Stream C)
             Settings.Apply();
+
+            // Browser build (#1423): a phone/tablet-class device is touch-first before any touch happens —
+            // pre-latch so the very first canvas gets touch-sized hit behavior — and the shell frame-time
+            // calibrator steps the auto-managed preset up/down by what THIS device actually measures.
+            if (Application.platform == RuntimePlatform.WebGLPlayer)
+            {
+                if (BrowserDevice.IsMobileBrowser)
+                {
+                    TouchControlsUi.NoteTouch();
+                }
+
+                gameObject.AddComponent<AutoQualityCalibrator>().Shell = this;
+            }
             if (StreamingAssetsCache.UsesRemoteStreamingAssets)
             {
                 StartCoroutine(LoadContentForStartup());
@@ -1395,6 +1408,14 @@ namespace BlocksBeyondTheStars.Client
 
         private void Update()
         {
+            // Shell-level touch latch (#1422): the first real touch flips the touch UI on for the MENUS
+            // too, not only in-game — the old latch lived in the in-game overlay's Update, so the whole
+            // pre-game phase (splash → intro → menu) ran with desktop mouse handling on tablets.
+            if (Input.touchCount > 0)
+            {
+                TouchControlsUi.NoteTouch();
+            }
+
             // A failed content load/download shows the blocking retry overlay (#422) — handled before
             // anything else so it appears no matter which shell phase the failure hit.
             bool contentError = !ContentReady && !string.IsNullOrEmpty(ContentLoadError);

--- a/client/Assets/BlocksBeyondTheStars/Scripts/AutoQualityCalibrator.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/AutoQualityCalibrator.cs
@@ -1,0 +1,100 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace BlocksBeyondTheStars.Client
+{
+    /// <summary>
+    /// Measures the browser build's real frame times during the fixed shell scenes (splash → intro →
+    /// main menu) and steps the quality preset one notch up or down per session (#1423). Device class
+    /// alone cannot answer "is this device fast enough" — a budget tablet reports desktop-like specs
+    /// and a weak office laptop is a "computer" — so the measured frame time is the authority; the
+    /// <see cref="BrowserDevice"/> start guess only picks where the ladder begins. One step per
+    /// session converges over a few launches and avoids visible mid-session flapping. Runs only while
+    /// <see cref="ClientSettings.PresetAuto"/> is set — a preset the player chose by hand is never
+    /// touched — and only samples shell phases: in-game frame times measure the world, not the device.
+    /// WebGL frames are vsynced to the display, so a loaded device shows up as DROPPED frames rather
+    /// than a raised median — the step-up test therefore requires a clean p90, not a low median.
+    /// </summary>
+    public sealed class AutoQualityCalibrator : MonoBehaviour
+    {
+        /// <summary>The owning shell; supplies the settings and the current phase.</summary>
+        public AppShell Shell;
+
+        private const float WarmupSeconds = 6f;    // skip startup spikes (shader warmup, content HTTP burst)
+        private const float SampleSeconds = 15f;   // enough frames for stable percentiles, done before play starts
+        private const float StepDownMedianMs = 40f; // median worse than 25 fps → the device is struggling
+        private const float StepUpP90Ms = 18f;      // ≥90 % of frames hit the 60 Hz budget → headroom for more
+
+        private readonly List<float> _samplesMs = new List<float>(1200);
+        private float _elapsed;
+        private bool _done;
+
+        private void Update()
+        {
+            if (_done || Shell == null || Shell.Settings == null)
+            {
+                return;
+            }
+
+            var settings = Shell.Settings;
+            if (!settings.PresetAuto)
+            {
+                _done = true; // the player took over in the settings menu — never fight a manual choice
+                return;
+            }
+
+            // Only the fixed shell scenes are comparable between devices; pause (don't reset) elsewhere.
+            switch (Shell.Phase)
+            {
+                case ShellPhase.Studio:
+                case ShellPhase.Splash:
+                case ShellPhase.Intro:
+                case ShellPhase.MainMenu:
+                    break;
+                default:
+                    return;
+            }
+
+            _elapsed += Time.unscaledDeltaTime;
+            if (_elapsed < WarmupSeconds)
+            {
+                return;
+            }
+
+            _samplesMs.Add(Time.unscaledDeltaTime * 1000f);
+            if (_elapsed < WarmupSeconds + SampleSeconds)
+            {
+                return;
+            }
+
+            _done = true;
+            _samplesMs.Sort();
+            float median = _samplesMs[_samplesMs.Count / 2];
+            float p90 = _samplesMs[Mathf.Min(_samplesMs.Count - 1, Mathf.FloorToInt(_samplesMs.Count * 0.9f))];
+
+            var preset = settings.Preset;
+            if (median > StepDownMedianMs && preset > QualityPreset.Potato)
+            {
+                preset--;
+            }
+            else if (p90 < StepUpP90Ms && preset < QualityPreset.High)
+            {
+                preset++;
+            }
+
+            if (preset == settings.Preset)
+            {
+                Debug.Log($"[AutoQuality] Preset {settings.Preset} confirmed (median {median:0.0} ms, p90 {p90:0.0} ms).");
+                return;
+            }
+
+            Debug.Log($"[AutoQuality] Preset {settings.Preset} → {preset} (median {median:0.0} ms, p90 {p90:0.0} ms).");
+            settings.Preset = preset;
+            settings.Apply();
+            settings.Save(); // the next launch starts on the calibrated preset right away
+        }
+    }
+}

--- a/client/Assets/BlocksBeyondTheStars/Scripts/AutoQualityCalibrator.cs.meta
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/AutoQualityCalibrator.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 726aec3273ab4e7ca30d1fd4aebcc98c

--- a/client/Assets/BlocksBeyondTheStars/Scripts/BrowserDevice.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/BrowserDevice.cs
@@ -1,0 +1,45 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using UnityEngine;
+
+namespace BlocksBeyondTheStars.Client
+{
+    /// <summary>
+    /// Classifies the browser build's host device once per session (#1423). "Mobile browser" means a
+    /// phone/tablet-class device, where the stripped-down browser profile applies (first-run defaults:
+    /// view distance 3 + synth music, plus tighter in-process server budgets and no music prefetch).
+    /// Deliberately only a START guess: the shell frame-time calibration
+    /// (<see cref="AutoQualityCalibrator"/>) is the authority on the quality preset and corrects in
+    /// both directions, so a strong tablet climbs back up and a weak desktop browser steps down.
+    /// </summary>
+    public static class BrowserDevice
+    {
+        private static bool? s_isMobileBrowser;
+
+        /// <summary>True in a WebGL player on a phone/tablet-class device; always false elsewhere.</summary>
+        public static bool IsMobileBrowser => s_isMobileBrowser ??= Detect();
+
+        private static bool Detect()
+        {
+            if (Application.platform != RuntimePlatform.WebGLPlayer)
+            {
+                return false;
+            }
+
+            // The WebGL renderer string names the GPU family, and it is the one static signal that
+            // separates device CLASSES cleanly: Mali/Adreno/PowerVR exist only in phone/tablet-class
+            // hardware, while desktops report NVIDIA/AMD/Intel/Apple-M. The tempting alternatives all
+            // lie — a budget tablet reports 8 cores like a desktop, and UA sniffing misses iPadOS
+            // Safari (desktop "Macintosh" UA). "Apple GPU" alone is ambiguous (M-series Macs report it
+            // in Safari too), so it only counts together with touch support, which Mac Safari lacks.
+            string gpu = SystemInfo.graphicsDeviceName ?? string.Empty;
+            bool mobileGpu = Contains(gpu, "Mali") || Contains(gpu, "Adreno") || Contains(gpu, "PowerVR");
+            bool appleTouch = Contains(gpu, "Apple") && Input.touchSupported;
+            return mobileGpu || appleTouch;
+        }
+
+        private static bool Contains(string haystack, string needle)
+            => haystack.IndexOf(needle, System.StringComparison.OrdinalIgnoreCase) >= 0;
+    }
+}

--- a/client/Assets/BlocksBeyondTheStars/Scripts/BrowserDevice.cs.meta
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/BrowserDevice.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: adb8d8494c544fab8d1f9590ae40c699

--- a/client/Assets/BlocksBeyondTheStars/Scripts/BrowserLocalServer.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/BrowserLocalServer.cs
@@ -27,8 +27,10 @@ namespace BlocksBeyondTheStars.Client
 
         /// <summary>Never simulate more than this many ticks in one frame — after a long tab stall we
         /// drop the backlog instead of freezing the frame trying to catch up (singleplayer: no one else
-        /// depends on the lost time).</summary>
-        private const int MaxTicksPerFrame = 5;
+        /// depends on the lost time). Phone/tablet browsers get a tighter cap (#1425): the tick runs on
+        /// the render thread, and a weak device that just missed one frame budget would otherwise be
+        /// handed a multi-tick catch-up burst next frame — a stutter feedback loop.</summary>
+        private static int MaxTicksPerFrame => BrowserDevice.IsMobileBrowser ? 2 : 5;
 
         /// <summary>Durable-save cadence driven by THIS host (SaveAll + Flush → blob → IndexedDB/cloud).
         /// Deliberately tighter than the server's internal 5-min autosave: a browser tab can vanish
@@ -137,7 +139,9 @@ namespace BlocksBeyondTheStars.Client
                     // multiplied by the MaxTicksPerFrame catch-up, is the main browser-SP hitch source.
                     // A wall-clock budget keeps cheap ticks streaming at full speed but cuts generation
                     // bursts off mid-loop (rest resumes next tick, nearest-first order unchanged).
-                    ChunkStreamBudgetMs = 6.0,
+                    // Phone/tablet browsers halve the budget (#1425): world streaming slows down, frames
+                    // smooth out — the right trade on a device that can't hold 30 fps to begin with.
+                    ChunkStreamBudgetMs = BrowserDevice.IsMobileBrowser ? 3.0 : 6.0,
                 };
 
                 // Same as the native bundled host (#642): the solo player is the WorldAdmin, so admin

--- a/client/Assets/BlocksBeyondTheStars/Scripts/ClientMusic.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/ClientMusic.cs
@@ -600,7 +600,12 @@ namespace BlocksBeyondTheStars.Client
             _plannedNext = name;
             _plannedKey = want;
             _prefetchedName = name;
-            if (!_musicCache.ContainsKey(name) && !_inFlight.ContainsKey(name))
+
+            // Phone/tablet browsers (#1424) skip the ahead-of-need fetch: a prefetched track means a THIRD
+            // decoded clip (~80 MB PCM each) alive at once, and that memory pressure is what makes the
+            // browser's decodeAudioData fail on 3–4 GB devices (#1419). The successor still plays — it just
+            // downloads at the seam (the current piece runs out, the next fades in when it arrives).
+            if (!BrowserDevice.IsMobileBrowser && !_musicCache.ContainsKey(name) && !_inFlight.ContainsKey(name))
             {
                 EnsureClip(name, _ => { });
             }

--- a/client/Assets/BlocksBeyondTheStars/Scripts/ClientSettings.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/ClientSettings.cs
@@ -176,6 +176,12 @@ namespace BlocksBeyondTheStars.Client
         // Graphics
         public QualityPreset Preset = QualityPreset.Medium;
 
+        /// <summary>True while <see cref="Preset"/> is auto-managed: set on a browser/mobile first run and
+        /// consumed by <see cref="AutoQualityCalibrator"/>, which steps the preset by measured frame time.
+        /// Cleared the moment the player picks a preset by hand — a manual choice is never overridden.
+        /// Existing installs load this as false, so their persisted preset stays untouched.</summary>
+        public bool PresetAuto;
+
         /// <summary>How the window is presented (windowed / borderless / exclusive). Default borderless so the
         /// game opens fullscreen on whichever monitor it launches on; switch to Windowed (in the settings menu)
         /// for a draggable, maximizable window, or to Exclusive for true exclusive fullscreen.</summary>
@@ -797,9 +803,21 @@ namespace BlocksBeyondTheStars.Client
                 // Tablets and the browser build are GPU-weak next to a desktop, and the scene is heavy (custom
                 // URP, SSAO, SMAA, PBR). Start those on a Lite preset so the first run is playable; the player
                 // can still raise it in Settings. Only on a genuine first run — a returning player keeps theirs.
+                // PresetAuto hands the preset to the shell frame-time calibration (#1423), which steps it up on
+                // capable devices (a desktop browser is not stuck on Low forever) and down on struggling ones.
                 if (Application.isMobilePlatform || Application.platform == RuntimePlatform.WebGLPlayer)
                 {
                     settings.Preset = QualityPreset.Low;
+                    settings.PresetAuto = true;
+
+                    // Phone/tablet-class browser (#1424): shorter horizon, and the synth music engine instead
+                    // of the MP3 library — no download and no browser-side decodeAudioData, whose ~80 MB PCM
+                    // per track is what tips a 3–4 GB tablet into EncodingError memory failures (#1419).
+                    if (BrowserDevice.IsMobileBrowser)
+                    {
+                        settings.ViewDistanceChunks = 3;
+                        settings.MusicMode = MusicMode.Synth;
+                    }
                 }
             }
 
@@ -977,8 +995,12 @@ namespace BlocksBeyondTheStars.Client
                     QualityPreset.Medium => 2,
                     _ => 4,
                 };
-                urp.supportsHDR = Preset > QualityPreset.Potato;
-                urp.renderScale = Preset == QualityPreset.Potato ? 0.75f : 1f;
+                // On WebGL, Low must actually be low (#1424): the wasm main thread also runs the in-process
+                // singleplayer server and all chunk meshing, so Low additionally drops HDR and renders the 3D
+                // view at 80 % — between Potato (75 %) and the desktop presets (100 %). Desktop Low is unchanged.
+                bool webglLow = Application.platform == RuntimePlatform.WebGLPlayer && Preset == QualityPreset.Low;
+                urp.supportsHDR = Preset > QualityPreset.Potato && !webglLow;
+                urp.renderScale = Preset == QualityPreset.Potato ? 0.75f : webglLow ? 0.8f : 1f;
 
                 // The shared asset bakes a 4096 main-light shadowmap for every level, but only High reaches far
                 // enough (90 m) to justify it — Medium and below cover 70 m or less, where 2048 is visually
@@ -1011,9 +1033,13 @@ namespace BlocksBeyondTheStars.Client
         /// Volume — bloom/tonemap/grade — and SMAA both need it), SMAA from <see cref="Smaa"/> (Medium+), and the
         /// renderer choice — index 0 = full-res SSAO (High), index 2 = half-res SSAO (Medium), index 1 = SSAO-free
         /// (Potato/Low). SSAO was the measured Low→Medium frame-time cliff (#374).</summary>
-        public void ApplyCameraLook()
+        public void ApplyCameraLook() => ApplyCameraLook(ActiveCameraData);
+
+        /// <summary>Same as <see cref="ApplyCameraLook()"/> for an explicit camera — the shell scenes
+        /// (intro cinematic, menu backdrop) pass their own camera data, which exists before
+        /// <see cref="ActiveCameraData"/> is ever assigned (#1421).</summary>
+        public void ApplyCameraLook(UniversalAdditionalCameraData cd)
         {
-            var cd = ActiveCameraData;
             if (cd == null)
             {
                 return;
@@ -1043,6 +1069,14 @@ namespace BlocksBeyondTheStars.Client
         /// OS maximize/resize affordances to appear in Windowed mode.</summary>
         private void ApplyWindowMode()
         {
+            // WebGL has no window to manage: the template owns the canvas and keeps the render target
+            // matched to the DOM size (index.html). Screen.SetResolution here fought that by forcing the
+            // backing store to Screen.currentResolution — wrong size AND wrong owner on tablets (#1420).
+            if (Application.platform == RuntimePlatform.WebGLPlayer)
+            {
+                return;
+            }
+
             var native = Screen.currentResolution;
             switch (Window)
             {

--- a/client/Assets/BlocksBeyondTheStars/Scripts/IntroCinematic.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/IntroCinematic.cs
@@ -233,8 +233,13 @@ namespace BlocksBeyondTheStars.Client
 
             if (UnityEngine.Rendering.GraphicsSettings.currentRenderPipeline != null)
             {
+                // Respect the player's preset (#1421): Medium+ keeps the full cinematic look (High post),
+                // but a device already downgraded to Low/Potato must not have the shell force it back up —
+                // the forced-High post stack + the default full-res-SSAO renderer made the intro the single
+                // heaviest scene on weak browsers. ApplyCameraLook picks the same renderer tier as in-game.
+                var settings = _shell.Settings;
                 var post = _root.AddComponent<UrpScenePost>();
-                post.Preset = QualityPreset.High;
+                post.Preset = settings.Preset >= QualityPreset.Medium ? QualityPreset.High : settings.Preset;
                 post.LensFlareEnabled = true;
                 post.MotionBlurEnabled = false;
                 post.ShellMode = true;
@@ -242,7 +247,7 @@ namespace BlocksBeyondTheStars.Client
                 var camData = _cam.GetUniversalAdditionalCameraData();
                 if (camData != null)
                 {
-                    camData.renderPostProcessing = true;
+                    settings.ApplyCameraLook(camData);
                 }
             }
 

--- a/client/Assets/BlocksBeyondTheStars/Scripts/MenuBackground.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/MenuBackground.cs
@@ -112,16 +112,25 @@ namespace BlocksBeyondTheStars.Client
             // URP Volume. The project always runs URP (every quality level assigns it), so there's no Built-in path.
             if (UnityEngine.Rendering.GraphicsSettings.currentRenderPipeline != null)
             {
+                // Respect the player's preset (#1421), like IntroCinematic: Medium+ keeps the full attract
+                // look (High post), Low/Potato get their own cheap tier — the menu backdrop otherwise ran
+                // forced-High post through the default full-res-SSAO renderer on devices set to Low.
+                var settings = Shell != null ? Shell.Settings : null;
+                var preset = settings?.Preset ?? QualityPreset.Medium;
                 var post = gameObject.AddComponent<UrpScenePost>();
-                post.Preset = QualityPreset.High;
+                post.Preset = preset >= QualityPreset.Medium ? QualityPreset.High : preset;
                 post.LensFlareEnabled = true;
                 post.MotionBlurEnabled = false;
                 post.ShellMode = true; // tighter bloom so the attract scene reads crisp, not hazy
 
-                // A code-created URP camera has post-processing OFF by default — turn it on or the global Volume
-                // (bloom/tonemap/vignette/lens flare) never touches the menu scene.
+                // A code-created URP camera has post-processing OFF by default — ApplyCameraLook turns it on
+                // and picks the preset's renderer tier, or the global Volume never touches the menu scene.
                 var camData = _cam.GetUniversalAdditionalCameraData();
-                if (camData != null)
+                if (camData != null && settings != null)
+                {
+                    settings.ApplyCameraLook(camData);
+                }
+                else if (camData != null)
                 {
                     camData.renderPostProcessing = true;
                 }

--- a/client/Assets/BlocksBeyondTheStars/Scripts/PrologueCinematic.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/PrologueCinematic.cs
@@ -306,6 +306,15 @@ namespace BlocksBeyondTheStars.Client
             }
         }
 
+        // RequiredPull walks up to 8 raymarched CameraClear probes (~400+ voxel lookups) and ran every
+        // frame — exactly while chunk streaming/meshing peaks after world reveal (#1425). The staged shot
+        // moves slowly (orbit 8°/s, damped radius), so the verified pull level is reused for a few frames;
+        // the per-frame CameraClear check on the actual camera spot below still catches late-streamed
+        // terrain immediately.
+        private const int PullRecheckFrames = 3;
+        private int _cachedPull;
+        private int _pullCheckedFrame = int.MinValue;
+
         private void LateUpdate()
         {
             if (!_cameraOverride || Camera == null)
@@ -343,7 +352,18 @@ namespace BlocksBeyondTheStars.Client
             // push-in can still put the ideal spot inside terrain. Each pull level trades radius for
             // height until the view is clear; blend levels smoothly so the correction reads as a camera
             // move, not a cut.
-            int needed = RequiredPull(look);
+            int needed;
+            if (Time.frameCount - _pullCheckedFrame < PullRecheckFrames)
+            {
+                needed = _cachedPull;
+            }
+            else
+            {
+                needed = RequiredPull(look);
+                _cachedPull = needed;
+                _pullCheckedFrame = Time.frameCount;
+            }
+
             if (needed < 0)
             {
                 // Nothing clear even fully pulled in — hold the last good pose rather than enter the rock.

--- a/client/Assets/BlocksBeyondTheStars/Scripts/TouchControlsUi.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/TouchControlsUi.cs
@@ -72,6 +72,23 @@ namespace BlocksBeyondTheStars.Client
         /// rigs stay dormant while touch laptops and iPad-Safari's desktop UA get controls on first tap.</summary>
         public static bool ShouldShow() => Application.isMobilePlatform || s_touchSeen;
 
+        /// <summary>Latches "touch is in use". AppShell calls this from the very first frame (per-frame
+        /// touch poll + the <see cref="BrowserDevice"/> phone/tablet classification), so the SHELL —
+        /// splash, menus, settings — reacts to touch too (#1422); before, the latch lived only in the
+        /// in-game overlay's Update and the whole pre-game phase ran with desktop mouse handling. Also
+        /// rescales the already-created EventSystem's tap-vs-drag threshold: the EventSystem is born with
+        /// the first splash canvas, long before any touch can have been seen.</summary>
+        public static void NoteTouch()
+        {
+            if (s_touchSeen)
+            {
+                return;
+            }
+
+            s_touchSeen = true;
+            UiKit.ApplyTouchDragThreshold();
+        }
+
         /// <summary>Whether the controls are currently live (built AND visible). The source reads zero when false.</summary>
         public bool Visible => _built && _rootPanel != null && _rootPanel.activeSelf;
 
@@ -188,7 +205,7 @@ namespace BlocksBeyondTheStars.Client
         {
             if (!s_touchSeen && Input.touchCount > 0)
             {
-                s_touchSeen = true;
+                NoteTouch();
             }
 
             if (!_built)

--- a/client/Assets/BlocksBeyondTheStars/Scripts/UiKit.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/UiKit.cs
@@ -381,6 +381,21 @@ namespace BlocksBeyondTheStars.Client
             }
         }
 
+        /// <summary>Touch devices: scale the live EventSystem's tap-vs-drag threshold with the display's
+        /// DPI. The default (10 px) is tuned for a mouse — on a high-DPI tablet a finger wobbles further
+        /// than that, so menu taps get misread as drags and silently do nothing; ~1 mm of physical
+        /// movement is the usual bound. Called when the EventSystem is created on a known-touch device
+        /// AND from <see cref="TouchControlsUi.NoteTouch"/> when touch is first seen later — the
+        /// EventSystem is born with the first splash canvas, usually before any touch (#1422).</summary>
+        public static void ApplyTouchDragThreshold()
+        {
+            var system = Object.FindAnyObjectByType<EventSystem>();
+            if (system != null && Screen.dpi > 0f)
+            {
+                system.pixelDragThreshold = Mathf.Max(10, Mathf.RoundToInt(Screen.dpi / 25.4f)); // ≈1 mm
+            }
+        }
+
         /// <param name="userScalable">True for HUD-style canvases, which follow the player's UI-scale
         /// setting. Menus must stay false — their layout is absolute 1920 coordinates.</param>
         public static Canvas CreateCanvas(string name, float refW = 1920f, float refH = 1080f, bool userScalable = false)
@@ -388,15 +403,12 @@ namespace BlocksBeyondTheStars.Client
             if (Object.FindAnyObjectByType<EventSystem>() == null)
             {
                 var es = new GameObject("EventSystem");
-                var system = es.AddComponent<EventSystem>();
+                es.AddComponent<EventSystem>();
                 es.AddComponent<StandaloneInputModule>();
 
-                // Touch devices: scale the tap-vs-drag threshold with the display's DPI. The default (10 px)
-                // is tuned for a mouse — on a high-DPI tablet a finger wobbles further than that, so menu taps
-                // get misread as drags and silently do nothing. ~1 mm of physical movement is the usual bound.
-                if (TouchControlsUi.ShouldShow() && Screen.dpi > 0f)
+                if (TouchControlsUi.ShouldShow())
                 {
-                    system.pixelDragThreshold = Mathf.Max(10, Mathf.RoundToInt(Screen.dpi / 25.4f)); // ≈1 mm
+                    ApplyTouchDragThreshold();
                 }
             }
 

--- a/client/Assets/BlocksBeyondTheStars/Scripts/UiSettings.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/UiSettings.cs
@@ -70,7 +70,9 @@ namespace BlocksBeyondTheStars.Client
             Head(ref y, L("ui.settings.graphics"));
             // Graphics rows apply immediately (like the window-mode row always did) so changes made from the
             // in-game pause menu are visible right away instead of only when the settings screen closes.
-            Cycle(ref y, L("ui.settings.preset"), L("ui.settings.preset." + S.Preset.ToString().ToLowerInvariant()), () => { S.Preset = (QualityPreset)(((int)S.Preset + 1) % 4); S.Apply(); ApplyLiveWorld(); Rebuild(); });
+            // A hand-picked preset ends auto-calibration (#1423): PresetAuto off means the shell
+            // frame-time calibrator never overrides the player's explicit choice again.
+            Cycle(ref y, L("ui.settings.preset"), L("ui.settings.preset." + S.Preset.ToString().ToLowerInvariant()), () => { S.Preset = (QualityPreset)(((int)S.Preset + 1) % 4); S.PresetAuto = false; S.Apply(); ApplyLiveWorld(); Rebuild(); });
             // Window mode cycles Windowed → Borderless → Exclusive and applies immediately so the player sees
             // the window change without leaving the menu (resolution/mode changes are pushed via Apply()).
             Cycle(ref y, L("ui.settings.window_mode"), L(WindowModeKey(S.Window)),

--- a/client/Assets/WebGLTemplates/BlocksBeyondTheStars/index.html
+++ b/client/Assets/WebGLTemplates/BlocksBeyondTheStars/index.html
@@ -104,6 +104,31 @@
         updateBannerVisibility();
       }
 
+      // A failed browser-side audio decode (EncodingError from decodeAudioData — seen under memory
+      // pressure on tablets) is fully recovered in-game: the track is dropped from its pool and the
+      // synth engine takes over. But Unity's default error handler still raises a fatal-looking
+      // "An error occurred running the Unity content" alert for it. Swallow exactly that message —
+      // to the console, not the player — and keep every other error on the loud path (#1419).
+      function bbsIsAudioDecodeError(msg) {
+        return typeof msg === "string" && msg.indexOf("decode audio data") !== -1;
+      }
+      var bbsNativeAlert = window.alert.bind(window);
+      window.alert = function (msg) {
+        if (bbsIsAudioDecodeError(String(msg))) {
+          console.warn("[BBS] Audio decode failed (recovered in-game): " + msg);
+          return;
+        }
+        bbsNativeAlert(msg);
+      };
+      window.addEventListener("unhandledrejection", function (e) {
+        var reason = e && e.reason;
+        var msg = String(reason && reason.message ? reason.message : reason);
+        if (bbsIsAudioDecodeError(msg)) {
+          console.warn("[BBS] Audio decode failed (recovered in-game): " + msg);
+          e.preventDefault();
+        }
+      });
+
       var buildUrl = "Build";
       // Unity emits STABLE file names (WebGL.data.unityweb, …), so URLs alone can't distinguish builds.
       // The server rewrites this stamp to "?v=<build timestamp>" when serving the page — every build gets
@@ -128,7 +153,13 @@
         showBanner: unityShowBanner,
       };
 
-      if (/iPhone|iPad|iPod|Android/i.test(navigator.userAgent)) {
+      // The UA regex misses tablets that present as desktops — iPadOS 13+ Safari reports a
+      // "Macintosh" UA, Android's "Desktop site" mode drops "Android" — so ALSO treat a multi-touch
+      // device whose PRIMARY pointer is coarse (a finger) as mobile (#1420). Touch-screen laptops
+      // keep a fine primary pointer (mouse/trackpad) and stay on the crisp native-DPR desktop path.
+      var bbsCoarseTouch = navigator.maxTouchPoints > 1
+        && window.matchMedia && window.matchMedia("(pointer: coarse)").matches;
+      if (/iPhone|iPad|iPod|Android/i.test(navigator.userAgent) || bbsCoarseTouch) {
         // Mobile: lock the visual viewport so the canvas maps 1:1 to CSS pixels (no pinch zoom).
         var meta = document.createElement('meta');
         meta.name = 'viewport';


### PR DESCRIPTION
## What & why

Browser singleplayer on a Galaxy Tab A8 stuttered hard from the intro on, controls felt sluggish, and leaving the ship popped a fatal-looking browser modal ("EncodingError: unable to decode audio data"). Delivery was verified clean on both hosts (VPS + glitch CDN: byte-identical `audio/mpeg`, real 404s) — the decode fails client-side under memory pressure, and the game already recovers via the synth fallback; only Unity's JS error handler made it look fatal.

Guiding principle: **touch detection and performance tiering are separate.** Touch decides input affordances; the quality tier is a device start guess corrected by a real frame-time measurement — never device class alone. Desktop browsers are never stripped down.

## Changes

- **Template (#1419, #1420):** swallow exactly the audio-decode alert to the console (`alert` filter + `unhandledrejection`); DPR-1 cap also fires for multi-touch coarse-pointer devices (iPadOS desktop UA) while touch-screen laptops keep native DPR.
- **Canvas (#1420):** `ApplyWindowMode` no-ops on WebGL — the template owns the canvas size.
- **Shell quality (#1421):** IntroCinematic/MenuBackground respect the player's preset (Medium+ keeps the High cinematic look); shell cameras use the new `ApplyCameraLook(camData)` overload → no forced-High post + full-res SSAO on Low/Potato devices.
- **Touch from frame one (#1422):** `TouchControlsUi.NoteTouch()` latches at AppShell level and rescales the live EventSystem's tap-vs-drag threshold, so menus get touch-sized behavior pre-game.
- **Auto quality (#1423):** new `BrowserDevice` (GPU-family start guess: Mali/Adreno/PowerVR; "Apple GPU"+touch) + new `AutoQualityCalibrator` (samples shell frame times ~15 s, steps the `PresetAuto`-managed preset one notch per session; a manual preset choice ends auto-management for good).
- **Mobile profile (#1424):** WebGL Low = renderScale 0.8 + HDR off; mobile first-run defaults view distance 3 + Synth music; no 45-s track prefetch on mobile (each decoded track ≈ 80 MB PCM).
- **Browser-SP smoothness (#1425):** mobile tick cap 2/frame + 3 ms chunk-gen budget; prologue `RequiredPull` raymarch burst cached across 3 frames.

## Verification

- Full non-Slow test suite green locally (3018 passed).
- `dotnet format --verify-no-changes` clean.
- Local Unity Windows build from this branch compiles and builds the player (no new warnings; only WebGL-*runtime* checks are used — no new `#if UNITY_WEBGL` blocks, so PR CI compiles every new line).
- ⚠ On-device playtest (Tab A8 + desktop-browser regression) needs the next WebGL release build.

closes #1419 closes #1420 closes #1421 closes #1422 closes #1423 closes #1424 closes #1425

🤖 Generated with [Claude Code](https://claude.com/claude-code)