### PR TITLE
fix(playtest): first-person hand paint+lighting, straight punch, per-world door reset (#1427 #1428 #1429)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@ the richer, screenshot-laden versions live there. `(#123)` references the pull r
 
 ### Fixed
 
+- The first-person hand shows your painted arm design and no longer renders as a black silhouette —
+  the viewmodel never received the appearance editor's arm painting and its materials lacked the
+  avatar's ambient lift, so dark suit colours sank to pure black. (#1427)
+- The first-person arm no longer looks cut off at the back when punching: the camera near plane
+  clipped the forearm open and the generic tool jab swung that end into view; the bare hand now
+  throws a straight punch of its own. (#1428)
+- Landing on another body no longer leaves a stale door floating in mid-air while your ship's hatch
+  goes doorless — door ids restart per world and the client recycled an old door object for the
+  ship's hatch id; doors are now dropped on every world change and rebuilt when their record moved,
+  and respawns restock the door list. (#1429)
+
 - WorldHost leaked ~1 GB of anonymous Docker volumes per world wake — the image declared `/app/clients`
   + `/app/webgl` as VOLUMEs, every start downloaded the client installers into one, and `docker rm`
   ran without `-v`. Now `rm -v`, `BBS_FETCH_CLIENT=0` for hosted instances, and only saves + config

--- a/TODO.md
+++ b/TODO.md
@@ -130,6 +130,25 @@ prefetch (each decoded track is ~80 MB PCM). **#1425** browser-SP server budgets
 Desktop behavior is unchanged except: the shell honors Low/Potato, and desktop-browser first runs now calibrate
 UP from Low instead of being stuck there. Needs an on-device playtest (Tab A8) after the next WebGL release.
 
+### ★ Justus playtest: black first-person hand, truncated punch arm, the floating asteroid door (#1427–#1429, 2026-08-31, branch fix/justus-playtest-hand-doors)
+Three F1 reports from Justus (v2026.8.24). **#1427** the empty-slot hand ignored the appearance editor's arm
+painting (it only resolved the flat `ArmColor`) and its materials lacked the avatar's `_Floor 0.62`/`_Fill 0.3`
+ambient lift, so a dark base sank to a pure black silhouette in Linear space; `HeldItem` now bakes the same
+`BodyPaintKit` arm atlas (cached, right-limb OUTER chunk via material ST — the held-block tile trick) onto
+forearm/fist/thumb with a white tint, and all four hand parts get the lift. **#1428** the forearm's open rear end
+became visible when punching: the gameplay camera used Unity's default 0.3 near plane (the preview rigs use 0.1)
+which clipped the back-culled cube into a hollow tube, and `Kind.Hand` fell into the generic 55°-pitch tool jab
+that swung that end into view — near plane now 0.1 and the bare hand gets its own straight-punch pose (light
+wrist tilt only). **#1429** door ids are per world and restart at 1 (`RegisterDoors`), but `DoorView` never
+cleared on `WorldReset` and `OnDoors` mutated only `Open` on a known id — after ship travel to a small asteroid
+the recycled id 1 kept the OLD settlement door object pinned at old-world coordinates (folded next to the player
+by the ±circ/2 wrap) while the ship's hatch got no object at all: the "floating door" and the doorless ship were
+one bug. `DoorView` now drops everything on `WorldResetReceived` (NpcView pattern) and rebuilds any door whose
+pos/kind/axis/width changed (`SameDoor`); server-side, the three `WorldReset` senders without a follow-up
+restock (`RecoverToShip`, heal-tank respawn, station undock-return) now `SendDoors` too. Tests: EditMode
+`DoorViewEditModeTests` (identity predicate) + `HeldItemEditModeTests` paint-resolver pin; server-side
+`AssertDoorsFollowTheReset` added to both #1346 death-respawn regressions.
+
 ### ★ WorldHost: the VPS disk leak — 92 GB of orphaned anonymous volumes (#1414, 2026-08-30, branch fix/worldhost-volume-leak)
 Marcel: "what exactly eats so much disk on my VPS?" — 121 GB / 237 GB, and `docker system df` said 379 volumes,
 351 dangling, 92 GB reclaimable (+ 93 images, 82 unused, 17 GB). Four pieces: the `Dockerfile` declares

--- a/client/Assets/BlocksBeyondTheStars/Scripts/DoorView.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/DoorView.cs
@@ -34,6 +34,7 @@ namespace BlocksBeyondTheStars.Client
             public string Kind;
             public Vector3 World;          // canonical world pos (gap centre, floor)
             public float Width;
+            public bool AxisX;
             public bool Open;
             public float Anim;             // 0 closed → 1 open, eased toward Open
             public Transform Field;        // energy door: the translucent blue field shown in the open doorway
@@ -50,6 +51,7 @@ namespace BlocksBeyondTheStars.Client
             if (!_subscribed && Game?.Network != null)
             {
                 Game.Network.DoorsReceived += OnDoors;
+                Game.Network.WorldResetReceived += OnWorldReset;
                 _subscribed = true;
             }
 
@@ -100,19 +102,51 @@ namespace BlocksBeyondTheStars.Client
             }
         }
 
+        /// <summary>Travelling wipes the world: door ids are per world and restart at 1 on the destination
+        /// body, so every held door object is stale. Without this reset a recycled id pinned an old door at
+        /// its old coordinates — the "floating door on the asteroid" while the landed ship went doorless
+        /// (#1429). The server re-sends the destination's doors after every WorldReset.</summary>
+        private void OnWorldReset(WorldReset m)
+        {
+            foreach (var d in _doors.Values)
+            {
+                if (d.Go != null)
+                {
+                    Destroy(d.Go);
+                }
+            }
+
+            _doors.Clear();
+        }
+
+        /// <summary>True when the incoming record still describes the door object we hold for its id —
+        /// only then is it safe to mutate in place. A mismatch means the id was recycled for a different
+        /// door (see <see cref="OnWorldReset"/>) and the object must be rebuilt, not reused (#1429).</summary>
+        public static bool SameDoor(string kind, Vector3 world, float width, bool axisX, NetDoor nd)
+            => kind == nd.Kind
+               && axisX == nd.AxisX
+               && Mathf.Approximately(width, Mathf.Max(1f, nd.Width))
+               && (world - new Vector3(nd.X, nd.Y, nd.Z)).sqrMagnitude < 0.01f;
+
         private void OnDoors(DoorList m)
         {
             var seen = new HashSet<int>();
             foreach (var nd in m.Doors)
             {
                 seen.Add(nd.Id);
-                if (!_doors.TryGetValue(nd.Id, out var d))
+                if (_doors.TryGetValue(nd.Id, out var d) && !SameDoor(d.Kind, d.World, d.Width, d.AxisX, nd))
+                {
+                    Destroy(d.Go);
+                    _doors.Remove(nd.Id);
+                    d = null;
+                }
+
+                if (d == null)
                 {
                     d = Build(nd);
                     _doors[nd.Id] = d;
                 }
-
-                if (d.Open != nd.Open)
+                else if (d.Open != nd.Open)
                 {
                     d.Open = nd.Open;
                     PlayDoorSfx(d);
@@ -211,6 +245,7 @@ namespace BlocksBeyondTheStars.Client
                 Kind = nd.Kind,
                 World = new Vector3(nd.X, nd.Y, nd.Z),
                 Width = w,
+                AxisX = nd.AxisX,
                 Open = nd.Open,
                 Anim = nd.Open ? 1f : 0f,
                 Field = field,
@@ -364,6 +399,7 @@ namespace BlocksBeyondTheStars.Client
             if (_subscribed && Game?.Network != null)
             {
                 Game.Network.DoorsReceived -= OnDoors;
+                Game.Network.WorldResetReceived -= OnWorldReset;
             }
 
             if (Instance == this)

--- a/client/Assets/BlocksBeyondTheStars/Scripts/GameBootstrap.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/GameBootstrap.cs
@@ -1625,8 +1625,10 @@ namespace BlocksBeyondTheStars.Client
                     ? (Atlas.Texture, Atlas.TileUv(b.NumericId.Value))
                     : null;
 
-            // The empty-slot hand (#1033) wears a glove in the player's suit arm colour.
+            // The empty-slot hand (#1033) wears a glove in the player's suit arm colour — and the player's
+            // own arm painting from the appearance editor, so first person matches third person (#1427).
             HeldItem.HandTintResolver = () => Settings?.ArmColor;
+            HeldItem.HandPaintResolver = () => Settings?.ArmPixels;
 
             if (Loopback != null)
             {

--- a/client/Assets/BlocksBeyondTheStars/Scripts/HeldItem.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/HeldItem.cs
@@ -4,6 +4,7 @@
 using UnityEngine;
 using BlocksBeyondTheStars.Shared.Content;
 using BlocksBeyondTheStars.Shared.Definitions;
+using BodyPaint = BlocksBeyondTheStars.Shared.State.BodyPaint;
 
 namespace BlocksBeyondTheStars.Client
 {
@@ -24,6 +25,11 @@ namespace BlocksBeyondTheStars.Client
         /// <summary>Resolves the local player's suit arm colour so the empty-slot hand matches the
         /// avatar's glove. Wired by GameBootstrap; null falls back to the default suit blue.</summary>
         public static System.Func<Color?> HandTintResolver;
+
+        /// <summary>Resolves the local player's arm painting (the <c>BodyPaint</c> wire payload from the
+        /// appearance editor) so the empty-slot hand shows the player's own design instead of only the
+        /// flat suit colour (#1427). Wired by GameBootstrap; null/empty keeps the flat tint.</summary>
+        public static System.Func<string> HandPaintResolver;
 
         /// <summary>Default glove colour when no resolver is wired (= <c>ClientSettings.ArmColor</c> default).</summary>
         private static readonly Color DefaultGlove = new Color(0.20f, 0.45f, 0.80f);
@@ -160,10 +166,15 @@ namespace BlocksBeyondTheStars.Client
                     // Empty slot (#1033): a gloved fist on the suit-coloured forearm — thumb on the inner
                     // side of a right hand, cuff a darker shade for definition.
                     var cuff = new Color(tint.r * 0.7f, tint.g * 0.7f, tint.b * 0.7f);
-                    Cube(holder.transform, new Vector3(0.02f, -0.06f, -0.16f), new Vector3(0.11f, 0.11f, 0.30f), tint); // forearm
-                    Cube(holder.transform, new Vector3(0f, -0.02f, -0.02f), new Vector3(0.12f, 0.12f, 0.07f), cuff);    // cuff
-                    Cube(holder.transform, new Vector3(0f, 0f, 0.07f), new Vector3(0.13f, 0.12f, 0.14f), tint);         // fist
-                    Cube(holder.transform, new Vector3(-0.075f, 0.01f, 0.05f), new Vector3(0.05f, 0.06f, 0.08f), tint); // thumb
+                    var forearm = Cube(holder.transform, new Vector3(0.02f, -0.06f, -0.16f), new Vector3(0.11f, 0.11f, 0.30f), tint);
+                    var cuffGo = Cube(holder.transform, new Vector3(0f, -0.02f, -0.02f), new Vector3(0.12f, 0.12f, 0.07f), cuff);
+                    var fist = Cube(holder.transform, new Vector3(0f, 0f, 0.07f), new Vector3(0.13f, 0.12f, 0.14f), tint);
+                    var thumb = Cube(holder.transform, new Vector3(-0.075f, 0.01f, 0.05f), new Vector3(0.05f, 0.06f, 0.08f), tint);
+                    PaintHand(tint, forearm, fist, thumb); // the player's own arm painting, when there is one (#1427)
+                    // The hand is suit-coloured like the avatar, so it shares the avatar's failure mode:
+                    // LitColor's fixed key light + Linear colour space sink dark tints to a black silhouette
+                    // without the ambient lift PlayerAvatar.Lit applies (#1427). Cuff included.
+                    LiftAmbient(forearm, cuffGo, fist, thumb);
                     break;
 
                 default: // Tool
@@ -172,6 +183,63 @@ namespace BlocksBeyondTheStars.Client
             }
 
             return holder;
+        }
+
+        // Cached hand-paint atlas: the hand rebuilds on every hotbar change, and baking a texture each
+        // time would leak one per switch. Keyed by payload + base colour; the stale one is destroyed.
+        private static Texture2D _handAtlas;
+        private static string _handAtlasKey;
+
+        /// <summary>Applies the player's arm painting to the hand parts (white tint + the atlas the avatar
+        /// also bakes, mapped to the right arm's OUTER chunk — the hero face of the paint editor). Without
+        /// a valid painting the parts keep their flat suit tint, matching the pre-#1427 look.</summary>
+        private static void PaintHand(Color baseColor, params GameObject[] parts)
+        {
+            string pixels = HandPaintResolver?.Invoke();
+            if (string.IsNullOrEmpty(pixels) || pixels.Length != BodyPaint.ExpectedLength(BodyPaint.Arms))
+            {
+                return;
+            }
+
+            string key = pixels + "#" + ColorUtility.ToHtmlStringRGB(baseColor);
+            if (_handAtlasKey != key || _handAtlas == null)
+            {
+                if (_handAtlas != null)
+                {
+                    Object.Destroy(_handAtlas);
+                }
+
+                _handAtlas = BodyPaintKit.BuildAtlas(BodyPaint.Arms, pixels, baseColor);
+                _handAtlasKey = key;
+            }
+
+            // Right limb = canvas row 1 → chunks 4..7 (front|outer|back|inner); outer is chunk 5. Cube
+            // face UVs are 0..1, so the material ST maps every face onto that chunk (same trick as the
+            // held block's atlas tile above). Transparent pixels are pre-composited onto the base colour.
+            var uv = BodyPaintKit.ChunkRect(BodyPaint.Arms, 5);
+            foreach (var go in parts)
+            {
+                var m = go.GetComponent<Renderer>().sharedMaterial;
+                m.color = Color.white; // the painting's true colours, like the avatar's painted parts
+                m.mainTexture = _handAtlas;
+                m.mainTextureScale = new Vector2(uv.width, uv.height);
+                m.mainTextureOffset = new Vector2(uv.x, uv.y);
+            }
+        }
+
+        /// <summary>Raises LitColor's ambient floor + fill to the avatar's values (see
+        /// <c>PlayerAvatar.Lit</c>) so suit-coloured hand parts never sink to black (#1427).</summary>
+        private static void LiftAmbient(params GameObject[] parts)
+        {
+            foreach (var go in parts)
+            {
+                var m = go.GetComponent<Renderer>().sharedMaterial;
+                if (m.HasProperty("_Floor")) // no-op on the Unlit/Color fallback
+                {
+                    m.SetFloat("_Floor", 0.62f);
+                    m.SetFloat("_Fill", 0.3f);
+                }
+            }
         }
 
         private static GameObject Cube(Transform parent, Vector3 localPos, Vector3 scale, Color color)

--- a/client/Assets/BlocksBeyondTheStars/Scripts/Viewmodel.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/Viewmodel.cs
@@ -192,6 +192,15 @@ namespace BlocksBeyondTheStars.Client
                     posOff += new Vector3(0f, 0.045f * kick, -0.11f * kick);
                     rot += new Vector3(-24f * kick, 0f, 0f);
                 }
+                else if (_kind == HeldItem.Kind.Hand)
+                {
+                    // Bare hand: a straight punch. The forearm is an open-ended stump that sits below and
+                    // right of the frustum at its shallow depths — the generic jab's 55° pitch used to swing
+                    // that open rear end up into view ("the arm ends at the back", #1428). Drive the fist
+                    // forward with only a light wrist tilt so the rear stays off-screen.
+                    posOff += new Vector3(-0.04f, -0.02f, 0.16f) * jab;
+                    rot += new Vector3(9f * jab, -7f * jab, -5f * jab);
+                }
                 else
                 {
                     // Tools / drill / block: a forward-down jab.

--- a/client/Assets/BlocksBeyondTheStars/Scripts/WorldRig.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/WorldRig.cs
@@ -102,6 +102,10 @@ namespace BlocksBeyondTheStars.Client
             var cam = camGo.AddComponent<Camera>();
             camGo.AddComponent<AudioListener>(); // hear procedural SFX (M26)
             camGo.tag = "MainCamera";
+            // Unity's default near plane (0.3) cuts through the first-person viewmodel: the forearm's rear
+            // ~6 cm sat behind it and was clipped into a hollow open tube whenever a swing raised it into
+            // view (#1428). 0.1 matches the avatar/ship preview rigs; reversed-Z depth keeps precision fine.
+            cam.nearClipPlane = 0.1f;
 
             // URP look wiring: a code-created URP camera has post-processing OFF by default, so the global
             // UrpScenePost Volume (bloom/tonemap/vignette/teal-orange grade/lens flare) and SMAA would never run

--- a/client/Assets/Tests/EditMode/DoorViewEditModeTests.cs
+++ b/client/Assets/Tests/EditMode/DoorViewEditModeTests.cs
@@ -1,0 +1,75 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using BlocksBeyondTheStars.Client;
+using BlocksBeyondTheStars.Networking.Messages;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace BlocksBeyondTheStars.Client.Tests.EditMode
+{
+    /// <summary>
+    /// Pins the door-identity check from issue #1429: door ids are per world and restart at 1 after
+    /// travel, so <see cref="DoorView"/> must treat an id whose record moved (or changed kind/axis/width)
+    /// as a DIFFERENT door and rebuild it — reusing the old object left a stale door floating at its old
+    /// world's coordinates while the landed ship went doorless.
+    /// </summary>
+    public sealed class DoorViewEditModeTests
+    {
+        private static NetDoor Door(float x = 10f, float y = 20f, float z = 30f, string kind = "energy",
+            bool axisX = true, float width = 2f, bool open = false)
+            => new NetDoor { Id = 1, X = x, Y = y, Z = z, Kind = kind, AxisX = axisX, Width = width, Open = open };
+
+        [Test]
+        public void UnchangedRecordIsTheSameDoor()
+        {
+            var nd = Door();
+            Assert.That(DoorView.SameDoor("energy", new Vector3(10f, 20f, 30f), 2f, true, nd), Is.True);
+        }
+
+        [Test]
+        public void OpenStateIsNotPartOfTheIdentity()
+        {
+            var nd = Door(open: true);
+            Assert.That(DoorView.SameDoor("energy", new Vector3(10f, 20f, 30f), 2f, true, nd), Is.True);
+        }
+
+        [Test]
+        public void MovedDoorIsADifferentDoor()
+        {
+            // The #1429 replay: the recycled id 1 now names the ship hatch on the asteroid, far from the
+            // old settlement door's coordinates.
+            var nd = Door(x: 863f, y: 50f, z: -31f);
+            Assert.That(DoorView.SameDoor("energy", new Vector3(10f, 20f, 30f), 2f, true, nd), Is.False);
+        }
+
+        [Test]
+        public void ChangedKindIsADifferentDoor()
+        {
+            var nd = Door(kind: "hinge");
+            Assert.That(DoorView.SameDoor("energy", new Vector3(10f, 20f, 30f), 2f, true, nd), Is.False);
+        }
+
+        [Test]
+        public void FlippedAxisIsADifferentDoor()
+        {
+            var nd = Door(axisX: false);
+            Assert.That(DoorView.SameDoor("energy", new Vector3(10f, 20f, 30f), 2f, true, nd), Is.False);
+        }
+
+        [Test]
+        public void ChangedWidthIsADifferentDoor()
+        {
+            var nd = Door(width: 3f);
+            Assert.That(DoorView.SameDoor("energy", new Vector3(10f, 20f, 30f), 2f, true, nd), Is.False);
+        }
+
+        [Test]
+        public void WidthComparesAgainstTheBuildClamp()
+        {
+            // Build() clamps the width to at least 1, so a sub-1 wire value must still match the stored 1.
+            var nd = Door(width: 0.5f);
+            Assert.That(DoorView.SameDoor("energy", new Vector3(10f, 20f, 30f), 1f, true, nd), Is.True);
+        }
+    }
+}

--- a/client/Assets/Tests/EditMode/DoorViewEditModeTests.cs.meta
+++ b/client/Assets/Tests/EditMode/DoorViewEditModeTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e77091d2743466a4dbc8586a47c138f2

--- a/client/Assets/Tests/EditMode/HeldItemEditModeTests.cs
+++ b/client/Assets/Tests/EditMode/HeldItemEditModeTests.cs
@@ -15,7 +15,11 @@ namespace BlocksBeyondTheStars.Client.Tests.EditMode
     public sealed class HeldItemEditModeTests
     {
         [TearDown]
-        public void TearDown() => HeldItem.HandTintResolver = null;
+        public void TearDown()
+        {
+            HeldItem.HandTintResolver = null;
+            HeldItem.HandPaintResolver = null;
+        }
 
         [Test]
         public void EmptySlotResolvesToHand()
@@ -43,6 +47,17 @@ namespace BlocksBeyondTheStars.Client.Tests.EditMode
         public void NonEmptyKeyWithoutContentStaysNone()
         {
             Assert.That(HeldItem.For(null, "iron_drill").kind, Is.EqualTo(HeldItem.Kind.None));
+        }
+
+        [Test]
+        public void PaintResolverDoesNotChangeTheResolvedTint()
+        {
+            // The painting is applied at build time on top of the base tint (#1427) — For() keeps
+            // resolving the flat arm colour so the cuff shade and the unpainted fallback stay stable.
+            var arm = new Color(0.9f, 0.1f, 0.2f);
+            HeldItem.HandTintResolver = () => arm;
+            HeldItem.HandPaintResolver = () => new string('1', 8 * 32 * 32);
+            Assert.That(HeldItem.For(null, "").tint, Is.EqualTo(arm));
         }
     }
 }

--- a/src/BlocksBeyondTheStars.GameServer/GameServer.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServer.cs
@@ -2055,6 +2055,7 @@ public sealed partial class GameServer
         SendCreatures(session);
         SendContainers(session);
         SendNpcs(session);
+        SendDoors(session); // the client drops all doors on WorldReset (#1429) — restock the home world's
     }
 
     /// <summary>Upper bound on a client-requested render distance (matches the in-game slider's max), so a

--- a/src/BlocksBeyondTheStars.GameServer/GameServerHealTanks.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerHealTanks.cs
@@ -290,6 +290,7 @@ public sealed partial class GameServer
         SendCreatures(session);
         SendContainers(session);
         SendNpcs(session);
+        SendDoors(session); // the client drops all doors on WorldReset (#1429) — restock the spawn world's
         return true;
     }
 

--- a/src/BlocksBeyondTheStars.GameServer/GameServerSpaceStations.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerSpaceStations.cs
@@ -399,6 +399,7 @@ public sealed partial class GameServer
         SendContainers(session);
         SendNpcs(session);
         SendInventory(session);
+        SendDoors(session); // the client drops all doors on WorldReset (#1429) — restock the return world's
 
         // Drop the now-empty station world from memory (its structure is persisted, NPCs re-spawn next visit).
         if (!OccupiedLocations().Contains(stationLoc))

--- a/tests/BlocksBeyondTheStars.Tests/LanPlaytestRegressionTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/LanPlaytestRegressionTests.cs
@@ -696,6 +696,20 @@ public sealed class LanPlaytestRegressionTests : IDisposable
         Assert.True(placement > reset, "…and re-arm the ship marker AFTER that reset (#1346)");
     }
 
+    /// <summary>Since #1429 the client also drops all door objects on EVERY WorldReset (door ids are per
+    /// world and restart at 1, so keeping them pinned stale doors at old-world coordinates). A reset that
+    /// is not followed by a DoorList leaves the respawn world doorless.</summary>
+    private static void AssertDoorsFollowTheReset(RecordingTransport transport, PlayerSession session)
+    {
+        var msgs = transport.Sent.Where(x => x.Conn == session.ConnectionId).Select(x => x.Msg).ToList();
+        int reset = msgs.FindIndex(m => m is WorldReset);
+        // PlaceLandedShip broadcasts a DoorList DURING the transition, i.e. before the reset that wipes
+        // it client-side — only a DoorList after the (first) reset actually restocks, so look from there.
+        int doors = msgs.FindLastIndex(m => m is DoorList);
+        Assert.True(reset >= 0, "a death away from the ship's world must reset the world");
+        Assert.True(doors > reset, "…and restock the doors AFTER that reset (#1429)");
+    }
+
     [Fact]
     public void DyingInSpace_ResendsTheShipPlacement_AfterTheWorldReset()
     {
@@ -711,6 +725,7 @@ public sealed class LanPlaytestRegressionTests : IDisposable
 
         Assert.True(host.State.AboardShip);
         AssertShipPlacementFollowsTheReset(transport, host);
+        AssertDoorsFollowTheReset(transport, host); // same gap for the door objects (#1429)
     }
 
     [Fact]
@@ -753,5 +768,6 @@ public sealed class LanPlaytestRegressionTests : IDisposable
         Assert.Equal(body.Id, host.CurrentLocationId);
         Assert.False(host.State.AboardShip); // woke at the home tank, on foot
         AssertShipPlacementFollowsTheReset(transport, host);
+        AssertDoorsFollowTheReset(transport, host); // same gap for the door objects (#1429)
     }
 }


### PR DESCRIPTION
Fixes the three bugs from Justus' 2026-08-31 playtest reports (v2026.8.24).

## #1427 — first-person hand renders black / ignores the painted arm

- `HeldItem` gains a `HandPaintResolver` (wired to `Settings.ArmPixels` in `GameBootstrap`): the
  empty-slot hand now bakes the same `BodyPaintKit` arm atlas the third-person avatar uses (cached,
  keyed by payload + base colour) and maps the right limb's OUTER chunk onto forearm/fist/thumb via
  the material ST transform — the held-block atlas-tile trick. Unpainted arms keep the flat tint.
- All four hand cubes get the avatar's ambient lift (`_Floor 0.62` / `_Fill 0.3`, see
  `PlayerAvatar.Lit`) so dark suit colours no longer sink to a pure black silhouette in Linear space.

## #1428 — first-person arm looks truncated ("ends at the back") when punching

- The gameplay camera used Unity's default 0.3 near plane, which clipped the back-culled forearm
  cube into a hollow open tube; it is now 0.1, matching the avatar/ship preview rigs.
- `Kind.Hand` no longer falls into the generic 55°-pitch tool jab (which swung the open rear end up
  into view): the bare hand gets its own straight-punch pose (forward drive, light wrist tilt).

## #1429 — floating door on the asteroid == the landed ship's missing hatch door (one bug)

Door ids are per world and restart at 1 (`RegisterDoors`), but `DoorView` survived world changes and
`OnDoors` mutated only `Open` on a known id. After travelling to a small asteroid the recycled id 1
kept the OLD settlement door object at its old-world coordinates (the ±circumference/2 wrap folded it
right next to the player) while the ship's hatch never got an object — one bug, both symptoms.

- Client: `DoorView` drops all door objects on `WorldResetReceived` (the `NpcView` pattern) and
  rebuilds any door whose position/kind/axis/width changed (`SameDoor` identity check), which also
  covers same-world re-registrations.
- Server: the three `WorldReset` senders that never restocked doors afterwards — `RecoverToShip`,
  the heal-tank respawn, and the station undock-return — now call `SendDoors` like the travel path.

## Tests

- `DoorViewEditModeTests` — pins the `SameDoor` identity predicate (moved/kind/axis/width ⇒ rebuild;
  open-state and the width clamp ⇒ same door).
- `HeldItemEditModeTests` — paint resolver must not change the resolved flat tint (cuff shade +
  unpainted fallback stay stable).
- `AssertDoorsFollowTheReset` added to both #1346 death-respawn regressions: every `WorldReset` in
  those flows must be followed by a `DoorList`.

Full non-Slow server suite green locally (2557 tests), `dotnet format` clean, local Unity build run
(client/Assets changed). No new locale keys or art assets are needed — the hand reuses the existing
body-paint atlas and doors are procedural.

closes #1427
closes #1428
closes #1429

🤖 Generated with [Claude Code](https://claude.com/claude-code)
