### PR TITLE
fix(client): tablet-profile review fixes — prologue pull-cache overflow, cross-browser audio-alert filter, BrowserDevice laptop misclassification (#1430-#1432)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -130,6 +130,16 @@ prefetch (each decoded track is ~80 MB PCM). **#1425** browser-SP server budgets
 Desktop behavior is unchanged except: the shell honors Low/Potato, and desktop-browser first runs now calibrate
 UP from Low instead of being stuck there. Needs an on-device playtest (Tab A8) after the next WebGL release.
 
+**Post-merge code review fixes (#1430–#1432, 2026-08-31, branch fix/tablet-profile-review-fixes):** the review
+of #1426 found **#1430** the prologue pull cache's `int.MinValue` frame sentinel overflowed in
+`frameCount - _pullCheckedFrame` — the cached branch always won, `RequiredPull` never ran and the terrain
+safety net was dead on every platform (camera could clip into late-streamed terrain); the sentinel is now
+`-PullRecheckFrames`. **#1431** the audio-decode alert filter only matched Chrome's wording — it now also
+catches Firefox ("…passed to decodeAudioData…") and Safari ("Decoding failed"). **#1432** `BrowserDevice`
+called Adreno/Mali laptops (Windows-on-ARM, MediaTek Chromebooks) phone/tablet-class — the mobile-GPU branch
+now requires touch, and a `Direct3D` renderer string (Windows ANGLE) always means desktop. Playtest note for
+the Tab A8: the VD-3/Synth first-run defaults only apply on a fresh origin — clear site data before testing.
+
 ### ★ Justus playtest: black first-person hand, truncated punch arm, the floating asteroid door (#1427–#1429, 2026-08-31, branch fix/justus-playtest-hand-doors)
 Three F1 reports from Justus (v2026.8.24). **#1427** the empty-slot hand ignored the appearance editor's arm
 painting (it only resolved the flat `ArmColor`) and its materials lacked the avatar's `_Floor 0.62`/`_Fill 0.3`

--- a/client/Assets/BlocksBeyondTheStars/Scripts/BrowserDevice.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/BrowserDevice.cs
@@ -33,10 +33,19 @@ namespace BlocksBeyondTheStars.Client
             // lie — a budget tablet reports 8 cores like a desktop, and UA sniffing misses iPadOS
             // Safari (desktop "Macintosh" UA). "Apple GPU" alone is ambiguous (M-series Macs report it
             // in Safari too), so it only counts together with touch support, which Mac Safari lacks.
+            // Those GPU families are NOT phone-exclusive though (#1432): Windows-on-ARM Snapdragon
+            // laptops report Adreno and MediaTek Chromebooks report Mali — so the mobile-GPU branch
+            // also requires touch (every real phone/tablet browser has it), and a renderer string
+            // naming Direct3D (Windows ANGLE backend) is a Windows machine, whatever the GPU vendor.
             string gpu = SystemInfo.graphicsDeviceName ?? string.Empty;
+            if (Contains(gpu, "Direct3D"))
+            {
+                return false;
+            }
+
             bool mobileGpu = Contains(gpu, "Mali") || Contains(gpu, "Adreno") || Contains(gpu, "PowerVR");
             bool appleTouch = Contains(gpu, "Apple") && Input.touchSupported;
-            return mobileGpu || appleTouch;
+            return (mobileGpu && Input.touchSupported) || appleTouch;
         }
 
         private static bool Contains(string haystack, string needle)

--- a/client/Assets/BlocksBeyondTheStars/Scripts/PrologueCinematic.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/PrologueCinematic.cs
@@ -313,7 +313,9 @@ namespace BlocksBeyondTheStars.Client
         // terrain immediately.
         private const int PullRecheckFrames = 3;
         private int _cachedPull;
-        private int _pullCheckedFrame = int.MinValue;
+        // NOT int.MinValue: `frameCount - int.MinValue` wraps negative and would keep the cache branch
+        // taken forever (#1430) — this sentinel makes the very first LateUpdate recompute.
+        private int _pullCheckedFrame = -PullRecheckFrames;
 
         private void LateUpdate()
         {

--- a/client/Assets/WebGLTemplates/BlocksBeyondTheStars/index.html
+++ b/client/Assets/WebGLTemplates/BlocksBeyondTheStars/index.html
@@ -109,8 +109,11 @@
       // synth engine takes over. But Unity's default error handler still raises a fatal-looking
       // "An error occurred running the Unity content" alert for it. Swallow exactly that message —
       // to the console, not the player — and keep every other error on the loud path (#1419).
+      // Every engine words the decodeAudioData EncodingError differently (#1431): Chrome "Unable to
+      // decode audio data", Firefox "The buffer passed to decodeAudioData contains an invalid
+      // content …", Safari "Decoding failed" — match all three.
       function bbsIsAudioDecodeError(msg) {
-        return typeof msg === "string" && msg.indexOf("decode audio data") !== -1;
+        return typeof msg === "string" && /decode audio data|decodeAudioData|Decoding failed/i.test(msg);
       }
       var bbsNativeAlert = window.alert.bind(window);
       window.alert = function (msg) {


### PR DESCRIPTION
Post-merge code review of the tablet-browser profile (PR #1426, unreleased) surfaced three defects; this PR fixes all of them before the next WebGL release ships the profile.

## #1430 — prologue pull cache never revalidated (int overflow)

`_pullCheckedFrame` was initialized to `int.MinValue`, and `Time.frameCount - _pullCheckedFrame` wraps to a large **negative** int for any realistic frame count — always `< PullRecheckFrames`. The cached branch won forever, `RequiredPull` never ran, and the prologue camera's terrain safety net was dead on **every** platform: the camera never pulled out of late-streamed terrain, and the per-frame clear-check fallback snapped to the same blocked spot. The sentinel is now `-PullRecheckFrames`, so the very first `LateUpdate` recomputes and the 3-frame cache works as #1425 intended.

## #1431 — audio-decode alert filter was Chrome-only

`bbsIsAudioDecodeError` matched the substring `"decode audio data"` — Chrome's wording. Firefox says "The buffer passed to decodeAudioData contains an invalid content …" and Safari says "Decoding failed", so both still got the fatal-looking "An error occurred running the Unity content" modal for a failure the game fully recovers from. The predicate now matches all three wordings case-insensitively; both interception points (alert override + `unhandledrejection`) share it.

## #1432 — BrowserDevice misclassified Adreno/Mali laptops

The Mali/Adreno/PowerVR branch had no touch requirement, so Windows-on-ARM Snapdragon laptops (Adreno through ANGLE) and MediaTek Chromebooks got the full stripped-down mobile profile — VD 3 + Synth first run, tighter server budgets, no prefetch, and a pre-latched in-game touch overlay on machines that may not even have a touchscreen. The mobile-GPU branch now also requires `Input.touchSupported`, and a renderer string containing `Direct3D` (Windows ANGLE backend) always classifies as desktop. Touch-capable Mali Chromebooks remain misclassified; accepted as rare — the frame-time calibrator still corrects their preset.

## Verification

- Local Unity Windows client build (batch mode) in a clean worktree: green.
- No `#if UNITY_WEBGL` involved — everything compiles in PR CI.

closes #1430
closes #1431
closes #1432

🤖 Generated with [Claude Code](https://claude.com/claude-code)
