### PR TITLE
perf(webgl): tablet OOM package — heap telemetry, 256 MB initial heap, VD-scaled mobile chunk horizon, NetCodec UTF-8 fast path

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -110,6 +110,26 @@ Per-item detail lives in the dated work log below. **Since 2026-07 versions are 
 #1144, #1146, #1147), all 28 sub-issues #1102–#1129 done. The whole package is UNRELEASED pending the big
 playtest; the post-epic implementation audit spawned the follow-up fix round #1149–#1156.
 
+### ★ WebGL tablet wasm-heap OOM: shell heap telemetry, 256 MB initial heap, VD-scaled mobile chunk horizon, NetCodec UTF-8 fast path (#1436–#1440, 2026-09-01, branch perf/webgl-mobile-memory)
+The Tab A8 retest of v2026.8.25 on a FRESH origin still died right after the loading screen —
+`abort("OOM")` via `abortOnCannotGrowMemory`: the wasm heap could not grow on the 3-4 GB device.
+**#1436** the WebGL shell template now watches `Module.HEAPU8.length` (re-read every sample; emscripten
+swaps the buffer on growth) and logs `[BBS-Heap] total/peak` on growth plus a 30 s heartbeat — the first
+heap visibility we have (peak also on `window.bbsHeapPeakMB`). **#1437** `webGLInitialMemorySize` 32 → 256 MB
+(maximum stays 2048 — deliberately NOT lowered, desktops keep their headroom): the heap starts at a size it
+reaches anyway instead of performing dozens of growth steps through the OOM-critical streaming phase.
+**#1438** on phone/tablet browsers the client's chunk horizon now scales with the join-time view distance
+instead of the desktop constants (unload 384 → `(VD+4)*16`, draw cull 256 → `(VD+2)*16`, collider ≤ cull;
+desktop unchanged): at VD 3 the server only streams a ~4-chunk radius, so the 384-block unload horizon let
+the resident set grow with travel, not view — thousands of chunk objects (render mesh + CPU-side collider
+mesh + voxel copy) in a heap that cannot afford them. **#1440** `NetCodec` JSON envelope now serializes
+straight to UTF-8 and parses/deserializes received bytes in place (was: 4 copies on encode, ~6 on decode
+incl. two full UTF-16 strings per message — at 16+ chunk messages/tick through BOTH in-process loopback
+directions, pure heap-growth churn); wire bytes unchanged, codec tests green. **#1439** (cheaper synth
+music on mobile) turned out already shipped — synth renders at 22.05 kHz since its introduction, mobile
+skips the prefetch (#1424) and the cache trims to active+fading; closed without code. Needs a Tab A8
+playtest; the `[BBS-Heap]` log now tells us where the memory actually goes if it still fails.
+
 ### ★ WebGL on tablets: audio EncodingError modal + browser-mobile profile + auto quality calibration (#1419–#1425, 2026-08-31, branch feat/webgl-tablet-profile)
 Marcel's Galaxy Tab A8 test of browser singleplayer: heavy stutter from the intro on, sluggish controls, and a
 fatal-looking "EncodingError: unable to decode audio data" modal after leaving the ship. Delivery was verified

--- a/client/Assets/BlocksBeyondTheStars/Scripts/GameBootstrap.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/GameBootstrap.cs
@@ -1509,6 +1509,29 @@ namespace BlocksBeyondTheStars.Client
         public float ChunkUnloadDistanceBlocks = 384f;
         private readonly List<ChunkCoord> _unloadScratch = new List<ChunkCoord>();
 
+        // Memory (#1438): on a phone/tablet browser the three distances above must scale with the ACTIVE
+        // view distance instead of staying at these desktop-sized constants. There the server only streams
+        // a VD+1 radius (VD 3 → ~64 blocks), so with a 384-block unload horizon the resident set is bounded
+        // by travel, not by view distance — after a long walk, thousands of chunk objects (each a render
+        // mesh + CPU-resident collider mesh + voxel copy) pile up in the wasm heap of a 3-4 GB tablet that
+        // OOMs (abortOnCannotGrowMemory). Scaled, not capped: a device that runs at a higher view distance
+        // gets its horizon back. Unload stays beyond the draw cull so a visible chunk is never dropped;
+        // the collider range never exceeds the cull (nothing interactable lives beyond it on mobile).
+        // ViewDistanceChunks is the join-time value the server actually streams at (0 = server default 4).
+        private (float Cull, float Collider, float Unload) EffectiveChunkDistances()
+        {
+            if (!BrowserDevice.IsMobileBrowser)
+            {
+                return (ChunkDrawDistanceBlocks, ChunkColliderDistanceBlocks, ChunkUnloadDistanceBlocks);
+            }
+
+            int vd = ViewDistanceChunks > 0 ? ViewDistanceChunks : 4;
+            float cull = Mathf.Min(ChunkDrawDistanceBlocks, (vd + 2) * WorldConstants.ChunkSize);
+            float collider = Mathf.Min(ChunkColliderDistanceBlocks, cull);
+            float unload = Mathf.Min(ChunkUnloadDistanceBlocks, (vd + 4) * WorldConstants.ChunkSize);
+            return (cull, collider, unload);
+        }
+
         // Performance (P2): assigning MeshCollider.sharedMesh cooks the collision mesh synchronously on the
         // main thread — the single heaviest per-chunk op. Instead we run Physics.BakeMesh on a worker thread
         // and assign the (now-cached) cook back on the main thread in DrainBakedColliders. _colliderGen +
@@ -2358,9 +2381,10 @@ namespace BlocksBeyondTheStars.Client
         private void RepositionChunks()
         {
             var pp = PlayerPosition;
-            float cullSq = ChunkDrawDistanceBlocks * ChunkDrawDistanceBlocks;
-            float colliderSq = ChunkColliderDistanceBlocks * ChunkColliderDistanceBlocks;
-            float unloadSq = ChunkUnloadDistanceBlocks * ChunkUnloadDistanceBlocks;
+            var (cull, collider, unload) = EffectiveChunkDistances();
+            float cullSq = cull * cull;
+            float colliderSq = collider * collider;
+            float unloadSq = unload * unload;
             _unloadScratch.Clear();
             foreach (var kv in _chunkObjects)
             {

--- a/client/Assets/WebGLTemplates/BlocksBeyondTheStars/index.html
+++ b/client/Assets/WebGLTemplates/BlocksBeyondTheStars/index.html
@@ -132,6 +132,28 @@
         }
       });
 
+      // Wasm-heap watcher (#1436): the OOM crash on low-memory tablets (abortOnCannotGrowMemory)
+      // is invisible without knowing how big the heap actually is at each point. Sampled here in
+      // the shell — plain JS shipped with every build, no engine-side code paths PR CI can't
+      // compile. HEAPU8 must be re-read every sample: emscripten replaces the buffer on growth.
+      // Logs on growth plus a 30 s heartbeat so a console capture stays low-noise but always has
+      // a recent size next to the game's own milestone logs. Peak also on window.bbsHeapPeakMB.
+      function bbsWatchHeap(unityInstance) {
+        var peak = 0, lastLogged = 0, lastHeartbeat = Date.now();
+        setInterval(function () {
+          var heap;
+          try { heap = unityInstance.Module.HEAPU8.length; } catch (e) { return; }
+          var mb = Math.round(heap / (1024 * 1024));
+          if (mb > peak) { peak = mb; window.bbsHeapPeakMB = peak; }
+          var now = Date.now();
+          if (mb !== lastLogged || now - lastHeartbeat >= 30000) {
+            console.log("[BBS-Heap] total=" + mb + "MB peak=" + peak + "MB");
+            lastLogged = mb;
+            lastHeartbeat = now;
+          }
+        }, 2000);
+      }
+
       var buildUrl = "Build";
       // Unity emits STABLE file names (WebGL.data.unityweb, …), so URLs alone can't distinguish builds.
       // The server rewrites this stamp to "?v=<build timestamp>" when serving the page — every build gets
@@ -187,6 +209,7 @@
           document.querySelector("#unity-fullscreen-button").onclick = () => {
             unityInstance.SetFullscreen(1);
           };
+          bbsWatchHeap(unityInstance);
         }).catch((message) => {
           alert(message);
         });

--- a/client/ProjectSettings/ProjectSettings.asset
+++ b/client/ProjectSettings/ProjectSettings.asset
@@ -617,7 +617,7 @@ PlayerSettings:
   webGLLinkerTarget: 1
   webGLThreadsSupport: 0
   webGLDecompressionFallback: 1
-  webGLInitialMemorySize: 32
+  webGLInitialMemorySize: 256
   webGLMaximumMemorySize: 2048
   webGLMemoryGrowthMode: 2
   webGLMemoryLinearGrowthStep: 16

--- a/src/BlocksBeyondTheStars.Networking/NetCodec.cs
+++ b/src/BlocksBeyondTheStars.Networking/NetCodec.cs
@@ -585,7 +585,16 @@ public static class NetCodec
         return false;
     }
 
-    /// <summary>Encodes a tagged JSON payload for browser WebSocket clients.</summary>
+    // Per-tag UTF-8 envelope prefix ("{\"tag\":<n>,\"body\":"), built once per tag. A benign race may
+    // compute an entry twice; both results are identical.
+    private static readonly byte[]?[] JsonEnvelopeHeads = new byte[byte.MaxValue + 1][];
+
+    /// <summary>Encodes a tagged JSON payload for browser WebSocket clients. Serializes straight to
+    /// UTF-8 and composes the envelope in the output buffer — the string-based path (body string →
+    /// envelope concat → GetBytes) made four full copies per message, two of them UTF-16. Chunk
+    /// streaming pushes 15-25 KB messages through here 16+ times per tick, and in browser
+    /// singleplayer BOTH loopback directions do — that churn is pure wasm-heap growth on tablets
+    /// (#1440). The wire bytes are unchanged.</summary>
     public static byte[] EncodeJson(object message)
     {
         var type = message.GetType();
@@ -594,12 +603,13 @@ public static class NetCodec
             throw new InvalidOperationException($"Message type '{type.Name}' is not registered with NetCodec.");
         }
 
-        string body = JsonSerializer.Serialize(message, type, JsonOptions);
-        string envelope = "{\"tag\":" + tag + ",\"body\":" + body + "}";
-        byte[] json = Encoding.UTF8.GetBytes(envelope);
-        var payload = new byte[json.Length + 1];
+        byte[] body = JsonSerializer.SerializeToUtf8Bytes(message, type, JsonOptions);
+        byte[] head = JsonEnvelopeHeads[tag] ??= Encoding.UTF8.GetBytes("{\"tag\":" + tag + ",\"body\":");
+        var payload = new byte[1 + head.Length + body.Length + 1];
         payload[0] = JsonEnvelopeTag;
-        Buffer.BlockCopy(json, 0, payload, 1, json.Length);
+        Buffer.BlockCopy(head, 0, payload, 1, head.Length);
+        Buffer.BlockCopy(body, 0, payload, 1 + head.Length, body.Length);
+        payload[payload.Length - 1] = (byte)'}';
         return payload;
     }
 
@@ -656,8 +666,10 @@ public static class NetCodec
 
         try
         {
-            string json = Encoding.UTF8.GetString(payload, 1, payload.Length - 1);
-            using var doc = JsonDocument.Parse(json, JsonDocumentOptions);
+            // Parse the received UTF-8 directly and deserialize the body element in place. The old
+            // path (GetString → Parse(string) → GetRawText() → Deserialize(string)) round-tripped
+            // every message through two full UTF-16 strings and two transcodes (#1440).
+            using var doc = JsonDocument.Parse(new ReadOnlyMemory<byte>(payload, 1, payload.Length - 1), JsonDocumentOptions);
             var root = doc.RootElement;
             if (!root.TryGetProperty("tag", out var tagElement)
                 || !tagElement.TryGetInt32(out int tag)
@@ -673,7 +685,7 @@ public static class NetCodec
                 return null;
             }
 
-            return JsonSerializer.Deserialize(bodyElement.GetRawText(), type, JsonOptions);
+            return bodyElement.Deserialize(type, JsonOptions);
         }
         catch (JsonException)
         {


### PR DESCRIPTION
## Context

The Galaxy Tab A8 retest of v2026.8.25 (fresh origin, tablet profile active) still crashes with `abort("OOM") / abortOnCannotGrowMemory` right after the loading screen — the wasm heap cannot grow on the 3-4 GB device. This package adds the first heap visibility and removes the demand drivers we can cut **without touching desktop behaviour** (explicit requirement: stronger devices keep their full horizon and headroom).

## Changes

- **Shell heap telemetry (#1436):** the WebGL template samples `Module.HEAPU8.length` (re-read every sample — emscripten swaps the buffer on growth) and logs `[BBS-Heap] total/peak` on growth plus a 30 s heartbeat; peak also on `window.bbsHeapPeakMB`. JS-only, no engine code paths PR CI can't compile.
- **Initial heap 32 → 256 MB (#1437):** `webGLInitialMemorySize` raised; `webGLMaximumMemorySize` deliberately stays 2048. The heap starts at a size it reaches anyway instead of performing dozens of growth steps through the OOM-critical streaming phase.
- **VD-scaled mobile chunk horizon (#1438):** on `BrowserDevice.IsMobileBrowser` the client's unload/cull/collider distances derive from the join-time view distance (unload `(VD+4)*16`, draw cull `(VD+2)*16`, collider ≤ cull) instead of the desktop constants (384/256/96). At VD 3 the server streams only a ~4-chunk radius, so the 384-block unload horizon let the resident set (render mesh + CPU-side collider mesh + voxel copy per chunk) grow with travel, not view. Scaling rule, not a cap — a device running a higher VD gets its horizon back. Desktop path returns the constants unchanged.
- **NetCodec UTF-8 fast path (#1440):** the JSON envelope now serializes straight to UTF-8 bytes (per-tag cached envelope head) and parses/deserializes received bytes in place (`JsonDocument.Parse(bytes)` + `JsonElement.Deserialize`), replacing 4 encode + ~6 decode copies (two of them full UTF-16 strings per message). Wire bytes unchanged; benefits the WebSocket edge and both in-process loopback directions in browser SP.

Not in this PR: #1439 (cheaper synth music on mobile) turned out to be already shipped — synth renders at 22.05 kHz since its introduction, mobile skips the prefetch (#1424) and the cache trims to active+fading — closed separately without code.

## Verification

- Full non-Slow suite in Release: **2557 server + 461 client tests, 0 failures** (includes the NetCodec fuzz/roundtrip tests).
- `dotnet format --verify-no-changes` clean.
- Local Unity Windows build (batch mode) green from this worktree.
- Pending: on-device Tab A8 playtest after the next WebGL release — the `[BBS-Heap]` log now shows where the memory goes if it still fails.

closes #1436
closes #1437
closes #1438
closes #1440

🤖 Generated with [Claude Code](https://claude.com/claude-code)