### PR TITLE
fix(graphics): daylight re-tune — overcast floor, block ambient, vignette/contrast, Neutral tonemap on LDR, brightness row first (#1457)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ the richer, screenshot-laden versions live there. `(#123)` references the pull r
 
 ## [Unreleased]
 
+### ☀️ Daylight re-tune — grey days are still days (#1457)
+
+- **Worlds read brighter by day** (#1457). "Die Welten wirken auch tagsüber sehr dunkel und drückend"
+  (school playtest, browser). Four small levers, no new look: overcast now dims the daylight to 78 %
+  instead of 65 % (on swamp, ashen and fungal worlds — which never clear — every day read as dusk),
+  sky-lit block faces turned away from the sun get a touch more ambient, the baseline vignette and
+  the extra contrast in the post grade are eased, and the brightness slider moved to the top of the
+  graphics settings. Browser Low/Potato, which render without an HDR buffer, use the Neutral tonemap
+  instead of ACES — ACES over an already-clamped frame only crushed the midtones.
+
 ### 🎒 School playtest 2026-09-02 — scanner, see-through edges, bed, cameras, hand, menu memory (#1456 #1458 #1459 #1460 #1463 #1464)
 
 - **Titans can be scanned** (#1458). The scanner tested a creature's *origin* — its feet at the body

--- a/TODO.md
+++ b/TODO.md
@@ -123,6 +123,20 @@ testing); **startup** — a refused initial wasm memory from `createUnityInstanc
 `[BBS-Heap]` peak so the number is readable on-device without USB debugging. Original messages still
 go to the console; every other error keeps the loud alert path. Desktop with enough RAM: no change.
 
+### ★ Daylight re-tune: overcast floor, ambient, vignette/contrast, Neutral tonemap on LDR, brightness row (#1457, 2026-09-02, branch fix/daylight-retune)
+Verena (school playtest, browser): "auch tagsüber sehr dunkel und drückend". The June brightness work (PR #65:
+night floor 0.35, weatherDim 0.65, `dayLit` shoulder, shader `nightFloor`, brightness slider) IS live; what
+remained is the PT-1 visual re-tune the Linear migration asked for and a WebGL-specific flattening. NOTE on the
+"gamma→linear double application" theory: `ShaderColor.Srgb(tint)` = `.linear` reproduces the gamma-era
+perceived product exactly (albedo_lin·light_lin → display = albedo_γ·0.35), so the scalar path is not a bug;
+the constants were simply tuned dark and the additive shader terms shifted. Changes: `Sky.cs` weatherDim floor
+0.65 → 0.78; `BlockAtlas.shader` `amb = lerp(0.26, 0.78, sky)` (was 0.24/0.70, both passes); `UrpScenePost`
+`BaseVignette` 0.26 → 0.18, contrast 6 → 3, `SetTonemapForHdr` (Neutral when the URP asset runs LDR, i.e.
+WebGL Low/Potato — called from `ClientSettings.ApplyCameraLook` on every preset change); `UiSettings` brightness
+stepper moved under the preset row. Not changed: night floor, fog opacity (#388 pop-in), the overcast
+`LadderFloor` on swamp/ashen/fungal (design), the per-species flora tint path (converting it would DARKEN flora).
+Verification: before/after captures (swamp, varied, fungal; clear noon via the capture pin) for Marcel's call.
+
 ### ★ School playtest 2026-09-02, group 1: titan scan, bevel slit, bed prompt, camera boom, hand refresh, menu atlas memory (#1456 #1458 #1459 #1460 #1463 #1464, 2026-09-02, branch fix/playtest-2026-09-02)
 First of the playtest fix groups (the branch carries the whole 2026-09-02 batch, one PR). **#1458** —
 `PlayerController.TryFindScanTarget` replaces the origin-in-cone test with the attack path's Size-scaled

--- a/client/Assets/BlocksBeyondTheStars/Scripts/ClientSettings.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/ClientSettings.cs
@@ -1000,6 +1000,7 @@ namespace BlocksBeyondTheStars.Client
                 // view at 80 % — between Potato (75 %) and the desktop presets (100 %). Desktop Low is unchanged.
                 bool webglLow = Application.platform == RuntimePlatform.WebGLPlayer && Preset == QualityPreset.Low;
                 urp.supportsHDR = Preset > QualityPreset.Potato && !webglLow;
+                UrpScenePost.Instance?.SetTonemapForHdr(urp.supportsHDR); // LDR gets Neutral, not ACES (#1457)
                 urp.renderScale = Preset == QualityPreset.Potato ? 0.75f : webglLow ? 0.8f : 1f;
 
                 // The shared asset bakes a 4096 main-light shadowmap for every level, but only High reaches far

--- a/client/Assets/BlocksBeyondTheStars/Scripts/Sky.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/Sky.cs
@@ -236,7 +236,10 @@ namespace BlocksBeyondTheStars.Client
             float dayLit = day * (2f - day);
             // Inside an orbital station there is no day/night — it's lit by its own constant lighting.
             float brightness = constantLight ? 1f : Mathf.Lerp(0.35f, 1f, dayLit); // night floor → noon
-            float weatherDim = constantLight ? 1f : Mathf.Lerp(1f, 0.65f, weatherIntensity); // storms darken
+            // Storms darken — but only to 0.78 now (was 0.65, #1457): the block light goes through the sRGB→linear
+            // conversion below, so 0.65 landed in the shader as ~0.38 of noon, and on the overcast-only worlds
+            // (swamp, ashen, fungal never clear) every daytime read as dusk. A grey day should still be a day.
+            float weatherDim = constantLight ? 1f : Mathf.Lerp(1f, 0.78f, weatherIntensity);
 
             // Twilight (golden hour): peaks with the sun sitting on the horizon (sunHeight → 0) and fades out by
             // full day / deep night. Off in airless (space) skies — no atmosphere means no scattering, so there the

--- a/client/Assets/BlocksBeyondTheStars/Scripts/UiSettings.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/UiSettings.cs
@@ -73,6 +73,12 @@ namespace BlocksBeyondTheStars.Client
             // A hand-picked preset ends auto-calibration (#1423): PresetAuto off means the shell
             // frame-time calibrator never overrides the player's explicit choice again.
             Cycle(ref y, L("ui.settings.preset"), L("ui.settings.preset." + S.Preset.ToString().ToLowerInvariant()), () => { S.Preset = (QualityPreset)(((int)S.Preset + 1) % 4); S.PresetAuto = false; S.Apply(); ApplyLiveWorld(); Rebuild(); });
+            // Brightness sits right under the preset (#1457): "the world is too dark" is the first thing a player
+            // looks for here, and it used to hide six rows down in the scroll viewport.
+            Stepper(ref y, L("ui.settings.brightness"), (S.Brightness - 0.7f) / 0.8f, 0.7f, 1.5f,
+                () => { S.Brightness = Mathf.Clamp(S.Brightness - 0.05f, 0.7f, 1.5f); UrpScenePost.Instance?.SetBrightness(S.Brightness); Rebuild(); },
+                () => { S.Brightness = Mathf.Clamp(S.Brightness + 0.05f, 0.7f, 1.5f); UrpScenePost.Instance?.SetBrightness(S.Brightness); Rebuild(); },
+                Mathf.RoundToInt(S.Brightness * 100f) + "%");
             // Window mode cycles Windowed → Borderless → Exclusive and applies immediately so the player sees
             // the window change without leaving the menu (resolution/mode changes are pushed via Apply()).
             Cycle(ref y, L("ui.settings.window_mode"), L(WindowModeKey(S.Window)),
@@ -96,10 +102,6 @@ namespace BlocksBeyondTheStars.Client
                 () => { S.UiScale = Mathf.Clamp(S.UiScale - 0.1f, UiKit.UserScaleMin, UiKit.UserScaleMax); S.Apply(); Rebuild(); },
                 () => { S.UiScale = Mathf.Clamp(S.UiScale + 0.1f, UiKit.UserScaleMin, UiKit.UserScaleMax); S.Apply(); Rebuild(); },
                 Mathf.RoundToInt(S.UiScale * 100f) + "%");
-            Stepper(ref y, L("ui.settings.brightness"), (S.Brightness - 0.7f) / 0.8f, 0.7f, 1.5f,
-                () => { S.Brightness = Mathf.Clamp(S.Brightness - 0.05f, 0.7f, 1.5f); UrpScenePost.Instance?.SetBrightness(S.Brightness); Rebuild(); },
-                () => { S.Brightness = Mathf.Clamp(S.Brightness + 0.05f, 0.7f, 1.5f); UrpScenePost.Instance?.SetBrightness(S.Brightness); Rebuild(); },
-                Mathf.RoundToInt(S.Brightness * 100f) + "%");
             // Frame pacing. VSync off (+ optional fps cap) is the recommended fix when the game runs sluggish
             // on the Linux/Proton client, where VSync can lock to a hard 30 fps.
             Toggle(ref y, L("ui.settings.vsync"), S.VSync, () => { S.VSync = !S.VSync; S.Apply(); Rebuild(); });

--- a/client/Assets/BlocksBeyondTheStars/Scripts/UrpScenePost.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/UrpScenePost.cs
@@ -53,7 +53,13 @@ namespace BlocksBeyondTheStars.Client
         private ScreenSpaceLensFlare _lensFlare;
         private float _speed; // 0..1 camera-motion intensity driver for the motion blur (set via SetMotion)
 
-        private const float BaseVignette = 0.26f;
+        private const float BaseVignette = 0.18f; // was 0.26 — with the AO stack it read as a dark, closed-in frame (#1457)
+        private Tonemapping _tonemap;
+
+        /// <summary>ACES on an HDR buffer, Neutral on an LDR one — ACES over clamped LDR pixels only darkens the
+        /// midtones (#1457). Called from ClientSettings whenever the preset flips HDR.</summary>
+        public void SetTonemapForHdr(bool hdr)
+            => _tonemap?.mode.Override(hdr ? TonemappingMode.ACES : TonemappingMode.Neutral);
         private float _damagePulse;   // decaying 0..1 → a red-tinted vignette kick on damage
         private float _oxygenAlarm;   // 0..1 low-O₂ alarm level (driven by HudUi each frame)
         private float _burstTimer, _burstDuration, _burstChroma, _burstGrain;
@@ -76,8 +82,12 @@ namespace BlocksBeyondTheStars.Client
 
             var profile = ScriptableObject.CreateInstance<VolumeProfile>();
 
-            var tonemap = profile.Add<Tonemapping>(true);
-            tonemap.mode.Override(TonemappingMode.ACES); // filmic ACES tonemap
+            _tonemap = profile.Add<Tonemapping>(true);
+            // Filmic ACES needs an HDR buffer to have anything to roll off; on an LDR buffer (WebGL Low/Potato,
+            // #1424) it only crushed the midtones of an already-clamped frame — the browser build read darker
+            // and flatter than the same scene on desktop (#1457). Neutral keeps the midtones there.
+            var rp = GraphicsSettings.currentRenderPipeline as UniversalRenderPipelineAsset;
+            SetTonemapForHdr(rp == null || rp.supportsHDR);
 
             var bloom = profile.Add<Bloom>(true);
             if (ShellMode)
@@ -107,7 +117,7 @@ namespace BlocksBeyondTheStars.Client
 
             _grade = profile.Add<ColorAdjustments>(true);
             _grade.postExposure.Override(ExposureFor(Brightness));
-            _grade.contrast.Override(6f);
+            _grade.contrast.Override(3f); // was 6 — the extra contrast pushed the shadow half of every daylight frame down (#1457)
             _grade.saturation.Override(6f);
             _grade.colorFilter.Override(Color.white);
 

--- a/client/Assets/BlocksBeyondTheStars/Shaders/BlockAtlas.shader
+++ b/client/Assets/BlocksBeyondTheStars/Shaders/BlockAtlas.shader
@@ -179,7 +179,7 @@ Shader "BlocksBeyondTheStars/BlockAtlas"
                 // Per-vertex AO (mesher, in .b) widened to a visible contact-shadow range, then multiplied by
                 // the texture-scale cavity AO (normal map alpha). Diffuse-only — spec/reflection stay crisp.
                 float faceAo = lerp(0.62, 1.0, i.mat.b) * lerp(1.0, nrm.a, 0.6);
-                float amb = lerp(0.24, 0.70, sky);
+                float amb = lerp(0.26, 0.78, sky); // #1457: sky-lit faces turned away from the sun sat at 0.70 — a shade too dark by day
                 float3 col = albedo * (light * (amb + 0.5 * ndl * sky * shadow) + 0.05) * faceAo;
                 col += albedo * (_Sc_Indoor * 0.5 * (1.0 - sky)) * faceAo;
 
@@ -505,7 +505,7 @@ Shader "BlocksBeyondTheStars/BlockAtlas"
                 // (outdoors ~0.70, a readable cave floor of 0.24). The directional adds the sunny side on top.
                 // A small flat term (sun/sky-independent) guarantees a minimum readable level, so blocks in a
                 // dark hole or deep cave are dim but never pure black.
-                float amb = lerp(0.24, 0.70, sky);
+                float amb = lerp(0.26, 0.78, sky); // #1457: sky-lit faces turned away from the sun sat at 0.70 — a shade too dark by day
                 fixed3 col = albedo * (light * (amb + 0.5 * ndl * sky) + 0.05) * faceAo;
 
                 // Ship interior fill: a neutral, day/night-independent fill on skylight-occluded faces only


### PR DESCRIPTION
## Summary

Daylight re-tune for **#1457** ("Die Welten wirken auch tagsüber sehr dunkel und drückend", school playtest in the browser). Stacked on #1465 (`fix/playtest-2026-09-02`) — kept separate so the look can be judged on its own.

No new look, four levers:
- `Sky.cs`: overcast dims the daylight to **0.78** instead of 0.65 — swamp / ashen / fungal never clear, so every day there read as dusk.
- `BlockAtlas.shader`: sky-lit faces turned away from the sun get `amb = lerp(0.26, 0.78, sky)` (was 0.24 / 0.70), both passes.
- `UrpScenePost`: vignette 0.26 → 0.18, grade contrast +6 → +3; **Neutral tonemapping whenever the URP asset runs LDR** (WebGL Low/Potato) — ACES over already-clamped pixels only crushed the midtones. `ClientSettings.ApplyCameraLook` re-applies it on every preset change.
- `UiSettings`: the brightness stepper sits right under the preset row.

Correction to the issue's cause 1 (commented there): the sRGB→linear conversion of the block light is not a double application — it reproduces the gamma-era perceived product exactly. The constants were simply tuned dark.

Left as is, deliberately: night floor, fog opacity (#388 pop-in), the overcast `LadderFloor` on swamp/ashen/fungal, the per-species flora tint path (linearising it would darken flora).

## Verification
- Local Unity Windows build: 0 errors. Before/after captures (swamp, varied, fungal; clear-noon capture pin) taken and shared with the maintainer — poses differ between runs, the after set is clearly brighter.
- No server code touched; the server suite/format run on the base branch applies.

closes #1457

🤖 Generated with [Claude Code](https://claude.com/claude-code)
