### PR TITLE
fix(server): seam-aware chunk sweep — stop evicting and re-streaming the spawn pad's view every 10 s (#1502)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -172,6 +172,22 @@ chunks (the `[FallGuard]` line no longer says "bake pending" for ever there); th
 now say scan-drones are stopped by a wall of four or more (they were, since #1452's own probe window).
 Tests: `StationGravityTests` (2).
 
+### ★ Chunk sweep: seam-aware eviction — the spawn pad no longer re-streams half its view every 10 s (#1502, 2026-09-04, branch perf/1502-seam-sweep)
+First PR of the performance package (epic #1501). Measured with the real server + a headless client: a player
+standing on the spawn pad — pad 0 is at world (0,0) on EVERY world, i.e. on the longitude seam — had **228
+chunks (view distance 4) / 603 chunks (view distance 8) evicted, regenerated and re-sent on every 10-s
+sweep**, 21–42 % of the tick thread while standing still, with the client re-meshing all of them; a control
+spawn 11 chunks off the seam showed 0 re-sends and a 0.18 ms idle tick. Cause: `StreamChunks` and the chunk
+cache use canonical coords (X in `[0, ChunksAround)`, Z in the latitude band), but `SweepFarChunks` /
+`ServerWorld.UnloadFarChunks` compared the raw player anchor with the unwrapped `ChunkCoord.DistanceSquared`,
+so everything across either seam read as a world away. Now `WorldConstants.WrappedChunkDistanceSquared`
+(the sent-set prune's private helper, promoted to Shared) measures the short way round both seams and the
+anchors are canonicalised in both the eviction and the prune. Tests: `WorldWrapTests
+.WrappedChunkDistanceSquared_MeasuresTheShortWayRoundBothSeams` (fast) and
+`ChunkStreamingTests.Sweep_KeepsTheWholeStreamedView_OfAPlayerStandingOnTheSeam` (Slow: real server, natural
+spawn, asserts the precondition that the spawn sits on the seam, streams the view, sweeps, every streamed
+chunk still resident + still in the sent-set).
+
 ### ★ Lyxette round 5 — player stations get real: hull drawn once, sealed-volume air, crew on demand, windows with a view; cargo tiers explain themselves; space salvage is lossless (#1469–#1478, 2026-09-03, branch fix/lyxette-reports-2026-09-03)
 Three F1 reports from the evening of 2026-09-02 (v2026.8.26), all decisions Marcel 2026-09-03. **Station drawn
 twice (#1469, #1470):** one player-built station id was rendered by two client paths — the voxel hull from its

--- a/src/BlocksBeyondTheStars.GameServer/GameServer.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServer.cs
@@ -2344,7 +2344,8 @@ public sealed partial class GameServer
         int maxViewRadius = 1;
         foreach (var session in JoinedInActiveWorld())
         {
-            anchors.Add(WorldConstants.WorldToChunk(session.State.Position.ToBlock()));
+            // Canonical like the cache keys (X in [0, ChunksAround), Z in the latitude band) — see #1502.
+            anchors.Add(WorldConstants.CanonicalChunk(WorldConstants.WorldToChunk(session.State.Position.ToBlock()), _world.Circumference));
             maxViewRadius = System.Math.Max(maxViewRadius, EffectiveViewRadius(session));
         }
 
@@ -2381,33 +2382,18 @@ public sealed partial class GameServer
         // sent-set by ITS OWN session's anchor too. The prune radius must stay below the client's 24-chunk
         // unload distance (or a client-unloaded chunk could survive in the sent-set); a chunk pruned while the
         // client still holds it merely re-streams when it re-enters the view, which is idempotent.
+        // Both the eviction above and this prune measure the short way round BOTH seams
+        // (WorldConstants.WrappedChunkDistanceSquared): the sent-set and the cache hold CANONICAL coords, so an
+        // unwrapped distance would read a chunk just across a seam as "far" — and a player standing near a seam
+        // (the spawn pad is at x = 0 on every world) would re-stream half their view every sweep (#1502).
         foreach (var session in JoinedInActiveWorld())
         {
-            var anchor = WorldConstants.WorldToChunk(session.State.Position.ToBlock());
+            var anchor = WorldConstants.CanonicalChunk(WorldConstants.WorldToChunk(session.State.Position.ToBlock()), _world.Circumference);
             int pruneRadius = System.Math.Min(EffectiveViewRadius(session) + 4, 20);
             int pruneSq = pruneRadius * pruneRadius;
             int circumference = _world.Circumference;
-            session.SentChunks.RemoveWhere(c => WrappedChunkDistanceSquared(c, anchor, circumference) > pruneSq);
+            session.SentChunks.RemoveWhere(c => WorldConstants.WrappedChunkDistanceSquared(c, anchor, circumference) > pruneSq);
         }
-    }
-
-    /// <summary>Squared chunk-grid distance measured the short way round BOTH seams (X wraps at the chunk
-    /// circumference, Z at the latitude chunk band; Y is linear). The sent-set prune must not read a chunk just
-    /// across a seam as "far", or a player standing near a seam would re-stream half their view every sweep.</summary>
-    private static int WrappedChunkDistanceSquared(ChunkCoord a, ChunkCoord b, int circumference)
-    {
-        int dx = WrapChunkDelta(a.X - b.X, WorldConstants.ChunksAroundOf(circumference));
-        int dy = a.Y - b.Y;
-        int dz = WrapChunkDelta(a.Z - b.Z, WorldConstants.LatitudePeriodFor(circumference) / WorldConstants.ChunkSize);
-        return dx * dx + dy * dy + dz * dz;
-    }
-
-    /// <summary>Shortest signed delta on a wrapping chunk axis with the given period (chunk-unit twin of
-    /// <see cref="WorldConstants.WrapDeltaX(int,int)"/>, whose parameter is a BLOCK circumference).</summary>
-    private static int WrapChunkDelta(int delta, int period)
-    {
-        int m = ((delta % period) + period) % period;
-        return m > period / 2 ? m - period : m;
     }
 
     /// <summary>Fills a chunk message's sparse colour-modifier + shape arrays from the chunk's dyed/glowing/

--- a/src/BlocksBeyondTheStars.GameServer/ServerWorld.cs
+++ b/src/BlocksBeyondTheStars.GameServer/ServerWorld.cs
@@ -213,13 +213,25 @@ public sealed class ServerWorld
         }
 
         int keepSq = keepRadius * keepRadius;
+
+        // #1502: the cache keys are canonical (X in [0, ChunksAround), Z in the latitude band) while a raw player
+        // anchor may sit anywhere, and the world is a torus — measure the short way round BOTH seams. The old
+        // unwrapped DistanceSquared read every chunk across a seam as a world away, so a player standing on the
+        // spawn pad (x = 0 on every world) had half their view evicted, regenerated and re-streamed on EVERY sweep
+        // (228 chunks per 10 s at view distance 4, 603 at 8 — 21–42 % of the tick thread while standing still).
+        var canonicalAnchors = new List<ChunkCoord>(anchors.Count);
+        foreach (var anchor in anchors)
+        {
+            canonicalAnchors.Add(WorldConstants.CanonicalChunk(anchor, Circumference));
+        }
+
         var toRemove = new List<ChunkCoord>();
         foreach (var coord in _loaded.Keys)
         {
             bool near = false;
-            foreach (var anchor in anchors)
+            foreach (var anchor in canonicalAnchors)
             {
-                if (coord.DistanceSquared(anchor) <= keepSq)
+                if (WorldConstants.WrappedChunkDistanceSquared(coord, anchor, Circumference) <= keepSq)
                 {
                     near = true;
                     break;

--- a/src/BlocksBeyondTheStars.Shared/World/WorldConstants.cs
+++ b/src/BlocksBeyondTheStars.Shared/World/WorldConstants.cs
@@ -176,6 +176,26 @@ public static class WorldConstants
     public static ChunkCoord CanonicalChunk(ChunkCoord chunk, int circumference)
         => new(CanonicalChunkX(chunk.X, circumference), chunk.Y, CanonicalChunkZ(chunk.Z, circumference));
 
+    /// <summary>Squared chunk-grid distance measured the short way round BOTH seams (X wraps at the chunk
+    /// circumference, Z at the latitude chunk band; Y is linear). Every keep/evict/prune decision over cached or
+    /// streamed chunks must use this: the cache keys are canonical, so an unwrapped distance reads a chunk just
+    /// across a seam as a whole world away (#1502 — the spawn pad sits at x = 0 on every world).</summary>
+    public static int WrappedChunkDistanceSquared(ChunkCoord a, ChunkCoord b, int circumference)
+    {
+        int dx = WrapChunkDelta(a.X - b.X, ChunksAroundOf(circumference));
+        int dy = a.Y - b.Y;
+        int dz = WrapChunkDelta(a.Z - b.Z, LatitudePeriodFor(circumference) / ChunkSize);
+        return dx * dx + dy * dy + dz * dz;
+    }
+
+    /// <summary>Shortest signed delta on a wrapping chunk axis with the given period in chunks (chunk-unit twin
+    /// of <see cref="WrapDeltaX(int,int)"/>, whose parameter is a BLOCK circumference).</summary>
+    public static int WrapChunkDelta(int delta, int period)
+    {
+        int m = ((delta % period) + period) % period;
+        return m > period / 2 ? m - period : m;
+    }
+
     /// <summary>Canonicalizes a world block position: X into [0, circumference), Z into the latitude domain.</summary>
     public static Vector3i CanonicalBlock(Vector3i world, int circumference)
         => new(WrapX(world.X, circumference), world.Y, WrapZ(world.Z, circumference));

--- a/tests/BlocksBeyondTheStars.Tests/ChunkStreamingTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/ChunkStreamingTests.cs
@@ -135,6 +135,65 @@ public sealed class ChunkStreamingTests : IDisposable
         Assert.True(server.World.IsChunkLoaded(nearChunk), "the player's own region must stay resident through the sweep");
     }
 
+    /// <summary>#1502: the spawn pad sits at x = 0 on every world, i.e. ON the longitude seam, so half of a fresh
+    /// player's view lives at canonical chunk x ≈ ChunksAround−1..−4. The sweep used to measure the unwrapped
+    /// distance to the raw anchor, read those chunks as a whole world away, evicted them and dropped them from
+    /// the sent-set — and the streamer regenerated and re-sent all of them on every sweep (228 chunks per 10 s at
+    /// view distance 4, 603 at 8, 21–42 % of the tick thread while standing still). The sweep must keep every
+    /// chunk it streamed to a player who has not moved, on the seam like anywhere else.</summary>
+    [Fact]
+    [Trait("Category", "Slow")]
+    public void Sweep_KeepsTheWholeStreamedView_OfAPlayerStandingOnTheSeam()
+    {
+        using var repo = new SqliteWorldRepository(new SaveGamePaths(_root, "sweep_seam"));
+        var st = new LoopbackServerTransport(new LoopbackLink());
+        var config = new ServerConfig
+        {
+            WorldName = "sweep_seam",
+            Seed = 1,
+            AutoSaveIntervalMinutes = 9999,
+            PlaceStarterShip = false,
+            ViewDistanceChunks = 4,
+        };
+        var server = new SvGameServer(config, _content, st, repo);
+        server.Start();
+
+        var p = server.AddLocalPlayer("Homebody");
+        var anchor = WorldConstants.WorldToChunk(p.State.Position.ToBlock());
+        int around = WorldConstants.ChunksAroundOf(server.World.Circumference);
+        int canonicalX = WorldConstants.CanonicalChunkX(anchor.X, server.World.Circumference);
+        int toSeam = Math.Min(canonicalX, around - canonicalX);
+        Assert.True(toSeam <= 2, $"precondition: the natural spawn (pad 0) must sit on the longitude seam for this test to bite (chunk x={anchor.X}, {toSeam} columns from the seam)");
+
+        // Stream the whole view (~500 chunks at radius 4 + the load-ahead ring), then let it settle.
+        for (int i = 0; i < 80; i++)
+        {
+            server.TickForTest(0.1);
+        }
+
+        var streamed = new System.Collections.Generic.List<ChunkCoord>(p.SentChunks);
+        Assert.True(streamed.Count > 200, $"precondition: the view should have streamed (got {streamed.Count} chunks)");
+        int acrossSeam = 0;
+        foreach (var c in streamed)
+        {
+            if (Math.Abs(c.X - anchor.X) > 8) acrossSeam++; // canonical coords on the far side of the seam
+        }
+
+        Assert.True(acrossSeam > 50, $"precondition: part of the view must lie across the seam (got {acrossSeam})");
+
+        // Tick past the sweep interval with the player standing still.
+        for (int i = 0; i < 15; i++)
+        {
+            server.TickForTest(1.0);
+        }
+
+        foreach (var c in streamed)
+        {
+            Assert.True(server.World.IsChunkLoaded(c), $"streamed chunk {c} was evicted by the sweep although the player never moved");
+            Assert.Contains(c, p.SentChunks);
+        }
+    }
+
     /// <summary>The multiplayer half of the sweep (#1030): the cache eviction only forgets chunks that are far
     /// from EVERY player, so chunks a camping partner kept alive stayed in a departed player's sent-set even
     /// though that player's client had long unloaded them (RepositionChunks drops everything past ~384 blocks).

--- a/tests/BlocksBeyondTheStars.Tests/WorldWrapTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/WorldWrapTests.cs
@@ -30,6 +30,28 @@ public class WorldWrapTests
         Assert.Equal(C / WorldConstants.ChunkSize, WorldConstants.ChunksAround);
     }
 
+    /// <summary>#1502: chunk-grid distances used for keep/evict/prune decisions must be measured the short way
+    /// round BOTH seams — the chunk cache and the sent-sets hold canonical coords, the player anchor may not.</summary>
+    [Fact]
+    public void WrappedChunkDistanceSquared_MeasuresTheShortWayRoundBothSeams()
+    {
+        int around = WorldConstants.ChunksAroundOf(C);
+        int band = P / WorldConstants.ChunkSize; // latitude chunk band, canonical z in [−band/2, band/2)
+        int half = band / 2;
+        var origin = new ChunkCoord(0, 4, 0);
+
+        // One column west of x = 0 is canonical x = around − 1: adjacent, not a world away.
+        Assert.Equal(1, WorldConstants.WrappedChunkDistanceSquared(new ChunkCoord(around - 1, 4, 0), origin, C));
+        Assert.Equal(25, WorldConstants.WrappedChunkDistanceSquared(new ChunkCoord(around - 5, 4, 0), origin, C));
+        // A raw (non-canonical) anchor measures the same way.
+        Assert.Equal(4, WorldConstants.WrappedChunkDistanceSquared(new ChunkCoord(around - 1, 4, 0), new ChunkCoord(1, 4, 0), C));
+        // Z wraps at the latitude band edge: the last band row and the first are neighbours.
+        Assert.Equal(1, WorldConstants.WrappedChunkDistanceSquared(new ChunkCoord(0, 4, half - 1), new ChunkCoord(0, 4, -half), C));
+        // Y never wraps; ordinary nearby coords keep their plain distance.
+        Assert.Equal(1 + 4 + 9, WorldConstants.WrappedChunkDistanceSquared(new ChunkCoord(1, 2, 3), origin, C));
+        Assert.Equal(40 * 40, WorldConstants.WrappedChunkDistanceSquared(new ChunkCoord(0, 44, 0), origin, C));
+    }
+
     [Theory]
     [InlineData("rocky")]
     [InlineData("desert")]


### PR DESCRIPTION
PR bundle 0 of the performance package (#1501): the one measured bug, shipped on its own so it can go into the next patch release.

## What was wrong

`StreamChunks` and the chunk cache work in **canonical** chunk coords (X in `[0, ChunksAround)`, Z in the latitude band), but `SweepFarChunks` → `ServerWorld.UnloadFarChunks` compared the **raw** player anchor with the unwrapped `ChunkCoord.DistanceSquared`. Everything across the longitude or latitude seam read as a world away, was evicted on every 10-s sweep, dropped from the sent-set, and regenerated + re-sent right away.

Landing pad 0 ("home touchdown") is at world (0,0) on every world — so the first spawn of every world sits **on** the seam.

## Measured (real `GameServer` + headless `NetworkClient` over loopback, fresh world, player standing still)

| | seed 424242 (spawn on the seam) | seed 123456 (11 chunks off) |
|---|---|---|
| chunks re-generated + re-sent per 10 s, VD 4 | 228 | 0 |
| same, VD 8 | 603 | 0 |
| idle tick | p50 0.2 ms, p95 190–220 ms, spikes to 290 ms | avg 0.18 ms, max 0.4 ms |
| tick CPU share while idle | 21 % (VD 4), 42 % (VD 8) | 0 % |

The client re-meshes every re-sent chunk (7 dirty marks each).

## Fix

- `WorldConstants.WrappedChunkDistanceSquared` / `WrapChunkDelta`: the sent-set prune's private helpers promoted to Shared, so eviction and prune measure the same way (short way round both seams).
- `ServerWorld.UnloadFarChunks` canonicalises the anchors and uses the wrapped distance.
- `SweepFarChunks` canonicalises the anchors for both the eviction and the per-session prune.

Behaviour otherwise unchanged; chunks that really are far are still evicted (existing sweep tests).

## Tests

- `WorldWrapTests.WrappedChunkDistanceSquared_MeasuresTheShortWayRoundBothSeams` (fast): X seam, Z seam, raw anchor, plain distances.
- `ChunkStreamingTests.Sweep_KeepsTheWholeStreamedView_OfAPlayerStandingOnTheSeam` (Slow): real server, natural spawn, asserts the precondition that pad 0 sits on the seam and that part of the view lies across it, streams the view, sweeps, then every streamed chunk must still be resident and in the sent-set. Verified to **fail against the old eviction** (`streamed chunk Chunk(743, 6, 0) was evicted by the sweep`).

## Verification

`dotnet format --verify-no-changes` clean · `dotnet build --no-incremental` 0 warnings / 0 errors · server suite non-Slow 2586 passed · Slow `ChunkStreamingTests` 12 passed · client suite 468 passed. Server-only change; the bundled singleplayer server picks it up with the next release build.

closes #1502

🤖 Generated with [Claude Code](https://claude.com/claude-code)
