### PR TITLE
perf(server): quick wins — one transaction per simulation step, prepared statements, settled-view streaming skip, 1 Hz flora, ship-stats memo, codec warm-up (#1505–#1510)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -230,6 +230,29 @@ testing); **startup** — a refused initial wasm memory from `createUnityInstanc
 `[BBS-Heap]` peak so the number is readable on-device without USB debugging. Original messages still
 go to the console; every other error keeps the loud alert path. Desktop with enough RAM: no change.
 
+### ★ Server quick wins: one transaction per simulation step, prepared statements, settled-view streaming skip, 1 Hz flora, ship-stats memo, codec warm-up (#1505–#1510, 2026-09-04, branch perf/1505-1510-server-quick-wins)
+PR bundle 2 of the performance package (epic #1501); server-only, no behaviour change. **#1505** fluid, fire,
+granular, flora-regrow and weather-snow steps now run inside `IWorldRepository.RunInTransaction` (SQLite,
+PostgreSQL and the Memory repo all implement it reentrantly) — measured 100–142 µs per autocommitted cell
+before vs 24–35 µs batched; a breached lake was ≈ 1600 commits/s on the tick thread. Consequence: a crash
+mid-step loses at most that one ≤ 0.25 s step. **#1506** `SqliteWorldRepository` keeps one prepared
+`SqliteCommand` per hot statement (SetBlock, LoadChunkEdits, fluid + fire cell rows — parameters bound
+once, values rebound per call) instead of re-parsing the SQL per call, plus `cache_size=-32000`,
+`mmap_size=256 MB`, `temp_store=MEMORY`; PostgreSQL gets Npgsql auto-prepare (`MaxAutoPrepare=64`) unless
+the operator set it. **#1507** `StreamChunks` remembers per session that the last pass found nothing to send
+(centre chunk, radius, sent-set size) and skips the `(2R+3)²` column enumeration until one of those changes
+or the 30-tick re-check comes due; the far-column surface band is cached per canonical column on the world
+(a pure function of terrain + sea level). Measured before: 0.2 ms per idle tick at VD 4 for one player,
+scaling with players × VD. **#1508** `TickFlora` steps the regrow timers once per second of sim time
+(accumulated dt) instead of 15× — each cell's step evaluates the local weather (three noise lookups);
+regrowth lands ≤ 1 s later. **#1509** custom-ship stats are memoised per `BuiltCells` blob instance
+(`ConditionalWeakTable`) so the per-cursor-switch recompute no longer re-parses the hull; the presence gear
+mask was NOT cached on purpose (inventory mutation is not centralised and the scan measured negligible).
+**#1510** `NetCodec.WarmUp()` encodes + decodes an empty instance of every registered message type at server
+start (26–39 ms per type on first use before — ~1 s during the first join burst). Tests:
+`ServerQuickWinsTests` (transactions per step, prepared-statement rebinding, settled skip + invalidation on
+move, blob memo, warm-up coverage).
+
 ### ★ Credits: Schul-AG — Ben, Marie, Nikita (2026-09-02, branch docs/schul-ag-credits)
 The school game club's first playtest day (browser build) gets its own playtester entry — README
 "Playtesters" list + `ui.credits.body` in all 14 locales (line after "sasas"), first names only. Verena

--- a/src/BlocksBeyondTheStars.GameServer/GameServer.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServer.cs
@@ -245,6 +245,10 @@ public sealed partial class GameServer
         // content update would silently decode every stored edit to the wrong block.
         _repo.EnsureBlockPalette(_content.BlockPalette());
 
+        // #1510: build every message formatter now, not one by one during the first player's join burst.
+        int warmed = NetCodec.WarmUp();
+        _log.Info($"NetCodec warm-up: {warmed} message formatters compiled.");
+
         var launchRules = _config.Rules.Clone();
         _meta = _repo.LoadMetadata() ?? CreateInitialMetadata();
 
@@ -2130,6 +2134,16 @@ public sealed partial class GameServer
     /// surface band, and stays within the sweep's keepRadius (maxViewRadius + 4) so it is not immediately evicted.</summary>
     private const int LoadAheadRings = 1;
 
+    /// <summary>#1507: a settled view is re-enumerated at least this often (ticks) even when nothing observable
+    /// changed — a cheap safety net against any sent-set change the count-based check could miss.</summary>
+    private const int StreamSettledRecheckTicks = 30;
+
+    /// <summary>#1507: upper bound for the per-world far-column band cache (entries are 16 bytes).</summary>
+    private const int FarColumnBandCacheCap = 250_000;
+
+    /// <summary>Diagnostic: how many full view-column enumerations StreamChunks ran (per player pass).</summary>
+    public int StreamEnumerationsForTest { get; private set; }
+
     /// <summary>This player's streaming radius in chunks: their requested view distance (clamped to the slider
     /// range) when they sent one, otherwise the host's configured default.</summary>
     private int EffectiveViewRadius(PlayerSession session)
@@ -2187,6 +2201,24 @@ public sealed partial class GameServer
             var center = WorldConstants.WorldToChunk(session.State.Position.ToBlock());
             center = new ChunkCoord(center.X, System.Math.Clamp(center.Y, minChunkY, maxChunkY), center.Z);
 
+            // #1507: a settled view (the last pass found nothing to send) is skipped until something that can
+            // change the answer changes — the centre chunk, the radius or the sent-set size (sweep/prune/ghost/
+            // footing all add or remove entries) — or the periodic re-check comes due. The enumeration below is
+            // up to ~1200 coords + one terrain lookup per far column, per player, per tick; standing still it
+            // produced an empty list every time.
+            int sentCount = session.SentChunks.Count;
+            if (session.StreamSettled
+                && session.StreamSettledCenter == center
+                && session.StreamSettledRadius == streamRadius
+                && session.StreamSettledSentCount == sentCount
+                && ++session.StreamSettledTicks < StreamSettledRecheckTicks)
+            {
+                continue;
+            }
+
+            session.StreamSettled = false;
+            StreamEnumerationsForTest++;
+
             // Collect the not-yet-sent chunks in the view column and stream them NEAREST-FIRST. The player's
             // own chunk (its floor) then loads before everything else, so a freshly spawned/teleported player
             // gets solid ground under them immediately instead of falling through while a fixed bottom-up
@@ -2213,15 +2245,30 @@ public sealed partial class GameServer
                     }
                     else
                     {
-                        int worldX = (center.X + dx) * WorldConstants.ChunkSize + WorldConstants.ChunkSize / 2;
-                        int worldZ = (center.Z + dz) * WorldConstants.ChunkSize + WorldConstants.ChunkSize / 2;
                         // SurfaceHeight is the TERRAIN top — under a sea that is the seabed, and the generator
                         // fills everything from there up to the sea level with the sea fluid. Anchoring the band
                         // at the seabed therefore cut a deep ocean off mid-water, and the client (which reads a
                         // missing chunk as air) rendered that cut as a wavy water SURFACE hanging in mid-water,
                         // with fake waterfall streaks down the band's side edges (#987). FarColumnBand stretches
                         // a submerged column up to its real waterline instead.
-                        var band = FarColumnBand(_generator.SurfaceHeight(planet, worldX, worldZ), seaLevel);
+                        // #1507: cached per canonical column on the world — the band is a pure function of the
+                        // generator's surface and the world's sea level, so it never changes for a world.
+                        var bands = _worlds.Active.FarColumnBands;
+                        var columnKey = (WorldConstants.CanonicalChunkX(center.X + dx, _world.Circumference),
+                            WorldConstants.CanonicalChunkZ(center.Z + dz, _world.Circumference));
+                        if (!bands.TryGetValue(columnKey, out var band))
+                        {
+                            int worldX = (center.X + dx) * WorldConstants.ChunkSize + WorldConstants.ChunkSize / 2;
+                            int worldZ = (center.Z + dz) * WorldConstants.ChunkSize + WorldConstants.ChunkSize / 2;
+                            band = FarColumnBand(_generator.SurfaceHeight(planet, worldX, worldZ), seaLevel);
+                            if (bands.Count >= FarColumnBandCacheCap)
+                            {
+                                bands.Clear(); // a lap around a big world at VD 8 is ~50k columns; keep the table bounded
+                            }
+
+                            bands[columnKey] = band;
+                        }
+
                         loDy = band.LoCy - center.Y;
                         hiDy = band.HiCy - center.Y;
                     }
@@ -2245,6 +2292,17 @@ public sealed partial class GameServer
                         pending.Add((coord, dx * dx + dy * dy + dz * dz));
                     }
                 }
+
+            if (pending.Count == 0)
+            {
+                // Nothing to send for this view: remember it, so the next ticks skip the enumeration (#1507).
+                session.StreamSettled = true;
+                session.StreamSettledCenter = center;
+                session.StreamSettledRadius = streamRadius;
+                session.StreamSettledSentCount = sentCount;
+                session.StreamSettledTicks = 0;
+                continue;
+            }
 
             pending.Sort((a, b) => a.DistSq.CompareTo(b.DistSq));
 

--- a/src/BlocksBeyondTheStars.GameServer/GameServerCustomShips.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerCustomShips.cs
@@ -208,12 +208,36 @@ public sealed partial class GameServer
         return (hull, speed, handling);
     }
 
-    /// <summary>Derived stats of a specific self-built ship (from its persisted blob).</summary>
+    /// <summary>#1509: derived custom-ship stats memoised per <see cref="ShipState.BuiltCells"/> blob INSTANCE.
+    /// <c>RecomputeShipCombatStats</c> runs on every ship-cursor switch — with N players that is N times per
+    /// tick — and for a self-built ship it re-parsed the whole cell blob (string split per cell + LINQ) each
+    /// time. Strings are immutable, so the same blob instance always yields the same stats; a rebuilt hull is a
+    /// new string and misses the cache. The table holds the key weakly, so replaced blobs are collected.</summary>
+    private readonly System.Runtime.CompilerServices.ConditionalWeakTable<string, CustomStatsBox> _customStatsCache = new();
+
+    private sealed class CustomStatsBox
+    {
+        public (float HullMax, float FlightSpeed, float Handling) Stats;
+    }
+
+    /// <summary>Diagnostic: how many times the custom-ship blob was actually parsed (cache misses).</summary>
+    public int CustomShipStatsParsesForTest { get; private set; }
+
+    /// <summary>Derived stats of a specific self-built ship (from its persisted blob), memoised per blob instance.</summary>
     private (float HullMax, float FlightSpeed, float Handling) CustomShipStatsFor(ShipState ship)
     {
-        var cells = ParseCustomCells(ship.BuiltCells);
+        string blob = ship.BuiltCells ?? string.Empty;
+        if (_customStatsCache.TryGetValue(blob, out var cached))
+        {
+            return cached.Stats;
+        }
+
+        var cells = ParseCustomCells(blob);
         int engines = cells.Values.Count(b => IsBlockId(b, ShipEngineBlock));
-        return CustomShipStats(cells.Count, engines);
+        var stats = CustomShipStats(cells.Count, engines);
+        _customStatsCache.AddOrUpdate(blob, new CustomStatsBox { Stats = stats });
+        CustomShipStatsParsesForTest++;
+        return stats;
     }
 
     // ---------------- Keel placement (construction start) ----------------

--- a/src/BlocksBeyondTheStars.GameServer/GameServerFire.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerFire.cs
@@ -239,7 +239,13 @@ public sealed partial class GameServer
 
         float step = (float)_sinceFire;
         _sinceFire = 0;
+        _repo.RunInTransaction(() => StepFire(step)); // #1505: one commit per step, not per burning cell
+    }
 
+    /// <summary>One burn step over the active cells (the body of <see cref="TickFire"/>; runs inside a
+    /// repository transaction).</summary>
+    private void StepFire(float step)
+    {
         var todo = new List<Vector3i>(_activeFire);
         _activeFire.Clear();
         int budget = FireUpdatesPerTick;

--- a/src/BlocksBeyondTheStars.GameServer/GameServerFlora.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerFlora.cs
@@ -268,13 +268,37 @@ public sealed partial class GameServer
         });
     }
 
+    /// <summary>Regrow timers are stepped once per second of sim time (#1508), not every tick: the timers are in
+    /// seconds and every cell's step evaluates the local weather (biome + temperature + precipitation — three
+    /// generator/noise lookups per cell), so at 15 Hz a harvested meadow of a few hundred cells cost thousands of
+    /// noise evaluations per second for nothing. Regrowth lands at most one second later than before.</summary>
+    private const double FloraStepSeconds = 1.0;
+
+    private double _sinceFloraStep;
+
     private void TickFlora(double dt)
     {
         if (_floraRegrow.Count == 0)
         {
+            _sinceFloraStep = 0;
             return;
         }
 
+        _sinceFloraStep += dt;
+        if (_sinceFloraStep < FloraStepSeconds)
+        {
+            return;
+        }
+
+        double stepDt = _sinceFloraStep;
+        _sinceFloraStep = 0;
+        _repo.RunInTransaction(() => StepFlora(stepDt)); // #1505: one commit per step for the regrown cells + row deletes
+    }
+
+    /// <summary>One regrow step over every tracked cell with the accumulated sim time (the body of
+    /// <see cref="TickFlora"/>; runs inside a repository transaction).</summary>
+    private void StepFlora(double dt)
+    {
         List<Vector3i>? done = null;
         // Iterate over a copy of the keys so we can update/remove entries safely.
         foreach (var pos in new List<Vector3i>(_floraRegrow.Keys))

--- a/src/BlocksBeyondTheStars.GameServer/GameServerFluids.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerFluids.cs
@@ -233,6 +233,17 @@ public sealed partial class GameServer
         _worlds.Active.FluidStep++;
         bool lavaRests = (_worlds.Active.FluidStep & 1) == 1; // #1316: lava moves on every second step only
 
+        // #1505: one transaction per step. Every cell the step touches persists through SetBlock/SaveFluidCell/
+        // DeleteFluidCell — as autocommits that was one commit per cell (measured 100–142 µs each on NVMe, far
+        // more on SD cards), i.e. up to 400 commits per step and a breached lake ≈ 1600 commits/s on the tick
+        // thread. Batched, the same writes cost ~24–35 µs each. A crash mid-step loses at most this one step.
+        _repo.RunInTransaction(() => StepFluids(lavaRests));
+    }
+
+    /// <summary>One fluid step over the woken cells (the body of <see cref="TickFluids"/>; runs inside a
+    /// repository transaction).</summary>
+    private void StepFluids(bool lavaRests)
+    {
         var todo = new List<Vector3i>(_activeFluid);
         _activeFluid.Clear();
         int budget = FluidUpdatesPerTick;

--- a/src/BlocksBeyondTheStars.GameServer/GameServerGranular.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerGranular.cs
@@ -74,7 +74,7 @@ public sealed partial class GameServer
         }
 
         _sinceGranular = 0;
-        StepGranular();
+        _repo.RunInTransaction(StepGranular); // #1505: one commit per step, not per settled cell
     }
 
     /// <summary>One settle step over the woken cells (the fluid cadence, its own budget).</summary>

--- a/src/BlocksBeyondTheStars.GameServer/GameServerWeatherEvents.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerWeatherEvents.cs
@@ -215,12 +215,22 @@ public sealed partial class GameServer
         }
 
         var deposits = _worlds.Active.WeatherDeposits;
-        if (ShouldAccumulateSnow())
+        bool snowing = ShouldAccumulateSnow();
+        if (!snowing && deposits.Count == 0)
         {
-            AccumulateSnow(deposits);
+            return; // nothing to lay down or melt — don't open an empty transaction
         }
 
-        MeltSnow(deposits);
+        // #1505: one commit per pass (deposits + melts), not one per cell.
+        _repo.RunInTransaction(() =>
+        {
+            if (snowing)
+            {
+                AccumulateSnow(deposits);
+            }
+
+            MeltSnow(deposits);
+        });
     }
 
     /// <summary>Snow only settles while snow is genuinely falling on this world.</summary>

--- a/src/BlocksBeyondTheStars.GameServer/PlayerSession.cs
+++ b/src/BlocksBeyondTheStars.GameServer/PlayerSession.cs
@@ -142,6 +142,16 @@ public sealed class PlayerSession
     /// <summary>Chunks already streamed to this client, to avoid resending.</summary>
     public HashSet<ChunkCoord> SentChunks { get; } = new();
 
+    /// <summary>#1507: the streaming pass found nothing left to send for this view — recorded with the centre
+    /// chunk, the stream radius and the sent-set size it was true for, so the next ticks can skip the whole
+    /// (2R+3)² column enumeration (up to ~1200 coords + hundreds of terrain lookups per player per tick) until
+    /// the player moves, the view changes, the sent-set changes, or the periodic re-check comes due.</summary>
+    public bool StreamSettled { get; set; }
+    public ChunkCoord StreamSettledCenter { get; set; }
+    public int StreamSettledRadius { get; set; }
+    public int StreamSettledSentCount { get; set; }
+    public int StreamSettledTicks { get; set; }
+
     /// <summary>Uptime at which each chunk last triggered a full ghost re-stream for this session (#965), so a
     /// burst of ghosts in one chunk costs one re-stream (and one log line), not one per cell.</summary>
     public Dictionary<ChunkCoord, double> GhostChunkSeen { get; } = new();

--- a/src/BlocksBeyondTheStars.GameServer/WorldManager.cs
+++ b/src/BlocksBeyondTheStars.GameServer/WorldManager.cs
@@ -111,6 +111,11 @@ internal sealed class LoadedWorld
     public List<SettlementInstance> Settlements { get; } = new();                 // 0..N settlements on this world
     public List<(string Type, Vector3f Pos)> WreckMarkers { get; } = new();
     public Dictionary<Vector3i, (ushort FloraId, double Timer)> FloraRegrow { get; } = new();
+
+    /// <summary>#1507: the far-column streaming band per chunk column (see <c>GameServer.FarColumnBand</c>). The
+    /// band is a pure function of the column's terrain surface and the world's sea level, so it is computed once
+    /// per column instead of once per player per tick (a SurfaceHeight call = a full noise chain each).</summary>
+    public Dictionary<(int Cx, int Cz), (int LoCy, int HiCy)> FarColumnBands { get; } = new();
     public Dictionary<Vector3i, byte> FluidLevel { get; } = new();
     public HashSet<Vector3i> ActiveFluid { get; } = new();
     public HashSet<Vector3i> FallingFluid { get; } = new(); // flowing cells filled from above (feed a waterfall)

--- a/src/BlocksBeyondTheStars.Networking/NetCodec.cs
+++ b/src/BlocksBeyondTheStars.Networking/NetCodec.cs
@@ -491,6 +491,36 @@ public static class NetCodec
         TagToType[tag] = type;
         TypeToTag[type] = tag;
     }
+    /// <summary>#1510: compiles every registered message type's formatter up front by encoding and decoding an
+    /// empty instance. The contractless resolver builds each type's formatter with Reflection.Emit on FIRST use —
+    /// measured 26–39 ms per type — and the join burst touches ~40 types, so a fresh server (and a fresh client)
+    /// paid about a second of formatter compilation on first contact. Call once after content load, before any
+    /// player joins. A type without a parameterless constructor (or whose empty instance refuses to serialize)
+    /// simply stays cold. Returns the number of types warmed.</summary>
+    public static int WarmUp()
+    {
+        int warmed = 0;
+        foreach (var type in TagToType.Values)
+        {
+            try
+            {
+                if (Activator.CreateInstance(type) is not { } instance)
+                {
+                    continue;
+                }
+
+                Decode(Encode(instance));
+                warmed++;
+            }
+            catch
+            {
+                // stays cold — compiled on its first real use like before
+            }
+        }
+
+        return warmed;
+    }
+
     public static byte[] Encode(object message)
         => UseJsonEncoding ? EncodeJson(message) : EncodeMessagePack(message);
 

--- a/src/BlocksBeyondTheStars.Persistence/PostgreSqlWorldRepository.cs
+++ b/src/BlocksBeyondTheStars.Persistence/PostgreSqlWorldRepository.cs
@@ -52,7 +52,18 @@ public sealed class PostgreSqlWorldRepository : IWorldRepository
         {
             _paths.EnsureDirectories();
 
-            _connection = new NpgsqlConnection(_connectionString);
+            // #1506: every repository call builds a fresh command, so without automatic preparation each hot
+            // statement (SetBlock per fluid/fire cell, LoadChunkEdits per streamed chunk) is re-planned by the
+            // server on every round trip. Npgsql's auto-prepare turns the recurring statements into server-side
+            // prepared statements transparently; an operator who set MaxAutoPrepare explicitly keeps their value.
+            var builder = new NpgsqlConnectionStringBuilder(_connectionString);
+            if (builder.MaxAutoPrepare == 0)
+            {
+                builder.MaxAutoPrepare = 64;
+                builder.AutoPrepareMinUsages = 2;
+            }
+
+            _connection = new NpgsqlConnection(builder.ConnectionString);
             _connection.Open();
 
             Execute($"CREATE SCHEMA IF NOT EXISTS {QuoteIdentifier(_schemaName)};");

--- a/src/BlocksBeyondTheStars.Persistence/SqliteWorldRepository.cs
+++ b/src/BlocksBeyondTheStars.Persistence/SqliteWorldRepository.cs
@@ -42,6 +42,53 @@ public sealed class SqliteWorldRepository : IWorldRepository
     private SqliteConnection Connection =>
         _connection ?? throw new InvalidOperationException("Repository is not initialized. Call Initialize() first.");
 
+    // #1506: cached, prepared commands for the hot statements. Microsoft.Data.Sqlite caches prepared
+    // statements per SqliteCommand INSTANCE, so the old create-a-command-per-call pattern re-parsed ~400
+    // characters of SQL on every block, fluid and fire write and on every streamed chunk's edit load. One
+    // long-lived command per statement — parameters added once, values rebound per call — is prepared on first
+    // use and disposed with the connection. Every caller holds _gate, so a command is never used concurrently.
+    private SqliteCommand? _setBlockCmd;
+    private SqliteCommand? _loadChunkEditsCmd;
+    private SqliteCommand? _saveFluidCellCmd;
+    private SqliteCommand? _deleteFluidCellCmd;
+    private SqliteCommand? _saveFireCellCmd;
+    private SqliteCommand? _deleteFireCellCmd;
+
+    private SqliteCommand Prepared(ref SqliteCommand? slot, string sql, params (string Name, SqliteType Type)[] parameters)
+    {
+        if (slot is not null && ReferenceEquals(slot.Connection, _connection))
+        {
+            return slot;
+        }
+
+        slot?.Dispose();
+        var cmd = Connection.CreateCommand();
+        cmd.CommandText = sql;
+        foreach (var (name, type) in parameters)
+        {
+            cmd.Parameters.Add(name, type);
+        }
+
+        cmd.Prepare();
+        slot = cmd;
+        return cmd;
+    }
+
+    private void DisposePreparedCommands()
+    {
+        _setBlockCmd?.Dispose();
+        _loadChunkEditsCmd?.Dispose();
+        _saveFluidCellCmd?.Dispose();
+        _deleteFluidCellCmd?.Dispose();
+        _saveFireCellCmd?.Dispose();
+        _deleteFireCellCmd?.Dispose();
+        _setBlockCmd = _loadChunkEditsCmd = _saveFluidCellCmd = _deleteFluidCellCmd = _saveFireCellCmd = _deleteFireCellCmd = null;
+    }
+
+    /// <summary>Diagnostic: how many <see cref="RunInTransaction"/> batches were opened (nested calls join the
+    /// outer batch and do not count). Lets a test prove a simulation step writes as ONE transaction (#1505).</summary>
+    public int TransactionsBegun { get; private set; }
+
     public void Initialize()
     {
         try
@@ -62,6 +109,12 @@ public sealed class SqliteWorldRepository : IWorldRepository
             Execute("PRAGMA journal_mode=WAL;");
             Execute("PRAGMA synchronous=NORMAL;");
             Execute("PRAGMA foreign_keys=ON;");
+            // #1506: a 32 MB page cache (default 2 MB) keeps the block_edit index of a built-up world in memory,
+            // mmap lets reads bypass the page-copy path, and temp tables/indices stay off the disk. All three are
+            // per-connection, file-format neutral, and safe on the smallest hosts (the mmap is a size CAP).
+            Execute("PRAGMA cache_size=-32000;");
+            Execute("PRAGMA mmap_size=268435456;");
+            Execute("PRAGMA temp_store=MEMORY;");
 
             Execute(@"
             CREATE TABLE IF NOT EXISTS world_meta (id INTEGER PRIMARY KEY CHECK (id = 0), json TEXT NOT NULL);
@@ -370,24 +423,27 @@ public sealed class SqliteWorldRepository : IWorldRepository
             int ownerId = string.IsNullOrEmpty(owner) ? 0 : InternPlayerLocked(owner);
             long now = ownerId == 0 ? 0 : DateTimeOffset.UtcNow.ToUnixTimeSeconds();
 
-            using var cmd = Connection.CreateCommand();
-            cmd.CommandText =
+            var cmd = Prepared(ref _setBlockCmd,
                 "INSERT INTO block_edit (planet, x, y, z, block, tint, glow, shape, owner_id, edited_unix) " +
                 "VALUES ($p, $x, $y, $z, $b, $t, $g, $s, $o, $u) " +
                 "ON CONFLICT(planet, x, y, z) DO UPDATE SET block = excluded.block, tint = excluded.tint, " +
                 "glow = excluded.glow, shape = excluded.shape, " +
                 "owner_id = CASE WHEN excluded.owner_id = 0 THEN block_edit.owner_id ELSE excluded.owner_id END, " +
-                "edited_unix = CASE WHEN excluded.owner_id = 0 THEN block_edit.edited_unix ELSE excluded.edited_unix END;";
-            cmd.Parameters.AddWithValue("$p", planet);
-            cmd.Parameters.AddWithValue("$x", worldPosition.X);
-            cmd.Parameters.AddWithValue("$y", worldPosition.Y);
-            cmd.Parameters.AddWithValue("$z", worldPosition.Z);
-            cmd.Parameters.AddWithValue("$b", block);
-            cmd.Parameters.AddWithValue("$t", tint);
-            cmd.Parameters.AddWithValue("$g", glow);
-            cmd.Parameters.AddWithValue("$s", shape);
-            cmd.Parameters.AddWithValue("$o", ownerId);
-            cmd.Parameters.AddWithValue("$u", now);
+                "edited_unix = CASE WHEN excluded.owner_id = 0 THEN block_edit.edited_unix ELSE excluded.edited_unix END;",
+                ("$p", SqliteType.Text), ("$x", SqliteType.Integer), ("$y", SqliteType.Integer), ("$z", SqliteType.Integer),
+                ("$b", SqliteType.Integer), ("$t", SqliteType.Integer), ("$g", SqliteType.Integer), ("$s", SqliteType.Integer),
+                ("$o", SqliteType.Integer), ("$u", SqliteType.Integer));
+            var ps = cmd.Parameters;
+            ps[0].Value = planet;
+            ps[1].Value = worldPosition.X;
+            ps[2].Value = worldPosition.Y;
+            ps[3].Value = worldPosition.Z;
+            ps[4].Value = (int)block;
+            ps[5].Value = tint;
+            ps[6].Value = glow;
+            ps[7].Value = shape;
+            ps[8].Value = ownerId;
+            ps[9].Value = now;
             cmd.ExecuteNonQuery();
         }
     }
@@ -510,16 +566,19 @@ public sealed class SqliteWorldRepository : IWorldRepository
         {
             // Attribution (owner_id/edited_unix) is deliberately NOT selected here: this runs for every streamed
             // chunk and the mesher has no use for it. Admin queries fetch it per cell via GetBlockAttribution.
-            using var cmd = Connection.CreateCommand();
-            cmd.CommandText = "SELECT x, y, z, block, tint, glow, shape FROM block_edit WHERE planet = $p " +
-                              "AND x BETWEEN $minx AND $maxx AND y BETWEEN $miny AND $maxy AND z BETWEEN $minz AND $maxz;";
-            cmd.Parameters.AddWithValue("$p", planet);
-            cmd.Parameters.AddWithValue("$minx", origin.X);
-            cmd.Parameters.AddWithValue("$maxx", maxX);
-            cmd.Parameters.AddWithValue("$miny", origin.Y);
-            cmd.Parameters.AddWithValue("$maxy", maxY);
-            cmd.Parameters.AddWithValue("$minz", origin.Z);
-            cmd.Parameters.AddWithValue("$maxz", maxZ);
+            var cmd = Prepared(ref _loadChunkEditsCmd,
+                "SELECT x, y, z, block, tint, glow, shape FROM block_edit WHERE planet = $p " +
+                "AND x BETWEEN $minx AND $maxx AND y BETWEEN $miny AND $maxy AND z BETWEEN $minz AND $maxz;",
+                ("$p", SqliteType.Text), ("$minx", SqliteType.Integer), ("$maxx", SqliteType.Integer),
+                ("$miny", SqliteType.Integer), ("$maxy", SqliteType.Integer), ("$minz", SqliteType.Integer), ("$maxz", SqliteType.Integer));
+            var ps = cmd.Parameters;
+            ps[0].Value = planet;
+            ps[1].Value = origin.X;
+            ps[2].Value = maxX;
+            ps[3].Value = origin.Y;
+            ps[4].Value = maxY;
+            ps[5].Value = origin.Z;
+            ps[6].Value = maxZ;
 
             using var reader = cmd.ExecuteReader();
             while (reader.Read())
@@ -860,16 +919,19 @@ public sealed class SqliteWorldRepository : IWorldRepository
     {
         lock (_gate)
         {
-            using var cmd = Connection.CreateCommand();
-            cmd.CommandText = "INSERT INTO fluid_cell (planet, x, y, z, level, falling) " +
-                              "VALUES ($p, $x, $y, $z, $l, $f) " +
-                              "ON CONFLICT(planet, x, y, z) DO UPDATE SET level=excluded.level, falling=excluded.falling;";
-            cmd.Parameters.AddWithValue("$p", planet);
-            cmd.Parameters.AddWithValue("$x", worldPosition.X);
-            cmd.Parameters.AddWithValue("$y", worldPosition.Y);
-            cmd.Parameters.AddWithValue("$z", worldPosition.Z);
-            cmd.Parameters.AddWithValue("$l", level);
-            cmd.Parameters.AddWithValue("$f", falling ? 1 : 0);
+            var cmd = Prepared(ref _saveFluidCellCmd,
+                "INSERT INTO fluid_cell (planet, x, y, z, level, falling) " +
+                "VALUES ($p, $x, $y, $z, $l, $f) " +
+                "ON CONFLICT(planet, x, y, z) DO UPDATE SET level=excluded.level, falling=excluded.falling;",
+                ("$p", SqliteType.Text), ("$x", SqliteType.Integer), ("$y", SqliteType.Integer), ("$z", SqliteType.Integer),
+                ("$l", SqliteType.Integer), ("$f", SqliteType.Integer));
+            var ps = cmd.Parameters;
+            ps[0].Value = planet;
+            ps[1].Value = worldPosition.X;
+            ps[2].Value = worldPosition.Y;
+            ps[3].Value = worldPosition.Z;
+            ps[4].Value = (int)level;
+            ps[5].Value = falling ? 1 : 0;
             cmd.ExecuteNonQuery();
         }
     }
@@ -899,12 +961,14 @@ public sealed class SqliteWorldRepository : IWorldRepository
     {
         lock (_gate)
         {
-            using var cmd = Connection.CreateCommand();
-            cmd.CommandText = "DELETE FROM fluid_cell WHERE planet = $p AND x = $x AND y = $y AND z = $z;";
-            cmd.Parameters.AddWithValue("$p", planet);
-            cmd.Parameters.AddWithValue("$x", worldPosition.X);
-            cmd.Parameters.AddWithValue("$y", worldPosition.Y);
-            cmd.Parameters.AddWithValue("$z", worldPosition.Z);
+            var cmd = Prepared(ref _deleteFluidCellCmd,
+                "DELETE FROM fluid_cell WHERE planet = $p AND x = $x AND y = $y AND z = $z;",
+                ("$p", SqliteType.Text), ("$x", SqliteType.Integer), ("$y", SqliteType.Integer), ("$z", SqliteType.Integer));
+            var ps = cmd.Parameters;
+            ps[0].Value = planet;
+            ps[1].Value = worldPosition.X;
+            ps[2].Value = worldPosition.Y;
+            ps[3].Value = worldPosition.Z;
             cmd.ExecuteNonQuery();
         }
     }
@@ -915,16 +979,19 @@ public sealed class SqliteWorldRepository : IWorldRepository
     {
         lock (_gate)
         {
-            using var cmd = Connection.CreateCommand();
-            cmd.CommandText = "INSERT INTO fire_cell (planet, x, y, z, remaining, gen) " +
-                              "VALUES ($p, $x, $y, $z, $r, $g) " +
-                              "ON CONFLICT(planet, x, y, z) DO UPDATE SET remaining=excluded.remaining, gen=excluded.gen;";
-            cmd.Parameters.AddWithValue("$p", planet);
-            cmd.Parameters.AddWithValue("$x", worldPosition.X);
-            cmd.Parameters.AddWithValue("$y", worldPosition.Y);
-            cmd.Parameters.AddWithValue("$z", worldPosition.Z);
-            cmd.Parameters.AddWithValue("$r", remaining);
-            cmd.Parameters.AddWithValue("$g", generation);
+            var cmd = Prepared(ref _saveFireCellCmd,
+                "INSERT INTO fire_cell (planet, x, y, z, remaining, gen) " +
+                "VALUES ($p, $x, $y, $z, $r, $g) " +
+                "ON CONFLICT(planet, x, y, z) DO UPDATE SET remaining=excluded.remaining, gen=excluded.gen;",
+                ("$p", SqliteType.Text), ("$x", SqliteType.Integer), ("$y", SqliteType.Integer), ("$z", SqliteType.Integer),
+                ("$r", SqliteType.Real), ("$g", SqliteType.Integer));
+            var ps = cmd.Parameters;
+            ps[0].Value = planet;
+            ps[1].Value = worldPosition.X;
+            ps[2].Value = worldPosition.Y;
+            ps[3].Value = worldPosition.Z;
+            ps[4].Value = remaining;
+            ps[5].Value = generation;
             cmd.ExecuteNonQuery();
         }
     }
@@ -954,12 +1021,14 @@ public sealed class SqliteWorldRepository : IWorldRepository
     {
         lock (_gate)
         {
-            using var cmd = Connection.CreateCommand();
-            cmd.CommandText = "DELETE FROM fire_cell WHERE planet = $p AND x = $x AND y = $y AND z = $z;";
-            cmd.Parameters.AddWithValue("$p", planet);
-            cmd.Parameters.AddWithValue("$x", worldPosition.X);
-            cmd.Parameters.AddWithValue("$y", worldPosition.Y);
-            cmd.Parameters.AddWithValue("$z", worldPosition.Z);
+            var cmd = Prepared(ref _deleteFireCellCmd,
+                "DELETE FROM fire_cell WHERE planet = $p AND x = $x AND y = $y AND z = $z;",
+                ("$p", SqliteType.Text), ("$x", SqliteType.Integer), ("$y", SqliteType.Integer), ("$z", SqliteType.Integer));
+            var ps = cmd.Parameters;
+            ps[0].Value = planet;
+            ps[1].Value = worldPosition.X;
+            ps[2].Value = worldPosition.Y;
+            ps[3].Value = worldPosition.Z;
             cmd.ExecuteNonQuery();
         }
     }
@@ -1753,6 +1822,7 @@ public sealed class SqliteWorldRepository : IWorldRepository
             }
 
             _inTransaction = true;
+            TransactionsBegun++;
             Execute("BEGIN;");
             try
             {
@@ -1832,6 +1902,7 @@ public sealed class SqliteWorldRepository : IWorldRepository
         {
             if (_connection is not null)
             {
+                DisposePreparedCommands(); // #1506: the cached statements belong to this connection
                 try
                 {
                     using var cmd = _connection.CreateCommand();

--- a/tests/BlocksBeyondTheStars.Tests/ServerQuickWinsTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/ServerQuickWinsTests.cs
@@ -1,0 +1,195 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using System;
+using System.IO;
+using System.Linq;
+using BlocksBeyondTheStars.Networking;
+using BlocksBeyondTheStars.Networking.Transport;
+using BlocksBeyondTheStars.Persistence;
+using BlocksBeyondTheStars.Shared.Configuration;
+using BlocksBeyondTheStars.Shared.Content;
+using BlocksBeyondTheStars.Shared.Geometry;
+using BlocksBeyondTheStars.Shared.Primitives;
+using BlocksBeyondTheStars.Shared.State;
+using BlocksBeyondTheStars.Shared.World;
+using Xunit;
+using SvGameServer = BlocksBeyondTheStars.GameServer.GameServer;
+
+namespace BlocksBeyondTheStars.Tests;
+
+/// <summary>PR bundle 2 of the performance package (#1501): server-side quick wins that change no behaviour —
+/// one transaction per simulation step (#1505), prepared SQLite statements (#1506), the settled-view skip in
+/// chunk streaming (#1507), the 1 Hz flora step (#1508), the custom-ship stats memo (#1509) and the codec
+/// formatter warm-up (#1510).</summary>
+public sealed class ServerQuickWinsTests : IDisposable
+{
+    private readonly string _root = Path.Combine(Path.GetTempPath(), "bbts_quickwins_" + Guid.NewGuid().ToString("N"));
+    private readonly GameContent _content = ContentLoader.LoadFromDirectory(TestPaths.DataDir());
+
+    private SvGameServer Start(string tag, out SqliteWorldRepository repo, int viewDistance = 1)
+    {
+        repo = new SqliteWorldRepository(new SaveGamePaths(_root, tag));
+        var config = new ServerConfig
+        {
+            WorldName = tag,
+            Seed = 1,
+            AutoSaveIntervalMinutes = 9999,
+            PlaceStarterShip = false,
+            ViewDistanceChunks = viewDistance,
+        };
+        var server = new SvGameServer(config, _content, new LoopbackServerTransport(new LoopbackLink()), repo);
+        server.Start();
+        return server;
+    }
+
+    [Fact]
+    public void FluidStep_WritesAllItsCells_InOneTransaction()
+    {
+        var server = Start("fluid_tx", out var repo);
+        using (repo)
+        {
+            server.AddLocalPlayer("Plumber");
+            int before = repo.TransactionsBegun;
+
+            // A water source high in the air column: it falls and spreads, so every fluid step touches many
+            // cells (each a SetBlock + fluid-cell row). Per cell that used to be one autocommit each.
+            server.PlaceFluidSource("water", 0, 130, 0);
+            for (int i = 0; i < 8; i++)
+            {
+                server.TickForTest(0.3); // 2.4 s ≈ 9 fluid steps at the 0.25 s cadence
+            }
+
+            int steps = repo.TransactionsBegun - before;
+            Assert.True(steps >= 2, $"the fluid steps should have run inside transactions (got {steps})");
+            Assert.True(steps <= 12, $"one transaction per STEP, not per cell (got {steps} for ~9 steps)");
+        }
+    }
+
+    [Fact]
+    public void PreparedStatements_RebindValuesPerCall()
+    {
+        // The cached commands are reused across calls with different values, planets and chunks — a stale
+        // binding would show up as the wrong block, the wrong planet or a missing fluid/fire row.
+        using var repo = new SqliteWorldRepository(new SaveGamePaths(_root, "prepared"));
+        repo.Initialize();
+
+        repo.SetBlock("planet:a", new Vector3i(3, 40, 5), 7);
+        repo.SetBlock("planet:a", new Vector3i(3, 40, 5), 9);          // same cell, new block → upsert
+        repo.SetBlock("planet:b", new Vector3i(3, 40, 5), 11, tint: 0x123456);
+        repo.SetBlock("planet:a", new Vector3i(100, 40, 5), 13);       // another chunk
+
+        var chunkA = WorldConstants.WorldToChunk(new Vector3i(3, 40, 5));
+        var editsA = repo.LoadChunkEdits("planet:a", chunkA);
+        Assert.Single(editsA);
+        Assert.Equal(9, editsA[0].Block);
+        var editsB = repo.LoadChunkEdits("planet:b", chunkA);
+        Assert.Single(editsB);
+        Assert.Equal(11, editsB[0].Block);
+        Assert.Equal(0x123456, editsB[0].Tint);
+        Assert.Single(repo.LoadChunkEdits("planet:a", WorldConstants.WorldToChunk(new Vector3i(100, 40, 5))));
+
+        repo.SaveFluidCell("planet:a", new Vector3i(1, 2, 3), 5, falling: true);
+        repo.SaveFluidCell("planet:a", new Vector3i(1, 2, 3), 6, falling: false); // upsert
+        repo.SaveFluidCell("planet:a", new Vector3i(4, 5, 6), 2, falling: false);
+        var fluids = repo.ListFluidCells("planet:a");
+        Assert.Equal(2, fluids.Count);
+        Assert.Contains(fluids, f => f.WorldPosition == new Vector3i(1, 2, 3) && f.Level == 6 && !f.Falling);
+        repo.DeleteFluidCell("planet:a", new Vector3i(1, 2, 3));
+        Assert.Single(repo.ListFluidCells("planet:a"));
+
+        repo.SaveFireCell("planet:a", new Vector3i(7, 8, 9), 12.5, generation: 2);
+        repo.SaveFireCell("planet:a", new Vector3i(7, 8, 9), 3.25, generation: 3);
+        var fires = repo.ListFireCells("planet:a");
+        Assert.Single(fires);
+        Assert.Equal(3.25, fires[0].Remaining, 6);
+        Assert.Equal(3, fires[0].Generation);
+        repo.DeleteFireCell("planet:a", new Vector3i(7, 8, 9));
+        Assert.Empty(repo.ListFireCells("planet:a"));
+    }
+
+    [Fact]
+    public void StreamChunks_SkipsTheEnumeration_WhileAPlayersViewIsSettled()
+    {
+        var server = Start("settled", out var repo);
+        using (repo)
+        {
+            var p = server.AddLocalPlayer("Camper");
+            // Stream the (small) view until nothing arrives for a while.
+            int lastSent = -1;
+            for (int i = 0; i < 60 && p.SentChunks.Count != lastSent; i++)
+            {
+                lastSent = p.SentChunks.Count;
+                server.TickForTest(0.1);
+            }
+
+            server.TickForTest(0.1); // the pass that records "settled"
+            int enumerations = server.StreamEnumerationsForTest;
+            for (int i = 0; i < 10; i++)
+            {
+                server.TickForTest(0.1);
+            }
+
+            Assert.True(server.StreamEnumerationsForTest - enumerations <= 1,
+                $"a settled, stationary player must not re-enumerate the view every tick (got {server.StreamEnumerationsForTest - enumerations} in 10 ticks)");
+
+            // Moving to another chunk column invalidates the settled marker at once.
+            var pos = p.State.Position;
+            p.State.Position = new Vector3f(pos.X + 32f, pos.Y, pos.Z);
+            int beforeMove = server.StreamEnumerationsForTest;
+            server.TickForTest(0.1);
+            Assert.True(server.StreamEnumerationsForTest > beforeMove, "a moved player re-enumerates on the next pass");
+            Assert.True(p.SentChunks.Count > lastSent, "and the new column streams");
+        }
+    }
+
+    [Fact]
+    public void CustomShipStats_AreParsedOnce_PerBuiltCellsBlob()
+    {
+        var server = Start("custom_memo", out var repo);
+        using (repo)
+        {
+            var a = server.AddLocalPlayer("Builder");
+            server.AddLocalPlayer("Neighbour");
+            var ship = a.Ships[a.ActiveShipId];
+            ship.ShipType = ShipState.CustomShipType;
+            ship.BuiltCells = "0:0:0:5;1:0:0:5;2:0:0:5;0:1:0:6";
+
+            // Two players ⇒ the ship cursor flips between them every tick, recomputing combat stats each time;
+            // the blob is parsed once per blob instance, not once per recompute.
+            for (int i = 0; i < 10; i++)
+            {
+                server.TickForTest(0.1);
+            }
+
+            Assert.Equal(1, server.CustomShipStatsParsesForTest);
+
+            ship.BuiltCells = "0:0:0:5;1:0:0:5"; // a rebuilt hull is a new string instance → one new parse
+            server.TickForTest(0.1);
+            server.TickForTest(0.1);
+            Assert.Equal(2, server.CustomShipStatsParsesForTest);
+        }
+    }
+
+    [Fact]
+    public void NetCodecWarmUp_CompilesTheRegisteredFormatters()
+    {
+        int warmed = NetCodec.WarmUp();
+        int registered = NetCodec.RegisteredMessages.Count;
+        Assert.True(warmed >= registered * 9 / 10,
+            $"warm-up should reach (nearly) every registered message type (warmed {warmed} of {registered})");
+        Assert.True(NetCodec.WarmUp() == warmed, "warm-up is idempotent");
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+        catch
+        {
+            // best-effort temp cleanup
+        }
+    }
+}


### PR DESCRIPTION
PR bundle 2 of the performance package (#1501): server-side quick wins with **no behaviour change**. Server/Persistence/Networking + tests only (no Unity files).

## What changes

| issue | change | measured basis |
|---|---|---|
| #1505 | fluid, fire, granular, flora-regrow and weather-snow steps run inside `RunInTransaction` (SQLite, PostgreSQL, Memory repo all reentrant) | 100–142 µs per autocommitted cell → 24–35 µs batched; a breached lake was ≈ 1600 commits/s on the tick thread |
| #1506 | one prepared `SqliteCommand` per hot statement (SetBlock, LoadChunkEdits, fluid + fire cells), pragmas `cache_size=-32000`, `mmap_size=256 MB`, `temp_store=MEMORY`; Npgsql auto-prepare for PostgreSQL unless the operator set it | SQL was re-parsed per call; `LoadChunkEdits` 30–260 µs per streamed chunk |
| #1507 | `StreamChunks` skips the `(2R+3)²` column enumeration while a session's view is settled (centre, radius, sent-set size unchanged; 30-tick re-check); far-column surface band cached per canonical column | 0.2–0.3 ms per idle tick per player at VD 4, scaling with players × VD |
| #1508 | `TickFlora` steps regrow timers at 1 Hz with the accumulated dt | three noise lookups per cell × 15 Hz for nothing |
| #1509 | custom-ship stats memoised per `BuiltCells` blob instance | the hull blob was re-parsed on every ship-cursor switch (N per tick with N players) |
| #1510 | `NetCodec.WarmUp()` at server start | 26–39 ms per message type on first use, ~1 s during the first join burst |

## Consequences

- A crash in the middle of a fluid/fire/granular/flora/snow step loses at most that one step (≤ 0.25 s of simulation) instead of nothing. Everything else is identical.
- Flora regrowth lands at most one second later than before (timers are in seconds).
- The presence gear mask is **not** cached (issue #1509 asked for it): inventory mutation is not centralised, so a cache could go stale, and the scan measured negligible.
- The PostgreSQL repository is covered by the shared `RunInTransaction` contract; the auto-prepare setting is a connection-string default and only applies when the operator did not set `Max Auto Prepare` themselves.

## Tests

`ServerQuickWinsTests`: one transaction per fluid step (bounded above by the step count), prepared statements rebind correctly across values, planets and chunks (incl. fluid + fire rows), a settled stationary player stops re-enumerating and a moved one resumes, the custom-ship blob is parsed once per instance, and the warm-up reaches ≥ 90 % of the registered message types and is idempotent. Affected suites re-run locally (fluids, flora, fire, granular, chunk streaming, weather/snow, codec, custom ships, stations).

## Verification

`dotnet format --verify-no-changes` clean · `dotnet build --no-incremental` 0 warnings / 0 errors · affected suites green; the full PR suite runs in CI.

closes #1505 closes #1506 closes #1507 closes #1508 closes #1509 closes #1510

🤖 Generated with [Claude Code](https://claude.com/claude-code)
