### PR TITLE
perf(client): quick wins — looping jetpack flames, input-binding tables, sky domes off when dark, shared creature materials, chunk bookkeeping, per-frame hygiene (#1511–#1516)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -121,6 +121,32 @@ behaviour stays covered outside the radius. `.vscode/` git-ignored. Player texts
 `vega.hint.base_walls`, `base-air` codex EN+DE) now name the 24-block guarantee beside the ring (#1495,
 all 14 locales, machine pass for the 12). UNRELEASED.
 
+### ★ Client quick wins: looping jetpack flames, input-binding tables, sky domes off when dark, shared creature materials, chunk bookkeeping, per-frame hygiene (#1511–#1516, 2026-09-04, branch perf/1511-1516-client-quick-wins)
+PR bundle 3 of the performance package (epic #1501); Unity client + Client.Core, nothing visible changes.
+**#1511** the jetpack drives two persistent looping thrust emitters (`WeaponFx.CreateThrustFlame` /
+`SetThrust`, the `SpaceView.BuildThruster` pattern) instead of spawning two one-shot particle systems every
+frame (~120 GameObject + ParticleSystem creations/s while flying); remote avatars get one emitter each.
+**#1512** `InputMap.Key` and `GamepadInputSource.ButtonFor` resolve through per-action `KeyCode[]` tables
+rebuilt only when `ClientSettings.BindingsVersion` changes (bumped by `SetBoundKey`/`SetBoundPad`/the new
+`ResetBindings`), and `Connected()` evaluates `Input.GetJoystickNames()` once per frame — the previous
+`action.ToString()` + string scan + `Enum.TryParse` (+ a fresh joystick-name array) ran on every one of the
+~25–35 polls per frame. **#1513** Starfield, NebulaField and AtmosphereDome switch their renderer off at
+brightness ≤ 0.001 and their shaders moved from the Background queue to Geometry+499 — drawn after the
+terrain, so the depth test rejects covered pixels instead of shading the whole sky first (additive over
+opaque is order-independent → same image). **#1514** `CreatureBuilder.Unlit/Lit` share one Material per
+(shader, colour, texture) and cache the shader lookups (8–16 fresh, never-destroyed Materials per creature
+build before); `SpaceView.Unlit` caches its shader. **#1515** all-air chunks get no GameObject at all,
+`RepositionChunks` writes a chunk's transform only when its seam-aware scene position changes, the mesh
+dispatcher picks the nearest `MeshChunksPerFrame` chunks by partial selection over precomputed distances
+instead of sorting the whole dirty set with a closure, and `ClientWorld` buckets light sources per chunk
+(`RemoveChunk` = one remove instead of 4096; `LightSourcesNear` visits the 27 neighbouring buckets instead
+of every light in the world). **#1516** HUD and flight-overlay hints are composed once and assigned once
+(the `text +=` pattern re-generated the Text mesh every refresh), the flight hint/cargo/instrument and
+radar readouts are formatted only when a displayed value changes, NPC nameplates cache their stage/greeting
+strings, `Sky` caches the biome grade and the lamp-colour property id, `VisorHud` writes its constant
+material properties once per effects-state and uses property ids, one-shot spatial SFX come from a pool of
+24 AudioSources instead of a GameObject per play, and the IMGUI weather overlay skips the Layout event.
+
 ### ★ Lyxette round 6 — the station stays where you built it and how you rebuilt it; walls stop the walking robots; torches burn in base air; the inventory stops moving under your click (#1480–#1484, #1486–#1489, 2026-09-03, branch fix/lyxette-reports-2026-09-03b)
 Eight F1 reports from the morning of 2026-09-03 (v2026.8.26), decisions Marcel 2026-09-03. **Station in every
 orbit (#1480):** `AddStationContacts` listed every `SpaceStation` body of the star system in every orbit — a

--- a/client/Assets/BlocksBeyondTheStars/Scripts/AtmosphereDome.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/AtmosphereDome.cs
@@ -18,7 +18,10 @@ namespace BlocksBeyondTheStars.Client
         public GameBootstrap Game;
         public Camera Camera;
 
+        private static readonly int BrightnessId = Shader.PropertyToID("_Brightness");
+
         private Transform _dome;
+        private MeshRenderer _renderer;
         private Material _mat;
         private float _brightness; // smoothed 0..1 fade
 
@@ -32,7 +35,6 @@ namespace BlocksBeyondTheStars.Client
             }
 
             _mat = new Material(shader);
-            _mat.SetFloat("_Brightness", 0f);
 
             var go = new GameObject("Atmosphere");
             go.transform.SetParent(transform, false);
@@ -43,7 +45,21 @@ namespace BlocksBeyondTheStars.Client
             mr.receiveShadows = false;
             mr.lightProbeUsage = UnityEngine.Rendering.LightProbeUsage.Off;
             mr.reflectionProbeUsage = UnityEngine.Rendering.ReflectionProbeUsage.Off;
+            _renderer = mr;
             _dome = go.transform;
+            ApplyBrightness(0f);
+        }
+
+        /// <summary>Writes the shader brightness and switches the renderer off while the halo is faded out
+        /// (#1513): in space and on airless bodies the whole-sky dome used to be drawn at brightness 0.</summary>
+        private void ApplyBrightness(float value)
+        {
+            _mat.SetFloat(BrightnessId, value);
+            bool visible = value > 0.001f;
+            if (_renderer != null && _renderer.enabled != visible)
+            {
+                _renderer.enabled = visible;
+            }
         }
 
         private void LateUpdate()
@@ -63,7 +79,7 @@ namespace BlocksBeyondTheStars.Client
                             || (Game.Environment != null && Game.Environment.SpaceSky) || Game.OnFootInSpace;
             float target = spaceSky ? 0f : 1f;
             _brightness = Mathf.MoveTowards(_brightness, target, Time.deltaTime * 0.9f);
-            _mat.SetFloat("_Brightness", _brightness);
+            ApplyBrightness(_brightness);
         }
 
         /// <summary>A unit UV-sphere dome (positions only — the shader derives the view direction from them).</summary>

--- a/client/Assets/BlocksBeyondTheStars/Scripts/ClientAudio.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/ClientAudio.cs
@@ -553,9 +553,10 @@ namespace BlocksBeyondTheStars.Client
                 clip = SampleKit.Muffle(clip);
             }
 
-            var go = new GameObject("sfx_" + label);
-            go.transform.position = pos;
-            var src = go.AddComponent<AudioSource>();
+            // #1516: pooled emitters instead of a GameObject + AudioSource per one-shot (creature phrases, growls,
+            // factory hums — 5–20 spawns/s) with a deferred Destroy each.
+            var src = PooledSfxSource();
+            src.transform.position = pos;
             src.clip = clip;
             src.spatialBlend = 1f;
             src.minDistance = 4f;
@@ -564,7 +565,40 @@ namespace BlocksBeyondTheStars.Client
             src.pitch = pitch;
             src.volume = Mathf.Clamp01(vol * SfxVol());
             src.Play();
-            Destroy(go, clip.length / Mathf.Max(0.1f, pitch) + 0.2f);
+        }
+
+        private readonly List<AudioSource> _sfxPool = new List<AudioSource>();
+        private int _sfxPoolNext;
+        private const int SfxPoolMax = 24;
+
+        /// <summary>A free pooled spatial AudioSource (idle one first; a new one up to the cap; else the oldest
+        /// in round-robin, which cuts the longest-running one-shot — same audible behaviour as Unity's own voice
+        /// limit).</summary>
+        private AudioSource PooledSfxSource()
+        {
+            for (int i = 0; i < _sfxPool.Count; i++)
+            {
+                var s = _sfxPool[i];
+                if (s != null && !s.isPlaying)
+                {
+                    return s;
+                }
+            }
+
+            if (_sfxPool.Count < SfxPoolMax)
+            {
+                var go = new GameObject("sfx_pooled");
+                go.transform.SetParent(transform, false);
+                var created = go.AddComponent<AudioSource>();
+                created.playOnAwake = false;
+                _sfxPool.Add(created);
+                return created;
+            }
+
+            _sfxPoolNext = (_sfxPoolNext + 1) % _sfxPool.Count;
+            var reused = _sfxPool[_sfxPoolNext];
+            reused.Stop();
+            return reused;
         }
 
         /// <summary>The raw clip behind a cue id, or null — creature voices need the AudioClip itself to

--- a/client/Assets/BlocksBeyondTheStars/Scripts/ClientSettings.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/ClientSettings.cs
@@ -607,6 +607,21 @@ namespace BlocksBeyondTheStars.Client
             }
         }
 
+        /// <summary>#1512: bumped whenever a key or pad binding changes, so <see cref="InputMap"/> and the gamepad
+        /// backend can keep a per-action lookup table instead of resolving <c>action.ToString()</c> + a string scan
+        /// + <c>Enum.TryParse</c> on EVERY poll (~25–35 polls per frame ⇒ ~100 allocations per frame). Not
+        /// persisted; a freshly loaded settings object starts at 0 and the tables rebuild on first use.</summary>
+        [NonSerialized] public int BindingsVersion;
+
+        /// <summary>Clears every key AND pad override (the settings screen's "reset controls"), bumping
+        /// <see cref="BindingsVersion"/> so the lookup tables rebuild.</summary>
+        public void ResetBindings()
+        {
+            KeyBindings?.Clear();
+            PadBindings?.Clear();
+            BindingsVersion++;
+        }
+
         /// <summary>The bound KeyCode NAME for an input action (empty = the action uses its default key). String-
         /// keyed so this stays decoupled from the <see cref="InputAction"/> enum; <see cref="InputMap"/> parses it.</summary>
         public string BoundKeyName(string action)
@@ -633,12 +648,14 @@ namespace BlocksBeyondTheStars.Client
                     if (KeyBindings[i].Key == keyName) return false;
                     if (string.IsNullOrEmpty(keyName)) KeyBindings.RemoveAt(i);
                     else KeyBindings[i].Key = keyName;
+                    BindingsVersion++;
                     return true;
                 }
             }
 
             if (string.IsNullOrEmpty(keyName)) return false;
             KeyBindings.Add(new KeyBinding { Action = action, Key = keyName });
+            BindingsVersion++;
             return true;
         }
 
@@ -668,12 +685,14 @@ namespace BlocksBeyondTheStars.Client
                     if (PadBindings[i].Key == keyName) return false;
                     if (string.IsNullOrEmpty(keyName)) PadBindings.RemoveAt(i);
                     else PadBindings[i].Key = keyName;
+                    BindingsVersion++;
                     return true;
                 }
             }
 
             if (string.IsNullOrEmpty(keyName)) return false;
             PadBindings.Add(new KeyBinding { Action = action, Key = keyName });
+            BindingsVersion++;
             return true;
         }
 

--- a/client/Assets/BlocksBeyondTheStars/Scripts/CreatureBuilder.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/CreatureBuilder.cs
@@ -584,10 +584,25 @@ namespace BlocksBeyondTheStars.Client
             return h & 0x7fffffff;
         }
 
+        // #1514: creature materials are never mutated after creation, so identical (shader, colour, texture)
+        // requests share ONE Material — every build used to create 8–16 fresh Materials (each behind a
+        // Shader.Find string lookup) that nothing ever destroyed, growing for the whole session as fauna
+        // spawned and despawned. Shared materials also let the SRP batcher group the parts.
+        private static Shader _unlitShader, _litShader;
+        private static readonly Dictionary<Color, Material> UnlitCache = new Dictionary<Color, Material>();
+        private static readonly Dictionary<(Color Color, Texture2D Tex), Material> LitCache = new Dictionary<(Color, Texture2D), Material>();
+
         private static Material Unlit(Color color)
         {
-            var shader = Shader.Find("Unlit/Color") ?? Shader.Find("BlocksBeyondTheStars/VertexColorOpaque");
-            return new Material(shader) { color = ShaderColor.Srgb(color) };
+            if (UnlitCache.TryGetValue(color, out var cached) && cached != null)
+            {
+                return cached;
+            }
+
+            _unlitShader ??= Shader.Find("Unlit/Color") ?? Shader.Find("BlocksBeyondTheStars/VertexColorOpaque");
+            var m = new Material(_unlitShader) { color = ShaderColor.Srgb(color) };
+            UnlitCache[color] = m;
+            return m;
         }
 
         // Shared (loaded once) tintable grayscale hide tiles; the body multiplies them by the species colour.
@@ -721,8 +736,14 @@ namespace BlocksBeyondTheStars.Client
 
         private static Material Lit(Color color, Texture2D tex)
         {
-            var shader = Shader.Find("BlocksBeyondTheStars/LitColor") ?? Shader.Find("Unlit/Color");
-            var m = new Material(shader) { color = ShaderColor.Srgb(color) };
+            var key = (color, tex);
+            if (LitCache.TryGetValue(key, out var cached) && cached != null)
+            {
+                return cached;
+            }
+
+            _litShader ??= Shader.Find("BlocksBeyondTheStars/LitColor") ?? Shader.Find("Unlit/Color");
+            var m = new Material(_litShader) { color = ShaderColor.Srgb(color) };
             if (tex != null)
             {
                 m.mainTexture = tex;
@@ -734,6 +755,7 @@ namespace BlocksBeyondTheStars.Client
                 m.SetFloat("_Fill", CreatureFill);
             }
 
+            LitCache[key] = m;
             return m;
         }
     }

--- a/client/Assets/BlocksBeyondTheStars/Scripts/GameBootstrap.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/GameBootstrap.cs
@@ -1478,6 +1478,8 @@ namespace BlocksBeyondTheStars.Client
             public MeshCollider Collider = null!;
             public bool ColliderEnabled = true;
             public bool RendererEnabled = true;
+            public Vector3 ScenePos;      // last position written to the transform (#1515: write only on change)
+            public bool ScenePosKnown;
         }
 
         private readonly Dictionary<ChunkCoord, ChunkView> _chunkObjects = new Dictionary<ChunkCoord, ChunkView>();
@@ -1507,6 +1509,7 @@ namespace BlocksBeyondTheStars.Client
         public int MeshChunksPerFrame = 4;
 #endif
         private readonly List<ChunkCoord> _dirtyScratch = new List<ChunkCoord>();
+        private readonly List<float> _dirtyDistScratch = new List<float>(); // parallel to _dirtyScratch during dispatch (#1515)
 
         // Distance culling (A4): chunks farther than this (blocks, seam-aware 3D distance) have their renderer
         // disabled — the client never unloads chunks, so without this the accumulated far chunks keep costing
@@ -2358,16 +2361,38 @@ namespace BlocksBeyondTheStars.Client
                 _dirtyScratch.Clear();
                 _dirtyScratch.AddRange(_dirty);
                 var pp = PlayerPosition;
-                _dirtyScratch.Sort((a, b) => ChunkDistSqToPlayer(a, pp).CompareTo(ChunkDistSqToPlayer(b, pp)));
+
+                // #1515: nearest-first WITHOUT sorting the whole set — the distances are computed once and the
+                // `budget` nearest entries are picked by partial selection (O(n·k), k ≤ MeshChunksPerFrame),
+                // instead of an O(n log n) sort with a closure and two seam-aware distances per comparison to
+                // take four. Same order as the sort produced.
+                _dirtyDistScratch.Clear();
+                for (int i = 0; i < _dirtyScratch.Count; i++)
+                {
+                    _dirtyDistScratch.Add(ChunkDistSqToPlayer(_dirtyScratch[i], pp));
+                }
 
                 int budget = Mathf.Max(1, MeshChunksPerFrame);
                 int built = 0;
-                foreach (var coord in _dirtyScratch)
+                while (built < budget && _dirtyScratch.Count > 0)
                 {
-                    if (built >= budget)
+                    int best = 0;
+                    float bestDist = _dirtyDistScratch[0];
+                    for (int i = 1; i < _dirtyScratch.Count; i++)
                     {
-                        break;
+                        if (_dirtyDistScratch[i] < bestDist)
+                        {
+                            bestDist = _dirtyDistScratch[i];
+                            best = i;
+                        }
                     }
+
+                    var coord = _dirtyScratch[best];
+                    int last = _dirtyScratch.Count - 1;
+                    _dirtyScratch[best] = _dirtyScratch[last];
+                    _dirtyDistScratch[best] = _dirtyDistScratch[last];
+                    _dirtyScratch.RemoveAt(last);
+                    _dirtyDistScratch.RemoveAt(last);
 
                     // Neighbours not yet streamed are no-ops — flush them without spending budget; they
                     // re-mark themselves dirty once their own data arrives.
@@ -2431,7 +2456,16 @@ namespace BlocksBeyondTheStars.Client
                 }
 
                 var origin = WorldConstants.ChunkOrigin(kv.Key);
-                view.Go.transform.position = new Vector3(SceneX(origin.X), origin.Y, SceneZ(origin.Z));
+                // #1515: only chunks across a wrap seam ever change scene position, yet every chunk's transform
+                // was written per block moved (a native call + transform-change notifications to the renderer
+                // and an enabled collider, ~1700 of them at VD 8). Write on change only.
+                var scenePos = new Vector3(SceneX(origin.X), origin.Y, SceneZ(origin.Z));
+                if (!view.ScenePosKnown || view.ScenePos != scenePos)
+                {
+                    view.Go.transform.position = scenePos;
+                    view.ScenePos = scenePos;
+                    view.ScenePosKnown = true;
+                }
 
                 float distSq = ChunkDistSqToPlayer(kv.Key, pp);
 
@@ -3050,12 +3084,31 @@ namespace BlocksBeyondTheStars.Client
             bool exists = _chunkObjects.TryGetValue(coord, out var view) && view?.Go != null;
             var (mesh, collider) = data.ToMeshes();
 
+            // #1515: an all-air (or all-fluid-free, geometry-less) chunk gets NO GameObject. A large share of the
+            // streamed set at a big view distance is sky, and each empty chunk used to carry a GameObject + three
+            // components + three materials + an empty mesh with full 16³ bounds — a transform write per block
+            // moved and a culling entry each. The chunk re-materialises through the normal path the moment an
+            // edit gives it geometry (the rebuild then finds no view and creates one).
+            if (!exists && collider == null && (mesh == null || mesh.vertexCount == 0) && (data.Scatter == null || data.Scatter.Count == 0))
+            {
+                if (mesh != null)
+                {
+                    Destroy(mesh);
+                }
+
+                int emptyGen = (_colliderGen.TryGetValue(coord, out var eg) ? eg : 0) + 1;
+                _colliderGen[coord] = emptyGen;
+                _colliderAppliedGen[coord] = emptyGen; // nothing to cook — no fall-guard "pending" state either
+                return;
+            }
+
             if (!exists)
             {
                 var go = new GameObject($"Chunk {coord.X},{coord.Y},{coord.Z}");
                 go.transform.SetParent(transform);
                 var origin = WorldConstants.ChunkOrigin(coord);
-                go.transform.position = new Vector3(SceneX(origin.X), origin.Y, SceneZ(origin.Z)); // seam-aware on both ground axes (torus)
+                var scenePos = new Vector3(SceneX(origin.X), origin.Y, SceneZ(origin.Z)); // seam-aware on both ground axes (torus)
+                go.transform.position = scenePos;
                 var filter = go.AddComponent<MeshFilter>();
                 var mr = go.AddComponent<MeshRenderer>();
                 // Submesh 0 → opaque atlas, submesh 1 → see-through atlas (glass/fields), submesh 2 → paint
@@ -3066,7 +3119,7 @@ namespace BlocksBeyondTheStars.Client
                         ? new[] { ChunkMaterial, ChunkMaterialTransparent }
                         : new[] { ChunkMaterial };
                 var mc = go.AddComponent<MeshCollider>();
-                view = new ChunkView { Go = go, Filter = filter, Renderer = mr, Collider = mc };
+                view = new ChunkView { Go = go, Filter = filter, Renderer = mr, Collider = mc, ScenePos = scenePos, ScenePosKnown = true };
                 _chunkObjects[coord] = view;
             }
 

--- a/client/Assets/BlocksBeyondTheStars/Scripts/HudUi.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/HudUi.cs
@@ -733,7 +733,10 @@ namespace BlocksBeyondTheStars.Client
             _toast.text = Game.LastMessage ?? string.Empty;
             _inSpace.text = Game.InSpace ? loc.Get("ui.hud.in_space") : string.Empty;
             _observer.text = Game.Spectating ? loc.Get("ui.hud.observer") : string.Empty;
-            _hint.text = InputMap.ActiveDevice switch
+            // #1516: compose the hint in a local and assign ONCE — assigning the base line first and then
+            // appending with `+=` dirtied the Text (mesh regeneration) on every refresh even when the final
+            // string was identical; the setter only early-outs on an equal string.
+            string hint = InputMap.ActiveDevice switch
             {
                 // On touch the on-screen buttons are self-labelling, so the text hint just adds clutter.
                 InputDeviceKind.Touch => string.Empty,
@@ -743,29 +746,31 @@ namespace BlocksBeyondTheStars.Client
 
             // Creative/Sandbox worlds only: the one control the hint can't afford to omit, because flight has
             // no other tell. Appended rather than baked into ui.hud.hint so Explorer worlds stay uncluttered.
-            if (Game.CanFly && _hint.text.Length > 0)
+            if (Game.CanFly && hint.Length > 0)
             {
-                _hint.text += " · " + loc.Get("ui.hud.hint_fly");
+                hint += " · " + loc.Get("ui.hud.hint_fly");
             }
 
             // Holding a rotatable block (a crafted shape or furniture): surface the rotate control (#863) —
             // nothing else in the game ever said the key exists. Appended only while it applies, like the
             // fly hint, so the always-on line stays short.
-            if (Game.HoldingRotatableBlock && _hint.text.Length > 0)
+            if (Game.HoldingRotatableBlock && hint.Length > 0)
             {
-                _hint.text += " · " + loc.Get("ui.hud.hint_rotate")
+                hint += " · " + loc.Get("ui.hud.hint_rotate")
                     .Replace("{key}", GlyphText(loc, InputAction.RotateShape));
             }
 
             // The middle-click slot-action ring (#924) has no other on-screen tell (#935): advertise it
             // while the hotbar is up and the selected slot holds anything to act on, like the hints above.
             // RefreshHotbar ran just before this, so the root's active state is current for this frame.
-            if (_hint.text.Length > 0 && _hotbarRoot != null && _hotbarRoot.activeSelf
+            if (hint.Length > 0 && _hotbarRoot != null && _hotbarRoot.activeSelf
                 && !string.IsNullOrEmpty(Game.ItemInSlot(Game.SelectedHotbarSlot)))
             {
-                _hint.text += " · " + loc.Get("ui.hud.hint_slot_actions")
+                hint += " · " + loc.Get("ui.hud.hint_slot_actions")
                     .Replace("{key}", GlyphText(loc, InputAction.HotbarAction));
             }
+
+            _hint.text = hint;
 
             // Prompts — on-foot only. While piloting/EVA the flight view draws its own prompts, so don't leak
             // a stale on-foot "Use: Cockpit" into the centre of the space view (you reach the cockpit/helm on

--- a/client/Assets/BlocksBeyondTheStars/Scripts/Input/GamepadInputSource.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/Input/GamepadInputSource.cs
@@ -79,10 +79,23 @@ namespace BlocksBeyondTheStars.Client
 
         public InputDeviceKind Kind => InputDeviceKind.Gamepad;
 
-        /// <summary>Whether at least one joystick is connected (a non-empty name). Recomputed cheaply per
-        /// call; when false the source stays fully inert so an unplugged pad costs nothing.</summary>
+        private static bool _connected;
+        private static int _connectedFrame = -1;
+
+        /// <summary>Whether at least one joystick is connected (a non-empty name). Evaluated once per frame
+        /// (#1512 — <c>Input.GetJoystickNames()</c> allocates a fresh string array, and this used to run on
+        /// every ActionDown/Held/Up poll); when false the source stays fully inert so an unplugged pad costs
+        /// nothing.</summary>
         public static bool Connected()
         {
+            int frame = Time.frameCount;
+            if (frame == _connectedFrame)
+            {
+                return _connected;
+            }
+
+            _connectedFrame = frame;
+            _connected = false;
             var names = Input.GetJoystickNames();
             if (names == null)
             {
@@ -93,6 +106,7 @@ namespace BlocksBeyondTheStars.Client
             {
                 if (!string.IsNullOrEmpty(names[i]))
                 {
+                    _connected = true;
                     return true;
                 }
             }
@@ -344,6 +358,28 @@ namespace BlocksBeyondTheStars.Client
         /// UI (<see cref="ClientSettings.PadBindings"/>) if set, else <see cref="DefaultButtonFor"/>.</summary>
         public static KeyCode ButtonFor(InputAction action)
         {
+            if (Settings == null)
+            {
+                return DefaultButtonFor(action);
+            }
+
+            // #1512: per-action table instead of action.ToString() + string scan + Enum.TryParse per poll.
+            if (_padTable == null || !ReferenceEquals(_padTableSettings, Settings) || _padTableVersion != Settings.BindingsVersion)
+            {
+                RebuildPadTable();
+            }
+
+            int i = (int)action;
+            return i >= 0 && i < _padTable.Length ? _padTable[i] : ResolveButton(action);
+        }
+
+        private static KeyCode[] _padTable;
+        private static ClientSettings _padTableSettings;
+        private static int _padTableVersion = -1;
+
+        /// <summary>The uncached resolution — the player's override if set, else the default.</summary>
+        private static KeyCode ResolveButton(InputAction action)
+        {
             var def = DefaultButtonFor(action);
             if (Settings == null)
             {
@@ -352,6 +388,26 @@ namespace BlocksBeyondTheStars.Client
 
             string name = Settings.BoundPadName(action.ToString());
             return !string.IsNullOrEmpty(name) && System.Enum.TryParse<KeyCode>(name, out var kc) ? kc : def;
+        }
+
+        private static void RebuildPadTable()
+        {
+            var values = (InputAction[])System.Enum.GetValues(typeof(InputAction));
+            int max = 0;
+            foreach (var v in values)
+            {
+                max = Mathf.Max(max, (int)v);
+            }
+
+            var table = new KeyCode[max + 1];
+            foreach (var v in values)
+            {
+                table[(int)v] = ResolveButton(v);
+            }
+
+            _padTable = table;
+            _padTableSettings = Settings;
+            _padTableVersion = Settings.BindingsVersion;
         }
 
         /// <summary>The two verbs that live on the d-pad's vertical axis (#1220). An axis cannot be

--- a/client/Assets/BlocksBeyondTheStars/Scripts/InputMap.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/InputMap.cs
@@ -215,8 +215,33 @@ namespace BlocksBeyondTheStars.Client
             _ => KeyCode.None,
         };
 
+        // #1512: the per-action key table. Resolving a binding used to cost action.ToString() + a linear string
+        // scan over the overrides + Enum.TryParse on EVERY poll — ~25–35 polls per frame across the controller,
+        // the flight view and the UI, i.e. ~100 small allocations per frame. The table is rebuilt only when the
+        // settings object or its BindingsVersion changes (rebind UI, reset, reload).
+        private static KeyCode[] _keyTable;
+        private static ClientSettings _keyTableSettings;
+        private static int _keyTableVersion = -1;
+
         /// <summary>The currently bound key for an action — the player's override if set, else the default.</summary>
         public static KeyCode Key(InputAction action)
+        {
+            if (_settings == null || KeyboardLocked(action))
+            {
+                return DefaultKey(action);
+            }
+
+            if (_keyTable == null || !ReferenceEquals(_keyTableSettings, _settings) || _keyTableVersion != _settings.BindingsVersion)
+            {
+                RebuildKeyTable();
+            }
+
+            int i = (int)action;
+            return i >= 0 && i < _keyTable.Length ? _keyTable[i] : ResolveKey(action);
+        }
+
+        /// <summary>The uncached resolution (the player's override if set, else the default) — the table's source.</summary>
+        private static KeyCode ResolveKey(InputAction action)
         {
             var def = DefaultKey(action);
             if (_settings == null || KeyboardLocked(action))
@@ -226,6 +251,26 @@ namespace BlocksBeyondTheStars.Client
 
             string name = _settings.BoundKeyName(action.ToString());
             return !string.IsNullOrEmpty(name) && System.Enum.TryParse<KeyCode>(name, out var kc) ? kc : def;
+        }
+
+        private static void RebuildKeyTable()
+        {
+            var values = (InputAction[])System.Enum.GetValues(typeof(InputAction));
+            int max = 0;
+            foreach (var v in values)
+            {
+                max = Mathf.Max(max, (int)v);
+            }
+
+            var table = new KeyCode[max + 1];
+            foreach (var v in values)
+            {
+                table[(int)v] = ResolveKey(v);
+            }
+
+            _keyTable = table;
+            _keyTableSettings = _settings;
+            _keyTableVersion = _settings.BindingsVersion;
         }
 
         // ---- Injected edges ------------------------------------------------------------------------------

--- a/client/Assets/BlocksBeyondTheStars/Scripts/NebulaField.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/NebulaField.cs
@@ -48,7 +48,6 @@ namespace BlocksBeyondTheStars.Client
             }
 
             _mat = new Material(shader);
-            _mat.SetFloat("_Brightness", 0f);
 
             var go = new GameObject("Nebula");
             go.transform.SetParent(transform, false);
@@ -61,7 +60,24 @@ namespace BlocksBeyondTheStars.Client
             mr.receiveShadows = false;
             mr.lightProbeUsage = UnityEngine.Rendering.LightProbeUsage.Off;
             mr.reflectionProbeUsage = UnityEngine.Rendering.ReflectionProbeUsage.Off;
+            _renderer = mr;
             _dome = go.transform;
+            ApplyBrightness(0f);
+        }
+
+        private static readonly int BrightnessId = Shader.PropertyToID("_Brightness");
+        private MeshRenderer _renderer;
+
+        /// <summary>Writes the shader brightness and switches the renderer off while the gas is dark (#1513): the
+        /// dome covers the whole sky and its two per-pixel fbm evaluations used to run by day at brightness 0.</summary>
+        private void ApplyBrightness(float value)
+        {
+            _mat.SetFloat(BrightnessId, value);
+            bool visible = value > 0.001f;
+            if (_renderer != null && _renderer.enabled != visible)
+            {
+                _renderer.enabled = visible;
+            }
         }
 
         private void LateUpdate()
@@ -94,7 +110,7 @@ namespace BlocksBeyondTheStars.Client
                 }
 
                 _brightness = Mathf.Clamp01(MenuBrightness);
-                _mat.SetFloat("_Brightness", _brightness * MaxBrightness);
+                ApplyBrightness(_brightness * MaxBrightness);
                 return;
             }
 
@@ -140,7 +156,7 @@ namespace BlocksBeyondTheStars.Client
                 _brightness = Mathf.MoveTowards(_brightness, target, Time.deltaTime * 0.7f);
             }
 
-            _mat.SetFloat("_Brightness", _brightness * MaxBrightness);
+            ApplyBrightness(_brightness * MaxBrightness);
         }
 
         /// <summary>Night strength 0..1 from the local time of day — mirrors the Starfield's dusk/dawn curve so

--- a/client/Assets/BlocksBeyondTheStars/Scripts/NpcView.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/NpcView.cs
@@ -28,6 +28,14 @@ namespace BlocksBeyondTheStars.Client
             public float GestureTimer;     // counts down to the next work gesture (mine/place/talk swing)
             public float GestureLo, GestureHi; // cadence range from the NPC's theme/role
             public string Greeting;        // item 15: a contextual speech-bubble line (empty = none showing)
+
+            // #1516: the per-frame nameplate/bubble strings, rebuilt only when their inputs change.
+            public string CachedLabel;
+            public string CachedLabelBase;
+            public string CachedStageKey;
+            public object CachedLabelLoc;
+            public string CachedGreetingSource;
+            public string CachedGreetingQuoted;
             public float GreetingUntil;    // world time after which the bubble fades out
         }
 
@@ -231,7 +239,17 @@ namespace BlocksBeyondTheStars.Client
                 string label = n.Label;
                 if (Game != null && Game.NpcStandings.TryGetValue(pair.Key, out string stageKey))
                 {
-                    label = $"{label} · {Game.Localizer?.Get(stageKey) ?? stageKey}";
+                    // #1516: format once per (name, stage, locale) instead of once per NPC per frame.
+                    var loc = Game.Localizer;
+                    if (n.CachedLabel == null || n.CachedStageKey != stageKey || !ReferenceEquals(n.CachedLabelBase, n.Label) || !ReferenceEquals(n.CachedLabelLoc, loc))
+                    {
+                        n.CachedStageKey = stageKey;
+                        n.CachedLabelBase = n.Label;
+                        n.CachedLabelLoc = loc;
+                        n.CachedLabel = $"{n.Label} · {loc?.Get(stageKey) ?? stageKey}";
+                    }
+
+                    label = n.CachedLabel;
                 }
 
                 // Names only read up close: fade out between 18 m and 28 m so distant NPCs stay anonymous.
@@ -240,7 +258,13 @@ namespace BlocksBeyondTheStars.Client
                 // A live greeting bubble sits just above the nameplate (item 15).
                 if (!string.IsNullOrEmpty(n.Greeting) && WorldNow < n.GreetingUntil)
                 {
-                    labels.World(cam, n.Go.transform.position + Vector3.up * 2.5f, $"“{n.Greeting}”", UiKit.TextCol, false, 18f, 28f);
+                    if (!ReferenceEquals(n.CachedGreetingSource, n.Greeting))
+                    {
+                        n.CachedGreetingSource = n.Greeting;
+                        n.CachedGreetingQuoted = $"“{n.Greeting}”";
+                    }
+
+                    labels.World(cam, n.Go.transform.position + Vector3.up * 2.5f, n.CachedGreetingQuoted, UiKit.TextCol, false, 18f, 28f);
                 }
             }
         }

--- a/client/Assets/BlocksBeyondTheStars/Scripts/PlayerController.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/PlayerController.cs
@@ -2410,6 +2410,9 @@ namespace BlocksBeyondTheStars.Client
         /// <summary>True when the player can fire the jetpack: carries one and has suit energy left.</summary>
         private bool CanJetpack() => Game != null && Game.SuitEnergy > 0f && HasItem("jetpack");
 
+        // Persistent jetpack thrust emitters (#1511), created on first use and toggled per frame.
+        private ParticleSystem _jetFlameL, _jetFlameR;
+
         /// <summary>Drives the jetpack thrust VFX/audio while firing and reports state edges to the server
         /// (which is authoritative for the suit-energy drain).</summary>
         private void UpdateJetpack(bool active)
@@ -2417,14 +2420,17 @@ namespace BlocksBeyondTheStars.Client
             if (active)
             {
                 ClientAudio.Instance?.JetTick();
-                if (Weapons != null)
+                if (Weapons != null && _jetFlameL == null && _jetFlameR == null)
                 {
-                    // Twin thrust flames at the player's feet (offset left/right of the pack).
-                    var feet = transform.position + Vector3.down * 0.1f;
-                    Weapons.Sparks(feet - transform.right * 0.2f, new Color(1f, 0.72f, 0.3f), 3);
-                    Weapons.Sparks(feet + transform.right * 0.2f, new Color(1f, 0.55f, 0.2f), 3);
+                    // Twin thrust flames at the player's feet (offset left/right of the pack) — persistent looping
+                    // emitters (#1511), created once and switched on/off below instead of a fresh burst per frame.
+                    _jetFlameL = Weapons.CreateThrustFlame(transform, new Vector3(-0.2f, -0.1f, 0f), new Color(1f, 0.72f, 0.3f));
+                    _jetFlameR = Weapons.CreateThrustFlame(transform, new Vector3(0.2f, -0.1f, 0f), new Color(1f, 0.55f, 0.2f));
                 }
             }
+
+            WeaponFx.SetThrust(_jetFlameL, active);
+            WeaponFx.SetThrust(_jetFlameR, active);
 
             if (active != _jetpackActive)
             {

--- a/client/Assets/BlocksBeyondTheStars/Scripts/RemotePlayers.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/RemotePlayers.cs
@@ -31,6 +31,7 @@ namespace BlocksBeyondTheStars.Client
             public string Name;
             public RemoteEntityInterpolator Interp; // buffered snapshot interpolation of the reported pose (B Tier1b)
             public bool Jetpacking;        // show a thrust flame under the avatar while firing
+            public ParticleSystem Thrust;  // the persistent flame emitter (#1511), created on first use; dies with Go
             public bool Seated;            // sit pose (#806) — avatar lowered onto the chair seat
             public bool Hidden;            // stealth field active, or the player is up in space — no avatar
             public int Gear = -1;          // cached so gear is only rebuilt on change
@@ -147,10 +148,15 @@ namespace BlocksBeyondTheStars.Client
                     r.Go.transform.rotation = Quaternion.Euler(0f, yaw, 0f);
                 }
 
-                if (r.Jetpacking && !r.Hidden && Weapons != null)
+                // Thrust flame under a jetpacking avatar: one persistent looping emitter per remote (#1511),
+                // switched on/off instead of a fresh particle burst per frame.
+                bool thrust = r.Jetpacking && !r.Hidden;
+                if (thrust && r.Thrust == null && Weapons != null && r.Go != null)
                 {
-                    Weapons.Sparks(r.Go.transform.position + Vector3.down * 0.1f, new Color(1f, 0.65f, 0.25f), 3);
+                    r.Thrust = Weapons.CreateThrustFlame(r.Go.transform, new Vector3(0f, -0.1f, 0f), new Color(1f, 0.65f, 0.25f));
                 }
+
+                WeaponFx.SetThrust(r.Thrust, thrust);
             }
         }
 

--- a/client/Assets/BlocksBeyondTheStars/Scripts/Sky.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/Sky.cs
@@ -35,6 +35,7 @@ namespace BlocksBeyondTheStars.Client
         private static readonly int GradeParamsId = Shader.PropertyToID("_Sc_GradeParams");
         private static readonly int IndoorId = Shader.PropertyToID("_Sc_Indoor");
         private static readonly int FloraTintId = Shader.PropertyToID("_Sc_FloraTint");
+        private static readonly int LampColorId = Shader.PropertyToID("_Sc_LampColor");
         // Explicit distance haze for the block shaders (Unity's MixFog doesn't engage on the unlit voxels):
         // x=start, y=end, z=max strength (already faded out indoors), w=on.
         private static readonly int FogId = Shader.PropertyToID("_Sc_Fog");
@@ -149,7 +150,7 @@ namespace BlocksBeyondTheStars.Client
                 Shader.SetGlobalColor(GradeTintId, new Color(0f, 0f, 0f, 0f)); // colour grade off
                 UrpScenePost.Instance?.ApplyGrade(Color.white, 1f, 1f);        // …and off on the URP volume too
                 UrpScenePost.Instance?.SetMoodLut(null);                       // …and drop the biome mood LUT in space
-                Shader.SetGlobalColor(Shader.PropertyToID("_Sc_LampColor"), new Color(0f, 0f, 0f, 0f));
+                Shader.SetGlobalColor(LampColorId, new Color(0f, 0f, 0f, 0f));
                 Shader.SetGlobalFloat(IndoorId, 0f);
                 Shader.SetGlobalColor(FloraTintId, new Color(0f, 0f, 0f, 0f)); // no planet flora tint in space
                 Shader.SetGlobalVector(FogId, new Vector4(0f, 1f, 0f, 0f)); // distance haze off in space
@@ -352,9 +353,19 @@ namespace BlocksBeyondTheStars.Client
         /// <summary>Drives the post-FX colour grade (the per-system/biome "mood LUT"): a biome tint +
         /// saturation/contrast, folded with the star system's sun colour as a subtle hue shift. Applied via the
         /// URP <c>UrpScenePost</c> volume (ColorAdjustments + mood LUT); only visible when tonemapping/post is on.</summary>
+        private string _gradeBiome;
+        private (Color tint, float sat, float contrast) _grade = (Color.white, 1f, 1.03f);
+
         private void SetGrade(string biome, Color sunColor)
         {
-            var (tint, sat, contrast) = GradeFor(biome);
+            // #1516: GradeFor lower-cases the biome key — once per biome change, not once per frame.
+            if (!ReferenceEquals(biome, _gradeBiome) && biome != _gradeBiome)
+            {
+                _gradeBiome = biome;
+                _grade = GradeFor(biome);
+            }
+
+            var (tint, sat, contrast) = _grade;
             float m = Mathf.Max(sunColor.r, Mathf.Max(sunColor.g, sunColor.b));
             Color norm = m > 0.001f ? new Color(sunColor.r / m, sunColor.g / m, sunColor.b / m) : Color.white;
             // The star's hue folds into the grade so each system visibly tints its worlds (0.4 keeps it a
@@ -523,7 +534,7 @@ namespace BlocksBeyondTheStars.Client
         {
             // Clear the tint so other scenes (menu) aren't affected.
             Shader.SetGlobalColor(LightId, new Color(1f, 1f, 1f, 0f));
-            Shader.SetGlobalColor(Shader.PropertyToID("_Sc_LampColor"), new Color(0f, 0f, 0f, 0f)); // headlamp off
+            Shader.SetGlobalColor(LampColorId, new Color(0f, 0f, 0f, 0f)); // headlamp off
             Shader.SetGlobalColor(GradeTintId, new Color(0f, 0f, 0f, 0f)); // colour grade off (menu/space)
             UrpScenePost.Instance?.SetMoodLut(null); // drop the biome mood LUT (menu/space)
             Shader.SetGlobalFloat(IndoorId, 0f); // interior fill off (menu/space)

--- a/client/Assets/BlocksBeyondTheStars/Scripts/SpaceRadar.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/SpaceRadar.cs
@@ -27,6 +27,13 @@ namespace BlocksBeyondTheStars.Client
         private Text _stationLabel;
         private Image _wpBlip;    // the nav waypoint (#597), amber — distinct from every entity colour
         private Text _wpLabel;    // waypoint distance readout under the radar
+
+        // #1516: last-formatted readout state so the label strings are built on change, not every frame.
+        private int _wpLastMeters = -1;
+        private string _readoutName;
+        private int _readoutMeters = -1;
+        private int _readoutVert;
+        private int _readoutKind; // 0 = none, 1 = station, 2 = body
         private readonly List<Image> _blips = new List<Image>();
 
         private static readonly Color WaypointCol = new Color(1f, 0.85f, 0.3f);
@@ -250,20 +257,42 @@ namespace BlocksBeyondTheStars.Client
 
                 _wpBlip.rectTransform.anchoredPosition = wv;
                 _wpBlip.rectTransform.SetAsLastSibling(); // over the entity/body blips
-                _wpLabel.text = $"⌖ {Mathf.RoundToInt(wdir.magnitude)}m";
+                int wpMeters = Mathf.RoundToInt(wdir.magnitude);
+                if (wpMeters != _wpLastMeters) // #1516: build the label only when the rounded distance moves
+                {
+                    _wpLastMeters = wpMeters;
+                    _wpLabel.text = $"⌖ {wpMeters}m";
+                }
             }
 
             // Readout under the radar: prefer a station name (dockable), else the nearest planet to head for.
+            // #1516: formatted only when the name, the rounded distance or the arrow changes (per frame before).
             if (nearestStation != null)
             {
                 // The disc is flat — an arrow says "it's above/below you" so a station parked over the
                 // flight plane isn't searched for at eye level.
-                string vert = nearestUp > 10f ? " ▲" : nearestUp < -10f ? " ▼" : string.Empty;
-                _stationLabel.text = $"{nearestStation} · {Mathf.RoundToInt(nearestDist)}m{vert}";
+                int vertState = nearestUp > 10f ? 1 : nearestUp < -10f ? -1 : 0;
+                int meters = Mathf.RoundToInt(nearestDist);
+                if (!ReferenceEquals(nearestStation, _readoutName) || meters != _readoutMeters || vertState != _readoutVert || _readoutKind != 1)
+                {
+                    _readoutName = nearestStation;
+                    _readoutMeters = meters;
+                    _readoutVert = vertState;
+                    _readoutKind = 1;
+                    string vert = vertState > 0 ? " ▲" : vertState < 0 ? " ▼" : string.Empty;
+                    _stationLabel.text = $"{nearestStation} · {meters}m{vert}";
+                }
             }
             else if (nearestBody != null)
             {
-                _stationLabel.text = $"➜ {nearestBody} · {Mathf.RoundToInt(nearestBodyDist)}m";
+                int meters = Mathf.RoundToInt(nearestBodyDist);
+                if (!ReferenceEquals(nearestBody, _readoutName) || meters != _readoutMeters || _readoutKind != 2)
+                {
+                    _readoutName = nearestBody;
+                    _readoutMeters = meters;
+                    _readoutKind = 2;
+                    _stationLabel.text = $"➜ {nearestBody} · {meters}m";
+                }
             }
 
             _stationLabel.gameObject.SetActive(nearestStation != null || nearestBody != null);

--- a/client/Assets/BlocksBeyondTheStars/Scripts/SpaceView.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/SpaceView.cs
@@ -4450,24 +4450,38 @@ namespace BlocksBeyondTheStars.Client
                 var loc = Game.Localizer;
                 // Device-aware controls hint (pad glyphs on a gamepad; blank on touch — the on-screen buttons
                 // are self-labelling; the keyboard text otherwise).
-                _hint.text = InputMap.ActiveDevice switch
+                // #1516: the hint depends only on (device, autopilot tier, localizer) — build it when one of
+                // those changes and assign once. Assigning the base and appending with `+=` every frame dirtied
+                // the Text mesh each frame although the final string never changed.
+                var device = InputMap.ActiveDevice;
+                bool autopilot = Game.AiCoreTier >= 2;
+                if (_flightHint == null || device != _flightHintDevice || autopilot != _flightHintAutopilot || !ReferenceEquals(loc, _flightHintLoc))
                 {
-                    InputDeviceKind.Touch => string.Empty,
-                    InputDeviceKind.Gamepad => loc != null ? loc.Get("ui.space.controls_pad")
-                        : "Left stick fly · Right stick steer · RB fire · (X) land/dock · (Y) view",
-                    _ => loc != null ? loc.Get("ui.space.controls").Replace("{feedback_key}", FeedbackUi.HotkeyName)
-                        : "WASD/Mouse fly · V view · E land/dock · L return · G EVA",
-                };
-                if (Game.AiCoreTier >= 2 && InputMap.ActiveDevice != InputDeviceKind.Touch)
-                {
-                    _hint.text += " · " + Loc("ui.vega.autopilot.hint", "[P] Autopilot");
+                    _flightHintDevice = device;
+                    _flightHintAutopilot = autopilot;
+                    _flightHintLoc = loc;
+                    string hint = device switch
+                    {
+                        InputDeviceKind.Touch => string.Empty,
+                        InputDeviceKind.Gamepad => loc != null ? loc.Get("ui.space.controls_pad")
+                            : "Left stick fly · Right stick steer · RB fire · (X) land/dock · (Y) view",
+                        _ => loc != null ? loc.Get("ui.space.controls").Replace("{feedback_key}", FeedbackUi.HotkeyName)
+                            : "WASD/Mouse fly · V view · E land/dock · L return · G EVA",
+                    };
+                    if (autopilot && device != InputDeviceKind.Touch)
+                    {
+                        hint += " · " + Loc("ui.vega.autopilot.hint", "[P] Autopilot");
+                    }
+
+                    if (device != InputDeviceKind.Touch)
+                    {
+                        hint += " · " + Loc("ui.spacemap.key_hint", "[M] Chart"); // system chart (#597)
+                    }
+
+                    _flightHint = hint;
                 }
 
-                if (InputMap.ActiveDevice != InputDeviceKind.Touch)
-                {
-                    _hint.text += " · " + Loc("ui.spacemap.key_hint", "[M] Chart"); // system chart (#597)
-                }
-
+                _hint.text = _flightHint;
                 _hint.gameObject.SetActive(true);
 
                 // Prompt whichever you're closest to: dock a station or land on a body you've flown up to —
@@ -4492,7 +4506,15 @@ namespace BlocksBeyondTheStars.Client
                 _board.gameObject.SetActive(showStation || showBody);
 
                 string cargoLabel = loc != null ? loc.Get("ui.space.cargo") : "Cargo";
-                _cargo.text = $"{cargoLabel}: {Game.Cargo.Length}";
+                int cargoCount = Game.Cargo.Length;
+                if (_cargoText == null || cargoCount != _cargoTextCount || !ReferenceEquals(cargoLabel, _cargoTextLabel))
+                {
+                    _cargoTextCount = cargoCount;
+                    _cargoTextLabel = cargoLabel;
+                    _cargoText = $"{cargoLabel}: {cargoCount}"; // #1516: formatted on change, not per frame
+                }
+
+                _cargo.text = _cargoText;
                 _cargo.color = Color.Lerp(UiKit.TextCol, UiKit.Cyan, _cargoFlash);
                 _cargo.gameObject.SetActive(true);
             }
@@ -4798,9 +4820,27 @@ namespace BlocksBeyondTheStars.Client
 
             int thr = Mathf.RoundToInt(Mathf.Clamp01(InputMap.MoveY()) * 100f);
             int hdg = Mathf.RoundToInt(Mathf.Repeat(_yaw, 360f));
+            int spd10 = Mathf.RoundToInt(_instSpeed * 10f);
             // Hull/shield are NOT repeated here — they're gauges in the ship-status block now (#915).
-            _instruments.text = $"SPD {_instSpeed:0.0}   THR {thr}%   HDG {hdg:000}°";
+            // #1516: format only when a displayed digit changes (the readout shows one decimal of speed).
+            if (spd10 != _instLastSpd10 || thr != _instLastThr || hdg != _instLastHdg)
+            {
+                _instLastSpd10 = spd10;
+                _instLastThr = thr;
+                _instLastHdg = hdg;
+                _instruments.text = $"SPD {_instSpeed:0.0}   THR {thr}%   HDG {hdg:000}°";
+            }
         }
+
+        // #1516: last-formatted flight overlay state (hint, cargo line, instruments).
+        private string _flightHint;
+        private InputDeviceKind _flightHintDevice;
+        private bool _flightHintAutopilot;
+        private object _flightHintLoc;
+        private string _cargoText;
+        private int _cargoTextCount = -1;
+        private string _cargoTextLabel;
+        private int _instLastSpd10 = -1, _instLastThr = -1, _instLastHdg = -1;
 
         private bool _hullWarn, _shieldWarn;
         private float _hullBeepTimer;
@@ -4883,10 +4923,12 @@ namespace BlocksBeyondTheStars.Client
             }
         }
 
+        private static Shader _unlitShader;
+
         private static Material Unlit(Color c)
         {
-            var shader = Shader.Find("Unlit/Color") ?? Shader.Find("BlocksBeyondTheStars/VertexColorOpaque");
-            return new Material(shader) { color = ShaderColor.Srgb(c) };
+            _unlitShader ??= Shader.Find("Unlit/Color") ?? Shader.Find("BlocksBeyondTheStars/VertexColorOpaque"); // #1514: no string lookup per part
+            return new Material(_unlitShader) { color = ShaderColor.Srgb(c) };
         }
 
         /// <summary>A translucent tinted "energy field" quad material — the same alpha-blend Cloud shader the

--- a/client/Assets/BlocksBeyondTheStars/Scripts/Starfield.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/Starfield.cs
@@ -25,7 +25,10 @@ namespace BlocksBeyondTheStars.Client
         private const int StarCount = 1500;
         private const float MaxBrightness = 1.3f; // additive cap (per-star dots, so the sky as a whole stays dark)
 
+        private static readonly int BrightnessId = Shader.PropertyToID("_Brightness");
+
         private Transform _dome;
+        private MeshRenderer _renderer;
         private Material _mat;
         private float _brightness; // smoothed 0..1 fade
 
@@ -39,7 +42,6 @@ namespace BlocksBeyondTheStars.Client
             }
 
             _mat = new Material(shader) { mainTexture = BuildDotTexture() };
-            _mat.SetFloat("_Brightness", 0f);
 
             var go = new GameObject("Starfield");
             go.transform.SetParent(transform, false);
@@ -50,7 +52,22 @@ namespace BlocksBeyondTheStars.Client
             mr.receiveShadows = false;
             mr.lightProbeUsage = UnityEngine.Rendering.LightProbeUsage.Off;
             mr.reflectionProbeUsage = UnityEngine.Rendering.ReflectionProbeUsage.Off;
+            _renderer = mr;
             _dome = go.transform;
+            ApplyBrightness(0f);
+        }
+
+        /// <summary>Writes the shader brightness and switches the renderer off entirely while the field is dark
+        /// (#1513): the 1500 additive sprites cover the whole sky and used to be drawn — and shaded — at
+        /// brightness 0 all day long on a planet, pure fill rate for nothing.</summary>
+        private void ApplyBrightness(float value)
+        {
+            _mat.SetFloat(BrightnessId, value);
+            bool visible = value > 0.001f;
+            if (_renderer != null && _renderer.enabled != visible)
+            {
+                _renderer.enabled = visible;
+            }
         }
 
         private void LateUpdate()
@@ -70,7 +87,7 @@ namespace BlocksBeyondTheStars.Client
             if (MenuBrightness >= 0f)
             {
                 _brightness = Mathf.Clamp01(MenuBrightness);
-                _mat.SetFloat("_Brightness", _brightness * MaxBrightness);
+                ApplyBrightness(_brightness * MaxBrightness);
                 return;
             }
 
@@ -93,7 +110,7 @@ namespace BlocksBeyondTheStars.Client
             float dayLen = Game.Environment != null ? Mathf.Max(30f, Game.Environment.DayLengthSeconds) : 600f;
             float rate = Mathf.Clamp(240f / dayLen, 0.25f, 1.0f);
             _brightness = hardSky ? target : Mathf.MoveTowards(_brightness, target, Time.deltaTime * rate);
-            _mat.SetFloat("_Brightness", _brightness * MaxBrightness);
+            ApplyBrightness(_brightness * MaxBrightness);
         }
 
         /// <summary>How visible the stars should be: full in space / on airless worlds / inside a station,

--- a/client/Assets/BlocksBeyondTheStars/Scripts/UiSettings.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/UiSettings.cs
@@ -189,7 +189,7 @@ namespace BlocksBeyondTheStars.Client
             }
 
             UiKit.AddButton(_content, _x, y, _rowW, 44, L("ui.settings.reset_controls"),
-                () => { S.KeyBindings.Clear(); S.PadBindings.Clear(); S.Save(); _rebinding = null; _rebindingPad = null; Rebuild(); });
+                () => { S.ResetBindings(); S.Save(); _rebinding = null; _rebindingPad = null; Rebuild(); });
             y += 52f;
 
             // Controller (#1219). Everything here is pad-only, so say plainly when there is no pad to tune

--- a/client/Assets/BlocksBeyondTheStars/Scripts/VisorHud.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/VisorHud.cs
@@ -265,21 +265,64 @@ namespace BlocksBeyondTheStars.Client
             {
                 _urpTime += Time.deltaTime;
                 bool fx = Settings == null || Settings.VisorEffects;
-                m.SetTexture("_HudTex", _rt);
-                m.SetFloat("_VisorTime", _urpTime);
-                m.SetFloat("_Aspect", Screen.height > 0 ? (float)Screen.width / Screen.height : 1.78f);
-                m.SetFloat("_HudOpacity", 0.97f);
-                m.SetColor("_RimColor", ShaderColor.Srgb(new Color(0.4f, 0.85f, 1f, 1f)));
-                m.SetFloat("_ScanCount", Mathf.Max(120f, _h * 0.5f));
-                m.SetFloat("_Intensity", fx ? _intensity : 0f);
-                m.SetFloat("_Curvature", fx ? 0.012f : 0f);   // gentle bow (was 0.045 — warped/softened the HUD)
-                m.SetFloat("_Chroma", fx ? 0.0015f : 0f);     // whisper of fringe (was 0.005)
-                m.SetVector("_Parallax", fx ? new Vector4(_parallax.x, _parallax.y, 0f, 0f) : Vector4.zero);
-                m.SetFloat("_Glow", fx ? 0.35f : 0f);         // softer hologram bloom (was 0.6)
-                m.SetFloat("_Reflect", fx ? 0.02f : 0f);      // barely-there world reflection (was 0.08 — ghosted the frame)
-                m.SetFloat("_RimIntensity", fx ? 0.05f : 0f); // faint edge glow (was 0.10)
+
+                // #1516: only the live values go every frame; the constants (and the rarely changing aspect,
+                // scan count and HUD texture) are written when they actually change — ids resolved once.
+                if (!ReferenceEquals(_urpLastRt, _rt))
+                {
+                    _urpLastRt = _rt;
+                    m.SetTexture(HudTexId, _rt);
+                }
+
+                float aspect = Screen.height > 0 ? (float)Screen.width / Screen.height : 1.78f;
+                if (aspect != _urpLastAspect)
+                {
+                    _urpLastAspect = aspect;
+                    m.SetFloat(AspectId, aspect);
+                }
+
+                if (_h != _urpLastH)
+                {
+                    _urpLastH = _h;
+                    m.SetFloat(ScanCountId, Mathf.Max(120f, _h * 0.5f));
+                }
+
+                int fxState = fx ? 1 : 0;
+                if (fxState != _urpLastFx)
+                {
+                    _urpLastFx = fxState;
+                    m.SetFloat(HudOpacityId, 0.97f);
+                    m.SetColor(RimColorId, ShaderColor.Srgb(new Color(0.4f, 0.85f, 1f, 1f)));
+                    m.SetFloat(CurvatureId, fx ? 0.012f : 0f);   // gentle bow (was 0.045 — warped/softened the HUD)
+                    m.SetFloat(ChromaId, fx ? 0.0015f : 0f);     // whisper of fringe (was 0.005)
+                    m.SetFloat(GlowId, fx ? 0.35f : 0f);         // softer hologram bloom (was 0.6)
+                    m.SetFloat(ReflectId, fx ? 0.02f : 0f);      // barely-there world reflection (was 0.08 — ghosted the frame)
+                    m.SetFloat(RimIntensityId, fx ? 0.05f : 0f); // faint edge glow (was 0.10)
+                }
+
+                m.SetFloat(VisorTimeId, _urpTime);
+                m.SetFloat(IntensityId, fx ? _intensity : 0f);
+                m.SetVector(ParallaxId, fx ? new Vector4(_parallax.x, _parallax.y, 0f, 0f) : Vector4.zero);
             }
         }
+
+        private static readonly int HudTexId = Shader.PropertyToID("_HudTex");
+        private static readonly int VisorTimeId = Shader.PropertyToID("_VisorTime");
+        private static readonly int AspectId = Shader.PropertyToID("_Aspect");
+        private static readonly int HudOpacityId = Shader.PropertyToID("_HudOpacity");
+        private static readonly int RimColorId = Shader.PropertyToID("_RimColor");
+        private static readonly int ScanCountId = Shader.PropertyToID("_ScanCount");
+        private static readonly int IntensityId = Shader.PropertyToID("_Intensity");
+        private static readonly int CurvatureId = Shader.PropertyToID("_Curvature");
+        private static readonly int ChromaId = Shader.PropertyToID("_Chroma");
+        private static readonly int ParallaxId = Shader.PropertyToID("_Parallax");
+        private static readonly int GlowId = Shader.PropertyToID("_Glow");
+        private static readonly int ReflectId = Shader.PropertyToID("_Reflect");
+        private static readonly int RimIntensityId = Shader.PropertyToID("_RimIntensity");
+        private RenderTexture _urpLastRt;
+        private float _urpLastAspect = -1f;
+        private int _urpLastH = -1;
+        private int _urpLastFx = -1;
 
         private void OnDestroy()
         {

--- a/client/Assets/BlocksBeyondTheStars/Scripts/WeaponFx.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/WeaponFx.cs
@@ -90,6 +90,88 @@ namespace BlocksBeyondTheStars.Client
         }
 
         private static Material _sparkMat;
+        private static Shader _particleShader;
+
+        /// <summary>#1511: a persistent, LOOPING thrust flame with the same look as a <see cref="Sparks"/> burst
+        /// (additive glow dots, world-space, arcing under gravity, fading + shrinking), parented to an avatar and
+        /// driven through <see cref="SetThrust"/>. The jetpack used to spawn two one-shot particle systems EVERY
+        /// FRAME while firing (a GameObject + ParticleSystem + ~10 module setups + a deferred Destroy each — ~120
+        /// creations/s and ~55 live systems at 60 fps). Returns null when the particle shader is unavailable.</summary>
+        public ParticleSystem CreateThrustFlame(Transform parent, Vector3 localOffset, Color color)
+        {
+            _particleShader ??= Shader.Find("BlocksBeyondTheStars/Particle");
+            if (_particleShader == null)
+            {
+                return null;
+            }
+
+            _sparkMat ??= new Material(_particleShader) { mainTexture = SparkDot() };
+
+            var go = new GameObject("ThrustFlame");
+            go.transform.SetParent(parent, false);
+            go.transform.localPosition = localOffset;
+            var ps = go.AddComponent<ParticleSystem>();
+            ps.Stop(true, ParticleSystemStopBehavior.StopEmittingAndClear);
+
+            var main = ps.main;
+            main.loop = true;
+            main.duration = 1f;
+            main.startLifetime = new ParticleSystem.MinMaxCurve(0.45f * 0.6f, 0.45f);
+            main.startSpeed = new ParticleSystem.MinMaxCurve(3.6f * 0.3f, 3.6f);
+            main.startSize = new ParticleSystem.MinMaxCurve(0.13f * 0.6f, 0.13f);
+            main.startColor = color;
+            main.maxParticles = 96;
+            main.simulationSpace = ParticleSystemSimulationSpace.World;
+            main.gravityModifier = 0.9f;
+
+            var em = ps.emission;
+            em.rateOverTime = 0f; // driven by SetThrust
+
+            var shape = ps.shape;
+            shape.shapeType = ParticleSystemShapeType.Sphere;
+            shape.radius = 0.05f;
+
+            var col = ps.colorOverLifetime;
+            col.enabled = true;
+            var grad = new Gradient();
+            grad.SetKeys(
+                new[] { new GradientColorKey(Color.white, 0f), new GradientColorKey(Color.white, 1f) },
+                new[] { new GradientAlphaKey(1f, 0f), new GradientAlphaKey(0f, 1f) });
+            col.color = new ParticleSystem.MinMaxGradient(grad);
+
+            var sol = ps.sizeOverLifetime;
+            sol.enabled = true;
+            sol.size = new ParticleSystem.MinMaxCurve(1f, AnimationCurve.EaseInOut(0f, 1f, 1f, 0.2f));
+
+            var r = go.GetComponent<ParticleSystemRenderer>();
+            r.material = _sparkMat;
+            r.renderMode = ParticleSystemRenderMode.Billboard;
+            r.shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.Off;
+            r.receiveShadows = false;
+            r.sortMode = ParticleSystemSortMode.None;
+            ps.Play();
+            return ps;
+        }
+
+        /// <summary>Particles per second one thrust flame emits while firing — three per frame at 60 fps was what
+        /// the per-frame bursts produced.</summary>
+        public const float ThrustRate = 180f;
+
+        /// <summary>Turns a <see cref="CreateThrustFlame"/> emitter on or off (cheap to call every frame).</summary>
+        public static void SetThrust(ParticleSystem flame, bool on)
+        {
+            if (flame == null)
+            {
+                return;
+            }
+
+            var em = flame.emission;
+            float want = on ? ThrustRate : 0f;
+            if (em.rateOverTime.constant != want)
+            {
+                em.rateOverTime = want;
+            }
+        }
 
         /// <summary>One-shot additive particle burst (sparks / flashes): <paramref name="count"/> glowing bits in
         /// <paramref name="color"/> flying out of a point, fading + shrinking, optionally arcing under gravity, then

--- a/client/Assets/BlocksBeyondTheStars/Scripts/WeatherFx.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/WeatherFx.cs
@@ -347,6 +347,13 @@ namespace BlocksBeyondTheStars.Client
 
         private void OnGUI()
         {
+            // IMGUI calls OnGUI once per event; everything below is GUI.DrawTexture (up to ~300 streaks + drops in
+            // rain), which only has an effect during the Repaint event — skip the Layout pass entirely (#1516).
+            if (Event.current.type != EventType.Repaint)
+            {
+                return;
+            }
+
             // Subtle blue submerged wash, drawn before (and independent of) the weather overlay so it shows
             // even underwater in a cave or at night. Hidden in space and while the menu is open.
             if (_underwater > 0.01f && Game != null && !Game.SpaceViewActive && !Game.MenuOpen)

--- a/client/Assets/BlocksBeyondTheStars/Shaders/Atmosphere.shader
+++ b/client/Assets/BlocksBeyondTheStars/Shaders/Atmosphere.shader
@@ -1,8 +1,10 @@
 // Additive atmospheric scattering glow drawn on a dome behind the world on planets with air. It does NOT
 // replace the camera's sky colour (Sky.cs still clears to the day/night sky) — it ADDS a horizon brightening
 // band + a soft sun-scattering halo (Mie) that warms toward orange when the sun is low, so dawn/dusk glow and
-// the horizon read like a real atmosphere instead of a flat fill. Additive + ZWrite Off in the Background queue,
-// so opaque geometry paints over it and it can only ever brighten the open sky (never black it out). Reads the
+// the horizon read like a real atmosphere instead of a flat fill. Additive + ZWrite Off at the end of the opaque
+// queue (Geometry+499, #1513): drawn after the terrain so the depth test rejects covered pixels instead of shading
+// the whole sky first; it can only ever brighten the open sky (never black it out), and additive-over-opaque is
+// order-independent, so the picture is unchanged. Reads the
 // same sky globals Sky.cs sets: _Sc_SunDir (dir TO the sun), _Sc_Sky (sky colour), _Sc_Light (sun colour ×
 // brightness; dark at night → the glow self-fades). Dual-pipeline (URP + Built-in RP).
 Shader "BlocksBeyondTheStars/Atmosphere"
@@ -15,7 +17,7 @@ Shader "BlocksBeyondTheStars/Atmosphere"
     // ---------------- URP ----------------
     SubShader
     {
-        Tags { "RenderType" = "Background" "Queue" = "Background" "RenderPipeline" = "UniversalPipeline" }
+        Tags { "RenderType" = "Background" "Queue" = "Geometry+499" "RenderPipeline" = "UniversalPipeline" }
         Cull Off
         ZWrite Off
         Blend One One // additive — only ever brightens the sky
@@ -79,7 +81,7 @@ Shader "BlocksBeyondTheStars/Atmosphere"
     // ---------------- Built-in RP (fallback) ----------------
     SubShader
     {
-        Tags { "RenderType" = "Background" "Queue" = "Background" }
+        Tags { "RenderType" = "Background" "Queue" = "Geometry+499" }
         Cull Off
         ZWrite Off
         Blend One One

--- a/client/Assets/BlocksBeyondTheStars/Shaders/Nebula.shader
+++ b/client/Assets/BlocksBeyondTheStars/Shaders/Nebula.shader
@@ -1,7 +1,8 @@
 // Procedural nebula backdrop for deep space — wispy coloured gas clouds + faint distant galaxies drawn on a
-// dome behind the starfield, so the void reads with depth and colour instead of flat black. Additive, in the
-// Background queue with ZWrite Off, so opaque geometry (ships, asteroids, planets) paints over it and it only
-// shows in open sky. Per-vertex COLOR carries the per-region nebula hue; _Brightness fades the whole field in
+// dome behind the starfield, so the void reads with depth and colour instead of flat black. Additive, ZWrite Off,
+// at the END of the opaque queue range (Geometry+499, #1513): drawn after the terrain/ships/planets, so the depth
+// test rejects every covered pixel instead of shading the whole sky first and overpainting it — it only shows in
+// open sky, and additive-over-opaque is order-independent, so the picture is unchanged. Per-vertex COLOR carries the per-region nebula hue; _Brightness fades the whole field in
 // (full in space / airless / station, off on lived-in planet skies). Dual-pipeline (URP + Built-in RP) to match
 // the rest of the project's shaders; only the active pipeline's SubShader compiles.
 Shader "BlocksBeyondTheStars/Nebula"
@@ -14,7 +15,7 @@ Shader "BlocksBeyondTheStars/Nebula"
     // ---------------- URP ----------------
     SubShader
     {
-        Tags { "RenderType" = "Background" "Queue" = "Background" "RenderPipeline" = "UniversalPipeline" }
+        Tags { "RenderType" = "Background" "Queue" = "Geometry+499" "RenderPipeline" = "UniversalPipeline" }
         Cull Off
         ZWrite Off
         Blend One One // additive — clouds glow over the dark sky
@@ -77,7 +78,7 @@ Shader "BlocksBeyondTheStars/Nebula"
     // ---------------- Built-in RP (fallback; the game ships on URP) ----------------
     SubShader
     {
-        Tags { "RenderType" = "Background" "Queue" = "Background" }
+        Tags { "RenderType" = "Background" "Queue" = "Geometry+499" }
         Cull Off
         ZWrite Off
         Blend One One

--- a/client/Assets/BlocksBeyondTheStars/Shaders/Starfield.shader
+++ b/client/Assets/BlocksBeyondTheStars/Shaders/Starfield.shader
@@ -1,8 +1,9 @@
 // Additive starfield dome drawn behind the world. Each star carries a twinkle phase + speed (TEXCOORD1)
 // and a colour (vertex colour); the shader pulses its brightness over time. _Brightness (set per-frame by
 // the Starfield component) fades the whole field in at night / in space and out during a bright day.
-// Background queue + ZWrite Off: stars draw right after the sky clear, and any opaque geometry (terrain,
-// the planet, the ship) drawn afterwards paints over them — so stars only show in open sky.
+// End of the opaque queue (Geometry+499, #1513) + ZWrite Off: stars draw AFTER the terrain/planet/ship, so the
+// depth test rejects every covered pixel instead of shading the whole sky and overpainting it — stars only show
+// in open sky, and additive-over-opaque is order-independent, so the picture is unchanged.
 // DUAL-PIPELINE: URP HLSL SubShader first, original Built-in CG below.
 Shader "BlocksBeyondTheStars/Starfield"
 {
@@ -15,7 +16,7 @@ Shader "BlocksBeyondTheStars/Starfield"
     // ---------------- URP ----------------
     SubShader
     {
-        Tags { "Queue" = "Background" "RenderType" = "Background" "IgnoreProjector" = "True" "RenderPipeline" = "UniversalPipeline" }
+        Tags { "Queue" = "Geometry+499" "RenderType" = "Background" "IgnoreProjector" = "True" "RenderPipeline" = "UniversalPipeline" }
         Blend One One     // additive — stars add light onto the dark sky
         ZWrite Off
         Cull Off
@@ -73,7 +74,7 @@ Shader "BlocksBeyondTheStars/Starfield"
     // ---------------- Built-in RP (original, unchanged) ----------------
     SubShader
     {
-        Tags { "Queue" = "Background" "RenderType" = "Background" "IgnoreProjector" = "True" }
+        Tags { "Queue" = "Geometry+499" "RenderType" = "Background" "IgnoreProjector" = "True" }
         Blend One One     // additive — stars add light onto the dark sky
         ZWrite Off
         Cull Off

--- a/src/BlocksBeyondTheStars.Client.Core/ClientWorld.cs
+++ b/src/BlocksBeyondTheStars.Client.Core/ClientWorld.cs
@@ -20,9 +20,12 @@ namespace BlocksBeyondTheStars.Client
         private int _circumference = WorldConstants.Circumference;
 
         // World positions of coloured light sources (placed glow blocks + dedicated light blocks) → light
-        // colour (0xRRGGBB). Lets the chunk mesher pull in nearby lights ACROSS chunk seams so a placed lamp's
-        // colour propagates into neighbouring chunks, not just its own.
-        private readonly Dictionary<Vector3i, int> _lightSources = new Dictionary<Vector3i, int>();
+        // colour (0xRRGGBB), bucketed per canonical chunk (#1515). Lets the chunk mesher pull in nearby lights
+        // ACROSS chunk seams so a placed lamp's colour propagates into neighbouring chunks, not just its own.
+        // Per-chunk buckets make unloading a chunk one dictionary remove (it used to be 4096 removes per chunk,
+        // 200k in one frame for a 50-chunk unload batch) and let LightSourcesNear visit only the neighbouring
+        // chunks instead of every light in the world per mesh dispatch.
+        private readonly Dictionary<ChunkCoord, Dictionary<Vector3i, int>> _lightSources = new Dictionary<ChunkCoord, Dictionary<Vector3i, int>>();
 
         // The inherent light colour of a block id (0 = not a light block), supplied once from GameContent.
         private System.Func<ushort, int> _blockLightColor = _ => 0;
@@ -90,20 +93,8 @@ namespace BlocksBeyondTheStars.Client
                 return false;
             }
 
-            // Clear this chunk's glow-block light sources too (only if any exist — usually none, so skip the
-            // 16³ scan entirely on the common path).
-            if (_lightSources.Count > 0)
-            {
-                var origin = WorldConstants.ChunkOrigin(coord);
-                int nsz = WorldConstants.ChunkSize;
-                for (int x = 0; x < nsz; x++)
-                    for (int y = 0; y < nsz; y++)
-                        for (int z = 0; z < nsz; z++)
-                        {
-                            _lightSources.Remove(new Vector3i(origin.X + x, origin.Y + y, origin.Z + z));
-                        }
-            }
-
+            // Clear this chunk's glow-block light sources too: one bucket remove (#1515).
+            _lightSources.Remove(coord);
             return true;
         }
 
@@ -182,11 +173,17 @@ namespace BlocksBeyondTheStars.Client
             int rgb = glow != 0 ? glow : (baseRgb != 0 && tint != 0 ? tint : baseRgb);
             if (rgb != 0)
             {
-                _lightSources[pos] = rgb;
+                if (!_lightSources.TryGetValue(affected, out var bucket))
+                {
+                    bucket = new Dictionary<Vector3i, int>();
+                    _lightSources[affected] = bucket;
+                }
+
+                bucket[pos] = rgb;
             }
-            else
+            else if (_lightSources.TryGetValue(affected, out var bucket) && bucket.Remove(pos) && bucket.Count == 0)
             {
-                _lightSources.Remove(pos);
+                _lightSources.Remove(affected);
             }
 
             return true;
@@ -211,57 +208,80 @@ namespace BlocksBeyondTheStars.Client
             var origin = WorldConstants.ChunkOrigin(coord);
             int nsz = WorldConstants.ChunkSize;
             int lo = -radius, hi = nsz + radius;
-            foreach (var kv in _lightSources)
-            {
-                var p = kv.Key;
-                int dy = p.Y - origin.Y;
-                if (dy < lo || dy > hi)
-                {
-                    continue;
-                }
 
-                int dx = WorldConstants.WrapDeltaX(p.X - origin.X, _circumference);
-                int dz = WorldConstants.WrapDeltaZ(p.Z - origin.Z, _circumference);
-                if (dx < lo || dx > hi || dz < lo || dz > hi)
-                {
-                    continue;
-                }
+            // #1515: only the chunks that can hold a source within `radius` blocks of this chunk's box are
+            // visited (the 3×3×3 neighbourhood for the mesher's radius) — the per-source distance test below is
+            // unchanged, so the result set is exactly what the world-wide scan produced.
+            int span = (radius + nsz - 1) / nsz;
+            for (int cx = -span; cx <= span; cx++)
+                for (int cy = -span; cy <= span; cy++)
+                    for (int cz = -span; cz <= span; cz++)
+                    {
+                        var neighbour = WorldConstants.CanonicalChunk(new ChunkCoord(coord.X + cx, coord.Y + cy, coord.Z + cz), _circumference);
+                        if (!_lightSources.TryGetValue(neighbour, out var bucket))
+                        {
+                            continue;
+                        }
 
-                result.Add((new Vector3i(origin.X + dx, p.Y, origin.Z + dz), kv.Value));
-            }
+                        foreach (var kv in bucket)
+                        {
+                            var p = kv.Key;
+                            int dy = p.Y - origin.Y;
+                            if (dy < lo || dy > hi)
+                            {
+                                continue;
+                            }
+
+                            int dx = WorldConstants.WrapDeltaX(p.X - origin.X, _circumference);
+                            int dz = WorldConstants.WrapDeltaZ(p.Z - origin.Z, _circumference);
+                            if (dx < lo || dx > hi || dz < lo || dz > hi)
+                            {
+                                continue;
+                            }
+
+                            result.Add((new Vector3i(origin.X + dx, p.Y, origin.Z + dz), kv.Value));
+                        }
+                    }
 
             return result;
         }
 
-        /// <summary>Re-indexes a chunk's light sources (placed glow blocks + dedicated light blocks).</summary>
+        /// <summary>Re-indexes a chunk's light sources (placed glow blocks + dedicated light blocks) into the
+        /// chunk's own bucket — built fresh per store, so no per-cell removes for the (usual) all-dark chunk.</summary>
         private void ScanChunkLightSources(ChunkCoord coord, ChunkData chunk)
         {
             var origin = WorldConstants.ChunkOrigin(coord);
             int nsz = WorldConstants.ChunkSize;
+            Dictionary<Vector3i, int>? bucket = null;
             for (int x = 0; x < nsz; x++)
                 for (int y = 0; y < nsz; y++)
                     for (int z = 0; z < nsz; z++)
                     {
                         var id = chunk.Get(x, y, z);
-                        var pos = new Vector3i(origin.X + x, origin.Y + y, origin.Z + z);
-                        int rgb = 0;
-                        if (!id.IsAir)
+                        if (id.IsAir)
                         {
-                            // Same priority as ApplyBlockChange (#1126): glow > dye-on-a-light-source > natural.
-                            var (tint, glow) = chunk.GetModifier(x, y, z);
-                            int baseRgb = _blockLightColor != null ? _blockLightColor(id.Value) : 0;
-                            rgb = glow != 0 ? glow : (baseRgb != 0 && tint != 0 ? tint : baseRgb);
+                            continue;
                         }
 
+                        // Same priority as ApplyBlockChange (#1126): glow > dye-on-a-light-source > natural.
+                        var (tint, glow) = chunk.GetModifier(x, y, z);
+                        int baseRgb = _blockLightColor != null ? _blockLightColor(id.Value) : 0;
+                        int rgb = glow != 0 ? glow : (baseRgb != 0 && tint != 0 ? tint : baseRgb);
                         if (rgb != 0)
                         {
-                            _lightSources[pos] = rgb;
-                        }
-                        else
-                        {
-                            _lightSources.Remove(pos);
+                            bucket ??= new Dictionary<Vector3i, int>();
+                            bucket[new Vector3i(origin.X + x, origin.Y + y, origin.Z + z)] = rgb;
                         }
                     }
+
+            if (bucket != null)
+            {
+                _lightSources[coord] = bucket;
+            }
+            else
+            {
+                _lightSources.Remove(coord);
+            }
         }
     }
 }


### PR DESCRIPTION
PR bundle 3 of the performance package (#1501): client-side quick wins. Unity client + Client.Core; **nothing visible changes**.

## What changes

| issue | change | what it replaces |
|---|---|---|
| #1511 | two persistent looping jetpack thrust emitters (`WeaponFx.CreateThrustFlame` / `SetThrust`, the `SpaceView.BuildThruster` pattern); one per remote avatar | two one-shot particle systems spawned **every frame** while flying (~120 GameObject + ParticleSystem creations/s, ~55 live systems) |
| #1512 | `InputMap.Key` / `GamepadInputSource.ButtonFor` resolve through per-action `KeyCode[]` tables rebuilt only when `ClientSettings.BindingsVersion` changes (`SetBoundKey` / `SetBoundPad` / new `ResetBindings`); `Connected()` polls `Input.GetJoystickNames()` once per frame | `action.ToString()` + linear string scan + `Enum.TryParse` (+ a fresh joystick-name array) on every one of the ~25–35 polls per frame |
| #1513 | Starfield / NebulaField / AtmosphereDome switch their renderer off at brightness ≤ 0.001 and their shaders move from `Background` to `Geometry+499` (drawn after the terrain, depth-rejected where covered); `PropertyToID` | three whole-sky additive passes shaded every frame even at brightness 0 (nebula: two 5-octave fbm per pixel), before the terrain that then overpainted them |
| #1514 | `CreatureBuilder.Unlit/Lit` share one Material per (shader, colour, texture) + cached shader lookups; `SpaceView.Unlit` caches its shader | 8–16 fresh, never-destroyed Materials per creature build behind `Shader.Find` string lookups |
| #1515 | no GameObject for all-air chunks; `RepositionChunks` writes transforms only on change; dispatcher partial-selects the nearest chunks over precomputed distances; `ClientWorld` buckets light sources per chunk | a GameObject + 3 components + 3 materials per sky chunk; ~1700 transform writes per block moved at VD 8; a full sort with a closure to pick 4; 4096 dictionary removes per unloaded chunk and a world-wide light scan per dispatch |
| #1516 | hints composed once and assigned once; flight hint / cargo / instruments / radar readouts formatted on change; NPC nameplate strings cached; Sky grade + lamp id cached; VisorHud constant properties written once per effects state with ids; pooled AudioSources (24) for one-shot SFX; IMGUI weather overlay only on Repaint | per-frame string building that also re-generated Text meshes, 13 string-keyed material writes per frame, a GameObject + AudioSource per one-shot sound, ~300 IMGUI draws executed for Layout and Repaint |

## Same picture, same behaviour

- Sky domes: additive blending over opaque geometry is order-independent, and every dome sits inside the far plane, so drawing them after the terrain with the default `ZTest LEqual` yields the identical image while skipping every covered pixel. The sun disc (`SkyBodyPhase`, opaque, `Geometry`) is unaffected.
- Creature materials are never mutated after creation (verified: only nameplate font materials are touched), so sharing them is invisible; it also lets the SRP batcher group parts.
- `LightSourcesNear` keeps the exact per-source distance test; only the set of candidate chunks shrank to the ones that can contain a hit.
- The empty-chunk path records the collider generation like a cooked chunk, so the #1493 fall-guard never sees a "pending" cook.
- Bindings: the tables are the same resolution logic evaluated once per change; the settings screen's "reset controls" now goes through `ResetBindings()` so the tables rebuild.

## Verification

- Client.Core suite 468/468 (ClientWorld light index).
- Local Unity player build (worktree, `build-client.ps1`): 0 compiler errors / warnings.
- PerfProbe A/B in one session, previous build vs this build, High/VD 8, seed 123456, idle 20 s + walk 30 s, two pairs in alternating order:

| run | build | phase | avg ms (FPS) | p50 | p95 | p99 | max | frames > 33 ms | GC/s |
|---|---|---|---|---|---|---|---|---|---|
| 1 | previous (main 2026-09-03) | idle | 10.01 (100) | 9.21 | 15.68 | 21.34 | 28.3 | 0 | 13.0 |
| 1 | previous | walk | 9.22 (109) | 8.32 | 17.08 | 22.25 | 35.6 | 2 | 13.5 |
| 2 | **this PR** | idle | **6.39 (156)** | 5.79 | **9.99** | 15.75 | 35.2 | 1 | **4.2** |
| 2 | **this PR** | walk | **5.60 (179)** | 5.06 | **9.36** | 14.57 | 26.6 | 0 | **5.2** |
| 3 | **this PR** | idle | **5.99 (167)** | 5.63 | **8.93** | 13.11 | 27.3 | 0 | **3.1** |
| 3 | **this PR** | walk | **5.42 (185)** | 5.00 | **8.55** | 13.01 | 24.4 | 0 | **6.0** |
| 4 | previous | idle | 9.28 (108) | 8.59 | 14.41 | 20.22 | 27.6 | 0 | 13.7 |
| 4 | previous | walk | 8.32 (120) | 7.36 | 14.77 | 22.02 | 32.8 | 0 | 13.6 |

Both pairs agree: **−36…40 % average frame time, −40…45 % p95, −65…75 % garbage collections per second** (Ryzen 9 7940HS / RTX 2000 Ada, High preset, view distance 8, off-seam seed so the server-side #1502 fix does not contribute). Absolute numbers are only comparable within this session.

closes #1511 closes #1512 closes #1513 closes #1514 closes #1515 closes #1516

🤖 Generated with [Claude Code](https://claude.com/claude-code)
