### PR TITLE
perf(client): render/engine configuration — no phantom light loop, gated shadow lookup, depth prepass, physics without a fixed step, opaque copy on demand, shader prewarm + desktop build flags (#1517–#1521)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -243,6 +243,27 @@ is read from the module stat (16) instead of being dead, and the station deploy 
 persisted ids after a restart (id collision). Tests: `PlayerStationReportsTests` (7), `DropLootTests` (+2).
 Locales: 9 new keys + 2 rewordings, EN/DE hand-written, 12 MT via translate_locale.
 
+### ★ Render/engine configuration: no phantom light loop, shadow lookup gated, depth prepass for the browser, physics without a fixed step, opaque copy on demand, shader prewarm + desktop build flags (#1517–#1521, 2026-09-04, branch perf/1517-1521-render-config)
+PR bundle 4 of the performance package (epic #1501); same picture at every preset. **#1517** the URP asset had
+Additional Lights on Per-Pixel (per-object limit 4) while no project shader consumes them — URP culled the 19
+spawned point lights and built per-object light lists for every chunk renderer each frame for nothing → Disabled;
+the three renderer assets drop `IntermediateTextureMode: Always` to Auto (an extra blit for the off-screen
+preview/HUD cameras); video shaders are no longer force-included. The dead Built-in-RP SubShaders and the stock
+always-included entries stay for a WebGL-verified follow-up. **#1518** `BlockAtlas`/`BlockAtlasTransparent`
+evaluate the soft-shadow tent filter only where `ndl*sky` (resp. `ndl`) is non-zero — about half of all voxel
+faces skipped, identical result — and `BlockAtlas`, `LitColor`, `VertexColorOpaque` gain a `DepthOnly` pass:
+URP draws a depth prepass wherever it cannot copy depth (WebGL + MSAA, depth priming) and only shaders with
+that pass land in `_CameraDepthTexture`, so browser SSAO / water depth / heat fade read the far plane before.
+The cutout-submesh split stays open. **#1519** `DynamicsManager` simulation mode → Update: the project has no
+Rigidbody, FixedUpdate or collision callback (CharacterController + raycasts against static colliders), yet
+PhysX stepped 50 Hz with up to 16 catch-up steps per frame at low fps (playtest: station fall, ladders, boat,
+speeder, EVA). **#1520** the opaque colour copy (an MSAA resolve + half-res blit every frame at Medium+) has
+exactly two consumers, the heat-haze and thermal quads — the asset no longer requests it; `ClientSettings
+.RequestOpaqueTexture` lets those two hold a per-camera request while visible (still Medium+ only). **#1521**
+`ShaderPrewarm` compiles the four world shaders' fog × shadow × soft variants once per process behind the
+loading veil (a 20–100 ms hitch per first use before); desktop builds get `CompressWithLz4HC`; Graphics Jobs were measured and stay OFF (+1.5–2 ms per frame on a CPU-bound 180 fps scene, A/B in the PR);
+managed stripping stays **Disabled** on desktop: a Low trial stripped the generic Serialize overloads that MessagePack's non-generic path finds by reflection, so the client could not encode its join request (caught by the PerfProbe A/B, pinned in BuildScript with the reason). WebGL wasm2023/BigInt stay for a WebGL-verified PR.
+
 ### ★ WebGL shell memory guard: low-RAM pre-flight warning + readable out-of-memory panels (#1445, 2026-09-01, branch feat/webgl-memory-guard)
 A low-memory device dies in one of three ways (instantiate OOM at startup, abort("OOM") mid-game,
 silent lmkd kill) and players saw a developer stack trace at best. The shell now guards all the paths

--- a/client/Assets/BlocksBeyondTheStars/Editor/BuildScript.cs
+++ b/client/Assets/BlocksBeyondTheStars/Editor/BuildScript.cs
@@ -127,12 +127,28 @@ namespace BlocksBeyondTheStars.Client.EditorTools
             Directory.CreateDirectory(outDir);
             string locationPathName = target == BuildTarget.WebGL ? outDir : Path.Combine(outDir, exeName);
 
+            // #1521 (desktop players only — WebGL keeps its own tuned settings below): Graphics Jobs let URP's
+            // Render Graph build the ~1.5–2.5k chunk/shadow draws off the main thread; LZ4HC compresses the data
+            // files at build time for a faster asset load (and smaller Velopack packages); managed stripping at
+            // Low uses the link.xml the WebGL build already relies on, so the reflection-based codec/content
+            // paths keep their types while unused framework code is dropped.
+            bool desktop = target != BuildTarget.WebGL;
+            if (desktop)
+            {
+                // Graphics Jobs stay OFF: measured 2026-09-04 (RTX 2000 Ada, High/VD 8, CPU-bound at ~180 fps) they cost
+                // 1.5–2 ms per frame (idle 5.2→7.0 ms, walk 5.3→6.7 ms); without them the same build runs 4.3–5.2 ms.
+                PlayerSettings.graphicsJobs = false;
+                // Managed stripping stays Disabled on desktop: Low already removes the generic Serialize overloads that
+                // MessagePack's non-generic path looks up by reflection (NetCodec.Encode → "Sequence contains no matching element").
+                PlayerSettings.SetManagedStrippingLevel(NamedBuildTarget.Standalone, ManagedStrippingLevel.Disabled);
+            }
+
             var options = new BuildPlayerOptions
             {
                 scenes = new[] { ScenePath },
                 locationPathName = locationPathName,
                 target = target,
-                options = BuildOptions.None,
+                options = desktop ? BuildOptions.CompressWithLz4HC : BuildOptions.None,
             };
 
             var report = BuildPipeline.BuildPlayer(options);

--- a/client/Assets/BlocksBeyondTheStars/Scripts/ClientSettings.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/ClientSettings.cs
@@ -1033,7 +1033,14 @@ namespace BlocksBeyondTheStars.Client
                 // which also disables every dependent effect for free (the features early-out without the textures).
                 bool wantsScreenSpace = Preset >= QualityPreset.Medium;
                 urp.supportsCameraDepthTexture = wantsScreenSpace;
-                urp.supportsCameraOpaqueTexture = wantsScreenSpace;
+                // #1520: the opaque colour copy (an MSAA resolve + a half-res blit EVERY frame at Medium+) has
+                // exactly two consumers — the heat-haze and thermal-vision screen quads — and they are inactive
+                // in deserts, caves, space and most of the time on temperate worlds. So the asset no longer
+                // requests the copy; the two effects request it per camera while they are active
+                // (RequestOpaqueTexture), still gated to the presets that had it.
+                urp.supportsCameraOpaqueTexture = false;
+                _opaqueTexturePresetAllows = wantsScreenSpace;
+                ApplyOpaqueTextureRequest();
 
                 // Tell the shaders whether the depth/opaque textures exist this preset. The water shader uses it to
                 // fall back to the simple alpha look on Potato/Low (otherwise its depth colour / refraction / SSR
@@ -1047,7 +1054,55 @@ namespace BlocksBeyondTheStars.Client
         /// <summary>The active gameplay camera's URP data, set by <see cref="WorldRig"/> so graphics changes made in
         /// the pause menu push live (SMAA + the SSAO-renderer choice). Null in the main menu (no world camera yet);
         /// the camera reads the settings on creation, so menu changes still apply on entry. Static (not serialized).</summary>
-        public static UniversalAdditionalCameraData ActiveCameraData;
+        public static UniversalAdditionalCameraData ActiveCameraData
+        {
+            get => _activeCameraData;
+            set
+            {
+                _activeCameraData = value;
+                ApplyOpaqueTextureRequest();
+            }
+        }
+
+        private static UniversalAdditionalCameraData _activeCameraData;
+        private static bool _opaqueTexturePresetAllows;
+        private static int _opaqueTextureRequests;
+
+        /// <summary>#1520: a screen-space effect that samples <c>_CameraOpaqueTexture</c> (heat haze, thermal
+        /// vision) holds a request while it is visible; the camera copies the opaque colour only while at least
+        /// one request is open — and only on the presets that had the copy before (Medium+). Balanced on/off
+        /// calls per requester; idempotent for repeated calls with the same state.</summary>
+        public static void RequestOpaqueTexture(bool on, ref bool held)
+        {
+            if (on == held)
+            {
+                return;
+            }
+
+            held = on;
+            _opaqueTextureRequests += on ? 1 : -1;
+            if (_opaqueTextureRequests < 0)
+            {
+                _opaqueTextureRequests = 0;
+            }
+
+            ApplyOpaqueTextureRequest();
+        }
+
+        private static void ApplyOpaqueTextureRequest()
+        {
+            if (_activeCameraData == null)
+            {
+                return;
+            }
+
+            bool want = _opaqueTexturePresetAllows && _opaqueTextureRequests > 0;
+            var option = want ? CameraOverrideOption.On : CameraOverrideOption.Off;
+            if (_activeCameraData.requiresColorOption != option)
+            {
+                _activeCameraData.requiresColorOption = option;
+            }
+        }
 
         /// <summary>Pushes the per-camera look settings to the gameplay camera: post-processing on (the global
         /// Volume — bloom/tonemap/grade — and SMAA both need it), SMAA from <see cref="Smaa"/> (Medium+), and the

--- a/client/Assets/BlocksBeyondTheStars/Scripts/GameBootstrap.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/GameBootstrap.cs
@@ -1655,6 +1655,14 @@ namespace BlocksBeyondTheStars.Client
             // Procedurally generate the block texture atlas and a material that samples it
             // (M27). Falls back to whatever WorldRig assigned if the shader is missing.
             Atlas = new BlockTextureAtlas(Content);
+
+            // #1521: compile the world shaders' variants now, behind the opaque loading veil, instead of one
+            // hitch each when the weather/sun/preset first switches a keyword mid-game. Once per process.
+            int warmedVariants = ShaderPrewarm.WarmUp();
+            if (warmedVariants > 0)
+            {
+                Debug.Log($"[Shaders] Prewarmed {warmedVariants} variants.");
+            }
             var atlasShader = Shader.Find("BlocksBeyondTheStars/BlockAtlas");
             if (atlasShader != null)
             {

--- a/client/Assets/BlocksBeyondTheStars/Scripts/HeatShimmer.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/HeatShimmer.cs
@@ -54,6 +54,13 @@ namespace BlocksBeyondTheStars.Client
             go.SetActive(false);
         }
 
+        private bool _opaqueHeld; // #1520: our open opaque-texture request, released when the quad hides or we die
+
+        private void OnDestroy()
+        {
+            ClientSettings.RequestOpaqueTexture(false, ref _opaqueHeld);
+        }
+
         private void Update()
         {
             if (_quad == null)
@@ -89,6 +96,7 @@ namespace BlocksBeyondTheStars.Client
             if (_quad.gameObject.activeSelf != active)
             {
                 _quad.gameObject.SetActive(active);
+                ClientSettings.RequestOpaqueTexture(active, ref _opaqueHeld); // #1520: the haze quad samples the opaque copy
             }
 
             if (!active)

--- a/client/Assets/BlocksBeyondTheStars/Scripts/ShaderPrewarm.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/ShaderPrewarm.cs
@@ -1,0 +1,98 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Rendering;
+
+namespace BlocksBeyondTheStars.Client
+{
+    /// <summary>
+    /// #1521: compiles the shader variants the world will need BEFORE the first frame that needs them. Unity
+    /// builds a variant on first use — with no preloaded collection (GraphicsSettings had none) every variant
+    /// switch mid-game cost a 20–100 ms hitch: the fog mode the weather changes, the cascade keyword when the
+    /// sun comes up, the soft-shadow keyword on a preset change. The four world shaders (terrain, see-through
+    /// terrain, lit models, vertex-coloured models) × fog × shadow × soft-shadow keywords are warmed once per
+    /// process, behind the opaque world-loading veil (GameBootstrap.Start), so the cost lands where a load is
+    /// expected. Variants a shader does not declare are skipped (the collection refuses them).
+    /// </summary>
+    public static class ShaderPrewarm
+    {
+        private static bool _done;
+
+        private static readonly string[] Shaders =
+        {
+            "BlocksBeyondTheStars/BlockAtlas",
+            "BlocksBeyondTheStars/BlockAtlasTransparent",
+            "BlocksBeyondTheStars/LitColor",
+            "BlocksBeyondTheStars/VertexColorOpaque",
+        };
+
+        // Keyword axes as declared by the shaders' multi_compile lines (only the modes the game actually sets:
+        // Sky uses linear fog, WeatherFx3D switches to exponential-squared; screen-space shadows are unused).
+        private static readonly string[] FogKeywords = { null, "FOG_LINEAR", "FOG_EXP2" };
+        private static readonly string[] ShadowKeywords = { null, "_MAIN_LIGHT_SHADOWS", "_MAIN_LIGHT_SHADOWS_CASCADE" };
+        private static readonly string[] SoftKeywords = { null, "_SHADOWS_SOFT" };
+
+        /// <summary>Warms the variant set once per process. Returns the number of variants added (0 on later calls).</summary>
+        public static int WarmUp()
+        {
+            if (_done)
+            {
+                return 0;
+            }
+
+            _done = true;
+            var collection = new ShaderVariantCollection();
+            var keywords = new List<string>(3);
+            int added = 0;
+            foreach (var name in Shaders)
+            {
+                var shader = Shader.Find(name);
+                if (shader == null)
+                {
+                    continue;
+                }
+
+                foreach (var fog in FogKeywords)
+                    foreach (var shadow in ShadowKeywords)
+                        foreach (var soft in SoftKeywords)
+                        {
+                            keywords.Clear();
+                            if (fog != null) keywords.Add(fog);
+                            if (shadow != null) keywords.Add(shadow);
+                            if (soft != null) keywords.Add(soft);
+                            if (TryAdd(collection, shader, PassType.ScriptableRenderPipeline, keywords.ToArray()))
+                            {
+                                added++;
+                            }
+                        }
+
+                if (TryAdd(collection, shader, PassType.ShadowCaster, System.Array.Empty<string>()))
+                {
+                    added++;
+                }
+            }
+
+            if (added > 0)
+            {
+                collection.WarmUp();
+            }
+
+            return added;
+        }
+
+        private static bool TryAdd(ShaderVariantCollection collection, Shader shader, PassType pass, string[] keywords)
+        {
+            try
+            {
+                collection.Add(new ShaderVariantCollection.ShaderVariant(shader, pass, keywords));
+                return true;
+            }
+            catch (System.ArgumentException)
+            {
+                return false; // this shader does not declare that keyword combination
+            }
+        }
+    }
+}

--- a/client/Assets/BlocksBeyondTheStars/Scripts/ShaderPrewarm.cs.meta
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/ShaderPrewarm.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ad39e3dc5f0caec47978c1f71da3ece6

--- a/client/Assets/BlocksBeyondTheStars/Scripts/ThermalVision.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/ThermalVision.cs
@@ -91,11 +91,19 @@ namespace BlocksBeyondTheStars.Client
                 }
 
                 _active = value;
+                ClientSettings.RequestOpaqueTexture(value, ref _opaqueHeld); // #1520: the thermal quad samples the opaque copy
                 if (value)
                 {
                     _lavaTimer = 0f; // sweep for lava immediately, not a second after switching on
                 }
             }
+        }
+
+        private bool _opaqueHeld;
+
+        private void OnDestroy()
+        {
+            ClientSettings.RequestOpaqueTexture(false, ref _opaqueHeld);
         }
 
         private void Update()

--- a/client/Assets/BlocksBeyondTheStars/Shaders/BlockAtlas.shader
+++ b/client/Assets/BlocksBeyondTheStars/Shaders/BlockAtlas.shader
@@ -174,7 +174,10 @@ Shader "BlocksBeyondTheStars/BlockAtlas"
 
                 // Sun shadow map (URP main light): 1 where lit, →0 in shadow. Only the direct-sun terms are
                 // shadowed (ambient/sky fill + emissive stay), so shadowed faces dim but never go black.
-                float shadow = MainLightRealtimeShadow(TransformWorldToShadowCoord(i.wp));
+                // #1518: the lookup only feeds terms multiplied by ndl*sky, so a face turned away from the sun
+                // or without skylight (caves, interiors — about half of all voxel faces) skips the soft-shadow
+                // tent filter entirely; the branch is per-face coherent and the result is identical.
+                float shadow = (ndl * sky > 0.0) ? MainLightRealtimeShadow(TransformWorldToShadowCoord(i.wp)) : 0.0;
 
                 // Per-vertex AO (mesher, in .b) widened to a visible contact-shadow range, then multiplied by
                 // the texture-scale cavity AO (normal map alpha). Diffuse-only — spec/reflection stay crisp.
@@ -347,6 +350,48 @@ Shader "BlocksBeyondTheStars/BlockAtlas"
             {
                 float a = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, i.uv).a;
                 clip(a - _LeafCutoff); // opaque tiles (a=1) always pass; foliage holes clip
+                return 0;
+            }
+            ENDHLSL
+        }
+
+        // #1518: depth prepass. URP renders one whenever it cannot copy the depth buffer — on WebGL (GLES3)
+        // with MSAA on, and whenever depth priming is enabled — and it only draws shaders that HAVE this pass.
+        // Without it the terrain was missing from _CameraDepthTexture in browsers at Medium/High, so SSAO,
+        // the water depth and the heat-haze fade all read the far plane. Same leaf clip as the shadow caster.
+        Pass
+        {
+            Name "DepthOnly"
+            Tags { "LightMode" = "DepthOnly" }
+            ZWrite On ColorMask R Cull Back
+
+            HLSLPROGRAM
+            #pragma vertex depthVert
+            #pragma fragment depthFrag
+            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
+
+            TEXTURE2D(_MainTex); SAMPLER(sampler_MainTex);
+
+            // Must match the forward pass's UnityPerMaterial layout exactly (SRP Batcher requirement).
+            CBUFFER_START(UnityPerMaterial)
+                float _LeafCutoff;
+            CBUFFER_END
+
+            struct DAttr { float4 positionOS : POSITION; float2 uv : TEXCOORD0; };
+            struct DVary { float4 positionCS : SV_POSITION; float2 uv : TEXCOORD0; };
+
+            DVary depthVert(DAttr v)
+            {
+                DVary o;
+                o.positionCS = TransformObjectToHClip(v.positionOS.xyz);
+                o.uv = v.uv;
+                return o;
+            }
+
+            half4 depthFrag(DVary i) : SV_Target
+            {
+                float a = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, i.uv).a;
+                clip(a - _LeafCutoff); // foliage holes stay holes in the depth buffer too
                 return 0;
             }
             ENDHLSL

--- a/client/Assets/BlocksBeyondTheStars/Shaders/BlockAtlasTransparent.shader
+++ b/client/Assets/BlocksBeyondTheStars/Shaders/BlockAtlasTransparent.shader
@@ -120,7 +120,8 @@ Shader "BlocksBeyondTheStars/BlockAtlasTransparent"
                 float emission = i.mat.a;              // glow (energy fields shine; plain glass = 0)
 
                 // Sun shadow on the directional half only — shadowed water/glass dims, never blacks out.
-                float shadow = MainLightRealtimeShadow(TransformWorldToShadowCoord(i.wp));
+                // #1518: only multiplied by ndl, so faces turned away from the sun skip the lookup (identical result).
+                float shadow = (ndl > 0.0) ? MainLightRealtimeShadow(TransformWorldToShadowCoord(i.wp)) : 0.0;
 
                 float3 col = albedo * light * (0.55 + 0.45 * ndl * shadow) * shade;
                 col += albedo * emission * 2.0;        // emissive energy-field glow (bloom catches it)

--- a/client/Assets/BlocksBeyondTheStars/Shaders/LitColor.shader
+++ b/client/Assets/BlocksBeyondTheStars/Shaders/LitColor.shader
@@ -142,6 +142,41 @@ Shader "BlocksBeyondTheStars/LitColor"
             half4 shadowFrag(SVary i) : SV_Target { return 0; }
             ENDHLSL
         }
+
+        // #1518: depth prepass (see BlockAtlas) — models must land in _CameraDepthTexture where URP draws a
+        // prepass instead of copying depth (WebGL + MSAA, depth priming).
+        Pass
+        {
+            Name "DepthOnly"
+            Tags { "LightMode" = "DepthOnly" }
+            ZWrite On ColorMask R Cull Back
+
+            HLSLPROGRAM
+            #pragma vertex depthVert
+            #pragma fragment depthFrag
+            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
+
+            // Same UnityPerMaterial layout as the forward pass (SRP Batcher).
+            CBUFFER_START(UnityPerMaterial)
+                float4 _MainTex_ST;
+                float4 _Color;
+                float _Floor;
+                float _Fill;
+            CBUFFER_END
+
+            struct DAttr { float4 positionOS : POSITION; };
+            struct DVary { float4 positionCS : SV_POSITION; };
+
+            DVary depthVert(DAttr v)
+            {
+                DVary o;
+                o.positionCS = TransformObjectToHClip(v.positionOS.xyz);
+                return o;
+            }
+
+            half4 depthFrag(DVary i) : SV_Target { return 0; }
+            ENDHLSL
+        }
     }
 
     // ---------------- Built-in RP (original, unchanged) ----------------

--- a/client/Assets/BlocksBeyondTheStars/Shaders/VertexColorOpaque.shader
+++ b/client/Assets/BlocksBeyondTheStars/Shaders/VertexColorOpaque.shader
@@ -96,6 +96,33 @@ Shader "BlocksBeyondTheStars/VertexColorOpaque"
             half4 shadowFrag(SVary i) : SV_Target { return 0; }
             ENDHLSL
         }
+
+        // #1518: depth prepass (see BlockAtlas) — vertex-coloured models (creatures, ships) must land in
+        // _CameraDepthTexture where URP draws a prepass instead of copying depth (WebGL + MSAA, depth priming).
+        Pass
+        {
+            Name "DepthOnly"
+            Tags { "LightMode" = "DepthOnly" }
+            ZWrite On ColorMask R Cull Back
+
+            HLSLPROGRAM
+            #pragma vertex depthVert
+            #pragma fragment depthFrag
+            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
+
+            struct DAttr { float4 positionOS : POSITION; };
+            struct DVary { float4 positionCS : SV_POSITION; };
+
+            DVary depthVert(DAttr v)
+            {
+                DVary o;
+                o.positionCS = TransformObjectToHClip(v.positionOS.xyz);
+                return o;
+            }
+
+            half4 depthFrag(DVary i) : SV_Target { return 0; }
+            ENDHLSL
+        }
     }
 
     // ---------------- Built-in RP (original, unchanged) ----------------

--- a/client/Assets/Settings/BlocksBeyondTheStarsURP.asset
+++ b/client/Assets/Settings/BlocksBeyondTheStarsURP.asset
@@ -46,7 +46,7 @@ MonoBehaviour:
   m_MainLightRenderingMode: 1
   m_MainLightShadowsSupported: 1
   m_MainLightShadowmapResolution: 4096
-  m_AdditionalLightsRenderingMode: 1
+  m_AdditionalLightsRenderingMode: 0
   m_AdditionalLightsPerObjectLimit: 4
   m_AdditionalLightShadowsSupported: 0
   m_AdditionalLightsShadowmapResolution: 2048
@@ -103,7 +103,7 @@ MonoBehaviour:
       m_Keys: []
       m_Values: 
   m_PrefilteringModeMainLightShadows: 3
-  m_PrefilteringModeAdditionalLight: 3
+  m_PrefilteringModeAdditionalLight: 0
   m_PrefilteringModeAdditionalLightShadows: 0
   m_PrefilterXRKeywords: 1
   m_PrefilteringModeForwardPlus: 0

--- a/client/Assets/Settings/BlocksBeyondTheStarsURP_Renderer.asset
+++ b/client/Assets/Settings/BlocksBeyondTheStarsURP_Renderer.asset
@@ -79,4 +79,4 @@ MonoBehaviour:
   m_DepthAttachmentFormat: 0
   m_DepthTextureFormat: 0
   m_AccurateGbufferNormals: 0
-  m_IntermediateTextureMode: 1
+  m_IntermediateTextureMode: 0

--- a/client/Assets/Settings/BlocksBeyondTheStarsURP_Renderer_Low.asset
+++ b/client/Assets/Settings/BlocksBeyondTheStarsURP_Renderer_Low.asset
@@ -52,4 +52,4 @@ MonoBehaviour:
   m_DepthAttachmentFormat: 0
   m_DepthTextureFormat: 0
   m_AccurateGbufferNormals: 0
-  m_IntermediateTextureMode: 1
+  m_IntermediateTextureMode: 0

--- a/client/Assets/Settings/BlocksBeyondTheStarsURP_Renderer_Medium.asset
+++ b/client/Assets/Settings/BlocksBeyondTheStarsURP_Renderer_Medium.asset
@@ -79,4 +79,4 @@ MonoBehaviour:
   m_DepthAttachmentFormat: 0
   m_DepthTextureFormat: 0
   m_AccurateGbufferNormals: 0
-  m_IntermediateTextureMode: 1
+  m_IntermediateTextureMode: 0

--- a/client/ProjectSettings/DynamicsManager.asset
+++ b/client/ProjectSettings/DynamicsManager.asset
@@ -18,7 +18,7 @@ PhysicsManager:
   m_ClothInterCollisionDistance: 0.1
   m_ClothInterCollisionStiffness: 0.2
   m_LayerCollisionMatrix: ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-  m_SimulationMode: 0
+  m_SimulationMode: 1
   m_AutoSyncTransforms: 0
   m_ReuseCollisionCallbacks: 1
   m_InvokeCollisionCallbacks: 1

--- a/client/ProjectSettings/GraphicsSettings.asset
+++ b/client/ProjectSettings/GraphicsSettings.asset
@@ -25,7 +25,7 @@ GraphicsSettings:
   m_LensFlare:
     m_Mode: 1
     m_Shader: {fileID: 102, guid: 0000000000000000f000000000000000, type: 0}
-  m_VideoShadersIncludeMode: 2
+  m_VideoShadersIncludeMode: 0
   m_AlwaysIncludedShaders:
   - {fileID: 7, guid: 0000000000000000f000000000000000, type: 0}
   - {fileID: 15104, guid: 0000000000000000f000000000000000, type: 0}

--- a/client/ProjectSettings/ProjectSettings.asset
+++ b/client/ProjectSettings/ProjectSettings.asset
@@ -343,7 +343,9 @@ PlayerSettings:
     m_StaticBatching: 0
     m_DynamicBatching: 0
   m_BuildTargetShaderSettings: []
-  m_BuildTargetGraphicsJobs: []
+  m_BuildTargetGraphicsJobs:
+  - m_BuildTarget: WindowsStandaloneSupport
+    m_GraphicsJobs: 0
   m_BuildTargetGraphicsJobMode: []
   m_BuildTargetGraphicsAPIs: []
   m_BuildTargetVRSettings: []
@@ -639,6 +641,7 @@ PlayerSettings:
     WebGL: 0
   il2cppStacktraceInformation: {}
   managedStrippingLevel:
+    Standalone: 0
     WebGL: 2
   incrementalIl2cppBuild: {}
   suppressCommonWarnings: 1


### PR DESCRIPTION
PR bundle 4 of the performance package (#1501): render and engine configuration. **Same picture at every preset**; Unity client only.

## What changes

| issue | change | what it replaces |
|---|---|---|
| #1517 | URP asset: Additional Lights **Disabled**; renderer assets: `IntermediateTextureMode` Always → Auto; video shaders no longer force-included | per-pixel additional-light culling + per-object light lists for every chunk renderer each frame although **no project shader reads them**; an extra blit for the off-screen preview/HUD cameras |
| #1518 | `BlockAtlas` / `BlockAtlasTransparent`: the soft-shadow lookup runs only where its result is used (`ndl*sky` resp. `ndl` non-zero); `BlockAtlas`, `LitColor`, `VertexColorOpaque` gain a `DepthOnly` pass | the tent filter on ~half of all voxel faces for a zero contribution; in browsers (GLES3 + MSAA) URP's depth prepass drew **nothing** from this project, so SSAO / water depth / heat fade read the far plane |
| #1519 | `DynamicsManager` simulation mode → Update | a 50 Hz fixed physics step (up to 16 catch-up steps per frame at low fps) with zero Rigidbodies, `FixedUpdate`s or collision callbacks in the project |
| #1520 | the opaque colour copy is requested per camera only while the heat-haze or thermal quad is visible (`ClientSettings.RequestOpaqueTexture`, still Medium+ only) | an MSAA resolve + half-res blit **every frame** at Medium+ although those two quads are its only consumers (verified by grep: `HeatHaze.shader`, `Thermal.shader`) |
| #1521 | `ShaderPrewarm` compiles the four world shaders' fog × shadow × soft-shadow variants once per process behind the loading veil; desktop builds: `CompressWithLz4HC`; Graphics Jobs and managed stripping were both tried and stay **off** (pinned in `BuildScript.cs` with the reason, see below) | a 20–100 ms hitch on each first use (weather fog switch, sunrise cascades, preset change); engine-default build flags |

## Consequences / what to check

- **Physics mode (#1519) needs the playtest checklist**: station-boarding fall + settle freeze, ladders, boat, speeder, EVA, mining outline and placement raycasts. The code shows no dependency on `Physics.Simulate` timing, but only play proves it.
- Graphics Jobs were measured and **rejected**: on this CPU-bound scene (~180 fps) they cost 1.5–2 ms per frame (idle 5.2→7.0 ms, walk 5.3→6.7 ms in a first A/B). The same build without them is the table below.
- Managed stripping Low was tried and **rejected**: it strips the generic `Serialize` overloads that MessagePack's non-generic path finds by reflection, so the client could not encode its join request (only space visible, no world). The PerfProbe A/B caught it; desktop stripping is now pinned to Disabled in `BuildScript.cs`.
- Deferred on purpose (need a WebGL build to verify): deleting the dead Built-in-RP SubShaders, pruning the stock always-included shader entries, the cutout-submesh split (#1518 item 3), WebGL wasm2023/BigInt.
- The depth prepass also enables depth priming on MSAA-off presets later (not switched on here).

## Verification

- Local Unity player build (worktree): 0 compiler errors / warnings.
- PerfProbe A/B in one session, PR 3 build vs this build, High/VD 8, the persisted `PerfProbe` save (seed 424242 — the `-seed` flag only applies when the world is first created), idle 20 s + walk 30 s, two alternating pairs:

| run (alternating, one session) | idle avg | idle p95 | idle p99 | walk avg | walk p95 | walk p99 |
|---|---|---|---|---|---|---|
| PR 3 build #1 | 5.56 ms | 6.22 | 9.06 | 5.44 ms | 9.16 | 15.31 |
| this PR #1 | 5.23 ms | 8.71 | 14.43 | 4.33 ms | 7.19 | 13.42 |
| this PR #2 | 4.68 ms | 6.55 | 10.79 | 4.34 ms | 7.08 | 11.77 |
| PR 3 build #2 | 5.56 ms | 6.21 | 9.33 | 5.40 ms | 9.03 | 14.96 |

  Walk −20 % average frame time, idle −6…−16 %; frames >33 ms: 0–1 in every run. The first run of a fresh build pays the driver shader cache (higher idle p95/p99 in run #1), the second run does not. Every run logs `[Shaders] Prewarmed 76 variants.` and the player joins and loads the world (the stripping trial did not — see above).

closes #1517 closes #1518 closes #1519 closes #1520 closes #1521

🤖 Generated with [Claude Code](https://claude.com/claude-code)
