### PR TITLE
perf(worldgen): column profiles shared by the stacked chunks, memoised SurfaceHeight, per-column noise lattices, ore invariants, tree pre-filter, oldest-out static caches — same bits out (#1526 #1527)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -243,6 +243,44 @@ is read from the module stat (16) instead of being dead, and the station deploy 
 persisted ids after a restart (id collision). Tests: `PlayerStationReportsTests` (7), `DropLootTests` (+2).
 Locales: 9 new keys + 2 rewordings, EN/DE hand-written, 12 MT via translate_locale.
 
+### ★ Worldgen, output-preserving: column profiles shared by the stacked chunks, memoised SurfaceHeight, per-column noise lattices, ore invariants, tree pre-filter, oldest-out static caches (#1526 #1527, 2026-09-04, branch perf/1526-1527-worldgen)
+
+**Why.** PR bundle 6 of the performance package (#1501), gated by the golden checksums (#1503). Every stacked chunk
+of a column recomputed the whole column phase (SurfaceHeight + ~20 wonder probes per column), every solid voxel
+re-projected the torus noise (4 trig + 32 hashes per field, up to 15 fields), StampTrees paid SurfaceHeight +
+BiomeIndex + a 3-octave FBM for all 576 margin columns before a roll that rejects ~99 % of them, and the static
+river/calibration/wonder caches evicted with `Clear()`.
+
+**What changed — same bits out.** **#1526** `SurfaceHeight` is memoised per generator instance, keyed on
+(planet, raw column) and dropped by `SetWorldMode` / `SetContinentsEnabled` / `SetWorldOptionFactors` or at the
+cap (262k entries); `SurfaceHeightUncached` stays for the tests. The column phase of `Generate` moved verbatim into
+`ComputeColumn` (a line-range move, not a rewrite) and is memoised as an immutable `ColumnProfile` per (planet,
+column), capped at 100k entries — the y-loop reads the profile, so only the first chunk of a column pays the
+phase. The forest mask of `StampTrees` is memoised the same way. **#1527** `TorusColumnSampler` samples one
+`ValueTorus` field for one column: the torus projection (the trig), the lattice x/z cell, the layer seeds and the
+blend weights are computed once per column with the original expressions, the eight corner hashes once per lattice
+row, and `Sample` finishes with the original `Lerp` chain in the original order — `WorldGenColumnCacheTests` proves
+bit-identity against `Noise.ValueTorus` on 24k random samples. The y-loop uses one lazily built sampler per
+(column, field): caves, lava pockets, a coarse + fine slot per vein. `SelectOre` reads per-chunk `OreSlot`
+invariants (depth band, shallow split, `rarity × richness` as the first factor of the original product, field
+seeds, the resolved `BlockId`) instead of re-deriving them and re-looking up the block string per hit.
+`StampTrees` rolls first against a conservative upper bound of every biome's density multiplier (1e-9 slack), then
+gates on whether any cell in `[surface+1, surface+18]` lands in this chunk, and only then does the exact work;
+the mushroom, prop and geyser stamps gate the same way (`MaxStampRise` = the jungle crown). The three static
+caches evict their oldest entry instead of clearing. Dropped from the plan: a `Y ≥ 320` all-air early-out
+(no chunk in the streamed band reaches it; the profile cache makes an all-air chunk sub-millisecond anyway) and
+the `Value3D` hash-prefix sharing (marginal after the lattice reuse).
+
+**Measured (scratch bench, non-tiered JIT, six columns × five planets, ms per chunk).** Stacked chunks of a
+column: deep solid 29–39 → 6–8, surface 15–18 → 2.5–5, all-air 3.5–8.4 → 0.5–1.0. First chunk of a column
+(pays the column phase + the static region caches): 48–80 → 47–60. `SurfaceHeight`, 20k columns asked twice:
+the repeat 31–76 ms → 2.6–3.5 ms. Goldens unchanged on every group; `WorldGenColumnCacheTests` pins that a warm
+generator produces what a cold one does for every stacked chunk and that a world-mode change drops the memos.
+
+**Consequences.** A generator instance now holds up to ~18 MB of column memos on a VD-8 world (server and browser
+host alike; the browser's VD 2–4 is a few MB); the memos assume a fixed world mode between the setters, which the
+server and client already guarantee (they call the setters before any query).
+
 ### ★ Startup & memory: one content snapshot per process, lazy locale tables + coverage manifest, shared block atlas, ambience loops compressed in memory, browser save blob only when dirty (#1522–#1525, 2026-09-04, branch perf/1522-1525-startup-memory)
 
 **Why.** PR bundle 5 of the performance package (#1501). The client parsed the whole content set on the shell AND

--- a/src/BlocksBeyondTheStars.WorldGeneration/Noise.cs
+++ b/src/BlocksBeyondTheStars.WorldGeneration/Noise.cs
@@ -31,9 +31,9 @@ public static class Noise
     public static double Value01(long seed, long x, long y, long z)
         => (Hash(seed, x, y, z) >> 11) * (1.0 / 9007199254740992.0); // 53-bit mantissa
 
-    private static double Smooth(double t) => t * t * (3.0 - 2.0 * t);
+    internal static double Smooth(double t) => t * t * (3.0 - 2.0 * t);
 
-    private static double Lerp(double a, double b, double t) => a + (b - a) * t;
+    internal static double Lerp(double a, double b, double t) => a + (b - a) * t;
 
     /// <summary>2D value noise in [0,1], sampled at continuous coordinates.</summary>
     public static double Value2D(long seed, double x, double z)
@@ -95,7 +95,11 @@ public static class Noise
         return norm > 0 ? sum / norm : 0;
     }
 
-    private const double Tau = 2.0 * System.Math.PI;
+    internal const double Tau = 2.0 * System.Math.PI;
+    /// <summary>Layer-seed primes of <see cref="Value4D"/> / <see cref="Value5D"/> — shared with
+    /// <see cref="TorusColumnSampler"/>, which must derive the identical layer seeds (#1527).</summary>
+    internal const long Value4DLayerPrime = 0x100000001B3L;
+    internal const long Value5DLayerPrime = unchecked((long)0x9E3779B97F4A7C15UL);
 
     /// <summary>
     /// 4D value noise in [0,1]. Built from two <see cref="Value3D"/> layers (at integer w) smoothly
@@ -107,8 +111,8 @@ public static class Noise
         double tw = Smooth(w - w0);
         unchecked
         {
-            long sa = seed + w0 * 0x100000001B3L;       // FNV prime, distinct layer per integer w
-            long sb = seed + (w0 + 1) * 0x100000001B3L;
+            long sa = seed + w0 * Value4DLayerPrime;       // FNV prime, distinct layer per integer w
+            long sb = seed + (w0 + 1) * Value4DLayerPrime;
             return Lerp(Value3D(sa, x, y, z), Value3D(sb, x, y, z), tw);
         }
     }
@@ -170,7 +174,7 @@ public static class Noise
         double tv = Smooth(v - v0);
         unchecked
         {
-            const long layerPrime = unchecked((long)0x9E3779B97F4A7C15UL); // distinct from Value4D's FNV prime
+            const long layerPrime = Value5DLayerPrime; // distinct from Value4D's FNV prime
             long sa = seed + v0 * layerPrime;
             long sb = seed + (v0 + 1) * layerPrime;
             return Lerp(Value4D(sa, x, y, z, w), Value4D(sb, x, y, z, w), tv);

--- a/src/BlocksBeyondTheStars.WorldGeneration/TorusColumnSampler.cs
+++ b/src/BlocksBeyondTheStars.WorldGeneration/TorusColumnSampler.cs
@@ -1,0 +1,137 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+namespace BlocksBeyondTheStars.WorldGeneration;
+
+/// <summary>
+/// #1527: <see cref="Noise.ValueTorus"/> for one world column, one field at a time — bit-identical to the
+/// original, only cheaper. For a fixed (worldX, worldZ) and field the torus projection (4 trig calls) and
+/// therefore the lattice x/z cell, the two layer seeds of <c>Value5D</c>/<c>Value4D</c> and their blend
+/// weights never change; only <c>worldY / scaleY</c> moves. And the eight corner hashes of <c>Value3D</c>
+/// only change when the floored y crosses an integer — every 16 (caves), 9 (ore) or 4.5 (fine ore)
+/// blocks — so the y-loop of a chunk re-evaluated 32 hashes + 4 trig calls per voxel for values that are
+/// constant across most of the column.
+/// <para>
+/// The sampler stores exactly the doubles the original computed (<c>cx, cy, zx, zy</c> → floors, smooth
+/// weights, layer seeds) and per lattice row the four x-interpolated corner pairs of each of the four
+/// <c>Value3D</c> layers; <see cref="Sample"/> finishes with the very same <c>Lerp</c> chain in the same
+/// order. Every intermediate is the same IEEE operation on the same operands, so the result is the same
+/// bits — <c>TorusColumnSamplerTests</c> proves it against <see cref="Noise.ValueTorus"/> and the world-gen
+/// goldens pin the chunks.
+/// </para>
+/// </summary>
+public struct TorusColumnSampler
+{
+    // Value3D layer seeds: (Value5D layer A|B) × (Value4D layer A|B).
+    private long _sAA, _sAB, _sBA, _sBB;
+    private long _x0, _z0, _y0;
+    private double _tx, _tz, _tw, _tv, _scaleY;
+    // Per lattice row (current _y0): the x-lerped corner pairs (x00, x10, x01, x11) of each layer.
+    private double _aa00, _aa10, _aa01, _aa11;
+    private double _ab00, _ab10, _ab01, _ab11;
+    private double _ba00, _ba10, _ba01, _ba11;
+    private double _bb00, _bb10, _bb01, _bb11;
+
+    /// <summary>False until the sampler has been built for the current column (see <see cref="ResetAll"/>).</summary>
+    public bool Ready;
+
+    /// <summary>Builds the column state exactly as <see cref="Noise.ValueTorus"/> derives it from its arguments.</summary>
+    public TorusColumnSampler(long seed, double worldX, double worldZ, double circX, double circZ,
+        double scaleX, double scaleY, double scaleZ)
+    {
+        // ValueTorus: the two circles of the torus projection.
+        double thetaX = Noise.Tau * worldX / circX;
+        double radX = circX / (scaleX * Noise.Tau);
+        double cx = radX * System.Math.Cos(thetaX);
+        double cy = radX * System.Math.Sin(thetaX);
+
+        double thetaZ = Noise.Tau * worldZ / circZ;
+        double radZ = circZ / (scaleZ * Noise.Tau);
+        double zx = radZ * System.Math.Cos(thetaZ);
+        double zy = radZ * System.Math.Sin(thetaZ);
+
+        // Value5D(seed, x: cx, y: worldY / scaleY, z: zx, w: cy, v: zy)
+        long v0 = (long)System.Math.Floor(zy);
+        _tv = Noise.Smooth(zy - v0);
+        // Value4D(sa|sb, x: cx, y, z: zx, w: cy)
+        long w0 = (long)System.Math.Floor(cy);
+        _tw = Noise.Smooth(cy - w0);
+        unchecked
+        {
+            long sa5 = seed + v0 * Noise.Value5DLayerPrime;
+            long sb5 = seed + (v0 + 1) * Noise.Value5DLayerPrime;
+            _sAA = sa5 + w0 * Noise.Value4DLayerPrime;
+            _sAB = sa5 + (w0 + 1) * Noise.Value4DLayerPrime;
+            _sBA = sb5 + w0 * Noise.Value4DLayerPrime;
+            _sBB = sb5 + (w0 + 1) * Noise.Value4DLayerPrime;
+        }
+
+        // Value3D(layer, x: cx, y, z: zx)
+        _x0 = (long)System.Math.Floor(cx);
+        _z0 = (long)System.Math.Floor(zx);
+        _tx = Noise.Smooth(cx - _x0);
+        _tz = Noise.Smooth(zx - _z0);
+        _scaleY = scaleY;
+        _y0 = long.MinValue;
+        _aa00 = _aa10 = _aa01 = _aa11 = 0.0;
+        _ab00 = _ab10 = _ab01 = _ab11 = 0.0;
+        _ba00 = _ba10 = _ba01 = _ba11 = 0.0;
+        _bb00 = _bb10 = _bb01 = _bb11 = 0.0;
+        Ready = true;
+    }
+
+    /// <summary>The same value <see cref="Noise.ValueTorus"/> returns for this column at <paramref name="worldY"/>.</summary>
+    public double Sample(double worldY)
+    {
+        double y = worldY / _scaleY;
+        long y0 = (long)System.Math.Floor(y);
+        double ty = Noise.Smooth(y - y0);
+        if (y0 != _y0)
+        {
+            Refresh(y0);
+        }
+
+        // Value3D per layer, then Value4D's blend over w, then Value5D's blend over v — the original chain.
+        double aa = Noise.Lerp(Noise.Lerp(_aa00, _aa10, ty), Noise.Lerp(_aa01, _aa11, ty), _tz);
+        double ab = Noise.Lerp(Noise.Lerp(_ab00, _ab10, ty), Noise.Lerp(_ab01, _ab11, ty), _tz);
+        double ba = Noise.Lerp(Noise.Lerp(_ba00, _ba10, ty), Noise.Lerp(_ba01, _ba11, ty), _tz);
+        double bb = Noise.Lerp(Noise.Lerp(_bb00, _bb10, ty), Noise.Lerp(_bb01, _bb11, ty), _tz);
+        return Noise.Lerp(Noise.Lerp(aa, ab, _tw), Noise.Lerp(ba, bb, _tw), _tv);
+    }
+
+    private void Refresh(long y0)
+    {
+        Corners(_sAA, y0, out _aa00, out _aa10, out _aa01, out _aa11);
+        Corners(_sAB, y0, out _ab00, out _ab10, out _ab01, out _ab11);
+        Corners(_sBA, y0, out _ba00, out _ba10, out _ba01, out _ba11);
+        Corners(_sBB, y0, out _bb00, out _bb10, out _bb01, out _bb11);
+        _y0 = y0;
+    }
+
+    /// <summary>Value3D's eight corners of the lattice cell (x0, y0, z0), pre-blended along x.</summary>
+    private void Corners(long seed, long y0, out double x00, out double x10, out double x01, out double x11)
+    {
+        double c000 = Noise.Value01(seed, _x0, y0, _z0);
+        double c100 = Noise.Value01(seed, _x0 + 1, y0, _z0);
+        double c010 = Noise.Value01(seed, _x0, y0 + 1, _z0);
+        double c110 = Noise.Value01(seed, _x0 + 1, y0 + 1, _z0);
+        double c001 = Noise.Value01(seed, _x0, y0, _z0 + 1);
+        double c101 = Noise.Value01(seed, _x0 + 1, y0, _z0 + 1);
+        double c011 = Noise.Value01(seed, _x0, y0 + 1, _z0 + 1);
+        double c111 = Noise.Value01(seed, _x0 + 1, y0 + 1, _z0 + 1);
+
+        x00 = Noise.Lerp(c000, c100, _tx);
+        x10 = Noise.Lerp(c010, c110, _tx);
+        x01 = Noise.Lerp(c001, c101, _tx);
+        x11 = Noise.Lerp(c011, c111, _tx);
+    }
+
+    /// <summary>Marks every slot stale — call at the start of each column; slots rebuild lazily on first use.</summary>
+    public static void ResetAll(TorusColumnSampler[] samplers)
+    {
+        for (int i = 0; i < samplers.Length; i++)
+        {
+            samplers[i].Ready = false;
+        }
+    }
+}

--- a/src/BlocksBeyondTheStars.WorldGeneration/WorldGenerator.cs
+++ b/src/BlocksBeyondTheStars.WorldGeneration/WorldGenerator.cs
@@ -85,6 +85,7 @@ public sealed class WorldGenerator
         // boost rides OUTSIDE the calibration, like the world-option ore factor, so the memoised
         // calibration cache needs no key extension.
         _frontierOreBoost = frontierOreBoost;
+        InvalidateColumnCaches(); // #1526: the column memos assume a fixed world mode
     }
 
     /// <summary>Rare-vein multiplier for the CURRENT body (#1122), set per world via
@@ -108,7 +109,11 @@ public sealed class WorldGenerator
     /// <summary>Enables the continents feature for this generator (#704) — from the save's
     /// <c>WorldDescription.TerrainContinents</c> on the server, from the join handshake on the client.
     /// Call BEFORE any chunk or height query, like <see cref="SetWorldOptionFactors"/>.</summary>
-    public void SetContinentsEnabled(bool enabled) => _continentsEnabled = enabled;
+    public void SetContinentsEnabled(bool enabled)
+    {
+        _continentsEnabled = enabled;
+        InvalidateColumnCaches(); // #1526
+    }
 
     /// <summary>The flattened pad surface height for a column, or null when it is not on a pad.</summary>
     private int? PadSurfaceAt(int worldX, int worldZ)
@@ -225,6 +230,7 @@ public sealed class WorldGenerator
     {
         _floraFactor = floraFactor;
         _oreFactor = oreFactor;
+        InvalidateColumnCaches(); // #1526 (the column phase does not read them today — cheap insurance)
     }
 
     /// <summary>
@@ -374,8 +380,65 @@ public sealed class WorldGenerator
     // almost always hit the instance slot and never touch the lock.
     private static readonly System.Collections.Generic.Dictionary<(long, string, int, bool, long, bool), WonderProfile> _wonders = new();
     private static readonly object _wonderLock = new object();
+    private static readonly System.Collections.Generic.Queue<(long, string, int, bool, long, bool)> _wonderOrder = new();
     private WonderProfile? _wonderCached;
     private (long, string, int, bool, long, bool) _wonderCachedKey;
+
+    /// <summary>#1527: the bounded static caches evict their OLDEST entry instead of clearing wholesale, so a
+    /// world past the cap only re-derives one entry, not every resident body's.</summary>
+    private static void EvictOldest<TValue>(
+        System.Collections.Generic.Dictionary<(long, string, int, bool, long, bool), TValue> cache,
+        System.Collections.Generic.Queue<(long, string, int, bool, long, bool)> order, int cap)
+    {
+        while (cache.Count >= cap && order.Count > 0)
+        {
+            cache.Remove(order.Dequeue()); // a key evicted earlier and re-inserted is simply gone already
+        }
+
+        if (cache.Count >= cap)
+        {
+            cache.Clear(); // unreachable unless the order queue and the cache disagree — keep the bound anyway
+        }
+    }
+
+    // #1526: per-instance column memos. SurfaceHeight and the whole column phase of Generate are pure functions
+    // of (world mode, planet, x, z) — the ~6 stacked chunks of a column, the tree/prop margins, the pond/river
+    // probes and the server's far-column band all asked for the same columns again and again. Keyed on the
+    // planet key + the raw (unwrapped) column; cleared by the world-mode setters and at the cap. Locked because
+    // the client's minimap bakes on its own thread while a server instance may be shared.
+    private readonly System.Collections.Generic.Dictionary<(string, long), int> _surfaceCache = new();
+    private readonly System.Collections.Generic.Dictionary<(string, long), double> _forestCache = new();
+    private readonly System.Collections.Generic.Dictionary<(string, long), ColumnProfile> _columnProfiles = new();
+    private readonly object _columnLock = new object();
+    private const int SurfaceCacheCap = 262_144;   // ~6 MB of entries at most
+    private const int ColumnProfileCap = 100_000;  // ~12 MB: a VD-8 view is ~74k columns
+
+    private static long ColumnKey(int worldX, int worldZ) => ((long)(uint)worldX << 32) | (uint)worldZ;
+
+    /// <summary>Drops every per-column memo — the world-mode setters call this because the memos are keyed
+    /// on the planet + column only and rely on the mode (circumference, cratered, body salt, continents,
+    /// option factors) staying put in between.</summary>
+    private void InvalidateColumnCaches()
+    {
+        lock (_columnLock)
+        {
+            _surfaceCache.Clear();
+            _forestCache.Clear();
+            _columnProfiles.Clear();
+        }
+    }
+
+    /// <summary>How many column profiles are memoised right now (tests).</summary>
+    internal int CachedColumnProfiles
+    {
+        get
+        {
+            lock (_columnLock)
+            {
+                return _columnProfiles.Count;
+            }
+        }
+    }
 
     private WonderProfile WonderFor(PlanetType planet)
     {
@@ -423,12 +486,9 @@ public sealed class WorldGenerator
                 ulong uh = Noise.Hash(seed ^ 0x57FADE, 2, 4, 8);
                 w.HybridA = 0.34 + (uh & 0xFF) / 255.0 * 0.08;
                 w.HybridB = w.HybridA + 0.08;
-                if (_wonders.Count >= 256)
-                {
-                    _wonders.Clear(); // soft cap — profiles are a few dozen bytes each
-                }
-
+                EvictOldest(_wonders, _wonderOrder, 256); // #1527: oldest-out, never the whole cache
                 _wonders[key] = w;
+                _wonderOrder.Enqueue(key);
             }
 
             _wonderCached = w;
@@ -444,6 +504,32 @@ public sealed class WorldGenerator
     /// Everything that consumes terrain (rivers, settlements, pads, previews) goes through here, so
     /// every system sees the same mountain.</summary>
     public int SurfaceHeight(PlanetType planet, int worldX, int worldZ)
+    {
+        var key = (planet.Key, ColumnKey(worldX, worldZ));
+        lock (_columnLock)
+        {
+            if (_surfaceCache.TryGetValue(key, out int cached))
+            {
+                return cached; // #1526
+            }
+        }
+
+        int h = SurfaceHeightUncached(planet, worldX, worldZ);
+        lock (_columnLock)
+        {
+            if (_surfaceCache.Count >= SurfaceCacheCap)
+            {
+                _surfaceCache.Clear();
+            }
+
+            _surfaceCache[key] = h;
+        }
+
+        return h;
+    }
+
+    /// <summary>The memo-free surface height — what <see cref="SurfaceHeight"/> caches (tests compare the two).</summary>
+    internal int SurfaceHeightUncached(PlanetType planet, int worldX, int worldZ)
     {
         var w = WonderFor(planet); // #712: every gate below is a cached boolean, not a re-derivation
         int h = RawSurfaceHeight(planet, w, worldX, worldZ);
@@ -2609,6 +2695,7 @@ public sealed class WorldGenerator
     // otherwise re-sample ~17k heights + 2×4096 field points.
     private static readonly System.Collections.Generic.Dictionary<(long, string, int, bool, long, bool), WorldCalibration> _calibs = new();
     private static readonly object _calibLock = new object();
+    private static readonly System.Collections.Generic.Queue<(long, string, int, bool, long, bool)> _calibOrder = new();
 
     private WorldCalibration CalibFor(PlanetType planet)
     {
@@ -2621,12 +2708,9 @@ public sealed class WorldGenerator
             }
 
             var calib = BuildCalibration(planet);
-            if (_calibs.Count >= 64)
-            {
-                _calibs.Clear(); // soft cap — entries are ~150 KB each (the sorted height sample)
-            }
-
+            EvictOldest(_calibs, _calibOrder, 64); // #1527: oldest-out — entries are ~150 KB each
             _calibs[key] = calib;
+            _calibOrder.Enqueue(key);
             return calib;
         }
     }
@@ -3114,6 +3198,7 @@ public sealed class WorldGenerator
     // re-run the ~300 ms network build per instance.
     private static readonly System.Collections.Generic.Dictionary<(long, string, int, bool, long, bool), RiverField> _riverFields = new();
     private static readonly object _riverLock = new object();
+    private static readonly System.Collections.Generic.Queue<(long, string, int, bool, long, bool)> _riverOrder = new();
 
     /// <summary>This world's routed river placement (built once per world, then cached). Empty on worlds that
     /// get no rivers (no water sea, or WaterAbundance below the river threshold).</summary>
@@ -3128,12 +3213,9 @@ public sealed class WorldGenerator
             }
 
             var field = BuildRiverField(planet);
-            if (_riverFields.Count >= 8)
-            {
-                _riverFields.Clear(); // soft cap: only a handful of worlds are resident at once
-            }
-
+            EvictOldest(_riverFields, _riverOrder, 8); // #1527: a ship alternating past 8 bodies no longer re-runs the ~300 ms build
             _riverFields[key] = field;
+            _riverOrder.Enqueue(key);
             return field;
         }
     }
@@ -3535,220 +3617,74 @@ public sealed class WorldGenerator
         var origin = WorldConstants.ChunkOrigin(coord);
 
         // Scratch spans reused by every column (#705/#708) — allocated once per chunk (CA2014).
-        System.Span<ColumnBand> bands = stackalloc ColumnBand[MaxColumnBands];
-        System.Span<(int Lo, int Hi)> tunnelSpans = stackalloc (int Lo, int Hi)[TunnelMaxSpans];
+        System.Span<ColumnBand> bandScratch = stackalloc ColumnBand[MaxColumnBands];
+        System.Span<(int Lo, int Hi)> tunnelScratch = stackalloc (int Lo, int Hi)[TunnelMaxSpans];
+
+        // #1526: everything the column phase reads, bundled once per chunk for ComputeColumn.
+        var ctx = new ColumnContext
+        {
+            Planet = planet,
+            Seed = seed,
+            Calib = calib,
+            RiverField = riverField,
+            Biomes = biomes,
+            FluidLevel = fluidLevel,
+            FluidId = fluidId,
+            SeaWaterId = seaWaterId,
+            CraterLavaId = craterLavaId,
+            BeachId = beachId,
+            SnowId = snowId,
+            IceId = iceId,
+            BasaltId = basaltId,
+            SaltBlockId = saltBlockId,
+            DeepId = deepId,
+            Ponds = ponds,
+            PondThreshold = pondThreshold,
+            VolcanoWorld = volcanoWorld,
+            TravertineWorld = travertineWorld,
+            CenoteWorld = cenoteWorld,
+            FreezeWater = freezeWater,
+            BeachPossible = beachPossible,
+            SnowPossible = snowPossible,
+            PenitenteWorld = penitenteWorld,
+            BasaltFieldWorld = basaltFieldWorld,
+            AnyBands = anyBands,
+            CavernWorld = cavernWorld,
+            TunnelWorld = tunnelWorld,
+        };
+
+        // #1527: per-chunk ore invariants + one lazily built noise lattice per (column, field): slot 0 caves,
+        // slot 1 the lava pockets, then a coarse + fine slot per vein.
+        var oreSlots = BuildOreSlots(planet, seed, oreRichness);
+        var samplers = new TorusColumnSampler[2 + oreSlots.Length * 2];
 
         for (int lx = 0; lx < WorldConstants.ChunkSize; lx++)
             for (int lz = 0; lz < WorldConstants.ChunkSize; lz++)
             {
                 int worldX = origin.X + lx;
                 int worldZ = origin.Z + lz;
-                int surfaceY = SurfaceHeight(planet, worldX, worldZ);
-
-                // An upland pond carves a shallow bowl here (seabed below the terrain) and fills it with water up to
-                // the original surface (a pond flush with the surrounding ground), so the column reads as a swimmable
-                // pool. Normal columns leave seabed=surface and fill the sea up to the global level, unchanged.
-                int seabedY = surfaceY;
-                int waterTop = fluidLevel;
-                var columnFluid = fluidId;
-                bool pondHere = false;
-                double? pondMask = null; // computed at most once per column; shared with the beach rim test (#679)
-                if (ponds && surfaceY > fluidLevel)
-                {
-                    pondMask = PondMaskAt(planet, seed, worldX, worldZ);
-                    int pondDepth = PondDepthFromMask(planet, seed, worldX, worldZ, pondThreshold, pondMask.Value);
-                    if (pondDepth > 0)
-                    {
-                        seabedY = surfaceY - pondDepth;
-                        waterTop = surfaceY;
-                        columnFluid = seaWaterId;
-                        pondHere = true;
-                    }
-                }
-
-                // Volcano (#477): the summit crater overrides the column's fluid to a molten pool — the same
-                // per-column mechanism ponds/rivers use — and the cone's flanks turn to basalt below.
-                bool craterHere = false;
-                double coneRise = 0.0;
-                if (volcanoWorld && TryGetVolcano(planet, seed, worldX, worldZ, out var vCone, out double vDist))
-                {
-                    coneRise = ConeOffsetOf(vCone, vDist);
-                    if (vDist < vCone.CraterR - 0.5)
-                    {
-                        craterHere = true;
-                        seabedY = surfaceY;
-                        waterTop = CraterLavaTop(planet, vCone);
-                        columnFluid = craterLavaId;
-                    }
-                }
-
-                // Rivers (routed): the RiverField places a channel whose water surface FOLLOWS the terrain — a
-                // thin sheet on a flowing reach (no floating wall), the pooled level inside a capped lake, and at
-                // a flagged step a vertical waterfall column poured into the lower reach. Skipped where a pond,
-                // a volcano crater or the global sea already claims the column. The river bed is carved to BedY.
-                bool riverHere = false;
-                if (!pondHere && !craterHere && surfaceY > fluidLevel && riverField.TryGet(worldX, worldZ, out var river))
-                {
-                    riverHere = true;
-                    seabedY = river.BedY;
-                    if (river.WaterfallDrop > 0)
-                    {
-                        // River incision (#709): the plunge pool under a waterfall cuts a slot into the bed —
-                        // the erosion look without simulating erosion.
-                        seabedY -= System.Math.Min(6, river.WaterfallDrop);
-                    }
-
-                    waterTop = river.WaterfallDrop > 0 ? river.WaterSurfaceY + river.WaterfallDrop : river.WaterSurfaceY;
-                    columnFluid = riverField.FillFluid; // water on watery worlds, lava on lava/ashen worlds (L2)
-                }
-
-                // Travertine deck pools (#701): shallow 1-deep water flush on the white terrace decks.
-                bool travertineHere = false;
-                if (travertineWorld && !pondHere && !craterHere && !riverHere && surfaceY > fluidLevel
-                    && TryGetTravertine(seed, worldX, worldZ, out double travDeck, out bool travPool))
-                {
-                    travertineHere = travDeck > 0.0 || travPool;
-                    if (travPool && !seaWaterId.IsAir)
-                    {
-                        seabedY = surfaceY - 1;
-                        waterTop = surfaceY;
-                        columnFluid = seaWaterId;
-                    }
-                }
-
-                // Cenote pools (#707): a turquoise pool standing over the shaft floor.
-                if (cenoteWorld && !pondHere && !craterHere && !riverHere && !seaWaterId.IsAir
-                    && TryGetCenotePool(planet, worldX, worldZ, out int cenotePoolTop)
-                    && cenotePoolTop > surfaceY)
-                {
-                    seabedY = surfaceY;
-                    waterTop = cenotePoolTop;
-                    columnFluid = seaWaterId;
-                }
-
-                // Frozen water (#494): a cold column's water freezes from the waterline down — a walkable
-                // ice sheet with liquid below on merely-cold bodies, frozen through to the seabed in the
-                // deep cold or where the sheet reaches the bed anyway. Lava columns never freeze.
-                int iceTop = 0;
-                if (freezeWater && columnFluid == seaWaterId && !seaWaterId.IsAir && waterTop > seabedY)
-                {
-                    iceTop = IceSheetThickness(calib, seed, worldX, worldZ, waterTop, waterTop - seabedY);
-                }
-
-                // Per-column biome → surface/sub-surface blocks (single-biome worlds use index 0).
-                int biomeIndex = biomes.Count <= 1 ? 0 : BiomeIndex(calib, seed, worldX, worldZ, biomes.Count, surfaceY);
-                var biome = biomes[biomeIndex];
-                var surfaceId = biome.Surface;
-                var subSurfaceId = biome.Sub;
-
-                // Beaches (#679): near a water shoreline the ground turns to the beach block — surface AND
-                // sub-surface, so the varied topsoil depth yields a real sand layer, and the shallow seabed
-                // apron continues the beach under water. The coast mask alternates beach and bare shore;
-                // the snow pass below still dusts cold coasts, and volcano basalt still wins near a cone.
-                bool beachHere = false;
-                if (beachPossible)
-                {
-                    if (surfaceY < fluidLevel && fluidId == seaWaterId)
-                    {
-                        beachHere = fluidLevel - surfaceY <= BeachApronDepth
-                            && CoastMaskAt(planet, seed, worldX, worldZ);
-                    }
-                    else if (!pondHere && !craterHere && !riverHere)
-                    {
-                        beachHere = DryBeachAt(planet, calib, seed, riverField, seaWaterId,
-                            worldX, worldZ, surfaceY, pondMask);
-                    }
-
-                    if (beachHere)
-                    {
-                        surfaceId = beachId;
-                        subSurfaceId = beachId;
-                    }
-                }
-
-                // Altitude climate (#476): above the snow line the ground gets a snow cover, further up solid
-                // ice. Dithered (±1.5 °C noise) so the line wanders naturally instead of cutting a contour.
-                if (snowPossible && surfaceY > waterTop)
-                {
-                    double surfT = TempAt(calib, surfaceY)
-                        + (FbmT(seed + 0x51F0, worldX, worldZ, 24.0, octaves: 2) - 0.5) * 3.0;
-                    if (surfT < IceLineC && !iceId.IsAir)
-                    {
-                        surfaceId = iceId;
-                        subSurfaceId = iceId;
-                    }
-                    else if (surfT < SnowLineC)
-                    {
-                        surfaceId = snowId;
-                    }
-                }
-
-                // Volcano flanks read as dark volcanic rock wherever the cone meaningfully rises (#477) —
-                // after the snow pass, so the warm basalt wins over a snow cap near the vent.
-                if (coneRise > 3.0 && !basaltId.IsAir)
-                {
-                    surfaceId = basaltId;
-                    subSurfaceId = basaltId;
-                }
-
-                // Travertine terraces read blinding white (#701) — salt is the closest shipped block.
-                if (travertineHere && !saltBlockId.IsAir)
-                {
-                    surfaceId = saltBlockId;
-                    subSurfaceId = saltBlockId;
-                }
-
-                // Penitente blades freeze to solid ice (#701) where they rise meaningfully.
-                if (penitenteWorld && !iceId.IsAir && PenitenteRise(planet, seed, worldX, worldZ) > 1.5)
-                {
-                    surfaceId = iceId;
-                    subSurfaceId = iceId;
-                }
-
-                // Basalt column fields read as dark columnar rock (#701).
-                if (basaltFieldWorld && !basaltId.IsAir && TryGetBasaltColumns(seed, worldX, worldZ, out _))
-                {
-                    surfaceId = basaltId;
-                    subSurfaceId = basaltId;
-                }
-
-                // Ejecta rays (#699): bright/contrast streaks radiating from the primary chain crater —
-                // repainted with the body's deep rock so the rays pop against the regolith.
-                if ((planet.Cratered || _crateredWorld) && CraterRayAt(planet, worldX, worldZ))
-                {
-                    surfaceId = deepId;
-                    subSurfaceId = deepId;
-                }
-
-                // Extra column bands (#705): sky-island tiers (with ponds + stalactites), arch bars,
-                // sea-stack/hoodoo caps, cenote lips and island waterfalls. Tier 0 keeps the classic
-                // sky-island fill; islandTop below feeds the island flora pass like before.
-                int bandCount = anyBands ? GetExtraBands(planet, worldX, worldZ, bands) : 0;
-                int islandTop = int.MinValue;
-                for (int b = 0; b < bandCount; b++)
-                {
-                    if (bands[b].Kind == BandKind.Island && bands[b].Top > islandTop)
-                    {
-                        islandTop = bands[b].Top;
-                    }
-                }
-
-                // Underground mega-cavern (#707): this column's void span, if a cavern covers it.
-                int cavLo = 0, cavHi = -1, cavLakeY = int.MinValue;
-                bool cavernHere = cavernWorld
-                    && TryGetCavernSpan(planet, worldX, worldZ, out cavLo, out cavHi, out cavLakeY);
-
-                // Tunnel carver (#708): this column's worm-carve y-spans (empty on most columns).
-                int tunnelCount = tunnelWorld ? TunnelSpans(planet, worldX, worldZ, tunnelSpans) : 0;
-
-                // Crater-floor metal clumps (item 33): on a cratered world, the top cells of a metal-bearing deep
-                // crater floor are exposed rare ore instead of regolith (only some craters, a few clumps each).
-                BlockId? craterMetal = (planet.Cratered || _crateredWorld)
-                    ? CraterFloorMetal(planet, seed, worldX, worldZ) : (BlockId?)null;
-
-                // Non-uniform topsoil: this column's surface/sub-surface layer thickness (varies per column, not a
-                // flat band) so the stone/ore boundary undulates and reaches close to the surface in the thin spots.
-                int effSurfaceDepth = VariedSurfaceDepth(planet, seed, worldX, worldZ);
+                // #1526: the whole column phase is memoised per (planet, column) — every stacked chunk of a column
+                // used to recompute it; now only the first one does (ComputeColumn holds the original code).
+                var col = ColumnProfileFor(ctx, worldX, worldZ, bandScratch, tunnelScratch);
+                TorusColumnSampler.ResetAll(samplers); // #1527: the per-column noise lattices rebuild lazily
+                int surfaceY = col.SurfaceY;
+                int seabedY = col.SeabedY;
+                int waterTop = col.WaterTop;
+                var columnFluid = col.ColumnFluid;
+                int iceTop = col.IceTop;
+                var biome = biomes[col.BiomeIndex];
+                var surfaceId = col.SurfaceId;
+                var subSurfaceId = col.SubSurfaceId;
+                bool beachHere = col.BeachHere;
+                var bands = col.Bands;
+                int bandCount = bands.Length;
+                int islandTop = col.IslandTop;
+                bool cavernHere = col.CavernHere;
+                int cavLo = col.CavLo, cavHi = col.CavHi, cavLakeY = col.CavLakeY;
+                var tunnelSpans = col.Tunnels;
+                int tunnelCount = tunnelSpans.Length;
+                BlockId? craterMetal = col.CraterMetal;
+                int effSurfaceDepth = col.EffSurfaceDepth;
 
                 for (int ly = 0; ly < WorldConstants.ChunkSize; ly++)
                 {
@@ -3857,7 +3793,7 @@ public sealed class WorldGenerator
                         {
                             // Below the lava table the same molten-pocket rule as blob caves applies (#580).
                             if (!airlessBody && depth > lavaTableDepth
-                                && ValueT(seed + 0xDEE9, worldX, worldY, worldZ, 56.0, 40.0, 56.0) > 0.47)
+                                && SampleField(samplers, LavaSampler, seed + 0xDEE9, worldX, worldZ, 56.0, 40.0, 56.0, worldY) > 0.47)
                             {
                                 chunk.Set(lx, ly, lz, lavaFloorId);
                             }
@@ -3869,7 +3805,7 @@ public sealed class WorldGenerator
                     // Carve caves below the surface layer (quantile-calibrated per world, #472).
                     if (caveThreshold > 0.0 && depth > 1)
                     {
-                        double cave = ValueT(seed + 7777, worldX, worldY, worldZ, 22.0, 16.0, 22.0);
+                        double cave = SampleField(samplers, CaveSampler, seed + 7777, worldX, worldZ, 22.0, 16.0, 22.0, worldY);
                         if (cave > caveThreshold)
                         {
                             // Below the world's lava table a carved cell fills with molten rock instead of
@@ -3880,7 +3816,7 @@ public sealed class WorldGenerator
                             // bath (mining down must stay rewarding, not frustrating). The pocket scale is
                             // large so each region reads as one coherent cave system, not salt-and-pepper.
                             if (!airlessBody && depth > lavaTableDepth
-                                && ValueT(seed + 0xDEE9, worldX, worldY, worldZ, 56.0, 40.0, 56.0) > 0.47)
+                                && SampleField(samplers, LavaSampler, seed + 0xDEE9, worldX, worldZ, 56.0, 40.0, 56.0, worldY) > 0.47)
                             {
                                 chunk.Set(lx, ly, lz, lavaFloorId);
                             }
@@ -3903,7 +3839,7 @@ public sealed class WorldGenerator
                         // Deep crust turns to a dark basalt mantle below this world's mantle depth (item 21), so the
                         // interior isn't one uniform stone column on every world. Ores still vein through it.
                         var rock = depth >= mantleDepth ? mantleId : deepId;
-                        block = SelectOre(planet, calib, seed, worldX, worldY, worldZ, depth, fallback: rock, oreRichness);
+                        block = SelectOre(calib, oreSlots, samplers, worldX, worldZ, worldY, depth, fallback: rock);
 
                         if (block == rock && planet.DataCacheRarity > 0 && !dataCacheId.IsAir)
                         {
@@ -4005,6 +3941,383 @@ public sealed class WorldGenerator
         return chunk;
     }
 
+    /// <summary>#1526: one column's terrain profile — everything Generate's y-loop needs that depends only on
+    /// (planet, x, z). Immutable once built; shared by every stacked chunk of the column.</summary>
+    private sealed class ColumnProfile
+    {
+        public int SurfaceY, SeabedY, WaterTop, IceTop, BiomeIndex, IslandTop, CavLo, CavHi, CavLakeY, EffSurfaceDepth;
+        public bool CavernHere, BeachHere;
+        public BlockId ColumnFluid, SurfaceId, SubSurfaceId;
+        public BlockId? CraterMetal;
+        public ColumnBand[] Bands = System.Array.Empty<ColumnBand>();
+        public (int Lo, int Hi)[] Tunnels = System.Array.Empty<(int Lo, int Hi)>();
+    }
+
+    /// <summary>The per-chunk constants the column phase reads (resolved once per Generate call).</summary>
+    private sealed class ColumnContext
+    {
+        public PlanetType Planet = null!;
+        public long Seed;
+        public WorldCalibration Calib = null!;
+        public RiverField RiverField = null!;
+        public List<BiomeResolved> Biomes = null!;
+        public int FluidLevel;
+        public BlockId FluidId, SeaWaterId, CraterLavaId, BeachId, SnowId, IceId, BasaltId, SaltBlockId, DeepId;
+        public bool Ponds, VolcanoWorld, TravertineWorld, CenoteWorld, FreezeWater, BeachPossible, SnowPossible;
+        public bool PenitenteWorld, BasaltFieldWorld, AnyBands, CavernWorld, TunnelWorld;
+        public double PondThreshold;
+    }
+
+    private ColumnProfile ColumnProfileFor(ColumnContext c, int worldX, int worldZ,
+        System.Span<ColumnBand> bands, System.Span<(int Lo, int Hi)> tunnelSpans)
+    {
+        var key = (c.Planet.Key, ColumnKey(worldX, worldZ));
+        lock (_columnLock)
+        {
+            if (_columnProfiles.TryGetValue(key, out var hit))
+            {
+                return hit;
+            }
+        }
+
+        var profile = ComputeColumn(c, worldX, worldZ, bands, tunnelSpans);
+        lock (_columnLock)
+        {
+            if (_columnProfiles.Count >= ColumnProfileCap)
+            {
+                _columnProfiles.Clear();
+            }
+
+            _columnProfiles[key] = profile;
+        }
+
+        return profile;
+    }
+
+    /// <summary>The column phase of <see cref="Generate"/>, moved here verbatim (#1526) — the same calls in the
+    /// same order on the same operands, so the profile is what the inline code computed.</summary>
+    private ColumnProfile ComputeColumn(ColumnContext c, int worldX, int worldZ,
+        System.Span<ColumnBand> bands, System.Span<(int Lo, int Hi)> tunnelSpans)
+    {
+        var planet = c.Planet;
+        long seed = c.Seed;
+        var calib = c.Calib;
+        var riverField = c.RiverField;
+        var biomes = c.Biomes;
+        int fluidLevel = c.FluidLevel;
+        var fluidId = c.FluidId;
+        var seaWaterId = c.SeaWaterId;
+        var craterLavaId = c.CraterLavaId;
+        var beachId = c.BeachId;
+        var snowId = c.SnowId;
+        var iceId = c.IceId;
+        var basaltId = c.BasaltId;
+        var saltBlockId = c.SaltBlockId;
+        var deepId = c.DeepId;
+        bool ponds = c.Ponds;
+        double pondThreshold = c.PondThreshold;
+        bool volcanoWorld = c.VolcanoWorld;
+        bool travertineWorld = c.TravertineWorld;
+        bool cenoteWorld = c.CenoteWorld;
+        bool freezeWater = c.FreezeWater;
+        bool beachPossible = c.BeachPossible;
+        bool snowPossible = c.SnowPossible;
+        bool penitenteWorld = c.PenitenteWorld;
+        bool basaltFieldWorld = c.BasaltFieldWorld;
+        bool anyBands = c.AnyBands;
+        bool cavernWorld = c.CavernWorld;
+        bool tunnelWorld = c.TunnelWorld;
+
+        int surfaceY = SurfaceHeight(planet, worldX, worldZ);
+
+        // An upland pond carves a shallow bowl here (seabed below the terrain) and fills it with water up to
+        // the original surface (a pond flush with the surrounding ground), so the column reads as a swimmable
+        // pool. Normal columns leave seabed=surface and fill the sea up to the global level, unchanged.
+        int seabedY = surfaceY;
+        int waterTop = fluidLevel;
+        var columnFluid = fluidId;
+        bool pondHere = false;
+        double? pondMask = null; // computed at most once per column; shared with the beach rim test (#679)
+        if (ponds && surfaceY > fluidLevel)
+        {
+            pondMask = PondMaskAt(planet, seed, worldX, worldZ);
+            int pondDepth = PondDepthFromMask(planet, seed, worldX, worldZ, pondThreshold, pondMask.Value);
+            if (pondDepth > 0)
+            {
+                seabedY = surfaceY - pondDepth;
+                waterTop = surfaceY;
+                columnFluid = seaWaterId;
+                pondHere = true;
+            }
+        }
+
+        // Volcano (#477): the summit crater overrides the column's fluid to a molten pool — the same
+        // per-column mechanism ponds/rivers use — and the cone's flanks turn to basalt below.
+        bool craterHere = false;
+        double coneRise = 0.0;
+        if (volcanoWorld && TryGetVolcano(planet, seed, worldX, worldZ, out var vCone, out double vDist))
+        {
+            coneRise = ConeOffsetOf(vCone, vDist);
+            if (vDist < vCone.CraterR - 0.5)
+            {
+                craterHere = true;
+                seabedY = surfaceY;
+                waterTop = CraterLavaTop(planet, vCone);
+                columnFluid = craterLavaId;
+            }
+        }
+
+        // Rivers (routed): the RiverField places a channel whose water surface FOLLOWS the terrain — a
+        // thin sheet on a flowing reach (no floating wall), the pooled level inside a capped lake, and at
+        // a flagged step a vertical waterfall column poured into the lower reach. Skipped where a pond,
+        // a volcano crater or the global sea already claims the column. The river bed is carved to BedY.
+        bool riverHere = false;
+        if (!pondHere && !craterHere && surfaceY > fluidLevel && riverField.TryGet(worldX, worldZ, out var river))
+        {
+            riverHere = true;
+            seabedY = river.BedY;
+            if (river.WaterfallDrop > 0)
+            {
+                // River incision (#709): the plunge pool under a waterfall cuts a slot into the bed —
+                // the erosion look without simulating erosion.
+                seabedY -= System.Math.Min(6, river.WaterfallDrop);
+            }
+
+            waterTop = river.WaterfallDrop > 0 ? river.WaterSurfaceY + river.WaterfallDrop : river.WaterSurfaceY;
+            columnFluid = riverField.FillFluid; // water on watery worlds, lava on lava/ashen worlds (L2)
+        }
+
+        // Travertine deck pools (#701): shallow 1-deep water flush on the white terrace decks.
+        bool travertineHere = false;
+        if (travertineWorld && !pondHere && !craterHere && !riverHere && surfaceY > fluidLevel
+            && TryGetTravertine(seed, worldX, worldZ, out double travDeck, out bool travPool))
+        {
+            travertineHere = travDeck > 0.0 || travPool;
+            if (travPool && !seaWaterId.IsAir)
+            {
+                seabedY = surfaceY - 1;
+                waterTop = surfaceY;
+                columnFluid = seaWaterId;
+            }
+        }
+
+        // Cenote pools (#707): a turquoise pool standing over the shaft floor.
+        if (cenoteWorld && !pondHere && !craterHere && !riverHere && !seaWaterId.IsAir
+            && TryGetCenotePool(planet, worldX, worldZ, out int cenotePoolTop)
+            && cenotePoolTop > surfaceY)
+        {
+            seabedY = surfaceY;
+            waterTop = cenotePoolTop;
+            columnFluid = seaWaterId;
+        }
+
+        // Frozen water (#494): a cold column's water freezes from the waterline down — a walkable
+        // ice sheet with liquid below on merely-cold bodies, frozen through to the seabed in the
+        // deep cold or where the sheet reaches the bed anyway. Lava columns never freeze.
+        int iceTop = 0;
+        if (freezeWater && columnFluid == seaWaterId && !seaWaterId.IsAir && waterTop > seabedY)
+        {
+            iceTop = IceSheetThickness(calib, seed, worldX, worldZ, waterTop, waterTop - seabedY);
+        }
+
+        // Per-column biome → surface/sub-surface blocks (single-biome worlds use index 0).
+        int biomeIndex = biomes.Count <= 1 ? 0 : BiomeIndex(calib, seed, worldX, worldZ, biomes.Count, surfaceY);
+        var biome = biomes[biomeIndex];
+        var surfaceId = biome.Surface;
+        var subSurfaceId = biome.Sub;
+
+        // Beaches (#679): near a water shoreline the ground turns to the beach block — surface AND
+        // sub-surface, so the varied topsoil depth yields a real sand layer, and the shallow seabed
+        // apron continues the beach under water. The coast mask alternates beach and bare shore;
+        // the snow pass below still dusts cold coasts, and volcano basalt still wins near a cone.
+        bool beachHere = false;
+        if (beachPossible)
+        {
+            if (surfaceY < fluidLevel && fluidId == seaWaterId)
+            {
+                beachHere = fluidLevel - surfaceY <= BeachApronDepth
+                    && CoastMaskAt(planet, seed, worldX, worldZ);
+            }
+            else if (!pondHere && !craterHere && !riverHere)
+            {
+                beachHere = DryBeachAt(planet, calib, seed, riverField, seaWaterId,
+                    worldX, worldZ, surfaceY, pondMask);
+            }
+
+            if (beachHere)
+            {
+                surfaceId = beachId;
+                subSurfaceId = beachId;
+            }
+        }
+
+        // Altitude climate (#476): above the snow line the ground gets a snow cover, further up solid
+        // ice. Dithered (±1.5 °C noise) so the line wanders naturally instead of cutting a contour.
+        if (snowPossible && surfaceY > waterTop)
+        {
+            double surfT = TempAt(calib, surfaceY)
+                + (FbmT(seed + 0x51F0, worldX, worldZ, 24.0, octaves: 2) - 0.5) * 3.0;
+            if (surfT < IceLineC && !iceId.IsAir)
+            {
+                surfaceId = iceId;
+                subSurfaceId = iceId;
+            }
+            else if (surfT < SnowLineC)
+            {
+                surfaceId = snowId;
+            }
+        }
+
+        // Volcano flanks read as dark volcanic rock wherever the cone meaningfully rises (#477) —
+        // after the snow pass, so the warm basalt wins over a snow cap near the vent.
+        if (coneRise > 3.0 && !basaltId.IsAir)
+        {
+            surfaceId = basaltId;
+            subSurfaceId = basaltId;
+        }
+
+        // Travertine terraces read blinding white (#701) — salt is the closest shipped block.
+        if (travertineHere && !saltBlockId.IsAir)
+        {
+            surfaceId = saltBlockId;
+            subSurfaceId = saltBlockId;
+        }
+
+        // Penitente blades freeze to solid ice (#701) where they rise meaningfully.
+        if (penitenteWorld && !iceId.IsAir && PenitenteRise(planet, seed, worldX, worldZ) > 1.5)
+        {
+            surfaceId = iceId;
+            subSurfaceId = iceId;
+        }
+
+        // Basalt column fields read as dark columnar rock (#701).
+        if (basaltFieldWorld && !basaltId.IsAir && TryGetBasaltColumns(seed, worldX, worldZ, out _))
+        {
+            surfaceId = basaltId;
+            subSurfaceId = basaltId;
+        }
+
+        // Ejecta rays (#699): bright/contrast streaks radiating from the primary chain crater —
+        // repainted with the body's deep rock so the rays pop against the regolith.
+        if ((planet.Cratered || _crateredWorld) && CraterRayAt(planet, worldX, worldZ))
+        {
+            surfaceId = deepId;
+            subSurfaceId = deepId;
+        }
+
+        // Extra column bands (#705): sky-island tiers (with ponds + stalactites), arch bars,
+        // sea-stack/hoodoo caps, cenote lips and island waterfalls. Tier 0 keeps the classic
+        // sky-island fill; islandTop below feeds the island flora pass like before.
+        int bandCount = anyBands ? GetExtraBands(planet, worldX, worldZ, bands) : 0;
+        int islandTop = int.MinValue;
+        for (int b = 0; b < bandCount; b++)
+        {
+            if (bands[b].Kind == BandKind.Island && bands[b].Top > islandTop)
+            {
+                islandTop = bands[b].Top;
+            }
+        }
+
+        // Underground mega-cavern (#707): this column's void span, if a cavern covers it.
+        int cavLo = 0, cavHi = -1, cavLakeY = int.MinValue;
+        bool cavernHere = cavernWorld
+            && TryGetCavernSpan(planet, worldX, worldZ, out cavLo, out cavHi, out cavLakeY);
+
+        // Tunnel carver (#708): this column's worm-carve y-spans (empty on most columns).
+        int tunnelCount = tunnelWorld ? TunnelSpans(planet, worldX, worldZ, tunnelSpans) : 0;
+
+        // Crater-floor metal clumps (item 33): on a cratered world, the top cells of a metal-bearing deep
+        // crater floor are exposed rare ore instead of regolith (only some craters, a few clumps each).
+        BlockId? craterMetal = (planet.Cratered || _crateredWorld)
+            ? CraterFloorMetal(planet, seed, worldX, worldZ) : (BlockId?)null;
+
+        // Non-uniform topsoil: this column's surface/sub-surface layer thickness (varies per column, not a
+        // flat band) so the stone/ore boundary undulates and reaches close to the surface in the thin spots.
+        int effSurfaceDepth = VariedSurfaceDepth(planet, seed, worldX, worldZ);
+
+        return new ColumnProfile
+        {
+            SurfaceY = surfaceY,
+            SeabedY = seabedY,
+            WaterTop = waterTop,
+            ColumnFluid = columnFluid,
+            IceTop = iceTop,
+            BiomeIndex = biomeIndex,
+            SurfaceId = surfaceId,
+            SubSurfaceId = subSurfaceId,
+            BeachHere = beachHere,
+            Bands = bandCount > 0 ? bands.Slice(0, bandCount).ToArray() : System.Array.Empty<ColumnBand>(),
+            IslandTop = islandTop,
+            CavernHere = cavernHere,
+            CavLo = cavLo,
+            CavHi = cavHi,
+            CavLakeY = cavLakeY,
+            Tunnels = tunnelCount > 0 ? tunnelSpans.Slice(0, tunnelCount).ToArray() : System.Array.Empty<(int Lo, int Hi)>(),
+            CraterMetal = craterMetal,
+            EffSurfaceDepth = effSurfaceDepth,
+        };
+    }
+
+    // #1527: the two non-ore noise fields of the y-loop and their sampler slots (ore veins follow at 2 + 2i).
+    private const int CaveSampler = 0;
+    private const int LavaSampler = 1;
+
+    /// <summary>ValueT for one column and field through its lazily built lattice sampler (#1527) — the same
+    /// value <see cref="ValueT"/> returns, without the per-voxel trig and corner hashes.</summary>
+    private double SampleField(TorusColumnSampler[] samplers, int slot, long seed, int worldX, int worldZ,
+        double scaleX, double scaleY, double scaleZ, int worldY)
+    {
+        ref var s = ref samplers[slot];
+        if (!s.Ready)
+        {
+            s = new TorusColumnSampler(seed, worldX, worldZ, _circumference, LatPeriod, scaleX, scaleY, scaleZ);
+        }
+
+        return s.Sample(worldY);
+    }
+
+    /// <summary>#1527: a vein's per-chunk invariants — the depth band, the shallow/deep split, the rarity×richness
+    /// product (the first factor of the original <c>rarity * richness * depthBonus * scale</c>, so the association
+    /// is unchanged), the field seeds and the resolved block.</summary>
+    private readonly struct OreSlot
+    {
+        public readonly int MinDepth, MaxDepth;
+        public readonly double Scale, Cap, RarityRichness;
+        public readonly bool Shallow;
+        public readonly long CoarseSeed, FineSeed;
+        public readonly BlockId? Block;
+
+        public OreSlot(int minDepth, int maxDepth, double scale, double cap, double rarityRichness, bool shallow,
+            long coarseSeed, long fineSeed, BlockId? block)
+        {
+            MinDepth = minDepth;
+            MaxDepth = maxDepth;
+            Scale = scale;
+            Cap = cap;
+            RarityRichness = rarityRichness;
+            Shallow = shallow;
+            CoarseSeed = coarseSeed;
+            FineSeed = fineSeed;
+            Block = block;
+        }
+    }
+
+    private OreSlot[] BuildOreSlots(PlanetType planet, long seed, double richness)
+    {
+        var slots = new OreSlot[planet.Ores.Count];
+        for (int i = 0; i < slots.Length; i++)
+        {
+            var ore = planet.Ores[i];
+            bool shallow = ore.MinDepth <= 8;
+            double rarity = ore.RareTier ? ore.Rarity * _frontierOreBoost : ore.Rarity;
+            slots[i] = new OreSlot(ore.MinDepth, ore.MaxDepth, shallow ? 0.30 : 0.15, shallow ? 0.08 : 0.05,
+                rarity * richness, shallow, seed + 100 + i * 31, seed + OreFineFieldSalt + i * 31,
+                _content.GetBlock(ore.Block)?.NumericId);
+        }
+
+        return slots;
+    }
+
     /// <summary>Stamps sparse scatter props ("Welten reicher" W-R2): boulder clusters (the world's deep rock),
     /// crystal shard outcrops, and bare dead trees — per-column deterministic rolls with a margin scan so a
     /// prop straddling a chunk edge generates identically from either side. Props sit ON the surface
@@ -4050,6 +4363,11 @@ public sealed class WorldGenerator
                 }
 
                 int sy = SurfaceHeight(planet, wx, wz);
+                if (sy + 1 > origin.Y + cs - 1 || sy + MaxStampRise < origin.Y)
+                {
+                    continue; // #1527: props write sy+1 .. sy+7 — none of it lands in this chunk
+                }
+
                 if (sy + 1 <= fluidLevel || SurfacePondDepth(planet, wx, wz) > 0 || SurfaceRiverDepth(planet, wx, wz) > 0)
                 {
                     continue; // dry ground only
@@ -4148,6 +4466,11 @@ public sealed class WorldGenerator
                 }
 
                 int sy = SurfaceHeight(planet, wx, wz);
+                if (sy < origin.Y || sy >= origin.Y + cs)
+                {
+                    continue; // #1527: the vent is the surface cell itself — not in this chunk
+                }
+
                 if (sy + 1 <= fluidLevel || SurfacePondDepth(planet, wx, wz) > 0 || SurfaceRiverDepth(planet, wx, wz) > 0)
                 {
                     continue; // a vent needs open ground (not a sea/pond column)
@@ -4198,6 +4521,11 @@ public sealed class WorldGenerator
                 }
 
                 int sy = SurfaceHeight(planet, wx, wz);
+                if (sy + 1 > origin.Y + cs - 1 || sy + MaxStampRise < origin.Y)
+                {
+                    continue; // #1527: a mushroom writes sy+1 .. sy+15 — none of it lands in this chunk
+                }
+
                 var surf = biomes[biomes.Count <= 1 ? 0 : BiomeIndex(calib, seed, wx, wz, biomes.Count, sy)].Surface;
                 if (surf != myceliumId)
                 {
@@ -4300,20 +4628,42 @@ public sealed class WorldGenerator
         var calib = CalibFor(planet);
         var waterId = _content.GetBlock("water")?.NumericId ?? BlockId.Air;
         var riverField = RiverFieldFor(planet); // cached — needed for the beach ground check (#679)
+
+        // #1527: the density roll is tested against a conservative UPPER BOUND of every biome's multiplier first,
+        // so the ~99 % of margin columns the exact test rejects never pay SurfaceHeight / BiomeIndex. The exact
+        // test still runs for the survivors: roll >= bound >= localDensity, and the bound carries a 1e-9 slack
+        // so float association can never put it below a biome's own product.
+        double maxTreeMul = 0.0;
+        foreach (var b in biomes)
+        {
+            maxTreeMul = System.Math.Max(maxTreeMul, b.TreeMul * b.Theme.TreeMul);
+        }
+
+        maxTreeMul *= 1.0 + 1e-9;
         for (int wx = origin.X - maxCrown; wx < origin.X + cs + maxCrown; wx++)
             for (int wz = origin.Z - maxCrown; wz < origin.Z + cs + maxCrown; wz++)
             {
-                int sy = SurfaceHeight(planet, wx, wz);
-                var biome = biomes[biomes.Count <= 1 ? 0 : BiomeIndex(calib, seed, wx, wz, biomes.Count, sy)];
-
                 // FORESTS: a low-frequency mask gathers trees into real groves/woods. Inside a forest patch the
                 // density is ~9x, on the fringe ~2x, the open land between almost bare — scaled by the biome's
                 // (and its theme's) tree density so savanna stays sparse, jungle dense, fungal/crystal treeless.
-                double forest = FbmT(seed + 0xF07E57, wx, wz, planet.TerrainScale * 2.0, octaves: 3);
-                double localDensity = density * biome.TreeMul * biome.Theme.TreeMul
-                    * (forest > 0.62 ? 9.0 : forest > 0.52 ? 2.0 : 0.15);
-                if (localDensity <= 0.0
-                    || Noise.Value01(seed + 5150, WorldConstants.WrapX(wx, _circumference), 11, Wz(wz)) >= localDensity)
+                double forest = ForestMaskAt(planet, seed, wx, wz);
+                double forestFactor = forest > 0.62 ? 9.0 : forest > 0.52 ? 2.0 : 0.15;
+                double roll = Noise.Value01(seed + 5150, WorldConstants.WrapX(wx, _circumference), 11, Wz(wz));
+                double densityBound = density * maxTreeMul * forestFactor;
+                if (densityBound <= 0.0 || roll >= densityBound)
+                {
+                    continue; // the exact test below cannot pass either
+                }
+
+                int sy = SurfaceHeight(planet, wx, wz);
+                if (sy + 1 > origin.Y + cs - 1 || sy + MaxStampRise < origin.Y)
+                {
+                    continue; // every cell a tree here could write lies outside this chunk — SetCell would clip them all
+                }
+
+                var biome = biomes[biomes.Count <= 1 ? 0 : BiomeIndex(calib, seed, wx, wz, biomes.Count, sy)];
+                double localDensity = density * biome.TreeMul * biome.Theme.TreeMul * forestFactor;
+                if (localDensity <= 0.0 || roll >= localDensity)
                 {
                     continue;
                 }
@@ -4385,6 +4735,39 @@ public sealed class WorldGenerator
                     default: BuildBroadleaf(wx, sy, wz, sizeF, hJit, cJit, logId, leafId, SetCell); break;
                 }
             }
+    }
+
+    /// <summary>The highest cell any surface stamp writes above its column's surface: the jungle crown
+    /// (trunk ≤ 14 + crown radius ≤ 4 = 18); conifers reach 14, giant mushrooms 15, props 7. A chunk whose
+    /// cells all lie above surface + 18 (or below surface + 1) cannot receive a single write from that
+    /// column, so the stamps skip it (#1527) — SetCell clipped those writes before, one by one.</summary>
+    private const int MaxStampRise = 18;
+
+    /// <summary>The forest mask of a column (#1527: memoised — StampTrees asks for the 576 margin columns of every
+    /// stacked chunk).</summary>
+    private double ForestMaskAt(PlanetType planet, long seed, int wx, int wz)
+    {
+        var key = (planet.Key, ColumnKey(wx, wz));
+        lock (_columnLock)
+        {
+            if (_forestCache.TryGetValue(key, out double cached))
+            {
+                return cached;
+            }
+        }
+
+        double forest = FbmT(seed + 0xF07E57, wx, wz, planet.TerrainScale * 2.0, octaves: 3);
+        lock (_columnLock)
+        {
+            if (_forestCache.Count >= SurfaceCacheCap)
+            {
+                _forestCache.Clear();
+            }
+
+            _forestCache[key] = forest;
+        }
+
+        return forest;
     }
 
     /// <summary>Picks one tree archetype for this column from the theme's palette. A low-frequency grove mask
@@ -4617,76 +5000,45 @@ public sealed class WorldGenerator
     private const double OreFineScale = 4.5;
     private const long OreFineFieldSalt = 61000;
 
-    private BlockId SelectOre(PlanetType planet, WorldCalibration calib, long seed, int x, int y, int z,
-        int depth, BlockId fallback, double richness)
+    private BlockId SelectOre(WorldCalibration calib, OreSlot[] ores, TorusColumnSampler[] samplers,
+        int x, int z, int y, int depth, BlockId fallback)
     {
-        for (int i = 0; i < planet.Ores.Count; i++)
+        for (int i = 0; i < ores.Length; i++)
         {
-            var ore = planet.Ores[i];
+            var ore = ores[i];
             if (depth < ore.MinDepth || depth > ore.MaxDepth)
             {
                 continue;
             }
 
-            // The coarse noise clusters into vein-like patches; the threshold comes from the field's OWN
-            // measured distribution (#472), so the kept fraction is exactly what we ask for. The old fixed
-            // formula assumed a uniform field and sat unreachably far in the interpolated torus sampler's
-            // tail — the root cause of the recurring "can't find any ore" feedback. The scale keeps the
-            // UNION over a planet's ~8 stacked veins near ~10 % of deep rock (measured) — without it,
-            // per-vein literalism turned half the underground into ore. SHALLOW starter veins (minDepth
-            // ≤ 8: iron/copper/silicate class) run twice as dense as the deep rarities: the quantile blobs
-            // cluster, and a new player's first ten blocks must reward digging (Severin M3, user playtest
-            // 2026-07-26 — "nothing but rock at the spawn").
-            double scale = ore.MinDepth <= 8 ? 0.30 : 0.15;
-            double cap = ore.MinDepth <= 8 ? 0.08 : 0.05;
-
-            // Depth pays (#580): ore density ramps up to +60 % over the first ~600 blocks down, so the
-            // now-reachable deep kilometre rewards the descent instead of frustrating it. Shallow bands
-            // are untouched (bonus ≈ 0 near the surface) — nothing moves away from new players.
             double depthBonus = 1.0 + 0.6 * System.Math.Min(1.0, depth / 600.0);
-            // Frontier scaling (#1122): only the RARE-tier veins (tier-2 tool gate) get richer out there —
-            // the starter iron/copper economy is the same everywhere, so the frontier never becomes the
-            // better place to begin, only the better place to RETURN to.
-            double rarity = ore.RareTier ? ore.Rarity * _frontierOreBoost : ore.Rarity;
-            double frac = System.Math.Clamp(rarity * richness * depthBonus * scale, 0.0, cap);
+            double frac = System.Math.Clamp(ore.RarityRichness * depthBonus * ore.Scale, 0.0, ore.Cap);
             if (frac <= 0.0)
             {
                 continue;
             }
 
             bool hit;
-            if (ore.MinDepth <= 8)
+            if (ore.Shallow)
             {
-                // Two-scale split (#1024): a quantile over ONE smooth 9-block field concentrates a vein's
-                // whole budget into few huge deposits (measured: >90 % of copper sat in ≥64-block blobs and
-                // a straight tunnel needed a median ~90 m to meet the first one — "which ore you find is a
-                // lottery"). Shallow starter veins therefore spend half their budget on the coarse field
-                // (big strikes stay worth prospecting for) and half on a fine 4.5-block field whose small
-                // veins turn up regularly while digging. The union stays ≈ frac (overlap is frac²/4).
                 double half = frac * 0.5;
                 double coarseThr = calib.OreCdf[(int)((1.0 - half) * (calib.OreCdf.Length - 1))];
-                hit = ValueT(seed + 100 + i * 31, x, y, z, 9.0, 9.0, 9.0) > coarseThr;
+                hit = SampleField(samplers, 2 + i * 2, ore.CoarseSeed, x, z, 9.0, 9.0, 9.0, y) > coarseThr;
                 if (!hit)
                 {
                     double fineThr = calib.OreFineCdf[(int)((1.0 - half) * (calib.OreFineCdf.Length - 1))];
-                    hit = ValueT(seed + OreFineFieldSalt + i * 31, x, y, z, OreFineScale, OreFineScale, OreFineScale) > fineThr;
+                    hit = SampleField(samplers, 3 + i * 2, ore.FineSeed, x, z, OreFineScale, OreFineScale, OreFineScale, y) > fineThr;
                 }
             }
             else
             {
-                // Deep rarities keep the single coarse field: a rare strike SHOULD be a find, and their
-                // budgets are too thin to split without dissolving into single-block specks.
                 double threshold = calib.OreCdf[(int)((1.0 - frac) * (calib.OreCdf.Length - 1))];
-                hit = ValueT(seed + 100 + i * 31, x, y, z, 9.0, 9.0, 9.0) > threshold;
+                hit = SampleField(samplers, 2 + i * 2, ore.CoarseSeed, x, z, 9.0, 9.0, 9.0, y) > threshold;
             }
 
-            if (hit)
+            if (hit && ore.Block.HasValue)
             {
-                var oreBlock = _content.GetBlock(ore.Block);
-                if (oreBlock is not null)
-                {
-                    return oreBlock.NumericId;
-                }
+                return ore.Block.Value; // an unknown vein block falls through to the next vein, as before
             }
         }
 

--- a/tests/BlocksBeyondTheStars.Tests/WorldGenColumnCacheTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/WorldGenColumnCacheTests.cs
@@ -1,0 +1,157 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using BlocksBeyondTheStars.Shared.Content;
+using BlocksBeyondTheStars.Shared.Geometry;
+using BlocksBeyondTheStars.Shared.World;
+using BlocksBeyondTheStars.WorldGeneration;
+using Xunit;
+
+namespace BlocksBeyondTheStars.Tests;
+
+/// <summary>
+/// #1526/#1527: the world generator memoises per-column work (surface height, forest mask, the whole column
+/// phase of Generate) and samples the torus noise fields through per-column lattices. None of it may change a
+/// single block — the goldens pin the chunks, these tests pin the mechanisms: the lattice sampler is bit-identical
+/// to <see cref="Noise.ValueTorus"/>, a warm generator produces exactly what a cold one does, and a world-mode
+/// change drops every memo.
+/// </summary>
+public class WorldGenColumnCacheTests
+{
+    private static readonly GameContent Content = ContentLoader.LoadFromDirectory(TestPaths.DataDir());
+
+    [Fact]
+    public void TorusColumnSampler_IsBitIdenticalToValueTorus()
+    {
+        var rng = new Random(20260904);
+        (double X, double Y, double Z)[] scales = { (22.0, 16.0, 22.0), (9.0, 9.0, 9.0), (4.5, 4.5, 4.5), (56.0, 40.0, 56.0), (18.0, 1.0, 18.0) };
+        int[] circumferences = { 800, 5472, 6000, 12000 };
+        int compared = 0;
+        for (int trial = 0; trial < 400; trial++)
+        {
+            long seed = rng.NextInt64(long.MinValue, long.MaxValue);
+            int circ = circumferences[rng.Next(circumferences.Length)];
+            int lat = WorldConstants.LatitudePeriodFor(circ);
+            var (sx, sy, sz) = scales[rng.Next(scales.Length)];
+            int x = rng.Next(-circ, 2 * circ);
+            int z = rng.Next(-lat, 2 * lat);
+            var sampler = new TorusColumnSampler(seed, x, z, circ, lat, sx, sy, sz);
+
+            // A monotone sweep (the y-loop), then random jumps (the loop crossing lattice rows both ways).
+            int y0 = rng.Next(-2100, 300);
+            for (int y = y0; y < y0 + 40; y++)
+            {
+                Check(seed, x, y, z, circ, lat, sx, sy, sz, ref sampler);
+                compared++;
+            }
+
+            for (int k = 0; k < 20; k++)
+            {
+                Check(seed, x, rng.Next(-2200, 320), z, circ, lat, sx, sy, sz, ref sampler);
+                compared++;
+            }
+        }
+
+        Assert.Equal(400 * 60, compared);
+
+        static void Check(long seed, int x, int y, int z, int circ, int lat, double sx, double sy, double sz, ref TorusColumnSampler sampler)
+        {
+            double expected = Noise.ValueTorus(seed, x, y, z, circ, lat, sx, sy, sz);
+            double actual = sampler.Sample(y);
+            Assert.Equal(BitConverter.DoubleToInt64Bits(expected), BitConverter.DoubleToInt64Bits(actual));
+        }
+    }
+
+    [Theory]
+    [InlineData("varied", 424242L)]
+    [InlineData("jungle", 20260903L)]
+    [InlineData("ice", 7L)]
+    public void SurfaceHeight_CachedPath_EqualsTheUncachedOne_AndForgetsOnWorldModeChange(string planetKey, long seed)
+    {
+        var planet = Content.GetPlanet(planetKey)!;
+        var gen = new WorldGenerator(seed, Content);
+        (int X, int Z)[] columns = { (0, 0), (100, 37), (-200, 150), (5999, 12), (6000, 12), (3000, -700) };
+
+        foreach (var (x, z) in columns)
+        {
+            int uncached = gen.SurfaceHeightUncached(planet, x, z);
+            Assert.Equal(uncached, gen.SurfaceHeight(planet, x, z));
+            Assert.Equal(uncached, gen.SurfaceHeight(planet, x, z)); // the memo hit
+        }
+
+        gen.SetWorldMode(5472, cratered: false, landingPads: null, locationId: "cache-test:body");
+        foreach (var (x, z) in columns)
+        {
+            Assert.Equal(gen.SurfaceHeightUncached(planet, x, z), gen.SurfaceHeight(planet, x, z));
+        }
+
+        gen.SetWorldMode(800, cratered: true, landingPads: null, locationId: "cache-test:moon");
+        foreach (var (x, z) in columns)
+        {
+            Assert.Equal(gen.SurfaceHeightUncached(planet, x, z), gen.SurfaceHeight(planet, x, z));
+        }
+    }
+
+    [Theory]
+    [InlineData("varied", 424242L, 0)]
+    [InlineData("varied", 424242L, 5472)]
+    [InlineData("jungle", 20260903L, 0)]
+    [InlineData("rocky", 1L, 0)]
+    [InlineData("ocean", 424242L, 0)]
+    [InlineData("asteroid", 14L, 800)]
+    public void WarmGenerator_ProducesWhatAColdOneDoes_ForEveryStackedChunk(string planetKey, long seed, int circumference)
+    {
+        var planet = Content.GetPlanet(planetKey)!;
+        var warm = new WorldGenerator(seed, Content);
+        if (circumference > 0)
+        {
+            warm.SetWorldMode(circumference, cratered: planetKey == "asteroid", landingPads: null, locationId: "cache-test:" + planetKey);
+        }
+
+        (int X, int Z)[] columns = { (0, 0), (100, 37), (-200, 150) };
+        int hashedChunks = 0;
+        foreach (var (x, z) in columns)
+        {
+            int cx = WorldConstants.WorldToChunk(x), cz = WorldConstants.WorldToChunk(z);
+            int surfaceCy = WorldConstants.WorldToChunk(warm.SurfaceHeight(planet, x, z));
+            // Deep → surface → high, then the surface chunk AGAIN: the second pass is served entirely from the
+            // column memos and the samplers, the first pass built them.
+            foreach (int cy in new[] { surfaceCy - 6, surfaceCy - 3, surfaceCy, surfaceCy + 2, surfaceCy + 5, surfaceCy })
+            {
+                var cold = new WorldGenerator(seed, Content);
+                if (circumference > 0)
+                {
+                    cold.SetWorldMode(circumference, cratered: planetKey == "asteroid", landingPads: null, locationId: "cache-test:" + planetKey);
+                }
+
+                var coord = new ChunkCoord(cx, cy, cz);
+                ulong expected = WorldGenerationGoldenTests.HashChunk(cold.Generate(planet, coord));
+                ulong actual = WorldGenerationGoldenTests.HashChunk(warm.Generate(planet, coord));
+                Assert.True(expected == actual, $"{planetKey} chunk {coord}: warm generator differs from a cold one");
+                hashedChunks++;
+            }
+        }
+
+        Assert.Equal(18, hashedChunks);
+        Assert.True(warm.CachedColumnProfiles >= 3 * 256, "the column profiles were not memoised");
+    }
+
+    [Fact]
+    public void WorldModeChange_DropsTheColumnProfiles()
+    {
+        var planet = Content.GetPlanet("varied")!;
+        var gen = new WorldGenerator(424242, Content);
+        gen.Generate(planet, new ChunkCoord(0, 3, 0));
+        Assert.Equal(256, gen.CachedColumnProfiles);
+
+        gen.SetWorldMode(5472, cratered: false, landingPads: null, locationId: "cache-test:body");
+        Assert.Equal(0, gen.CachedColumnProfiles);
+
+        // ...and the new mode's chunk equals a cold generator's chunk in that mode.
+        var cold = new WorldGenerator(424242, Content);
+        cold.SetWorldMode(5472, cratered: false, landingPads: null, locationId: "cache-test:body");
+        var coord = new ChunkCoord(0, 3, 0);
+        Assert.Equal(WorldGenerationGoldenTests.HashChunk(cold.Generate(planet, coord)),
+            WorldGenerationGoldenTests.HashChunk(gen.Generate(planet, coord)));
+    }
+}


### PR DESCRIPTION
PR bundle 6 of the performance package (#1501): world generation, **output-preserving** — every chunk hashes exactly as before (the #1503 goldens are the gate, unchanged on all eight groups).

## What changes

| issue | change | what it replaces |
|---|---|---|
| #1526 | `SurfaceHeight` memoised per generator instance (planet + raw column; dropped by `SetWorldMode` / `SetContinentsEnabled` / `SetWorldOptionFactors`, capped at 262k); the **column phase of `Generate` moved verbatim into `ComputeColumn`** (a line-range move) and memoised as an immutable `ColumnProfile` per (planet, column), capped at 100k; the `StampTrees` forest mask memoised the same way | every stacked chunk of a column recomputing SurfaceHeight + ~20 wonder probes for all 256 columns; the tree/prop margins, pond/river probes and the server's far-column band re-deriving the same heights |
| #1527 | `TorusColumnSampler`: one `ValueTorus` field for one column — trig, lattice cell, layer seeds and blend weights once per column, the eight corner hashes once per lattice row, the original `Lerp` chain per voxel; one lazy sampler per (column, field) in the y-loop (caves, lava pockets, coarse + fine per vein) | 4 trig + 32 hashes per field per voxel (up to 15 fields on a solid chunk) |
| #1527 | `SelectOre` reads per-chunk `OreSlot` invariants (depth band, shallow split, `rarity × richness` as the first factor of the original product, field seeds, resolved `BlockId`) | re-deriving them per voxel and a block-string lookup per hit |
| #1527 | `StampTrees` rolls first against a conservative upper bound of every biome's multiplier (1e-9 slack), gates on `[surface+1, surface+18]` intersecting the chunk, then does the exact work; mushrooms / props / geysers gate the same way (`MaxStampRise`) | SurfaceHeight + BiomeIndex + a 3-octave FBM on all 576 margin columns before a roll that rejects ~99 % of them, for chunks 48 blocks underground too |
| #1527 | the static river / calibration / wonder caches evict their **oldest** entry | `Clear()` past the cap — a ship alternating between bodies re-ran the ~300 ms river build mid-tick |

## Bit-identity, proven three ways

- **Goldens** (`WorldGenerationGoldenTests`): all eight groups unchanged.
- **`WorldGenColumnCacheTests.TorusColumnSampler_IsBitIdenticalToValueTorus`**: 24,000 random samples (seeds, 4 circumferences, 5 field scales, monotone sweeps and random jumps) compared bit-for-bit against `Noise.ValueTorus`.
- **`WorldGenColumnCacheTests`**: a warm generator produces exactly what a cold one does for deep / surface / high / repeated chunks on six planet–mode combinations; a world-mode change drops every memo.

The column phase was moved by line range, not retyped; the tree pre-filter only skips columns the exact test rejects (`roll ≥ bound ≥ localDensity`); the chunk gates only skip writes `SetCell` would have clipped.

## Dropped from the plan (on purpose)

- The `Y ≥ 320` all-air early-out: no chunk in the streamed band reaches it, and an all-air chunk is now sub-millisecond through the profile cache.
- `Value3D` hash-prefix sharing: marginal once the lattice rows are reused.

## Consequences

- A generator instance holds up to ~18 MB of column memos on a VD-8 world (the browser host's VD 2–4: a few MB). The memos assume a fixed world mode between the setters — which the server and the client already guarantee (setters before any query).
- Nothing changes for the client build (no `client/Assets` change; the WorldGeneration DLL only gained internal members and a public struct).

## Verification

- `dotnet build` / fast tier of both test projects / `dotnet format` clean; new tests: `WorldGenColumnCacheTests` (11 cases, incl. the 24k-sample sampler bit-identity).
- Scratch bench (pre-change sources vs this branch, non-tiered JIT, back to back, six columns × five planets, ms per chunk):

| chunk class | pre-change | this PR |
|---|---|---|
| deep solid, stacked (column already seen) | 29–39 | **6–8** |
| surface, stacked | 15–18 | **2.5–5** |
| all-air, stacked | 3.5–8.4 | **0.5–1.0** |
| first chunk of a column (column phase + static region caches) | 48–80 | 47–60 |
| `SurfaceHeight`, 20k columns asked a second time | 31–76 ms | **2.6–3.5 ms** |

closes #1526 closes #1527

🤖 Generated with [Claude Code](https://claude.com/claude-code)
