### PR TITLE
perf(net): RLE from the chunk's backing array, single-buffer MessagePack encode, one encoded payload per chunk version, WebSocket JSON conversion once per payload (#1532, #1531 part)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -243,6 +243,39 @@ is read from the module stat (16) instead of being dead, and the station deploy 
 persisted ids after a restart (id collision). Tests: `PlayerStationReportsTests` (7), `DropLootTests` (+2).
 Locales: 9 new keys + 2 rewordings, EN/DE hand-written, 12 MT via translate_locale.
 
+### ★ Chunk payload and transport: RLE from the backing array, single-buffer MessagePack encode, one encoded payload per chunk version, WebSocket JSON conversion once per payload (#1532, #1531 part, 2026-09-04, branch perf/1531-1532-transport)
+
+**Why.** PR bundle 9 of the performance package (#1501). `StreamChunkNow` cloned the 4096-cell block array per
+player per chunk only to run-length it (a growing `List<ushort>` + `ToArray`), `NetCodec.Encode` allocated the
+MessagePack body and then a second tag-prefixed copy of it, N co-located players meant N encodes of the same
+chunk, and `WebSocketServerTransport.Send` decoded MessagePack and re-encoded JSON once per recipient although
+`BroadcastToWorld` / the presence beat hand it the same bytes for every browser connection.
+
+**What changed — wire bytes identical.** `ChunkBlocksRle.Encode(ReadOnlySpan<ushort>)` runs from
+`ChunkData.RawBlocks` with a reusable run buffer and an exact-size result (the array overload delegates to it).
+`NetCodec.EncodeMessagePack` writes tag + body into one thread-static `ArrayBufferWriter` and copies out once;
+the #1250 formatter fallback and its test seam keep their byte-array form. `ChunkData.Version` is a process-wide
+monotonic stamp taken at construction and on every `Set` / `SetModifier` / `SetShape`; `LoadedWorld.ChunkPayloads`
+caches the encoded `ChunkDataMessage` per (coord, version, codec format), capped at 1024 entries, so co-located
+players and a re-stream after a sweep reuse the bytes (`GameServer.ChunkPayloadEncodes` / `ChunkPayloadCacheHits`
+are the diagnostics). `WebSocketServerTransport` memoises the last MessagePack→JSON conversion by payload
+reference (`JsonConversions` counts them), so N browser recipients pay it once. Dense chunks (RLE not smaller)
+still clone — the message must not alias the live chunk.
+
+**Deferred to a WebGL-verified PR (#1531 stays open for them):** the object-passing in-process loopback for the
+browser singleplayer (needs an `IServerTransport` object overload, an object inbox in `NetworkClient`, an
+object-aware `IsChunkPayload`, and copy-on-adopt of the dense array — `ChunkData.FromRaw` wraps without copying)
+and the HEAP-pointer bridge for the browser WebSocket client (four base64 copies per message today). Both change
+only WebGL code paths that PR CI cannot compile.
+
+**Verified.** `ChunkPayloadTests`: the span overload matches the array overload bit for bit on terrain,
+checkerboard, noisy and mostly-uniform chunks; `Encode` is exactly tag + `MessagePackSerializer.Serialize` for
+chunk, presence and player-state messages (and the reused buffer never leaks a tail); the version stamp changes
+on every mutation and never repeats; two co-located players share one encoded payload per chunk; the WebSocket
+transport converts a shared payload once. `NetworkingTests` (RLE sizes, codec round trips), `NetCodecTests`
+(both formats for every registered message, the fallback pair), `WebSocketTransportTests`, `ChunkStreamingTests`,
+the client↔server harness and the full fast tier are green.
+
 ### ★ Server: presence on change + keep-alive, one entity list per type per tick, one player state per tick, NPC area of interest, single-read sightlines, allocation-free reconcile and space tick (#1530, 2026-09-04, branch perf/1530-server-presence)
 
 **Why.** PR bundle 8 of the performance package (#1501). `TickPresence` encoded and sent every subject to every

--- a/src/BlocksBeyondTheStars.GameServer/GameServer.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServer.cs
@@ -2338,30 +2338,58 @@ public sealed partial class GameServer
     private void StreamChunkNow(PlayerSession session, ChunkCoord coord)
     {
         var chunk = _world.GetOrLoadChunk(coord);
-        var dense = chunk.ToArray();
-        // Ship the run-length-encoded payload when it is smaller (terrain almost always is; a rare
-        // unrunnable chunk goes dense). Decisive on the browser JSON path — ~15-25 KB of JSON
-        // numbers per chunk shrink to usually a few hundred bytes — and it trims native payloads
-        // and VPS egress too. The client accepts both representations (ChunkDataMessage.DecodeBlocks).
-        var rle = ChunkBlocksRle.Encode(dense);
+        SendEncoded(session.ConnectionId, ChunkPayloadFor(chunk, coord));
+        session.SentChunks.Add(coord);
+        MarkExploredCell(session, coord); // #1113: the planet map remembers this across sessions
+    }
+
+    /// <summary>Diagnostics for #1532: chunk payloads encoded vs served from the per-version cache.</summary>
+    public int ChunkPayloadEncodes { get; private set; }
+    public int ChunkPayloadCacheHits { get; private set; }
+    private const int ChunkPayloadCacheCap = 1024; // ~2–20 KB each
+
+    /// <summary>#1532: the encoded ChunkDataMessage of a chunk, cached per (chunk version, codec format) on the
+    /// world. Two players streaming the same chunk used to encode it twice, and a player returning after a
+    /// sweep re-encoded it again. The RLE runs straight from the chunk's backing array (no 4096-cell clone);
+    /// the client accepts both representations (ChunkDataMessage.DecodeBlocks), dense only for a degenerate
+    /// chunk. Decisive on the browser JSON path — ~15-25 KB of JSON numbers per chunk shrink to usually a few
+    /// hundred bytes — and it trims native payloads and VPS egress too.</summary>
+    private byte[] ChunkPayloadFor(ChunkData chunk, ChunkCoord coord)
+    {
+        var cache = _worlds.Active.ChunkPayloads;
+        bool json = NetCodec.UseJsonEncoding;
+        if (cache.TryGetValue(coord, out var hit) && hit.Version == chunk.Version && hit.Json == json)
+        {
+            ChunkPayloadCacheHits++;
+            return hit.Payload;
+        }
+
         var msg = new ChunkDataMessage
         {
             Cx = coord.X,
             Cy = coord.Y,
             Cz = coord.Z,
         };
-        if (rle.Length < dense.Length)
+        var rle = ChunkBlocksRle.Encode(chunk.RawBlocks);
+        if (rle.Length < WorldConstants.BlocksPerChunk)
         {
             msg.BlocksRle = rle;
         }
         else
         {
-            msg.Blocks = dense;
+            msg.Blocks = chunk.ToArray();
         }
+
         PackChunkModifiers(chunk, msg); // dyed-block / coloured-light cells, if any
-        Send(session, msg);
-        session.SentChunks.Add(coord);
-        MarkExploredCell(session, coord); // #1113: the planet map remembers this across sessions
+        var payload = NetCodec.Encode(msg);
+        ChunkPayloadEncodes++;
+        if (cache.Count >= ChunkPayloadCacheCap)
+        {
+            cache.Clear();
+        }
+
+        cache[coord] = (chunk.Version, json, payload);
+        return payload;
     }
 
     /// <summary>Pre-loads the ground under a player about to be snapped to <paramref name="feet"/>: the

--- a/src/BlocksBeyondTheStars.GameServer/WorldManager.cs
+++ b/src/BlocksBeyondTheStars.GameServer/WorldManager.cs
@@ -124,6 +124,10 @@ internal sealed class LoadedWorld
     public bool CreatureListDirty { get; set; }
     public bool NpcListDirty { get; set; }
 
+    /// <summary>#1532: the encoded ChunkDataMessage per chunk, valid for one chunk version and codec format —
+    /// co-located players and a re-stream after a sweep reuse the bytes instead of re-encoding.</summary>
+    public Dictionary<ChunkCoord, (long Version, bool Json, byte[] Payload)> ChunkPayloads { get; } = new();
+
     /// <summary>#1530: the per-world fauna jitter of <c>WorldCreatureCap</c> (a pure function of seed + location,
     /// documented "stable per world") — hashed once instead of an interpolated string 15× per second.</summary>
     public double? FaunaJitter { get; set; }

--- a/src/BlocksBeyondTheStars.Networking/ChunkBlocksRle.cs
+++ b/src/BlocksBeyondTheStars.Networking/ChunkBlocksRle.cs
@@ -14,14 +14,28 @@ public static class ChunkBlocksRle
 {
     /// <summary>Encodes a dense cell array as flat (value, runLength) pairs. A run is capped at
     /// ushort.MaxValue, comfortably above the 4096 cells a chunk holds.</summary>
-    public static ushort[] Encode(ushort[] dense)
+    public static ushort[] Encode(ushort[] dense) => Encode((System.ReadOnlySpan<ushort>)dense);
+
+    // #1532: the run buffer is a reusable thread-static (worst case 2·n entries — a checkerboard) trimmed to an
+    // exact-size result; the old path grew a List and copied it once more with ToArray().
+    [System.ThreadStatic] private static ushort[]? _runScratch;
+
+    /// <summary>The same encoding straight from a chunk's backing array (<c>ChunkData.RawBlocks</c>) — the
+    /// server no longer clones 4096 cells per streamed chunk just to run-length them (#1532).</summary>
+    public static ushort[] Encode(System.ReadOnlySpan<ushort> dense)
     {
         if (dense.Length == 0)
         {
             return System.Array.Empty<ushort>();
         }
 
-        var runs = new List<ushort>(64);
+        var runs = _runScratch;
+        if (runs == null || runs.Length < dense.Length * 2)
+        {
+            runs = _runScratch = new ushort[System.Math.Max(dense.Length * 2, 256)];
+        }
+
+        int w = 0;
         ushort value = dense[0];
         int count = 1;
         for (int i = 1; i < dense.Length; i++)
@@ -32,15 +46,17 @@ public static class ChunkBlocksRle
                 continue;
             }
 
-            runs.Add(value);
-            runs.Add((ushort)count);
+            runs[w++] = value;
+            runs[w++] = (ushort)count;
             value = dense[i];
             count = 1;
         }
 
-        runs.Add(value);
-        runs.Add((ushort)count);
-        return runs.ToArray();
+        runs[w++] = value;
+        runs[w++] = (ushort)count;
+        var result = new ushort[w];
+        System.Array.Copy(runs, result, w);
+        return result;
     }
 
     /// <summary>Decodes flat (value, runLength) pairs into a dense array of exactly

--- a/src/BlocksBeyondTheStars.Networking/NetCodec.cs
+++ b/src/BlocksBeyondTheStars.Networking/NetCodec.cs
@@ -1,6 +1,7 @@
 // Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using System.Buffers;
 using System.Text;
 using System.Text.Json;
 using BlocksBeyondTheStars.Networking.Messages;
@@ -578,27 +579,52 @@ public static class NetCodec
             throw new InvalidOperationException($"Message type '{type.Name}' is not registered with NetCodec.");
         }
 
-        byte[] body;
+        if (MessagePackSerializeOverride is { } serialize)
+        {
+            // Test seam (#1250): the override hands back a body array — keep the prefix-copy form for it.
+            byte[] body;
+            try
+            {
+                body = serialize(type, message);
+            }
+            catch (MessagePackSerializationException ex) when (IsFormatterBuildFailure(ex))
+            {
+                UseJsonEncoding = true;
+                MessagePackFallbackActivated?.Invoke(ex);
+                return EncodeJson(message);
+            }
+
+            var prefixed = new byte[body.Length + 1];
+            prefixed[0] = tag;
+            Buffer.BlockCopy(body, 0, prefixed, 1, body.Length);
+            return prefixed;
+        }
+
+        // #1532: the tag and the body go into ONE reusable buffer, then one exact-size copy out. The old path
+        // allocated the body, then a second tag-prefixed array, and copied the whole body across — two
+        // allocations and a full copy per message, sixteen chunk payloads per tick per player.
+        var writer = _encodeScratch ??= new ArrayBufferWriter<byte>(16 * 1024);
+        writer.Clear();
+        writer.GetSpan(1)[0] = tag;
+        writer.Advance(1);
         try
         {
-            body = MessagePackSerializeOverride is { } serialize
-                ? serialize(type, message)
-                : MessagePackSerializer.Serialize(type, message, Options);
+            MessagePackSerializer.Serialize(type, writer, message, Options);
         }
         catch (MessagePackSerializationException ex) when (IsFormatterBuildFailure(ex))
         {
             // The formatter factory itself is broken for this process (see MessagePackFallbackActivated) —
             // not this message. Switch the whole codec to JSON and encode this one that way too.
+            writer.Clear();
             UseJsonEncoding = true;
             MessagePackFallbackActivated?.Invoke(ex);
             return EncodeJson(message);
         }
 
-        var payload = new byte[body.Length + 1];
-        payload[0] = tag;
-        Buffer.BlockCopy(body, 0, payload, 1, body.Length);
-        return payload;
+        return writer.WrittenSpan.ToArray();
     }
+
+    [ThreadStatic] private static ArrayBufferWriter<byte>? _encodeScratch;
 
     /// <summary>A serialization failure rooted in the formatter cache's static initializer (the dynamic
     /// assembly could not be created) rather than in the message being serialized.</summary>

--- a/src/BlocksBeyondTheStars.Networking/Transport/WebSocketServerTransport.cs
+++ b/src/BlocksBeyondTheStars.Networking/Transport/WebSocketServerTransport.cs
@@ -423,6 +423,34 @@ public sealed class WebSocketServerTransport : IServerTransport
         }
     }
 
+    // #1531: BroadcastToWorld / the presence beat hand the SAME encoded payload to Send once per browser
+    // connection — the conversion (a full MessagePack decode + JSON encode) is memoised by reference, so N
+    // recipients pay it once. Payloads are immutable after NetCodec.Encode, so identity is the whole key.
+    private byte[]? _lastConvertedSource;
+    private byte[]? _lastConvertedJson;
+
+    /// <summary>How many MessagePack→JSON conversions ran (diagnostics / tests).</summary>
+    public int JsonConversions { get; private set; }
+
+    private bool TryConvert(byte[] payload, out byte[] browserPayload)
+    {
+        if (ReferenceEquals(payload, _lastConvertedSource) && _lastConvertedJson != null)
+        {
+            browserPayload = _lastConvertedJson;
+            return true;
+        }
+
+        if (!NetCodec.TryConvertToJsonPayload(payload, out browserPayload))
+        {
+            return false;
+        }
+
+        JsonConversions++;
+        _lastConvertedSource = payload;
+        _lastConvertedJson = browserPayload;
+        return true;
+    }
+
     public void Send(int connectionId, byte[] payload, DeliveryMode mode)
     {
         if (!_clients.TryGetValue(connectionId, out var client))
@@ -430,7 +458,7 @@ public sealed class WebSocketServerTransport : IServerTransport
             return;
         }
 
-        if (!NetCodec.TryConvertToJsonPayload(payload, out var browserPayload))
+        if (!TryConvert(payload, out var browserPayload))
         {
             LogWarning($"Dropped server payload for browser connection {connectionId}: could not convert NetCodec payload to JSON.");
             return;
@@ -452,7 +480,7 @@ public sealed class WebSocketServerTransport : IServerTransport
 
     public void Broadcast(byte[] payload, DeliveryMode mode)
     {
-        if (!NetCodec.TryConvertToJsonPayload(payload, out var browserPayload))
+        if (!TryConvert(payload, out var browserPayload))
         {
             LogWarning("Dropped broadcast payload for browser clients: could not convert NetCodec payload to JSON.");
             return;

--- a/src/BlocksBeyondTheStars.Shared/World/ChunkData.cs
+++ b/src/BlocksBeyondTheStars.Shared/World/ChunkData.cs
@@ -17,6 +17,16 @@ public sealed class ChunkData
 
     private readonly ushort[] _blocks;
 
+    // #1532: a process-wide monotonic stamp, taken at construction and on every mutation, so an encoded wire
+    // payload can be cached per chunk and reused until the chunk changes (a regenerated chunk gets a fresh
+    // stamp, so a stale cache entry can never match it).
+    private static long s_versionClock;
+
+    /// <summary>Changes whenever a cell, modifier or shape of this chunk is written (#1532).</summary>
+    public long Version { get; private set; } = System.Threading.Interlocked.Increment(ref s_versionClock);
+
+    private void Touch() => Version = System.Threading.Interlocked.Increment(ref s_versionClock);
+
     /// <summary>
     /// Sparse per-voxel colour modifiers, keyed by local index: a surface tint (0xRRGGBB) and/or a
     /// light colour (0xRRGGBB) stamped on a placed dyed/glowing block. Lazily allocated — the vast
@@ -62,6 +72,7 @@ public sealed class ChunkData
     {
         int idx = WorldConstants.LocalIndex(x, y, z);
         _blocks[idx] = block.Value;
+        Touch();
 
         // A cleared (air) cell can carry no colour — drop any stale modifier so mining a dyed block
         // and re-placing a plain one there never inherits the old colour.
@@ -93,6 +104,7 @@ public sealed class ChunkData
     /// <summary>Stamps (or clears) the colour modifier at a flat local index.</summary>
     public void SetModifierLocal(int localIndex, int tint, int glow)
     {
+        Touch();
         tint &= 0xFFFFFF;
         glow &= 0xFFFFFF;
         if (tint == 0 && glow == 0)
@@ -126,6 +138,7 @@ public sealed class ChunkData
     /// <summary>Stamps (or clears) the packed shape descriptor at a flat local index.</summary>
     public void SetShapeLocal(int localIndex, int shape)
     {
+        Touch();
         if (shape == 0)
         {
             _shapes?.Remove(localIndex);

--- a/tests/BlocksBeyondTheStars.Tests/ChunkPayloadTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/ChunkPayloadTests.cs
@@ -1,0 +1,189 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using BlocksBeyondTheStars.Networking;
+using BlocksBeyondTheStars.Networking.Messages;
+using BlocksBeyondTheStars.Networking.Transport;
+using BlocksBeyondTheStars.Persistence;
+using BlocksBeyondTheStars.Shared.Configuration;
+using BlocksBeyondTheStars.Shared.Content;
+using BlocksBeyondTheStars.Shared.Geometry;
+using BlocksBeyondTheStars.Shared.Primitives;
+using BlocksBeyondTheStars.Shared.World;
+using MessagePack;
+using MessagePack.Resolvers;
+using Xunit;
+using SvGameServer = BlocksBeyondTheStars.GameServer.GameServer;
+
+namespace BlocksBeyondTheStars.Tests;
+
+/// <summary>
+/// #1532 / #1531: the chunk send path and the codec keep their bytes while doing less work — the RLE runs from
+/// the chunk's backing array, the MessagePack encode writes tag + body into one buffer, a chunk's payload is
+/// encoded once per version and format, and the WebSocket transport converts a shared payload once.
+/// </summary>
+public sealed class ChunkPayloadTests : IDisposable
+{
+    private readonly string _root = Path.Combine(Path.GetTempPath(), "bbts_chunkpayload_" + Guid.NewGuid().ToString("N"));
+    private readonly GameContent _content = ContentLoader.LoadFromDirectory(TestPaths.DataDir());
+
+    private static readonly MessagePackSerializerOptions SameAsCodec =
+        MessagePackSerializerOptions.Standard
+            .WithResolver(ContractlessStandardResolver.Instance)
+            .WithSecurity(MessagePackSecurity.UntrustedData);
+
+    [Fact]
+    public void Rle_SpanOverload_MatchesTheArrayOverload_Exactly()
+    {
+        var rng = new Random(1532);
+        for (int trial = 0; trial < 50; trial++)
+        {
+            var dense = new ushort[WorldConstants.BlocksPerChunk];
+            int mode = trial % 4;
+            for (int i = 0; i < dense.Length; i++)
+            {
+                dense[i] = mode switch
+                {
+                    0 => (ushort)(i < 2000 ? 3 : i < 2100 ? 7 : 0),          // terrain-like
+                    1 => (ushort)(i & 1),                                     // checkerboard (worst case)
+                    2 => (ushort)rng.Next(0, 3),                              // noisy
+                    _ => (ushort)(rng.Next(0, 40) == 0 ? rng.Next(1, 200) : 5), // mostly one value
+                };
+            }
+
+            var viaArray = ChunkBlocksRle.Encode(dense);
+            var viaSpan = ChunkBlocksRle.Encode((ReadOnlySpan<ushort>)dense);
+            Assert.Equal(viaArray, viaSpan);
+            Assert.Equal(dense, ChunkBlocksRle.Decode(viaSpan, dense.Length));
+        }
+    }
+
+    [Fact]
+    public void Encode_WritesExactlyTagPlusMessagePackBody()
+    {
+        NetCodec.UseJsonEncoding = false;
+        var messages = new object[]
+        {
+            new ChunkDataMessage { Cx = 3, Cy = -2, Cz = 9, BlocksRle = new ushort[] { 0, 100, 4, 3996 } },
+            new PlayerPresence { PlayerId = "p1", Name = "Alice", X = 1.5f, Y = 64f, Z = -3f, Yaw = 0.25f, Gear = 5, Held = "torch" },
+            new PlayerStateUpdate { PlayerId = "p1", X = 1, Y = 2, Z = 3, Health = 90f },
+        };
+        foreach (var msg in messages)
+        {
+            var body = MessagePackSerializer.Serialize(msg.GetType(), msg, SameAsCodec);
+            var encoded = NetCodec.Encode(msg);
+            Assert.Equal(body.Length + 1, encoded.Length);
+            Assert.Equal(body, encoded.AsSpan(1).ToArray());
+            Assert.IsType(msg.GetType(), NetCodec.Decode(encoded));
+        }
+
+        // back to back: the reusable buffer must not leak the previous message's tail
+        var small = NetCodec.Encode(new PlayerStateUpdate { PlayerId = "p1" });
+        var big = NetCodec.Encode(new ChunkDataMessage { Cx = 1, Blocks = new ushort[WorldConstants.BlocksPerChunk] });
+        var smallAgain = NetCodec.Encode(new PlayerStateUpdate { PlayerId = "p1" });
+        Assert.Equal(small, smallAgain);
+        Assert.True(big.Length > small.Length);
+    }
+
+    [Fact]
+    public void ChunkData_Version_ChangesOnEveryMutation_AndNeverRepeats()
+    {
+        var a = new ChunkData(new ChunkCoord(0, 0, 0));
+        var b = new ChunkData(new ChunkCoord(0, 0, 0));
+        Assert.NotEqual(a.Version, b.Version);
+
+        long v0 = a.Version;
+        a.Set(1, 2, 3, new BlockId(5));
+        long v1 = a.Version;
+        a.SetModifier(1, 2, 3, 0x112233, 0);
+        long v2 = a.Version;
+        a.SetShape(1, 2, 3, 7);
+        long v3 = a.Version;
+        Assert.True(v0 < v1 && v1 < v2 && v2 < v3);
+    }
+
+    private sealed class CountingTransport : IServerTransport
+    {
+        public event Action<int>? ClientConnected;
+        public event Action<int>? ClientDisconnected;
+        public event Action<int, byte[]>? PayloadReceived;
+        public readonly Dictionary<int, int> ChunkSends = new();
+        public readonly HashSet<byte[]> DistinctChunkPayloads = new(ReferenceEqualityComparer.Instance);
+
+        public void Start(int port) { }
+        public void Send(int connectionId, byte[] payload, DeliveryMode mode)
+        {
+            if (NetCodec.IsMessageType<ChunkDataMessage>(payload))
+            {
+                ChunkSends[connectionId] = ChunkSends.GetValueOrDefault(connectionId) + 1;
+                DistinctChunkPayloads.Add(payload);
+            }
+        }
+        public void Broadcast(byte[] payload, DeliveryMode mode) { }
+        public void Poll() { _ = ClientConnected; _ = ClientDisconnected; _ = PayloadReceived; }
+        public void Stop() { }
+        public void Dispose() { }
+    }
+
+    [Fact]
+    public void CoLocatedPlayers_ShareOneEncodedPayloadPerChunk()
+    {
+        using var repo = new SqliteWorldRepository(new SaveGamePaths(_root, "shared"));
+        var transport = new CountingTransport();
+        var config = new ServerConfig
+        {
+            WorldName = "shared",
+            Seed = 1,
+            AutoSaveIntervalMinutes = 9999,
+            PlaceStarterShip = false,
+            ViewDistanceChunks = 2,
+            ChunkStreamPerTick = 64,
+        };
+        var server = new SvGameServer(config, _content, transport, repo);
+        server.Start();
+        var a = server.AddLocalPlayer("Alice");
+        var b = server.AddLocalPlayer("Bob");
+        b.State.Position = a.State.Position;
+        for (int i = 0; i < 12; i++)
+        {
+            server.TickForTest(0.1);
+        }
+
+        int sendsA = transport.ChunkSends.GetValueOrDefault(a.ConnectionId);
+        int sendsB = transport.ChunkSends.GetValueOrDefault(b.ConnectionId);
+        Assert.True(sendsA > 20 && sendsB > 20, $"both players should have streamed a view ({sendsA} / {sendsB})");
+        Assert.True(server.ChunkPayloadCacheHits > 0, "the second player's chunks should come from the payload cache");
+        Assert.True(server.ChunkPayloadEncodes < sendsA + sendsB, $"encodes {server.ChunkPayloadEncodes} vs sends {sendsA + sendsB}");
+        Assert.Equal(server.ChunkPayloadEncodes, transport.DistinctChunkPayloads.Count);
+    }
+
+    [Fact]
+    public void WebSocketTransport_ConvertsASharedPayloadOnce()
+    {
+        NetCodec.UseJsonEncoding = false;
+        using var transport = new WebSocketServerTransport();
+        var payload = NetCodec.Encode(new PlayerPresence { PlayerId = "p1", Name = "Alice" });
+        transport.Broadcast(payload, DeliveryMode.ReliableOrdered);
+        transport.Broadcast(payload, DeliveryMode.ReliableOrdered);
+        transport.Broadcast(payload, DeliveryMode.ReliableOrdered);
+        Assert.Equal(1, transport.JsonConversions);
+
+        transport.Broadcast(NetCodec.Encode(new PlayerPresence { PlayerId = "p2", Name = "Bob" }), DeliveryMode.ReliableOrdered);
+        Assert.Equal(2, transport.JsonConversions);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_root))
+            {
+                Directory.Delete(_root, recursive: true);
+            }
+        }
+        catch
+        {
+            // best effort
+        }
+    }
+}


### PR DESCRIPTION
PR bundle 9 of the performance package (#1501): the chunk send path and the transports. **Wire bytes identical** — `ChunkPayloadTests` pins the RLE output, the tag + body layout and the round trips.

## What changes

| issue | change | what it replaces |
|---|---|---|
| #1532 | `ChunkBlocksRle.Encode(ReadOnlySpan<ushort>)` runs straight from `ChunkData.RawBlocks` with a reusable run buffer and an exact-size result; the array overload delegates to it | a 4096-cell clone per player per chunk, a growing `List<ushort>` + `ToArray` |
| #1532 | `NetCodec.EncodeMessagePack` writes tag + body into one thread-static `ArrayBufferWriter` and copies out once (the #1250 fallback + its test seam keep the byte-array form) | body allocation, then a second tag-prefixed array and a full copy — per message, sixteen chunks per tick per player |
| #1532 | `ChunkData.Version` (process-wide monotonic stamp on construction and every `Set` / `SetModifier` / `SetShape`); `LoadedWorld.ChunkPayloads` caches the encoded `ChunkDataMessage` per (coord, version, codec format), capped at 1024 | N co-located players = N encodes of the same chunk; a re-stream after a sweep re-encoded too |
| #1531 (part) | `WebSocketServerTransport` memoises the last MessagePack→JSON conversion by payload reference (`JsonConversions` counts them) | one full MessagePack decode + JSON encode **per recipient** although `BroadcastToWorld` and the presence beat hand it the same bytes for every browser connection |

## Deferred to a WebGL-verified PR — #1531 stays open for these

- The object-passing in-process loopback for the browser singleplayer: needs an `IServerTransport` object overload, an object inbox in `NetworkClient`, an object-aware `IsChunkPayload`, and copy-on-adopt of the dense array (`ChunkData.FromRaw` wraps without copying, so an object loopback plus the copy-free encode would alias the server's chunk).
- The HEAP-pointer bridge for the browser WebSocket client (four base64 copies per message today).
- Both live only in `#if UNITY_WEBGL` code that PR CI cannot compile; they need a browser build to verify.

## Consequences / what to check

- A dense (unrunnable) chunk still clones its array — the cached message must never alias the live chunk.
- The payload cache holds up to 1024 encoded chunks per world (~2–20 KB each) and clears wholesale at the cap; a stale entry can never match because a regenerated chunk gets a fresh version stamp.
- `NetCodec.UseJsonEncoding` is part of the cache key, so the browser host (JSON) and a native host never share entries.

## Verification

- New: `ChunkPayloadTests` — span == array RLE bit for bit on terrain / checkerboard / noisy / mostly-uniform chunks (50 trials); `Encode` == tag + `MessagePackSerializer.Serialize` for chunk, presence and player-state messages and the reused buffer never leaks a tail; the version stamp changes on every mutation and never repeats; two co-located players share one encoded payload per chunk (`ChunkPayloadCacheHits > 0`, encodes == distinct payload instances); the WebSocket transport converts a shared payload once.
- Green: `NetworkingTests` (RLE sizes, codec round trips), `NetCodecTests` (both formats for every registered message, the #1250 fallback pair), `NetCodecServerHardeningTests`, `WebSocketTransportTests`, `ChunkStreamingTests`, `LanPlaytestRegressionTests`, `PersistenceTests`, the client↔server harness (all 464 Client.Tests), the full server fast tier, `dotnet format`.

closes #1532

Part of #1531 (the WebSocket conversion); the loopback and HEAP-bridge items remain open there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
