### PR TITLE
feat(net): protocol v4 — LZ4 block arrays above 256 B, the presence beat on a sequenced delivery, inventory updates without the unchanged blueprint list (#1533 #1534 #1535)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ the richer, screenshot-laden versions live there. `(#123)` references the pull r
 
 ## [Unreleased]
 
+⚠️ **Compatibility:** the network protocol version moves to **4** (#1533 #1534 #1535 — LZ4-compressed entity
+lists and chunks, a sequenced presence beat, and inventory updates that no longer re-send the unchanged
+blueprint list). Updated servers reject older game versions at join with a clear "protocol mismatch" message —
+update the game (desktop installs auto-update; the browser version is always current).
+
 ## [2026.9.1] — 2026-09-03
 
 The school-club release. On 2 September the game-development club at the Kurfürst-Balduin

--- a/TODO.md
+++ b/TODO.md
@@ -243,6 +243,43 @@ is read from the module stat (16) instead of being dead, and the station deploy 
 persisted ids after a restart (id collision). Tests: `PlayerStationReportsTests` (7), `DropLootTests` (+2).
 Locales: 9 new keys + 2 rewordings, EN/DE hand-written, 12 MT via translate_locale.
 
+### ★ Protocol v4: LZ4 block arrays above 256 B, the presence beat on a sequenced delivery, inventory updates without the unchanged blueprint list (#1533 #1534 #1535, 2026-09-04, branch perf/1533-1535-protocol-v4) — ⚠ RELEASE NOTE: older game versions cannot join a v4 server
+
+**Why.** PR bundle 10 of the performance package (#1501), the one wire-incompatible bundle, shipped as ONE version
+bump 3 → 4. Contractless MessagePack repeats every property name as a map key and resends static species
+descriptors at 2–5 Hz (a 30-creature list = 14.9 KB, ~85 % repeated strings); every server→client message rode
+one ReliableOrdered stream, so a lost fragment of a 1–12 KB chunk stalled every avatar pose queued behind it for
+a resend round trip; and `InventoryUpdate` carried the whole unlocked-blueprint list (100+ keys, 2–3 KB) on
+every pickup.
+
+**What changed.** **#1533** `NetCodec.Options` gains `Lz4BlockArray` with `CompressionMinLength` =
+`NetCodec.CompressionMinLengthBytes` (256): a 30-creature list shrinks to well under a third, a presence (~150 B)
+stays byte-identical to v3; `Decode` catches every exception from untrusted bytes (a corrupted LZ4 block must
+drop, not throw). The JSON envelope (browser) is untouched. **#1534 part A** the presence beat is
+`DeliveryMode.Sequenced` (new enum member → LiteNetLib `Sequenced`, its own queue; loopback/WebSocket treat it as
+reliable); the join snapshot stays reliable. **Part B (a second channel for chunks + BlockChanged) is deferred**:
+LiteNetLib orders only within a channel, and the client relies on `JoinAccepted` / `WorldReset` / paint-and-shape
+registry pushes preceding the chunks and edits that depend on them — that needs a client-side epoch gate and a
+real-UDP test first (noted on the issue). **#1535** `InventoryUpdate.BlueprintsUnchanged`: `SendInventory`
+signs the unlocked set per session and omits the list while the signature holds (scan unlocks, achievement
+rewards and creative grants all count — the signature is over the set, not the handler); `GameBootstrap` keeps
+its set when the flag is set (an omitted list used to mean "none" and would grey out the tech tree).
+`Protocol.Version` = 4 with the v4 line in its changelog comment; CHANGELOG `[Unreleased]` carries the
+compatibility note (desktop installs auto-update via Velopack, the browser is always current).
+
+**Consequences.** Pre-v4 native clients are rejected at join with the localized "protocol mismatch" text until
+they update. The server pays an LZ4 decompress per browser recipient when it converts a native payload to JSON
+(the #1531 memo makes that once per payload). `ChunkPayloads` (#1532) caches encoded — now compressed — bytes;
+the cache key already carries the codec format.
+
+**Verified.** `ProtocolV4Tests`: version 4 on the wire; a 30-creature list compresses below a third while a
+presence is byte-identical to v3; a v3 reader throws on a compressed body (the reason for the bump); corrupted
+and truncated compressed payloads decode to null without throwing; `Sequenced` maps to LiteNetLib `Sequenced`;
+the presence beat is the only Sequenced traffic; the inventory update omits the list until the set changes.
+`ChunkPayloadTests` mirrors the compressed options; `NetCodecTests` (both formats for every registered message,
+fuzz, the #1250 fallback), `NetworkingTests`, hardening, presence, observer, hosted-worlds, LAN regression,
+creative and scanning suites, the client fast tier and the full server fast tier are green; local Unity build.
+
 ### ★ Chunk payload and transport: RLE from the backing array, single-buffer MessagePack encode, one encoded payload per chunk version, WebSocket JSON conversion once per payload (#1532, #1531 part, 2026-09-04, branch perf/1531-1532-transport)
 
 **Why.** PR bundle 9 of the performance package (#1501). `StreamChunkNow` cloned the 4096-cell block array per

--- a/client/Assets/BlocksBeyondTheStars/Scripts/GameBootstrap.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/GameBootstrap.cs
@@ -1859,7 +1859,10 @@ namespace BlocksBeyondTheStars.Client
                 RefreshSuitStats();
                 Cargo = m.Cargo;
                 CargoSlots = m.CargoSlotCount;
-                UnlockedBlueprints = new System.Collections.Generic.HashSet<string>(m.UnlockedBlueprints ?? System.Array.Empty<string>());
+                if (!m.BlueprintsUnchanged) // #1535: an omitted list means "same as before", not "none"
+                {
+                    UnlockedBlueprints = new System.Collections.Generic.HashSet<string>(m.UnlockedBlueprints ?? System.Array.Empty<string>());
+                }
 
                 // Research toast (#763): a knowledge gain that crosses a still-locked blueprint's
                 // threshold makes it newly researchable — queue it for the HUD. Threshold-only on

--- a/src/BlocksBeyondTheStars.GameServer/GameServer.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServer.cs
@@ -6238,15 +6238,31 @@ public sealed partial class GameServer
 
     private void SendInventory(PlayerSession session)
     {
+        // #1535: the unlocked set rides only when it changed since this session's last update (a signature over
+        // the set, so scan unlocks / achievement rewards / creative grants all count, not just HandleUnlock).
+        var unlocked = session.State.UnlockedBlueprints;
+        long signature = unchecked(unlocked.Count * 1000003L);
+        foreach (var key in unlocked)
+        {
+            signature = unchecked(signature * 31 + StringComparer.Ordinal.GetHashCode(key));
+        }
+
+        bool unchanged = session.SentBlueprintsOnce && session.SentBlueprintsSignature == signature;
+        session.SentBlueprintsOnce = true;
+        session.SentBlueprintsSignature = signature;
         Send(session, new InventoryUpdate
         {
             Personal = DumpInventory(session.State.Inventory),
             Cargo = session.State.AboardShip ? DumpInventory(_ship.Cargo) : Array.Empty<NetItemStack>(),
             CargoSlotCount = session.State.AboardShip ? _ship.Cargo.SlotCount : 0,
-            UnlockedBlueprints = session.State.UnlockedBlueprints.ToArray(),
+            UnlockedBlueprints = unchanged ? Array.Empty<string>() : unlocked.ToArray(),
+            BlueprintsUnchanged = unchanged,
             KnowledgePoints = session.State.KnowledgePoints,
         });
     }
+
+    /// <summary>Test seam for #1535.</summary>
+    internal void SendInventoryForTest(PlayerSession session) => SendInventory(session);
 
     private static NetItemStack[] DumpInventory(Inventory inv)
     {
@@ -6267,8 +6283,8 @@ public sealed partial class GameServer
 
     /// <summary>Sends an already-encoded payload (so a broadcast encodes the message once and reuses the same
     /// bytes for every recipient instead of re-serializing per send). The payload is read-only after encoding.</summary>
-    private void SendEncoded(int connectionId, byte[] payload)
-        => _transport.Send(connectionId, payload, DeliveryMode.ReliableOrdered);
+    private void SendEncoded(int connectionId, byte[] payload, DeliveryMode mode = DeliveryMode.ReliableOrdered)
+        => _transport.Send(connectionId, payload, mode);
 
     private void SendTo(int connectionId, object message)
         => _transport.Send(connectionId, NetCodec.Encode(message), DeliveryMode.ReliableOrdered);

--- a/src/BlocksBeyondTheStars.GameServer/GameServerPresence.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerPresence.cs
@@ -448,7 +448,7 @@ public sealed partial class GameServer
                 }
 
                 payload ??= NetCodec.Encode(presence);
-                SendEncoded(viewer.ConnectionId, payload);
+                SendEncoded(viewer.ConnectionId, payload, DeliveryMode.Sequenced); // #1534: never behind a chunk resend
                 subject.PresenceSentTo[viewer.ConnectionId] = (hash, beat);
             }
 

--- a/src/BlocksBeyondTheStars.GameServer/PlayerSession.cs
+++ b/src/BlocksBeyondTheStars.GameServer/PlayerSession.cs
@@ -402,6 +402,10 @@ public sealed class PlayerSession
     public Dictionary<int, (ulong Hash, int Beat)> PresenceSentTo { get; } = new();
     public int PresenceBeat { get; set; }
 
+    // #1535: signature of the unlocked-blueprint set as last sent — SendInventory omits the list while it holds.
+    public long SentBlueprintsSignature { get; set; }
+    public bool SentBlueprintsOnce { get; set; }
+
     public PlayerSession(int connectionId, PlayerState state)
     {
         ConnectionId = connectionId;

--- a/src/BlocksBeyondTheStars.Networking/Messages.cs
+++ b/src/BlocksBeyondTheStars.Networking/Messages.cs
@@ -916,6 +916,11 @@ public sealed class InventoryUpdate
     /// <summary>Blueprint keys the player has unlocked — lets the client show craftable/locked status.</summary>
     public string[] UnlockedBlueprints { get; set; } = System.Array.Empty<string>();
 
+    /// <summary>#1535 (protocol v4): true = the unlocked set has not changed since this session's last
+    /// InventoryUpdate, so <see cref="UnlockedBlueprints"/> is omitted and the client keeps what it has (the
+    /// list used to ride every pickup — 100+ keys, 2–3 KB, ReliableOrdered).</summary>
+    public bool BlueprintsUnchanged { get; set; }
+
     /// <summary>The player's current knowledge total (kept in sync so the HUD/menu/trade panel show it).</summary>
     public int KnowledgePoints { get; set; }
 

--- a/src/BlocksBeyondTheStars.Networking/NetCodec.cs
+++ b/src/BlocksBeyondTheStars.Networking/NetCodec.cs
@@ -30,10 +30,18 @@ public static class NetCodec
     // UntrustedData (#424 S10): every decoded payload is attacker-controlled, so deserialization must be
     // depth-limited (a ~5-byte header can declare an absurdly nested/huge structure inside the 1 MB cap)
     // and allocation-clamped. Security options only affect reading — the encode path is unchanged.
+    /// <summary>#1533 (protocol v4): MessagePack bodies at or above this many bytes are LZ4 block arrays.
+    /// Entity lists are ~85 % repeated key strings and static descriptors (a 30-creature list shrinks to
+    /// ~13 %); a presence (~150 B) would only grow, so it stays plain. Both peers must run v4: a reader
+    /// without compression hands the LZ4 ext block to the plain formatter and fails.</summary>
+    public const int CompressionMinLengthBytes = 256;
+
     private static readonly MessagePackSerializerOptions Options =
         MessagePackSerializerOptions.Standard
             .WithResolver(ContractlessStandardResolver.Instance)
-            .WithSecurity(MessagePackSecurity.UntrustedData);
+            .WithSecurity(MessagePackSecurity.UntrustedData)
+            .WithCompression(MessagePackCompression.Lz4BlockArray)
+            .WithCompressionMinLength(CompressionMinLengthBytes);
 
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
@@ -707,9 +715,11 @@ public static class NetCodec
             var body = new ReadOnlyMemory<byte>(payload, 1, payload.Length - 1);
             return MessagePackSerializer.Deserialize(type, body, Options);
         }
-        catch (MessagePackSerializationException)
+        catch (Exception)
         {
-            return null; // corrupt/truncated body for this tag — drop it
+            // Untrusted bytes must never throw out of the codec — the formatter's own exception, and since
+            // #1533 whatever a corrupted LZ4 block makes the decompressor raise, all mean "drop it".
+            return null;
         }
     }
 

--- a/src/BlocksBeyondTheStars.Networking/Protocol.cs
+++ b/src/BlocksBeyondTheStars.Networking/Protocol.cs
@@ -11,8 +11,12 @@ public static class Protocol
     /// cannot decode it, so the join-time version check keeps them off newer servers).
     /// v3: the pixel-payload alphabet widened from hex to base32 (#899 — a 32-colour palette). An older
     /// server charset-checks against hex and would drop a face/body painting/block design containing any
-    /// of the new symbols WITHOUT telling anyone; refusing the join says so plainly instead.</summary>
-    public const int Version = 3;
+    /// of the new symbols WITHOUT telling anyone; refusing the join says so plainly instead.
+    /// v4 (#1533/#1535): MessagePack bodies above NetCodec.CompressionMinLengthBytes are LZ4 block arrays — a
+    /// v3 reader hands the LZ4 ext block to the plain formatter and silently drops every entity list and
+    /// chunk; and InventoryUpdate.BlueprintsUnchanged lets the server omit the unlocked-blueprint list, which
+    /// a v3 client would read as "no blueprints" and grey out its whole tech tree.</summary>
+    public const int Version = 4;
 
     public const int DefaultGameplayPort = 31415;
     public const int DefaultAdminPort = 31416;
@@ -31,4 +35,9 @@ public enum DeliveryMode
 
     /// <summary>Best-effort, may drop/reorder — for frequent position updates.</summary>
     Unreliable,
+
+    /// <summary>Best-effort, never duplicated, arrives in order (an older packet behind a newer one is dropped)
+    /// — for the presence beat (#1534): a lost fragment of a chunk on the reliable stream no longer holds every
+    /// avatar pose behind its resend round trip. Transports without the distinction treat it as reliable.</summary>
+    Sequenced,
 }

--- a/src/BlocksBeyondTheStars.Networking/Transport/LiteNetLibTransport.cs
+++ b/src/BlocksBeyondTheStars.Networking/Transport/LiteNetLibTransport.cs
@@ -13,6 +13,7 @@ internal static class DeliveryMapping
     {
         DeliveryMode.ReliableOrdered => DeliveryMethod.ReliableOrdered,
         DeliveryMode.Unreliable => DeliveryMethod.Unreliable,
+        DeliveryMode.Sequenced => DeliveryMethod.Sequenced, // #1534: its own queue — not behind chunk resends
         _ => DeliveryMethod.ReliableOrdered,
     };
 }

--- a/tests/BlocksBeyondTheStars.Tests/ChunkPayloadTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/ChunkPayloadTests.cs
@@ -30,7 +30,9 @@ public sealed class ChunkPayloadTests : IDisposable
     private static readonly MessagePackSerializerOptions SameAsCodec =
         MessagePackSerializerOptions.Standard
             .WithResolver(ContractlessStandardResolver.Instance)
-            .WithSecurity(MessagePackSecurity.UntrustedData);
+            .WithSecurity(MessagePackSecurity.UntrustedData)
+            .WithCompression(MessagePackCompression.Lz4BlockArray)
+            .WithCompressionMinLength(NetCodec.CompressionMinLengthBytes);
 
     [Fact]
     public void Rle_SpanOverload_MatchesTheArrayOverload_Exactly()
@@ -82,7 +84,7 @@ public sealed class ChunkPayloadTests : IDisposable
         var big = NetCodec.Encode(new ChunkDataMessage { Cx = 1, Blocks = new ushort[WorldConstants.BlocksPerChunk] });
         var smallAgain = NetCodec.Encode(new PlayerStateUpdate { PlayerId = "p1" });
         Assert.Equal(small, smallAgain);
-        Assert.True(big.Length > small.Length);
+        Assert.Equal(WorldConstants.BlocksPerChunk, ((ChunkDataMessage)NetCodec.Decode(big)!).Blocks.Length); // a dense chunk of one value LZ4-compresses below a state update — compare content, not size
     }
 
     [Fact]

--- a/tests/BlocksBeyondTheStars.Tests/ProtocolV4Tests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/ProtocolV4Tests.cs
@@ -1,0 +1,214 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using System.Linq;
+using BlocksBeyondTheStars.Networking;
+using BlocksBeyondTheStars.Networking.Messages;
+using BlocksBeyondTheStars.Networking.Transport;
+using BlocksBeyondTheStars.Persistence;
+using BlocksBeyondTheStars.Shared.Configuration;
+using BlocksBeyondTheStars.Shared.Content;
+using BlocksBeyondTheStars.Shared.Geometry;
+using LiteNetLib;
+using MessagePack;
+using MessagePack.Resolvers;
+using Xunit;
+using SvGameServer = BlocksBeyondTheStars.GameServer.GameServer;
+
+namespace BlocksBeyondTheStars.Tests;
+
+/// <summary>
+/// Protocol v4 (#1533 #1534 #1535): LZ4 block arrays above <see cref="NetCodec.CompressionMinLengthBytes"/>, the
+/// presence beat on a sequenced delivery, and inventory updates that omit an unchanged blueprint list. The
+/// version bump exists because a v3 reader cannot open an LZ4 body and would read an omitted blueprint list as
+/// "none" — both pinned here.
+/// </summary>
+public sealed class ProtocolV4Tests : IDisposable
+{
+    private readonly string _root = Path.Combine(Path.GetTempPath(), "bbts_v4_" + Guid.NewGuid().ToString("N"));
+    private readonly GameContent _content = ContentLoader.LoadFromDirectory(TestPaths.DataDir());
+
+    private static readonly MessagePackSerializerOptions V3Options =
+        MessagePackSerializerOptions.Standard
+            .WithResolver(ContractlessStandardResolver.Instance)
+            .WithSecurity(MessagePackSecurity.UntrustedData);
+
+    private static CreatureList BigCreatureList()
+        => new()
+        {
+            Creatures = Enumerable.Range(0, 30).Select(i => new NetCreature
+            {
+                Id = "c" + i,
+                SpeciesId = "fauna_grazer_" + (i % 3),
+                Name = "Grazer",
+                X = i * 3f,
+                Y = 64f,
+                Z = -i * 2f,
+                Hull = 10f + i,
+                HullMax = 40f,
+            }).ToArray(),
+        };
+
+    [Fact]
+    public void Version_IsFour()
+    {
+        Assert.Equal(4, Protocol.Version);
+        Assert.Equal(4, new JoinRequest().ProtocolVersion);
+    }
+
+    [Fact]
+    public void LargeMessages_CompressAboveTheThreshold_SmallOnesStayPlain()
+    {
+        NetCodec.UseJsonEncoding = false;
+        var big = BigCreatureList();
+        var plain = MessagePackSerializer.Serialize(big, V3Options);
+        var encoded = NetCodec.Encode(big);
+        Assert.True(plain.Length > NetCodec.CompressionMinLengthBytes, "the fixture must be above the threshold");
+        Assert.True(encoded.Length < plain.Length / 3, $"a 30-creature list should shrink to well under a third ({encoded.Length} vs {plain.Length})");
+        var back = Assert.IsType<CreatureList>(NetCodec.Decode(encoded));
+        Assert.Equal(30, back.Creatures.Length);
+        Assert.Equal("fauna_grazer_2", back.Creatures[29].SpeciesId);
+
+        var small = new PlayerPresence { PlayerId = "p1", Name = "Alice", X = 1f, Y = 64f, Z = 2f };
+        var smallPlain = MessagePackSerializer.Serialize(small, V3Options);
+        var smallEncoded = NetCodec.Encode(small);
+        Assert.True(smallPlain.Length < NetCodec.CompressionMinLengthBytes);
+        Assert.Equal(smallPlain, smallEncoded.AsSpan(1).ToArray()); // byte-identical to v3 below the threshold
+    }
+
+    [Fact]
+    public void CompressedBody_IsUnreadableForAV3Reader_WhichIsWhyTheVersionMoved()
+    {
+        NetCodec.UseJsonEncoding = false;
+        var encoded = NetCodec.Encode(BigCreatureList());
+        var body = new ReadOnlyMemory<byte>(encoded, 1, encoded.Length - 1);
+        Assert.ThrowsAny<Exception>(() => MessagePackSerializer.Deserialize<CreatureList>(body, V3Options));
+        Assert.NotNull(NetCodec.Decode(encoded)); // the v4 reader is fine
+    }
+
+    [Fact]
+    public void CorruptedCompressedPayload_DecodesToNull_NeverThrows()
+    {
+        NetCodec.UseJsonEncoding = false;
+        var encoded = NetCodec.Encode(BigCreatureList());
+        for (int i = 1; i < encoded.Length; i += 7)
+        {
+            var mutated = (byte[])encoded.Clone();
+            mutated[i] ^= 0xFF;
+            var ex = Record.Exception(() => NetCodec.Decode(mutated));
+            Assert.Null(ex);
+        }
+
+        for (int cut = 2; cut < encoded.Length; cut += 11)
+        {
+            var truncated = encoded.AsSpan(0, cut).ToArray();
+            Assert.Null(Record.Exception(() => NetCodec.Decode(truncated)));
+        }
+    }
+
+    [Fact]
+    public void Sequenced_MapsToLiteNetLibSequenced()
+    {
+        Assert.Equal(DeliveryMethod.Sequenced, DeliveryMode.Sequenced.ToLiteNetLib());
+        Assert.Equal(DeliveryMethod.ReliableOrdered, DeliveryMode.ReliableOrdered.ToLiteNetLib());
+        Assert.Equal(DeliveryMethod.Unreliable, DeliveryMode.Unreliable.ToLiteNetLib());
+    }
+
+    private sealed class ModeRecordingTransport : IServerTransport
+    {
+        public event Action<int>? ClientConnected;
+        public event Action<int>? ClientDisconnected;
+        public event Action<int, byte[]>? PayloadReceived;
+        public readonly List<(int Conn, object Msg, DeliveryMode Mode)> Sent = new();
+
+        public void Start(int port) { }
+        public void Send(int connectionId, byte[] payload, DeliveryMode mode)
+        {
+            if (NetCodec.Decode(payload) is { } m) Sent.Add((connectionId, m, mode));
+        }
+        public void Broadcast(byte[] payload, DeliveryMode mode)
+        {
+            if (NetCodec.Decode(payload) is { } m) Sent.Add((int.MinValue, m, mode));
+        }
+        public void Poll() { _ = ClientConnected; _ = ClientDisconnected; _ = PayloadReceived; }
+        public void Stop() { }
+        public void Dispose() { }
+    }
+
+    private (SvGameServer Server, ModeRecordingTransport Transport, SqliteWorldRepository Repo) NewServer(string world)
+    {
+        var repo = new SqliteWorldRepository(new SaveGamePaths(_root, world));
+        var transport = new ModeRecordingTransport();
+        var config = new ServerConfig { WorldName = world, Seed = 1, AutoSaveIntervalMinutes = 9999, PlaceStarterShip = false };
+        var server = new SvGameServer(config, _content, transport, repo);
+        server.Start();
+        return (server, transport, repo);
+    }
+
+    [Fact]
+    public void PresenceBeat_IsSequenced_TheJoinSnapshotStaysReliable()
+    {
+        var (server, transport, repo) = NewServer("beat");
+        using (repo)
+        {
+            var alice = server.AddLocalPlayer("Alice");
+            var bob = server.AddLocalPlayer("Bob");
+            bob.State.Position = new Vector3f(5, 64, 7);
+            transport.Sent.Clear();
+            server.Tick(0.2);
+
+            var beats = transport.Sent.Where(x => x.Msg is PlayerPresence p && p.PlayerId == "Bob" && x.Conn == alice.ConnectionId).ToList();
+            Assert.NotEmpty(beats);
+            Assert.All(beats, b => Assert.Equal(DeliveryMode.Sequenced, b.Mode));
+
+            // everything else on the stream is still reliable
+            Assert.All(transport.Sent.Where(x => x.Msg is not PlayerPresence), s => Assert.NotEqual(DeliveryMode.Sequenced, s.Mode));
+        }
+    }
+
+    [Fact]
+    public void InventoryUpdate_OmitsTheBlueprintList_UntilItChanges()
+    {
+        var (server, transport, repo) = NewServer("blueprints");
+        using (repo)
+        {
+            var alice = server.AddLocalPlayer("Alice");
+            alice.State.UnlockedBlueprints.Add("bp_alpha");
+            transport.Sent.Clear();
+
+            server.SendInventoryForTest(alice);
+            var first = (InventoryUpdate)transport.Sent.Last(x => x.Msg is InventoryUpdate).Msg;
+            // the join already sent one list; whether this one repeats it depends on the join — what matters is
+            // that the NEXT one, with nothing changed, omits it
+            transport.Sent.Clear();
+            server.SendInventoryForTest(alice);
+            var second = (InventoryUpdate)transport.Sent.Last(x => x.Msg is InventoryUpdate).Msg;
+            Assert.True(second.BlueprintsUnchanged);
+            Assert.Empty(second.UnlockedBlueprints);
+
+            alice.State.UnlockedBlueprints.Add("bp_beta");
+            transport.Sent.Clear();
+            server.SendInventoryForTest(alice);
+            var third = (InventoryUpdate)transport.Sent.Last(x => x.Msg is InventoryUpdate).Msg;
+            Assert.False(third.BlueprintsUnchanged);
+            Assert.Contains("bp_alpha", third.UnlockedBlueprints);
+            Assert.Contains("bp_beta", third.UnlockedBlueprints);
+            _ = first;
+        }
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_root))
+            {
+                Directory.Delete(_root, recursive: true);
+            }
+        }
+        catch
+        {
+            // best effort
+        }
+    }
+}


### PR DESCRIPTION
PR bundle 10 of the performance package (#1501): **protocol v4**, the one wire-incompatible bundle, shipped as a single version bump 3 → 4.

> ⚠️ **Release note:** older game versions cannot join a v4 server — they get the localized "protocol mismatch" text at join until they update. Desktop installs auto-update via Velopack; the browser is always current. CHANGELOG `[Unreleased]` carries the note; the release that ships this should call it out.

## What changes

| issue | change | what it replaces |
|---|---|---|
| #1533 | `NetCodec.Options` + `Lz4BlockArray` with `CompressionMinLength` = 256 B (`NetCodec.CompressionMinLengthBytes`); `Decode` catches every exception from untrusted bytes | contractless MessagePack repeating every property name and static descriptor at 2–5 Hz — a 30-creature list was 14.9 KB, now well under a third; a presence (~150 B) stays byte-identical |
| #1534 part A | the presence beat is `DeliveryMode.Sequenced` (new enum member → LiteNetLib `Sequenced`, its own queue); the join snapshot stays reliable | every avatar pose queued behind a lost chunk fragment's resend round trip on the single ReliableOrdered stream |
| #1535 | `InventoryUpdate.BlueprintsUnchanged`: `SendInventory` signs the unlocked set per session and omits the list while the signature holds; `GameBootstrap` keeps its set when the flag is set | the whole unlocked-blueprint list (100+ keys, 2–3 KB, ReliableOrdered) on every pickup |

## Why one bump

- A v3 reader hands an LZ4 ext block to the plain formatter and fails — every entity list and chunk would silently drop.
- A v3 client reads an omitted blueprint list as "none" and greys out its whole tech tree.
- The JSON envelope (browser) is untouched by both.

## Deferred — #1534 part B (second LiteNetLib channel for chunks + `BlockChanged`)

LiteNetLib orders only within a channel, and the client relies on cross-message ordering that a second channel would break: `JoinAccepted` (circumference, world info) before the first chunks, `WorldReset` before the new world's chunks, and `PaintDesign` / `CustomShape` registry pushes before the `BlockChanged` that references them. Doing it right needs a client-side epoch gate (buffer bulk payloads until the join/reset they belong to has been dispatched) and a real-UDP LiteNetLib test — there is none today. Noted on the issue; it needs no further version bump if it lands with the next one.

## Consequences / what to check

- The server pays an LZ4 decompress per browser recipient when converting a native payload to JSON; the #1531 memo makes that once per payload.
- `ChunkPayloads` (#1532) caches the encoded — now compressed — bytes; the cache key already carries the codec format.
- Under `Sequenced`, a dropped keep-alive is not resent; with #1530's 0.5 s keep-alive and the client's 3 s stale-hide that is six consecutive losses before an avatar hides.
- Playtest with two clients on real Wi-Fi: presence stays smooth while chunks stream; tech tree stays intact across pickups.

## Verification

- New: `ProtocolV4Tests` — version 4 on the wire; a 30-creature list compresses below a third while a presence is byte-identical to v3; a v3 reader throws on a compressed body; corrupted and truncated compressed payloads decode to null without throwing; `Sequenced` maps to LiteNetLib `Sequenced`; the presence beat is the only Sequenced traffic; the inventory update omits the list until the set changes.
- Updated: `ChunkPayloadTests` mirrors the compressed options.
- Green: `NetCodecTests` (both formats for every registered message, fuzz, the #1250 fallback pair), `NetworkingTests`, `NetCodecServerHardeningTests`, `ProtocolHardeningTests`, `PresenceTests`, `PresenceKeepAliveTests`, `AdminObserverTests`, `HostedWorldsFoundationTests`, `LanPlaytestRegressionTests`, `WebSocketTransportTests`, `CreativeModeTests`, `ScanningTests` (144 tests), the client fast tier (464), the full server fast tier, `dotnet format`; local Unity player build clean.

closes #1533 closes #1535

Part of #1534 (part A shipped; part B deferred with the reasoning on the issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
