### PR TITLE
perf(server): a 1 ms timer for the Windows run loop, explicit workstation GC, GCConserveMemory in the images; ReadyToRun, non-concurrent GC and invariant globalization measured and rejected (#1536)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,11 @@ RUN chmod +x /usr/local/bin/entrypoint.sh
 # Default the admin UI/portal bind to all interfaces (the app's own default is loopback, which would be
 # unreachable from outside the container). ALWAYS pair a public admin port with BBS_ADMIN_PASSWORD.
 ENV BBS_ADMIN_BIND=0.0.0.0
+# #1536: give memory back readily on the many-worlds VPS (the cgroup limit already bounds each heap;
+# GCConserveMemory=5 measured −1.3 MB private at idle and trims harder under load). NOT gcConcurrent=0 (+7.5 MB
+# per process on the dev box) and NOT invariant globalization (the name screening normalises diacritics with
+# ICU — a "hïtler" evasion stopped matching without it).
+ENV DOTNET_GCConserveMemory=5
 
 # 31415/udp native client · 31415/tcp browser WebSocket (when BBS_ENABLE_WEBSOCKET=true) · 31416/tcp admin+portal+download+/play
 EXPOSE 31415/udp 31415/tcp 31416/tcp

--- a/Dockerfile.worldhost
+++ b/Dockerfile.worldhost
@@ -36,6 +36,8 @@ COPY --from=build /app ./
 
 # In a container the app must bind all interfaces (its own default is loopback); reachability is then
 # controlled by the docker network / reverse proxy. The registry lives on the /data volume.
+# #1536: the host itself is small; the same memory knob as the world image (see Dockerfile).
+ENV DOTNET_GCConserveMemory=5
 ENV BBS_WH_BIND=0.0.0.0
 ENV BBS_WH_DATA_DIR=/data
 

--- a/TODO.md
+++ b/TODO.md
@@ -243,6 +243,31 @@ is read from the module stat (16) instead of being dead, and the station deploy 
 persisted ids after a restart (id collision). Tests: `PlayerStationReportsTests` (7), `DropLootTests` (+2).
 Locales: 9 new keys + 2 rewordings, EN/DE hand-written, 12 MT via translate_locale.
 
+### ★ Server runtime configuration: a 1 ms timer for the Windows run loop, explicit workstation GC, GCConserveMemory in the images; ReadyToRun, non-concurrent GC and invariant globalization measured and rejected (#1536, 2026-09-04, branch perf/1536-runtime-config)
+
+**Why.** PR bundle 11 of the performance package (#1501). No GC/JIT/globalization settings existed; the issue listed
+four knobs. Each was measured on its own (bundled server on the dev box, three starts each, idle working set,
+tick count per 5 s window) and only what paid off ships — the rest is recorded next to the setting.
+
+**What ships.** `HighResolutionTimerScope`: the run loop's `Thread.Sleep` quantised to the Windows 15.6 ms timer, so
+the 66.7 ms period slept as alternating 62.5 / 78 ms and the server ran ~13.8 Hz instead of 15 (68–70 ticks per
+window); `Run()` now holds `timeBeginPeriod(1)` for the loop's lifetime (restored on exit; a no-op elsewhere and in
+the Unity/WebGL library flavour) → 76–77 ticks per window. `GameServer.csproj` pins `ServerGarbageCollector=false`
+explicitly (the many-worlds VPS must never flip to server GC by accident). The container images set
+`DOTNET_GCConserveMemory=5` (−1.3 MB private at idle, trims harder under load; the cgroup limit already bounds each
+heap).
+
+**Rejected with numbers.** `ConcurrentGarbageCollection=false`: +7.5 MB private / +8 MB working set per idle
+process (larger gen0 budget); the background thread it saves only runs during rare gen2 passes. `PublishReadyToRun`
+(bundled + container): time-to-"started" unchanged (4.4–8.5 s either way — worldgen dominates), +28 MB exe
+(76 → 104 MB in every client download), +10 MB working set. `InvariantGlobalization`: the server fast tier under
+`DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1` fails `NameScreenTests.BlockList_CatchesEvasions("hïtler")` — the name
+screening normalises diacritics with `string.Normalize`, which needs ICU; without it an accented slur slips past the
+block list. ICU stays; its RSS is the price of that filter.
+
+**Consequences.** Windows-hosted servers (the bundled singleplayer server, LAN hosts) tick at the configured
+15 Hz; nothing changes on Linux. The VPS images trade a little GC CPU for memory.
+
 ### ★ Protocol v4: LZ4 block arrays above 256 B, the presence beat on a sequenced delivery, inventory updates without the unchanged blueprint list (#1533 #1534 #1535, 2026-09-04, branch perf/1533-1535-protocol-v4) — ⚠ RELEASE NOTE: older game versions cannot join a v4 server
 
 **Why.** PR bundle 10 of the performance package (#1501), the one wire-incompatible bundle, shipped as ONE version

--- a/src/BlocksBeyondTheStars.GameServer/BlocksBeyondTheStars.GameServer.csproj
+++ b/src/BlocksBeyondTheStars.GameServer/BlocksBeyondTheStars.GameServer.csproj
@@ -26,4 +26,19 @@
     <Compile Remove="Program.cs" />
   </ItemGroup>
 
+  <!-- #1536 runtime configuration of the server HOST (the net10.0 exe; the Unity/WebGL library flavour has no
+       runtimeconfig of its own). Workstation GC is pinned explicitly so the many-worlds VPS can never flip to
+       server GC by accident. Measured on the dev box (bundled server, idle) and REJECTED — do not re-try blind:
+         · ConcurrentGarbageCollection=false: +7.5 MB private / +8 MB working set per process (the non-concurrent
+           GC keeps a larger gen0 budget); the background GC thread it saves only runs during rare gen2 passes.
+         · PublishReadyToRun: no measurable change in time-to-"started" (worldgen dominates), +28 MB exe, +10 MB
+           working set.
+         · InvariantGlobalization: NameScreenTests' "hïtler" evasion stopped matching — the name screening
+           normalises diacritics with string.Normalize, which needs ICU. ICU stays; its RSS is the price of that filter.
+       The Windows run loop's timer resolution (HighResolutionTimerScope) is the knob that paid off: 68–70 → 76 ticks
+       per 5 s window, i.e. the configured 15 Hz instead of ~13.8. -->
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <ServerGarbageCollector>false</ServerGarbageCollector>
+  </PropertyGroup>
+
 </Project>

--- a/src/BlocksBeyondTheStars.GameServer/GameServer.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServer.cs
@@ -1097,6 +1097,9 @@ public sealed partial class GameServer
         _runLoopActive = true;
         _stopped.Reset();
         double tickSeconds = 1.0 / System.Math.Max(1, _config.TickRate);
+        // #1536: on Windows Thread.Sleep quantises to the system timer (15.6 ms by default), so a 66.7 ms
+        // period slept as 62.5 / 78 ms — raise the resolution to 1 ms for the lifetime of the loop.
+        using var timerResolution = HighResolutionTimerScope.Enter();
         var sw = System.Diagnostics.Stopwatch.StartNew();
         double last = sw.Elapsed.TotalSeconds;
 

--- a/src/BlocksBeyondTheStars.GameServer/HighResolutionTimerScope.cs
+++ b/src/BlocksBeyondTheStars.GameServer/HighResolutionTimerScope.cs
@@ -1,0 +1,63 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using System.Runtime.InteropServices;
+
+namespace BlocksBeyondTheStars.GameServer;
+
+/// <summary>
+/// #1536: raises the Windows system timer resolution to 1 ms while the run loop sleeps between ticks — the
+/// default 15.6 ms quantum turned the 66.7 ms tick period into alternating 62.5 / 78 ms sleeps. A no-op on
+/// other platforms (their sleep is already millisecond-accurate) and in the Unity/WebGL library flavour.
+/// Restored on dispose so a bundled singleplayer server that stops leaves the system as it found it.
+/// </summary>
+internal sealed class HighResolutionTimerScope : IDisposable
+{
+    private const uint PeriodMs = 1;
+    private readonly bool _raised;
+
+    private HighResolutionTimerScope(bool raised) => _raised = raised;
+
+    public static HighResolutionTimerScope Enter()
+    {
+#if NET
+        if (OperatingSystem.IsWindows())
+        {
+            try
+            {
+                return new HighResolutionTimerScope(TimeBeginPeriod(PeriodMs) == 0);
+            }
+            catch (Exception)
+            {
+                // winmm missing (Nano Server / Wine without it) — the loop simply keeps the coarse timer
+            }
+        }
+#endif
+        return new HighResolutionTimerScope(false);
+    }
+
+    public void Dispose()
+    {
+#if NET
+        if (_raised)
+        {
+            try
+            {
+                TimeEndPeriod(PeriodMs);
+            }
+            catch (Exception)
+            {
+                // best effort
+            }
+        }
+#endif
+    }
+
+#if NET
+    [DllImport("winmm.dll", EntryPoint = "timeBeginPeriod")]
+    private static extern uint TimeBeginPeriod(uint periodMs);
+
+    [DllImport("winmm.dll", EntryPoint = "timeEndPeriod")]
+    private static extern uint TimeEndPeriod(uint periodMs);
+#endif
+}


### PR DESCRIPTION
PR bundle 11 of the performance package (#1501): the server host's runtime knobs. **No gameplay code changes.** Every knob the issue listed was measured on its own; only what paid off ships, the rest is recorded next to the setting so nobody re-tries it blind.

## What ships

| where | change | what it replaces |
|---|---|---|
| `HighResolutionTimerScope` (new) + `Run()` | `timeBeginPeriod(1)` for the loop's lifetime on Windows, restored on exit; a no-op elsewhere and in the Unity/WebGL library flavour | `Thread.Sleep` quantised to the 15.6 ms system timer — the 66.7 ms period slept as alternating 62.5 / 78 ms, i.e. **~13.8 Hz instead of the configured 15** |
| `GameServer.csproj` (net10.0 host) | `ServerGarbageCollector=false` pinned explicitly | an implicit default the many-worlds VPS could flip by accident |
| `Dockerfile`, `Dockerfile.worldhost` | `DOTNET_GCConserveMemory=5` in the runtime images | defaults; the cgroup limit already bounds each container's heap, so no `GCHeapHardLimit` |

## Measured and rejected

| knob | result | why not |
|---|---|---|
| `ConcurrentGarbageCollection=false` | **+7.5 MB private / +8 MB working set** per idle process | the non-concurrent GC keeps a larger gen0 budget; the background thread it saves only runs during rare gen2 passes — memory matters more on the VPS |
| `PublishReadyToRun` (bundled + container) | time-to-"started" unchanged (4.4–8.5 s either way — worldgen dominates), **+28 MB exe** (76 → 104 MB in every client download), +10 MB working set | no gain to pay for |
| `InvariantGlobalization` | the server fast tier under `DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1` fails **`NameScreenTests.BlockList_CatchesEvasions("hïtler")`** | the name screening normalises diacritics with `string.Normalize`, which needs ICU — without it an accented slur slips past the block list; ICU's RSS is the price of that filter |

## Numbers (dev box, bundled server, three starts each; idle working set / private in MB, ticks per 5 s window)

| configuration | WS / private | ticks per 5 s |
|---|---|---|
| PR 10 exe | 118–120 / 60 | 68–70 |
| + timer (this PR) | 118–119 / 60 | **76–77** |
| + `gcConcurrent=0` (rejected) | 126–133 / 68 | 76–77 |
| + ReadyToRun (rejected) | 128–132 / 68 (exe 104 MB) | 76–77 |
| + `GCConserveMemory=5` | 118–119 / 58.7 | 76–77 |

The tick count is 76–77 rather than 75 because the sleep truncates to whole milliseconds; the simulation is dt-based, so the cadence, not the clock, is what changed.

## What to check

- On the VPS: `docker stats` RSS per idle world process before/after the image update (GCConserveMemory).
- A LAN session hosted from Windows: the tick log's `(n ticks)` per window now matches 15 Hz.

closes #1536

🤖 Generated with [Claude Code](https://claude.com/claude-code)
