### PR TITLE
perf(client): attribute the steady-state allocations — Development-build switch, PerfProbe -perfProfile, headless profiler-capture report (#1537)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -243,6 +243,34 @@ is read from the module stat (16) instead of being dead, and the station deploy 
 persisted ids after a restart (id collision). Tests: `PlayerStationReportsTests` (7), `DropLootTests` (+2).
 Locales: 9 new keys + 2 rewordings, EN/DE hand-written, 12 MT via translate_locale.
 
+### ★ Client allocations attributed: a Development-build switch, `PerfProbe -perfProfile`, a headless profiler-capture report; seven follow-up issues ranked (#1537, 2026-09-04, branch perf/1537-gc-investigation)
+
+**Why.** The last item of the performance package (#1501): the client collected 4–7 times per second at
+Medium/High and the p95 sat at 2–3× the p50, and nothing was attributed. The issue asked for a ranked allocation
+list with call sites before any fix, so this PR ships the tooling and the list, no code change to the game.
+
+**What ships.** `BBS_DEV_BUILD=1` makes `BuildScript` produce a `BuildOptions.Development` player (never set by the
+release scripts; deep-profiling support was tried and rejected — it instruments every method, 3–7 fps and 18 GB of
+capture in 40 s, while the plain Development player runs at release speed). `PerfProbe -perfProfile <file>` turns
+the profiler's binary log with allocation call stacks on for the idle + walk phases (a documented no-op in a
+release player). `Editor/ProfilerCaptureReport.cs` loads such a `.raw` headless (`-executeMethod
+BlocksBeyondTheStars.Client.EditorTools.ProfilerCaptureReport.Run`, env `BBS_PROFILE_RAW` / `BBS_PROFILE_OUT`),
+walks every frame's raw sample tree, attributes each `GC.Alloc` to its profiler scope path and to the resolved
+call stack, and prints KB/s + allocs/s tables (scopes, methods, 6-frame chains). The Editor keeps the last 2000
+frames of a capture, so the phases stay at 10 s.
+
+**Findings (walk, High / VD 8, 7.0 MB/s, 20 400 allocs/s; ranked list on #1537).** Chunk-build dispatch ~1.8 MB/s
+(the 8 KB `ChunkData.ToArray` clone per build at 141 builds/s, `Neighbourhood`, closures, `Task.Run`) → #1550;
+uGUI `Outline` text rebuilds ~2.0 MB/s (550 KB per rebuild, 3.6/s) → #1552; IMGUI overlays (`WeatherFx.OnGUI`,
+`FinaleView.OnGUI`) 146 KB/s certain plus 1.4 MB/s in `GUI.Repaint` to verify → #1553; `GroundScatter.Setup` with a
+`System.Random` per scatter point 440 KB/s → #1551; the receive path copies (`ChunkBlocksRle.Decode` 412 KB/s,
+LiteNetLib packet copy, NPC-list strings) → #1555; creature voice variants resolved at runtime (250 KB LOH each)
+→ #1556; the per-frame tail (`RingBand` randoms, `VoiceChat`, `PlayersWithin`, `ToLowerInvariant`, HUD strings)
+→ #1554.
+
+**Consequences.** None for players: the release build and PerfProbe results are unchanged. Every follow-up's
+acceptance check is one capture + one report.
+
 ### ★ Server runtime configuration: a 1 ms timer for the Windows run loop, explicit workstation GC, GCConserveMemory in the images; ReadyToRun, non-concurrent GC and invariant globalization measured and rejected (#1536, 2026-09-04, branch perf/1536-runtime-config)
 
 **Why.** PR bundle 11 of the performance package (#1501). No GC/JIT/globalization settings existed; the issue listed

--- a/client/Assets/BlocksBeyondTheStars/Editor/BuildScript.cs
+++ b/client/Assets/BlocksBeyondTheStars/Editor/BuildScript.cs
@@ -143,12 +143,22 @@ namespace BlocksBeyondTheStars.Client.EditorTools
                 PlayerSettings.SetManagedStrippingLevel(NamedBuildTarget.Standalone, ManagedStrippingLevel.Disabled);
             }
 
+            // #1537: BBS_DEV_BUILD=1 → a Development player, so PerfProbe -perfProfile
+            // can write a Unity Profiler capture (allocation call stacks) headless. Never set by the release scripts.
+            bool devBuild = string.Equals(Environment.GetEnvironmentVariable("BBS_DEV_BUILD"), "1", StringComparison.OrdinalIgnoreCase);
+            var buildOptions = desktop ? BuildOptions.CompressWithLz4HC : BuildOptions.None;
+            if (devBuild)
+            {
+                buildOptions |= BuildOptions.Development; // NOT EnableDeepProfilingSupport: it instruments every method — 3 fps and 18 GB per 40 s capture
+                Debug.Log("BlocksBeyondTheStars build: DEVELOPMENT player (BBS_DEV_BUILD=1) — profiler capture enabled");
+            }
+
             var options = new BuildPlayerOptions
             {
                 scenes = new[] { ScenePath },
                 locationPathName = locationPathName,
                 target = target,
-                options = desktop ? BuildOptions.CompressWithLz4HC : BuildOptions.None,
+                options = buildOptions,
             };
 
             var report = BuildPipeline.BuildPlayer(options);

--- a/client/Assets/BlocksBeyondTheStars/Editor/ProfilerCaptureReport.cs
+++ b/client/Assets/BlocksBeyondTheStars/Editor/ProfilerCaptureReport.cs
@@ -1,0 +1,217 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using UnityEditor;
+using UnityEditor.Profiling;
+using UnityEditorInternal;
+using UnityEngine;
+
+namespace BlocksBeyondTheStars.Client.EditorTools
+{
+    /// <summary>
+    /// #1537: ranks managed allocations in a Unity Profiler capture (.raw) written by a development player
+    /// (PerfProbe <c>-perfProfile &lt;file&gt;</c>) — headless, so the attribution runs from a script instead of the
+    /// Profiler window. Every <c>GC.Alloc</c> sample carries its size; it is attributed twice: to the profiler
+    /// sample path it sits in (the MonoBehaviour callback / instrumented scope — always available) and, when the
+    /// player recorded allocation call stacks, to the allocating managed method. Sums are per second of capture.
+    /// Run: <c>Unity.exe -batchmode -nographics -projectPath client -executeMethod
+    /// BlocksBeyondTheStars.Client.EditorTools.ProfilerCaptureReport.Run -quit</c> with env
+    /// <c>BBS_PROFILE_RAW</c> (the capture) and <c>BBS_PROFILE_OUT</c> (the report path).
+    /// </summary>
+    public static class ProfilerCaptureReport
+    {
+        public static void Run()
+        {
+            string raw = Environment.GetEnvironmentVariable("BBS_PROFILE_RAW");
+            string outPath = Environment.GetEnvironmentVariable("BBS_PROFILE_OUT");
+            if (string.IsNullOrEmpty(raw) || !File.Exists(raw))
+            {
+                Debug.LogError($"ProfilerCaptureReport: capture not found: '{raw}'");
+                EditorApplication.Exit(2);
+                return;
+            }
+
+            string report;
+            try
+            {
+                report = Build(raw);
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError("ProfilerCaptureReport failed: " + ex);
+                EditorApplication.Exit(3);
+                return;
+            }
+
+            if (!string.IsNullOrEmpty(outPath))
+            {
+                Directory.CreateDirectory(Path.GetDirectoryName(outPath));
+                File.WriteAllText(outPath, report);
+            }
+
+            Debug.Log("ProfilerCaptureReport:\n" + report);
+            EditorApplication.Exit(0);
+        }
+
+        public static string Build(string rawPath)
+        {
+            // The Editor keeps only the LAST 2000 frames of a loaded capture (~10 s at 200 fps; the cap lives in the
+            // internal ProfilerUserSettings and setting it by reflection did not change what LoadProfile keeps), so
+            // a capture of idle + walk reports the walk phase — keep the PerfProbe phases at 10 s or shorter.
+            if (!ProfilerDriver.LoadProfile(rawPath, false))
+            {
+                return "could not load " + rawPath;
+            }
+
+            int first = ProfilerDriver.firstFrameIndex, last = ProfilerDriver.lastFrameIndex;
+            var byScope = new Dictionary<string, (long Bytes, long Count)>(StringComparer.Ordinal);
+            var byMethod = new Dictionary<string, (long Bytes, long Count)>(StringComparer.Ordinal);
+            var byStack = new Dictionary<string, (long Bytes, long Count)>(StringComparer.Ordinal);
+            var stack = new List<ulong>();
+            var path = new List<string>();
+            var remaining = new List<int>();
+            long totalBytes = 0, totalCount = 0, withStacks = 0;
+            int frames = 0, gcAllocMarker = -1;
+            double firstTime = double.NaN, lastTime = double.NaN;
+
+            for (int f = first; f <= last; f++)
+            {
+                using var view = ProfilerDriver.GetRawFrameDataView(f, 0); // main thread
+                if (view == null || !view.valid)
+                {
+                    continue;
+                }
+
+                frames++;
+                if (double.IsNaN(firstTime))
+                {
+                    firstTime = view.frameStartTimeMs;
+                }
+
+                lastTime = view.frameStartTimeMs + view.frameTimeMs;
+                if (gcAllocMarker < 0)
+                {
+                    gcAllocMarker = view.GetMarkerId("GC.Alloc");
+                }
+
+                path.Clear();
+                remaining.Clear();
+                for (int s = 0; s < view.sampleCount; s++)
+                {
+                    // Samples come depth-first; rebuild the scope path from the children counts.
+                    while (remaining.Count > 0 && remaining[remaining.Count - 1] == 0)
+                    {
+                        path.RemoveAt(path.Count - 1);
+                        remaining.RemoveAt(remaining.Count - 1);
+                    }
+
+                    if (remaining.Count > 0)
+                    {
+                        remaining[remaining.Count - 1]--;
+                    }
+
+                    int children = view.GetSampleChildrenCount(s);
+                    if (view.GetSampleMarkerId(s) == gcAllocMarker)
+                    {
+                        long bytes = view.GetSampleMetadataCount(s) > 0 ? view.GetSampleMetadataAsLong(s, 0) : 0;
+                        totalBytes += bytes;
+                        totalCount++;
+
+                        int from = Math.Max(0, path.Count - 4);
+                        string scope = path.Count == 0 ? "(root)" : string.Join(" / ", path.Skip(from).Select(Short));
+                        Add(byScope, scope, bytes);
+
+                        stack.Clear();
+                        view.GetSampleCallstack(s, stack);
+                        string top = null;
+                        var chain = new StringBuilder();
+                        int shown = 0;
+                        foreach (ulong addr in stack)
+                        {
+                            var info = view.ResolveMethodInfo(addr);
+                            if (string.IsNullOrEmpty(info.methodName))
+                            {
+                                continue;
+                            }
+
+                            string name = Short(info.methodName);
+                            top ??= name;
+                            if (shown < 6)
+                            {
+                                chain.Append(shown == 0 ? "" : " ← ").Append(name);
+                                shown++;
+                            }
+                        }
+
+                        if (top != null)
+                        {
+                            withStacks++;
+                            Add(byMethod, top, bytes);
+                            Add(byStack, chain.ToString(), bytes);
+                        }
+                    }
+
+                    path.Add(view.GetSampleName(s));
+                    remaining.Add(children);
+                }
+            }
+
+            double seconds = Math.Max(0.001, (lastTime - firstTime) / 1000.0);
+            var sb = new StringBuilder();
+            sb.AppendLine($"Capture {Path.GetFileName(rawPath)}: {frames} frames, {seconds:0.0} s, {totalCount} GC.Alloc samples ({withStacks} with call stacks), {totalBytes / 1024.0 / seconds:0.0} KB/s, {totalCount / seconds:0.0} allocs/s");
+            sb.AppendLine();
+            sb.AppendLine("Top allocating scopes (profiler sample path; bytes/s, allocs/s):");
+            foreach (var kv in byScope.OrderByDescending(k => k.Value.Bytes).Take(45))
+            {
+                sb.AppendLine($"  {kv.Value.Bytes / 1024.0 / seconds,9:0.0} KB/s {kv.Value.Count / seconds,8:0.0}/s  {kv.Key}");
+            }
+
+            if (byMethod.Count > 0)
+            {
+                sb.AppendLine();
+                sb.AppendLine("Top allocating methods (call stacks; bytes/s, allocs/s):");
+                foreach (var kv in byMethod.OrderByDescending(k => k.Value.Bytes).Take(60))
+                {
+                    sb.AppendLine($"  {kv.Value.Bytes / 1024.0 / seconds,9:0.0} KB/s {kv.Value.Count / seconds,8:0.0}/s  {kv.Key}");
+                }
+
+                sb.AppendLine();
+                sb.AppendLine("Top call stacks (bytes/s):");
+                foreach (var kv in byStack.OrderByDescending(k => k.Value.Bytes).Take(60))
+                {
+                    sb.AppendLine($"  {kv.Value.Bytes / 1024.0 / seconds,9:0.0} KB/s {kv.Value.Count / seconds,8:0.0}/s  {kv.Key}");
+                }
+            }
+
+            return sb.ToString();
+        }
+
+        /// <summary>Drops the assembly prefix and the project namespace: "X.dll!A.B::C.D()" → "C.D()".</summary>
+        private static string Short(string name)
+        {
+            if (string.IsNullOrEmpty(name))
+            {
+                return name;
+            }
+
+            int bang = name.IndexOf("!", StringComparison.Ordinal);
+            if (bang >= 0 && name.IndexOf("::", StringComparison.Ordinal) > bang)
+            {
+                name = name.Substring(name.IndexOf("::", StringComparison.Ordinal) + 2);
+            }
+
+            return name;
+        }
+
+        private static void Add(Dictionary<string, (long Bytes, long Count)> map, string key, long bytes)
+        {
+            map.TryGetValue(key, out var cur);
+            map[key] = (cur.Bytes + bytes, cur.Count + 1);
+        }
+    }
+}

--- a/client/Assets/BlocksBeyondTheStars/Editor/ProfilerCaptureReport.cs.meta
+++ b/client/Assets/BlocksBeyondTheStars/Editor/ProfilerCaptureReport.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a79eb437409e70840b1905e154102961

--- a/client/Assets/BlocksBeyondTheStars/Scripts/PerfProbe.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/PerfProbe.cs
@@ -63,6 +63,11 @@ namespace BlocksBeyondTheStars.Client
         // clock stays daytime, so strictly nocturnal glow species may be under-represented; cathemeral/passive
         // species and the raw entity-view density still populate the scene. A first dense probe, refine later.
         private bool _dense;
+
+        // #1537: -perfProfile <file> — in a Development player, write a Unity Profiler capture (binary log with
+        // allocation call stacks) of the idle + walk phases so the allocations can be attributed headless
+        // (Editor: ProfilerCaptureReport). Ignored in a release player (Profiler.enabled is a no-op there).
+        private string _profilePath;
         private const float DenseSettle = 12f; // extra settle so the creature ring fills toward its cap before sampling
         private const string DensePlanet = "jungle"; // breathable + vegetated ⇒ dense fauna (incl. glowers)
 
@@ -84,6 +89,7 @@ namespace BlocksBeyondTheStars.Client
             int vd = -1;
             string feature = null;
             bool dense = false;
+            string profilePath = null;
             for (int i = 0; i < args.Length; i++)
             {
                 string a = args[i];
@@ -122,6 +128,10 @@ namespace BlocksBeyondTheStars.Client
                 else if (string.Equals(a, "-perfDense", StringComparison.OrdinalIgnoreCase))
                 {
                     dense = true;
+                }
+                else if (string.Equals(a, "-perfProfile", StringComparison.OrdinalIgnoreCase) && i + 1 < args.Length)
+                {
+                    profilePath = args[i + 1];
                 }
             }
 
@@ -169,6 +179,7 @@ namespace BlocksBeyondTheStars.Client
             p._vdOverride = vd;
             p._featureSpec = feature;
             p._dense = dense;
+            p._profilePath = profilePath;
         }
 
         private void Start() => StartCoroutine(Run());
@@ -273,6 +284,26 @@ namespace BlocksBeyondTheStars.Client
 
             // Phase 1: idle — steady-state cost with the spawn area fully streamed.
             PhaseResult r = null;
+            if (!string.IsNullOrEmpty(_profilePath))
+            {
+                // #1537: capture idle + walk. Debug.isDebugBuild = a Development player; the release player has
+                // no profiler, so the flag is a documented no-op there.
+                if (Debug.isDebugBuild)
+                {
+                    Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(_profilePath)));
+                    UnityEngine.Profiling.Profiler.logFile = _profilePath;
+                    UnityEngine.Profiling.Profiler.enableBinaryLog = true;
+                    UnityEngine.Profiling.Profiler.enableAllocationCallstacks = true;
+                    UnityEngine.Profiling.Profiler.maxUsedMemory = 512 * 1024 * 1024;
+                    UnityEngine.Profiling.Profiler.enabled = true;
+                    Debug.Log($"[PerfProbe] Profiler capture → {_profilePath}.raw");
+                }
+                else
+                {
+                    Debug.LogWarning("[PerfProbe] -perfProfile needs a Development player (BBS_DEV_BUILD=1) — ignored.");
+                }
+            }
+
             yield return Sample("idle", _idleSeconds, x => r = x);
             phases.Add(r);
 
@@ -292,6 +323,13 @@ namespace BlocksBeyondTheStars.Client
             InputMap.ScriptedMove = Vector2.zero;
             StopCoroutine(hop);
             phases.Add(r);
+            if (!string.IsNullOrEmpty(_profilePath) && Debug.isDebugBuild)
+            {
+                UnityEngine.Profiling.Profiler.enabled = false;
+                UnityEngine.Profiling.Profiler.enableBinaryLog = false;
+                UnityEngine.Profiling.Profiler.logFile = string.Empty;
+                Debug.Log("[PerfProbe] Profiler capture closed.");
+            }
 
             // Phase 3 (optional): dense — force visual midnight and stand among the Extreme creature pack so the
             // glowing entities' point lights dominate the frame (#361). Walking first left a filled ring; a short


### PR DESCRIPTION
PR bundle 12 (the last) of the performance package #1501: the #1537 investigation. No game code changes — tooling plus the attributed allocation list; the fixes are #1550–#1556.

**Tooling**
- `BuildScript`: `BBS_DEV_BUILD=1` → a `BuildOptions.Development` player (never set by the release scripts). Deep-profiling support was tried and rejected: it instruments every method — 3–7 fps and 18 GB of capture in 40 s — while the plain Development player runs at release speed (idle 189 fps / walk 203 fps in the capture run).
- `PerfProbe -perfProfile <file>`: writes the profiler's binary log with allocation call stacks for the idle + walk phases; a documented no-op in a release player.
- `Editor/ProfilerCaptureReport.cs`: loads a `.raw` headless (`Unity -batchmode -nographics -executeMethod BlocksBeyondTheStars.Client.EditorTools.ProfilerCaptureReport.Run` with `BBS_PROFILE_RAW` / `BBS_PROFILE_OUT`), rebuilds each frame's scope tree from the raw sample data, attributes every `GC.Alloc` to its scope path and to the resolved call stack, and prints KB/s + allocs/s tables (scopes, methods, 6-frame chains). The Editor keeps only the last 2000 frames of a capture, so the PerfProbe phases stay at 10 s.

**Findings** (walk, High / VD 8, the persisted PerfProbe save: 7.0 MB/s, 20 400 allocs/s) — full table on #1537:
- chunk-build dispatch ~1.8 MB/s (8 KB `ChunkData.ToArray` clone × 141 builds/s, `Neighbourhood`, closures, `Task.Run`) → #1550
- uGUI `Outline` text rebuilds ~2.0 MB/s (550 KB per rebuild, 3.6/s) → #1552
- IMGUI overlays `WeatherFx.OnGUI` + `FinaleView.OnGUI`: 146 KB/s certain, 1.4 MB/s in `GUI.Repaint` to verify → #1553
- `GroundScatter.Setup` `System.Random` per scatter point 440 KB/s → #1551
- receive-path copies (`ChunkBlocksRle.Decode` 412 KB/s, LiteNetLib packet copy, NPC-list strings) → #1555
- creature voice variants resolved at runtime, 250 KB LOH each → #1556
- per-frame tail (`RingBand` randoms, `VoiceChat`, `PlayersWithin`, `ToLowerInvariant`, HUD strings) → #1554

**Verification**
- Development player built with the switch; capture (780 MB / 20 s) and report produced end to end; the report tool compiled and ran headless (exit 0).
- The release build path is untouched (`BBS_DEV_BUILD` unset → the same `BuildPlayerOptions` as before).
- TODO.md entry added.

closes #1537

🤖 Generated with [Claude Code](https://claude.com/claude-code)
