### PR TITLE
perf(client): hash-based ground scatter, pooled voice bakes, and the per-frame allocation tail (#1551 #1554 #1556)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -243,6 +243,31 @@ is read from the module stat (16) instead of being dead, and the station deploy 
 persisted ids after a restart (id collision). Tests: `PlayerStationReportsTests` (7), `DropLootTests` (+2).
 Locales: 9 new keys + 2 rewordings, EN/DE hand-written, 12 MT via translate_locale.
 
+### ★ Client garbage, part 1: hash-based ground scatter, pooled voice bakes, and the per-frame tail (#1551 #1554 #1556, 2026-09-04, branch perf/1551-1554-1556-small-allocs)
+
+**Why.** PR bundle 13 of the performance package (#1501), the first three follow-ups of the #1537 attribution: the
+mechanical ones. Nothing here changes what the player sees or hears; every site was measured in the walk capture
+before and after (Development player, High / VD 8, the persisted PerfProbe save).
+
+**What ships.** `GroundScatter.Setup` derives yaw / scale / jitter from an xorshift mix of the cell hash instead of a
+`System.Random` per scatter point (a `Random` is ~250 B of seed table), and builds into two shared scratch lists
+(#1551: 440 → 46 KB/s, 2000 → 52 allocs/s). `SampleKit` keeps the decoded mono source per clip (the same handful of
+sample files feeds every species) and rents every intermediate bake buffer from `ArrayPool<float>` for the duration
+of one `Variant()` call — the ops work on `Span<float>`, the reverb's four comb lines share one pooled buffer, and the
+clip is filled through the `ReadOnlySpan` overload of `SetData` (#1556: ~250 KB of Large-Object-Heap garbage per bake
+→ pool warm-up only; `SampleKit.ReadMono` 244 → 26 KB/s once, `Comb` gone). The per-frame tail (#1554): `RingBand`
+derives the ring-plane rotation once per ring seed (was two `System.Random` per frame); `VoiceChat` polls
+`Microphone.devices` every 2 s and parses the push-to-talk key per setting value; `RemotePlayers.FirstPlayerWithin`
+replaces the per-frame `PlayersWithin` list in `PlayerInteractions`; `UrpScenePost.MoodKey`, `MicroFauna.Richness` /
+`SurfaceKinds` and `MusicLibrary.ContextForBiome` remember the last biome → key instead of lower-casing per call;
+`MicroFaunaView` keeps its `RemoveAll` predicate; `GamepadInputSource.Connected` re-polls the joystick names once a
+second; `HudUi` formats the vitals, hotbar numbers / counts, the time-of-day read-out and the playtime only when
+their inputs changed; `VegaPanel`'s typewriter substrings once per revealed character.
+
+**Measured (walk, same capture recipe).** 7.0 → 4.4 MB/s and 20 400 → 13 400 allocs/s; PerfProbe walk collections
+19 → 11 per 10 s. The remaining sources are the next bundles: the chunk-build dispatch (#1550), the IMGUI overlays
+(#1553), the receive path (#1555), the outlined HUD texts (#1552 — absent from this capture, so it is situational).
+
 ### ★ Client allocations attributed: a Development-build switch, `PerfProbe -perfProfile`, a headless profiler-capture report; seven follow-up issues ranked (#1537, 2026-09-04, branch perf/1537-gc-investigation)
 
 **Why.** The last item of the performance package (#1501): the client collected 4–7 times per second at

--- a/client/Assets/BlocksBeyondTheStars/Scripts/GroundScatter.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/GroundScatter.cs
@@ -32,6 +32,11 @@ namespace BlocksBeyondTheStars.Client
         private static Camera _cam;
         private static int _camFrame = -1;
 
+        // #1551: Setup ran per chunk mesh with a System.Random per point (~250 B each, ~2000 allocs/s while
+        // walking) — the variation now comes from a hash mix, and the two build lists are shared scratch.
+        private static readonly List<Matrix4x4> _tuftScratch = new List<Matrix4x4>();
+        private static readonly List<Matrix4x4> _pebbleScratch = new List<Matrix4x4>();
+
         private Matrix4x4[] _tufts;
         private Matrix4x4[] _pebbles;
         private Vector3 _worldCenter;
@@ -52,18 +57,20 @@ namespace BlocksBeyondTheStars.Client
                 return;
             }
 
-            var tufts = new List<Matrix4x4>();
-            var pebbles = new List<Matrix4x4>();
+            var tufts = _tuftScratch;
+            var pebbles = _pebbleScratch;
+            tufts.Clear();
+            pebbles.Clear();
             var l2w = transform.localToWorldMatrix;
             foreach (var p in points)
             {
-                // Deterministic per-point variation from the local cell position.
-                int h = unchecked((int)p.x * 73856093 ^ (int)p.z * 19349663 ^ Mathf.RoundToInt(p.y) * 83492791);
-                var rng = new System.Random(h);
-                float yaw = (float)rng.NextDouble() * 360f;
-                float scale = 0.7f + (float)rng.NextDouble() * 0.6f;
-                float jx = ((float)rng.NextDouble() - 0.5f) * 0.5f;
-                float jz = ((float)rng.NextDouble() - 0.5f) * 0.5f;
+                // Deterministic per-point variation from the local cell position: four hash draws (a different
+                // but equally uniform sequence than the System.Random this replaced — the look is unchanged).
+                uint h = unchecked((uint)((int)p.x * 73856093 ^ (int)p.z * 19349663 ^ Mathf.RoundToInt(p.y) * 83492791));
+                float yaw = Draw(ref h) * 360f;
+                float scale = 0.7f + Draw(ref h) * 0.6f;
+                float jx = (Draw(ref h) - 0.5f) * 0.5f;
+                float jz = (Draw(ref h) - 0.5f) * 0.5f;
                 var local = Matrix4x4.TRS(
                     new Vector3(p.x + jx, p.y, p.z + jz),
                     Quaternion.Euler(0f, yaw, 0f),
@@ -79,12 +86,24 @@ namespace BlocksBeyondTheStars.Client
                 }
             }
 
-            _tufts = tufts.ToArray();
-            _pebbles = pebbles.ToArray();
+            _tufts = tufts.Count > 0 ? tufts.ToArray() : null;
+            _pebbles = pebbles.Count > 0 ? pebbles.ToArray() : null;
+            tufts.Clear();
+            pebbles.Clear();
             _worldCenter = transform.TransformPoint(new Vector3(
                 WorldConstants.ChunkSize * 0.5f, WorldConstants.ChunkSize * 0.5f, WorldConstants.ChunkSize * 0.5f));
             _ready = true;
             enabled = true;
+        }
+
+        /// <summary>One uniform [0,1) draw from a 32-bit state (xorshift step + a multiplicative mix).</summary>
+        private static float Draw(ref uint state)
+        {
+            state ^= state << 13;
+            state ^= state >> 17;
+            state ^= state << 5;
+            uint mixed = unchecked(state * 2654435761u);
+            return (mixed >> 8) * (1f / 16777216f);
         }
 
         private void Update()

--- a/client/Assets/BlocksBeyondTheStars/Scripts/HudUi.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/HudUi.cs
@@ -82,7 +82,7 @@ namespace BlocksBeyondTheStars.Client
         private readonly System.Collections.Generic.List<RectTransform> _compassBeacons = new();
         private readonly System.Collections.Generic.List<RectTransform> _compassMarkers = new(); // named markers + pings (#1217)
 
-        private struct VitalRow { public Image Fill; public Text Label; public GameObject Go; public bool Warn; public Color BaseColor; }
+        private struct VitalRow { public Image Fill; public Text Label; public GameObject Go; public bool Warn; public Color BaseColor; public string LastLabel; public int LastValue; }
         private VitalRow[] _vitals;
         private float _lowVitalBeepTimer; // shared low-vitals alarm cadence (#753)
 
@@ -155,6 +155,11 @@ namespace BlocksBeyondTheStars.Client
         // that anyway. Motion-coupled elements (compass blips) still update per frame, and a hotbar
         // selection change forces an immediate refresh so input feedback never lags.
         private const float RefreshInterval = 0.1f;
+        private int _todKey = int.MinValue; // #1554 change keys of the formatted read-outs
+        private string _todWeather, _todPrecip, _todFamily;
+        private bool _todSpaceSky;
+        private object _todLoc, _playtimeLoc;
+        private long _playtimeShown = -1;
         private float _refreshTimer;
         private int _lastCompassDist = int.MinValue;
         private int _lastCompassWpDist = int.MinValue;
@@ -922,7 +927,28 @@ namespace BlocksBeyondTheStars.Client
             if (!active) return;
             v.Fill.color = color;
             v.Fill.fillAmount = Mathf.Clamp01(frac);
-            v.Label.text = $"{label}  {Mathf.RoundToInt(value)}";
+            int shown = Mathf.RoundToInt(value);
+            if (shown != v.LastValue || !ReferenceEquals(label, v.LastLabel) || v.LastLabel == null)
+            {
+                // #1554: 10 Hz × 6 rows of interpolated strings — only when the rounded value or label changed.
+                v.LastValue = shown;
+                v.LastLabel = label;
+                _vitals[i] = v;
+                v.Label.text = $"{label}  {shown}";
+            }
+        }
+
+        /// <summary>Small-integer strings for the hotbar (slot numbers, stack counts) without a ToString per refresh.</summary>
+        private static readonly string[] _smallInts = new string[1000];
+
+        private static string SmallInt(int n)
+        {
+            if (n < 0 || n >= _smallInts.Length)
+            {
+                return n.ToString();
+            }
+
+            return _smallInts[n] ??= n.ToString();
         }
 
         private static readonly Color VitalWarnRed = new(1f, 0.25f, 0.2f);
@@ -995,7 +1021,7 @@ namespace BlocksBeyondTheStars.Client
                 var s = _hotbar[i];
                 bool sel = i == Game.SelectedHotbarSlot;
                 UiKit.StyleQuickSlot(s, sel);
-                s.Num.text = (i + 1).ToString();
+                s.Num.text = SmallInt(i + 1);
 
                 string item = Game.ItemInSlot(i);
                 if (string.IsNullOrEmpty(item))
@@ -1008,7 +1034,7 @@ namespace BlocksBeyondTheStars.Client
 
                 // Stack size top-right (#744): only for real stacks, so tools (max stack 1) stay clean.
                 int count = Game.CountInSlot(i);
-                s.Count.text = count > 1 ? count.ToString() : string.Empty;
+                s.Count.text = count > 1 ? SmallInt(count) : string.Empty;
 
                 var blockDef = Game.Content?.GetBlock(item);
                 if (blockDef == null && Game.Content?.GetItem(item)?.PlacesBlock is string pb && pb.Length > 0)
@@ -1556,6 +1582,24 @@ namespace BlocksBeyondTheStars.Client
             float frac = nextEdge - t; if (frac < 0f) frac += 1f;
             float secs = frac * Mathf.Max(1f, env.DayLengthSeconds);
             int mm = Mathf.FloorToInt(secs / 60f), ss = Mathf.FloorToInt(secs % 60f);
+            // #1554: the readout only changes once a second (or with the weather / temperature / gravity), so
+            // skip the five-part interpolation on the other nine refreshes.
+            int todKey = (day ? 1 : 0) ^ (mm << 1) ^ (ss << 12) ^ (Mathf.RoundToInt(env.Temperature) << 18)
+                         ^ (Mathf.RoundToInt(env.GravityFactor * 10f) << 26) ^ (Game.OnFootInSpace ? 1 << 30 : 0);
+            if (todKey == _todKey && ReferenceEquals(env.Weather, _todWeather) && ReferenceEquals(env.Precipitation, _todPrecip)
+                && ReferenceEquals(env.WeatherFamily, _todFamily) && env.SpaceSky == _todSpaceSky
+                && ReferenceEquals(loc, _todLoc))
+            {
+                _todMarker.anchoredPosition = new Vector2(10 + 150 * t, _todMarker.anchoredPosition.y);
+                return;
+            }
+
+            _todKey = todKey;
+            _todWeather = env.Weather;
+            _todPrecip = env.Precipitation;
+            _todFamily = env.WeatherFamily;
+            _todSpaceSky = env.SpaceSky;
+            _todLoc = loc;
             string tempStr = env.Temperature <= -900f ? "—" : ColoredTemp(env.Temperature);
             // Show this world's gravity (e.g. "0.6 g") only when it notably differs from Earth-like, so normal
             // worlds stay uncluttered. Hidden in space (on-foot zero-g) where gravity doesn't apply.
@@ -1640,7 +1684,15 @@ namespace BlocksBeyondTheStars.Client
                 return;
             }
 
-            _playtimeText.text = $"{loc.Get("ui.hud.playtime")}  {FormatDuration((long)Game.SessionSeconds)}"
+            long session = (long)Game.SessionSeconds;
+            if (session == _playtimeShown && ReferenceEquals(loc, _playtimeLoc))
+            {
+                return; // #1554: changes once a second, refreshed ten times a second
+            }
+
+            _playtimeShown = session;
+            _playtimeLoc = loc;
+            _playtimeText.text = $"{loc.Get("ui.hud.playtime")}  {FormatDuration(session)}"
                                  + $"  ·  {loc.Get("ui.hud.playtime_total")}  {FormatDuration(Game.TotalPlaytimeSeconds)}";
         }
 

--- a/client/Assets/BlocksBeyondTheStars/Scripts/Input/GamepadInputSource.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/Input/GamepadInputSource.cs
@@ -80,21 +80,21 @@ namespace BlocksBeyondTheStars.Client
         public InputDeviceKind Kind => InputDeviceKind.Gamepad;
 
         private static bool _connected;
-        private static int _connectedFrame = -1;
+        private static float _connectedUntil = -1f; // #1554: re-poll once a second (the names array is a fresh allocation)
 
-        /// <summary>Whether at least one joystick is connected (a non-empty name). Evaluated once per frame
+        /// <summary>Whether at least one joystick is connected (a non-empty name). Evaluated once a second
         /// (#1512 — <c>Input.GetJoystickNames()</c> allocates a fresh string array, and this used to run on
         /// every ActionDown/Held/Up poll); when false the source stays fully inert so an unplugged pad costs
         /// nothing.</summary>
         public static bool Connected()
         {
-            int frame = Time.frameCount;
-            if (frame == _connectedFrame)
+            float now = Time.unscaledTime;
+            if (now < _connectedUntil)
             {
                 return _connected;
             }
 
-            _connectedFrame = frame;
+            _connectedUntil = now + 1f;
             _connected = false;
             var names = Input.GetJoystickNames();
             if (names == null)

--- a/client/Assets/BlocksBeyondTheStars/Scripts/MicroFauna.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/MicroFauna.cs
@@ -138,9 +138,24 @@ namespace BlocksBeyondTheStars.Client
         public static int Index(string key) => IndexByKey.TryGetValue(key, out int i) ? i : 0;
 
         /// <summary>0 = no surface micro-fauna here, up to ~1.3 = lush. Drives the target population per biome.</summary>
+        // #1554: Richness and SurfaceKinds run every frame while the population is short — lower-case the
+        // biome key once per distinct value instead of per call.
+        private static string _lowerSrc, _lowerBiome = string.Empty;
+
+        private static string LowerBiome(string biome)
+        {
+            if (!string.Equals(biome, _lowerSrc, System.StringComparison.Ordinal))
+            {
+                _lowerSrc = biome;
+                _lowerBiome = (biome ?? string.Empty).ToLowerInvariant();
+            }
+
+            return _lowerBiome;
+        }
+
         public static float Richness(string biome)
         {
-            switch ((biome ?? string.Empty).ToLowerInvariant())
+            switch (LowerBiome(biome))
             {
                 case "jungle":
                 case "forest":
@@ -176,7 +191,7 @@ namespace BlocksBeyondTheStars.Client
         public static void SurfaceKinds(string biome, bool night, bool wet, List<int> into)
         {
             into.Clear();
-            string b = (biome ?? string.Empty).ToLowerInvariant();
+            string b = LowerBiome(biome);
             bool lush = b is "jungle" or "forest" or "tropical" or "swamp" or "wetland";
             bool cold = b is "ice" or "frozen" or "tundra" or "snow" or "alpine";
             bool hot = b is "desert" or "lava" or "ashen" or "volcanic";

--- a/client/Assets/BlocksBeyondTheStars/Scripts/MicroFaunaView.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/MicroFaunaView.cs
@@ -264,6 +264,8 @@ namespace BlocksBeyondTheStars.Client
 
         // --- spawning ---------------------------------------------------------------------------------------
 
+        private System.Predicate<int> _notKeptOnPlanet;
+
         private bool SpawnSurfaceOrWater(bool night)
         {
             // Roughly a third of spawns go to the water roster when a pond/sea is nearby.
@@ -280,7 +282,7 @@ namespace BlocksBeyondTheStars.Client
             {
                 bool anyKept = false;
                 for (int i = 0; i < _surfaceKinds.Count && !anyKept; i++) anyKept = _planetKeep[_surfaceKinds[i]];
-                if (anyKept) _surfaceKinds.RemoveAll(i => !_planetKeep[i]);
+                if (anyKept) _surfaceKinds.RemoveAll(_notKeptOnPlanet ??= i => !_planetKeep[i]); // #1554: one delegate, not one per spawn
             }
 
             if (_surfaceKinds.Count == 0) return false;

--- a/client/Assets/BlocksBeyondTheStars/Scripts/PlayerInteractions.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/PlayerInteractions.cs
@@ -94,8 +94,7 @@ namespace BlocksBeyondTheStars.Client
                 return null;
             }
 
-            var near = Remotes.PlayersWithin(Game.PlayerPosition, InteractRange);
-            return near.Count > 0 ? near[0] : null;
+            return Remotes.FirstPlayerWithin(Game.PlayerPosition, InteractRange);
         }
 
         /// <summary>True while a trade / dock request could be sent right now: a player in reach, and we are

--- a/client/Assets/BlocksBeyondTheStars/Scripts/RemotePlayers.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/RemotePlayers.cs
@@ -59,6 +59,23 @@ namespace BlocksBeyondTheStars.Client
         private readonly Dictionary<string, string[]> _bodyPaints = new Dictionary<string, string[]>();
         private bool _subscribed;
 
+        /// <summary>The first other player within <paramref name="range"/> of <paramref name="from"/>, or null —
+        /// the same pick as <see cref="PlayersWithin"/>'s first entry, without building a list (#1554: this runs
+        /// from PlayerInteractions' Update and LateUpdate every frame).</summary>
+        public string FirstPlayerWithin(Vector3 from, float range)
+        {
+            float sq = range * range;
+            foreach (var r in _remotes.Values)
+            {
+                if (!r.TimedOut && (r.Go.transform.position - from).sqrMagnitude <= sq)
+                {
+                    return r.Name;
+                }
+            }
+
+            return null;
+        }
+
         /// <summary>Names of other players within <paramref name="range"/> of <paramref name="from"/> (for dock/trade targeting).</summary>
         public List<string> PlayersWithin(Vector3 from, float range)
         {

--- a/client/Assets/BlocksBeyondTheStars/Scripts/RingBand.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/RingBand.cs
@@ -22,6 +22,7 @@ namespace BlocksBeyondTheStars.Client
         private Material _mat;
         private string _builtFor = "\0";
         private int _ringSeed;
+        private Quaternion _ringRot; // #1554: seeded tilt/azimuth, derived once per ring (was two System.Random per frame)
         private Color _tint;
         private float _fade = -1f; // smoothed day/night strength; <0 = snap to the target on first sight
                                    // (playtest: the ramp-in from 0 left the band invisible for minutes)
@@ -81,8 +82,7 @@ namespace BlocksBeyondTheStars.Client
             // halo; steep arcs read as "the ring stands in the sky"), seeded azimuth. Offsetting the plane
             // from the eye along its normal is what gives the arc its visible width (~10-12°).
             float r = Mathf.Max(200f, Camera.farClipPlane) * 0.35f;
-            var rot = Quaternion.AngleAxis(PlanetRings.AzimuthDegrees(_ringSeed), Vector3.up)
-                      * Quaternion.AngleAxis(90f - Mathf.Abs(PlanetRings.TiltDegrees(_ringSeed)), Vector3.right);
+            var rot = _ringRot;
             Vector3 normal = rot * Vector3.up;
             _band.SetPositionAndRotation(Camera.transform.position + normal * (r * 0.3f), rot);
             _band.localScale = new Vector3(r, r, r);
@@ -141,6 +141,8 @@ namespace BlocksBeyondTheStars.Client
             {
                 _mat.mainTexture = PlanetRings.BandTexture(_ringSeed);
                 _tint = PlanetRings.TintFor(_ringSeed, Color.white);
+                _ringRot = Quaternion.AngleAxis(PlanetRings.AzimuthDegrees(_ringSeed), Vector3.up)
+                           * Quaternion.AngleAxis(90f - Mathf.Abs(PlanetRings.TiltDegrees(_ringSeed)), Vector3.right);
             }
         }
     }

--- a/client/Assets/BlocksBeyondTheStars/Scripts/SampleKit.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/SampleKit.cs
@@ -1,6 +1,7 @@
 // Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using System;
 using System.Collections.Generic;
 using BlocksBeyondTheStars.Shared.Definitions;
 using UnityEngine;
@@ -42,6 +43,33 @@ namespace BlocksBeyondTheStars.Client
 
         private static readonly Dictionary<string, Entry> _cache = new Dictionary<string, Entry>();
         private static readonly List<string> _evictScratch = new List<string>();
+
+        // #1556: a bake used to allocate ~250 KB of throw-away float[] (the decoded source, the mono downmix,
+        // one buffer per op stage) — Large Object Heap garbage twice a second while creatures are around.
+        // The decoded sources are kept (the same handful of sample files feeds every species), and every
+        // intermediate buffer is rented from the shared pool for the duration of one Variant() call.
+        private const int MaxMonoEntries = 32;
+        private static readonly Dictionary<string, float[]> _mono = new Dictionary<string, float[]>();
+        private static readonly List<float[]> _rented = new List<float[]>();
+
+        private static Span<float> Rent(int length)
+        {
+            var array = System.Buffers.ArrayPool<float>.Shared.Rent(Mathf.Max(1, length));
+            _rented.Add(array);
+            var span = array.AsSpan(0, Mathf.Max(1, length));
+            span.Clear(); // pooled memory is not zeroed; the delay lines and mix targets rely on silence
+            return length > 0 ? span : span.Slice(0, 0);
+        }
+
+        private static void ReturnRented()
+        {
+            for (int i = 0; i < _rented.Count; i++)
+            {
+                System.Buffers.ArrayPool<float>.Shared.Return(_rented[i]);
+            }
+
+            _rented.Clear();
+        }
 
         /// <summary>A dripping-cavern tail for cave-dweller calls (replaces AudioReverbFilter.Cave):
         /// small Schroeder reverb — 4 parallel feedback combs into 2 series allpasses, ~0.9 s tail.</summary>
@@ -85,33 +113,42 @@ namespace BlocksBeyondTheStars.Client
 
             // Mono throughout: these are 3D point sources, so a stereo bake doubles both the memory and the
             // DSP cost for something the spatialiser collapses anyway.
-            var data = ReadMono(src);
-            if (data == null)
+            var mono = ReadMono(src);
+            if (mono == null)
             {
                 return src; // unreadable (not Decompress-On-Load) — play the dry clip rather than nothing
             }
 
-            int rate = src.frequency;
-            if (layer != null)
+            try
             {
-                var lay = ReadMono(layer);
-                if (lay != null)
+                var data = Rent(mono.Length);
+                mono.AsSpan().CopyTo(data); // the ops work in place, and the decoded source is shared
+                int rate = src.frequency;
+                if (layer != null)
                 {
-                    data = MixLayer(data, lay, rate, layerOffsetMs, layerDetune);
+                    var lay = ReadMono(layer);
+                    if (lay != null)
+                    {
+                        data = MixLayer(data, lay, rate, layerOffsetMs, layerDetune);
+                    }
                 }
-            }
 
-            data = Apply(op, data, rate, amount);
-            if (tail > 0)
+                data = Apply(op, data, rate, amount);
+                if (tail > 0)
+                {
+                    data = Reverb(data, rate, tail);
+                }
+
+                Normalise(data);
+                var clip = AudioClip.Create(key, data.Length, 1, rate, false);
+                clip.SetData(data, 0); // the ReadOnlySpan overload copies into the clip
+                Insert(key, clip);
+                return clip;
+            }
+            finally
             {
-                data = Reverb(data, rate, tail);
+                ReturnRented();
             }
-
-            Normalise(data);
-            var clip = AudioClip.Create(key, data.Length, 1, rate, false);
-            clip.SetData(data, 0);
-            Insert(key, clip);
-            return clip;
         }
 
         /// <summary>Frees every baked clip. MUST be called on world teardown (GameBootstrap.OnDestroy):
@@ -123,11 +160,12 @@ namespace BlocksBeyondTheStars.Client
             {
                 if (entry.Clip != null)
                 {
-                    Object.Destroy(entry.Clip);
+                    UnityEngine.Object.Destroy(entry.Clip);
                 }
             }
 
             _cache.Clear();
+            _mono.Clear();
         }
 
         /// <summary>How many variants are currently resident — used by the client's audio diagnostics.</summary>
@@ -177,7 +215,7 @@ namespace BlocksBeyondTheStars.Client
                 {
                     if (entry.Clip != null)
                     {
-                        Object.Destroy(entry.Clip);
+                        UnityEngine.Object.Destroy(entry.Clip);
                     }
 
                     _cache.Remove(key2);
@@ -185,40 +223,61 @@ namespace BlocksBeyondTheStars.Client
             }
         }
 
-        /// <summary>Decodes a clip to mono float PCM. Returns null when the clip is not readable — which on
-        /// Web means it was not imported Decompress-On-Load.</summary>
+        /// <summary>Decodes a clip to mono float PCM, kept per source clip (callers must NOT write into it).
+        /// Returns null when the clip is not readable — which on Web means it was not imported
+        /// Decompress-On-Load.</summary>
         private static float[] ReadMono(AudioClip src)
         {
-            var raw = new float[src.samples * src.channels];
-            if (!src.GetData(raw, 0))
+            if (_mono.TryGetValue(src.name, out var kept) && kept.Length == src.samples)
             {
-                return null;
+                return kept;
             }
 
-            if (src.channels == 1)
-            {
-                return raw;
-            }
-
-            var mono = new float[src.samples];
+            // GetData wants an array of exactly the clip's sample count (no span overload) — this is the one
+            // allocation left per distinct source, and the stereo scratch is pooled.
             int ch = src.channels;
-            for (int i = 0; i < mono.Length; i++)
+            float[] mono;
+            if (ch == 1)
             {
-                float sum = 0f;
-                for (int c = 0; c < ch; c++)
+                mono = new float[src.samples];
+                if (!src.GetData(mono, 0))
                 {
-                    sum += raw[i * ch + c];
+                    return null;
+                }
+            }
+            else
+            {
+                var raw = new float[src.samples * ch];
+                if (!src.GetData(raw, 0))
+                {
+                    return null;
                 }
 
-                mono[i] = sum / ch;
+                mono = new float[src.samples];
+                for (int i = 0; i < mono.Length; i++)
+                {
+                    float sum = 0f;
+                    for (int c = 0; c < ch; c++)
+                    {
+                        sum += raw[i * ch + c];
+                    }
+
+                    mono[i] = sum / ch;
+                }
             }
 
+            if (_mono.Count >= MaxMonoEntries)
+            {
+                _mono.Clear(); // a handful of files per world; a full reset is simpler than an LRU here
+            }
+
+            _mono[src.name] = mono;
             return mono;
         }
 
         // ── species timbre ops (#903) — each a plain float[] → float[] pass, all WebGL-safe ────────────
 
-        private static float[] Apply(VoiceOp op, float[] d, int rate, int amount)
+        private static Span<float> Apply(VoiceOp op, Span<float> d, int rate, int amount)
         {
             int a = Mathf.Clamp(amount, 0, 2);
             switch (op)
@@ -236,7 +295,7 @@ namespace BlocksBeyondTheStars.Client
         }
 
         /// <summary>Algebraic soft-clip — a throaty, saturated edge for hostile fauna.</summary>
-        private static float[] Drive(float[] d, int amount)
+        private static Span<float> Drive(Span<float> d, int amount)
         {
             float g = new[] { 2.5f, 5f, 9f }[amount];
             for (int i = 0; i < d.Length; i++)
@@ -249,7 +308,7 @@ namespace BlocksBeyondTheStars.Client
         }
 
         /// <summary>Amplitude modulation — the alien warble, and what a limbless buzzing body reads as.</summary>
-        private static float[] Tremolo(float[] d, int rate, int amount)
+        private static Span<float> Tremolo(Span<float> d, int rate, int amount)
         {
             float hz = new[] { 7f, 12f, 19f }[amount];
             float depth = new[] { 0.35f, 0.55f, 0.75f }[amount];
@@ -264,11 +323,11 @@ namespace BlocksBeyondTheStars.Client
 
         /// <summary>Feed-forward comb — evenly spaced notches read as metallic/insectoid resonance. Chosen
         /// over a feedback comb because it cannot ring away into instability.</summary>
-        private static float[] Comb(float[] d, int rate, int amount)
+        private static Span<float> Comb(Span<float> d, int rate, int amount)
         {
             int delay = Mathf.Max(1, Mathf.RoundToInt(new[] { 1.2f, 2.2f, 3.5f }[amount] * 0.001f * rate));
             float g = new[] { 0.6f, 0.75f, 0.9f }[amount];
-            var wet = new float[d.Length];
+            var wet = Rent(d.Length);
             for (int i = 0; i < d.Length; i++)
             {
                 wet[i] = d[i] + (i >= delay ? d[i - delay] * g : 0f);
@@ -278,7 +337,7 @@ namespace BlocksBeyondTheStars.Client
         }
 
         /// <summary>Bit + sample-rate reduction — chittery and slightly artificial, good on insect bodies.</summary>
-        private static float[] Crush(float[] d, int amount)
+        private static Span<float> Crush(Span<float> d, int amount)
         {
             float levels = new[] { 64f, 24f, 10f }[amount];
             int hold = new[] { 2, 3, 5 }[amount];
@@ -298,12 +357,12 @@ namespace BlocksBeyondTheStars.Client
 
         /// <summary>Appends a reversed, quieter echo of the sample. Baked rather than played at a negative
         /// pitch because Unity Web forbids negative pitch outright.</summary>
-        private static float[] ReverseTail(float[] d, int amount)
+        private static Span<float> ReverseTail(Span<float> d, int amount)
         {
             float gain = new[] { 0.35f, 0.5f, 0.7f }[amount];
             int gap = d.Length / 8;
-            var wet = new float[d.Length + gap + d.Length];
-            System.Array.Copy(d, wet, d.Length);
+            var wet = Rent(d.Length + gap + d.Length);
+            d.CopyTo(wet);
             for (int i = 0; i < d.Length; i++)
             {
                 float fade = 1f - i / (float)d.Length;
@@ -315,14 +374,13 @@ namespace BlocksBeyondTheStars.Client
 
         /// <summary>Envelope reshape: a clipped bark at amount 0, a slow drawn-out swell at amount 2 — the
         /// difference between an animal that snaps and one that sighs, from the same sample.</summary>
-        private static float[] Shape(float[] d, int rate, int amount)
+        private static Span<float> Shape(Span<float> d, int rate, int amount)
         {
             int n = d.Length;
             if (amount == 0)
             {
                 int keep = Mathf.Max(rate / 8, n / 3); // a short bark, then a fast fade
-                var bark = new float[Mathf.Min(n, keep)];
-                System.Array.Copy(d, bark, bark.Length);
+                var bark = d.Slice(0, Mathf.Min(n, keep)); // in place: the fade only touches the kept head
                 int fade = bark.Length / 4;
                 for (int i = 0; i < fade; i++)
                 {
@@ -347,13 +405,13 @@ namespace BlocksBeyondTheStars.Client
 
         /// <summary>Mixes a second sample in behind the first, offset and detuned — the only op here that
         /// truly multiplies the palette, because it combines two samples rather than modulating one.</summary>
-        private static float[] MixLayer(float[] baseData, float[] layerData, int rate, int offsetMs, int detune)
+        private static Span<float> MixLayer(Span<float> baseData, float[] layerData, int rate, int offsetMs, int detune)
         {
             float ratio = new[] { 0.82f, 1f, 1.28f }[Mathf.Clamp(detune, 0, 2)];
             int offset = Mathf.Max(0, Mathf.RoundToInt(offsetMs * 0.001f * rate));
             int layerLen = Mathf.Max(1, (int)(layerData.Length / ratio));
-            var wet = new float[Mathf.Max(baseData.Length, offset + layerLen)];
-            System.Array.Copy(baseData, wet, baseData.Length);
+            var wet = Rent(Mathf.Max(baseData.Length, offset + layerLen));
+            baseData.CopyTo(wet);
             for (int i = 0; i < layerLen; i++)
             {
                 // Linear resample of the layer — pitch and speed move together, exactly like a sampler.
@@ -377,31 +435,37 @@ namespace BlocksBeyondTheStars.Client
         /// <summary>Small Schroeder cave reverb: 4 mutually-prime feedback combs into 2 series allpasses.
         /// The tail length and wet mix scale with <paramref name="amount"/> so a species can have "a little
         /// space" without sounding like it lives in a cavern.</summary>
-        private static float[] Reverb(float[] dry, int rate, int amount)
+        private static readonly float[] CombMs = { 29.7f, 37.1f, 41.1f, 43.7f };
+        private static readonly float[] CombGain = { 0.72f, 0.70f, 0.68f, 0.66f };
+
+        private static Span<float> Reverb(Span<float> dry, int rate, int amount)
         {
-            float[] combMs = { 29.7f, 37.1f, 41.1f, 43.7f };
-            float[] combGain = { 0.72f, 0.70f, 0.68f, 0.66f };
             float tailSec = new[] { 0f, 0.45f, 0.9f }[Mathf.Clamp(amount, 0, 2)];
             float wetMix = new[] { 0f, 0.22f, 0.45f }[Mathf.Clamp(amount, 0, 2)];
             int tail = Mathf.CeilToInt(tailSec * rate);
-            var wet = new float[dry.Length + tail];
+            var wet = Rent(dry.Length + tail);
 
-            var combBuf = new float[combMs.Length][];
-            for (int c = 0; c < combMs.Length; c++)
+            // The four comb delay lines, back to back in one pooled buffer (Rent zeroes it).
+            Span<int> combLen = stackalloc int[CombMs.Length];
+            Span<int> combStart = stackalloc int[CombMs.Length];
+            int total = 0;
+            for (int c = 0; c < CombMs.Length; c++)
             {
-                combBuf[c] = new float[Mathf.Max(1, Mathf.RoundToInt(combMs[c] * 0.001f * rate))];
+                combLen[c] = Mathf.Max(1, Mathf.RoundToInt(CombMs[c] * 0.001f * rate));
+                combStart[c] = total;
+                total += combLen[c];
             }
 
+            var combBuf = Rent(total);
             for (int i = 0; i < wet.Length; i++)
             {
                 float x = i < dry.Length ? dry[i] : 0f;
                 float sum = 0f;
-                for (int c = 0; c < combBuf.Length; c++)
+                for (int c = 0; c < CombMs.Length; c++)
                 {
-                    var buf = combBuf[c];
-                    int j = i % buf.Length;
-                    float y = x + buf[j] * combGain[c]; // buf[j] still holds y from one delay ago
-                    buf[j] = y;
+                    int j = combStart[c] + i % combLen[c];
+                    float y = x + combBuf[j] * CombGain[c]; // combBuf[j] still holds y from one delay ago
+                    combBuf[j] = y;
                     sum += y;
                 }
 
@@ -422,9 +486,9 @@ namespace BlocksBeyondTheStars.Client
 
         /// <summary>In-place series allpass (y = z − g·w, w = x + g·z) — smears the comb output into a dense
         /// tail without colouring the spectrum.</summary>
-        private static void Allpass(float[] s, int delaySamples, float g)
+        private static void Allpass(Span<float> s, int delaySamples, float g)
         {
-            var buf = new float[Mathf.Max(1, delaySamples)];
+            var buf = Rent(Mathf.Max(1, delaySamples));
             for (int i = 0; i < s.Length; i++)
             {
                 int j = i % buf.Length;
@@ -435,7 +499,7 @@ namespace BlocksBeyondTheStars.Client
             }
         }
 
-        private static float[] LowPass(float[] d, int rate, float cutoff)
+        private static Span<float> LowPass(Span<float> d, int rate, float cutoff)
         {
             float a = 1f - Mathf.Exp(-2f * Mathf.PI * cutoff / rate);
             float state = 0f;
@@ -448,7 +512,7 @@ namespace BlocksBeyondTheStars.Client
             return d;
         }
 
-        private static float[] HighPass(float[] d, int rate, float cutoff)
+        private static Span<float> HighPass(Span<float> d, int rate, float cutoff)
         {
             float a = 1f - Mathf.Exp(-2f * Mathf.PI * cutoff / rate);
             float state = 0f;
@@ -463,7 +527,7 @@ namespace BlocksBeyondTheStars.Client
 
         /// <summary>Levels the bake back to the source's headroom. Drive and layering both add gain, and an
         /// un-levelled variant would make a species louder rather than different.</summary>
-        private static void Normalise(float[] d)
+        private static void Normalise(Span<float> d)
         {
             float peak = 0f;
             for (int i = 0; i < d.Length; i++)

--- a/client/Assets/BlocksBeyondTheStars/Scripts/UrpScenePost.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/UrpScenePost.cs
@@ -383,7 +383,21 @@ namespace BlocksBeyondTheStars.Client
 
         /// <summary>Maps a biome string to a mood key (mirrors Sky.GradeFor's grouping). Null/empty → "" (LUT off);
         /// any other unmatched biome → the gentle "default" film look.</summary>
+        private static string _moodBiome, _moodKeyCached; // #1554: called per frame from Sky.SetGrade
+
         private static string MoodKey(string biome)
+        {
+            if (_moodKeyCached != null && string.Equals(biome, _moodBiome, System.StringComparison.Ordinal))
+            {
+                return _moodKeyCached;
+            }
+
+            _moodBiome = biome;
+            _moodKeyCached = MoodKeyUncached(biome);
+            return _moodKeyCached;
+        }
+
+        private static string MoodKeyUncached(string biome)
         {
             switch ((biome ?? string.Empty).ToLowerInvariant())
             {

--- a/client/Assets/BlocksBeyondTheStars/Scripts/VegaPanel.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/VegaPanel.cs
@@ -51,6 +51,7 @@ namespace BlocksBeyondTheStars.Client
         private readonly Queue<(string Text, bool Prologue)> _queue = new Queue<(string, bool)>();
         private string _current = string.Empty;  // the page being typed/read (not the whole line)
         private float _shown;     // characters revealed so far
+        private int _shownChars = -1; // #1554: the character count last pushed into the text (skip equal frames)
 
         // Long lines are split into panel-sized pages, advanced with the same continue key (#736). German
         // runs 12–20 % longer than English, so the bandit briefing and several hints exceed the ~4 visible
@@ -531,7 +532,13 @@ namespace BlocksBeyondTheStars.Client
             {
                 // Still typing: the continue key fast-completes the reveal instead of skipping the page.
                 _shown = pressed ? _current.Length : Mathf.Min(_current.Length, _shown + Time.deltaTime * CharsPerSecond);
-                _speechText.text = _current.Substring(0, (int)_shown);
+                int visible = (int)_shown;
+                if (visible != _shownChars) // #1554: one Substring per revealed character, not per frame
+                {
+                    _shownChars = visible;
+                    _speechText.text = _current.Substring(0, visible);
+                }
+
                 if (_shown >= _current.Length)
                 {
                     StopChatter();
@@ -570,6 +577,7 @@ namespace BlocksBeyondTheStars.Client
             _page = index;
             _current = _pages.Count > 0 ? _pages[index] : string.Empty;
             _shown = 0f;
+            _shownChars = -1;
             _speechText.text = string.Empty;
             _continueHint.gameObject.SetActive(false);
         }

--- a/client/Assets/BlocksBeyondTheStars/Scripts/VoiceChat.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/VoiceChat.cs
@@ -201,26 +201,46 @@ namespace BlocksBeyondTheStars.Client
             _hudBuilt = true;
         }
 
+        // #1554: Microphone.devices allocates a fresh string[] per call — poll it every 2 s, not every frame.
+        private float _micPollAt = -1f;
+        private bool _micPresent;
+
         private bool CodecAndMicReady()
         {
 #if BBS_VOICE
             // Playback works regardless; a mic is only needed to transmit. Treat "voice available" as having a
             // capture device — VoiceInputEnabled then gates whether we actually transmit (see HandlePushToTalk).
-            return Microphone.devices.Length > 0;
+            float now = Time.unscaledTime;
+            if (now >= _micPollAt)
+            {
+                _micPollAt = now + 2f;
+                _micPresent = Microphone.devices.Length > 0;
+            }
+
+            return _micPresent;
 #else
             return false; // voice requires the Concentus plugin (BBS_VOICE) — see docs/developer/VOICE_CHAT.md
 #endif
         }
 
+        // #1554: Enum.TryParse splits the name and boxes the result on every call — cache per setting value
+        // (the setting string is reference-stable until the player rebinds it).
+        private string _pttName;
+        private KeyCode _pttKey = KeyCode.V;
+
         private KeyCode PushToTalkKey()
         {
             string name = Settings?.PushToTalkKey;
-            if (!string.IsNullOrEmpty(name) && System.Enum.TryParse(name, ignoreCase: true, out KeyCode k))
+            if (string.Equals(name, _pttName, System.StringComparison.Ordinal))
             {
-                return k;
+                return _pttKey;
             }
 
-            return KeyCode.V;
+            _pttName = name;
+            _pttKey = !string.IsNullOrEmpty(name) && System.Enum.TryParse(name, ignoreCase: true, out KeyCode k)
+                ? k
+                : KeyCode.V;
+            return _pttKey;
         }
 
         private void HandlePushToTalk()

--- a/src/BlocksBeyondTheStars.Client.Core/Music/MusicLibrary.cs
+++ b/src/BlocksBeyondTheStars.Client.Core/Music/MusicLibrary.cs
@@ -183,6 +183,21 @@ namespace BlocksBeyondTheStars.Client.Music
         /// <summary>Maps the server's planet/biome key (data/planets.json) to a surface context key.</summary>
         public static string ContextForBiome(string? biome)
         {
+            // #1554: called per frame from ClientMusic.Update — remember the last biome → context pair.
+            if (_contextResult != null && string.Equals(biome, _contextBiome, StringComparison.Ordinal))
+            {
+                return _contextResult;
+            }
+
+            _contextBiome = biome;
+            _contextResult = ContextForBiomeUncached(biome);
+            return _contextResult;
+        }
+
+        private static string? _contextBiome, _contextResult;
+
+        private static string ContextForBiomeUncached(string? biome)
+        {
             string key = (biome ?? string.Empty).ToLowerInvariant();
             switch (key)
             {


### PR DESCRIPTION
PR bundle 13 of the performance package #1501 — the first three follow-ups of the #1537 attribution, the mechanical ones. No visible or audible change.

**#1551 GroundScatter** — `Setup` derives yaw / scale / jitter from an xorshift mix of the cell hash instead of a `System.Random` per scatter point (~250 B of seed table each), and builds into two shared scratch lists. The variation is a different but equally uniform sequence; scatter is not golden-tested and reads as "random tufts" as before.

**#1556 SampleKit** — the decoded mono source is kept per clip (the same handful of sample files feeds every species), and every intermediate bake buffer is rented from `ArrayPool<float>` for the duration of one `Variant()` call: the ops work on `Span<float>`, the reverb's four comb lines share one pooled buffer, the clip is filled through the `ReadOnlySpan` overload of `SetData`. The ~250 KB of Large-Object-Heap garbage per bake is gone; what remains is the pool's warm-up.

**#1554 per-frame tail** — `RingBand` derives the ring-plane rotation once per ring seed (was two `System.Random` per frame); `VoiceChat` polls `Microphone.devices` every 2 s and parses the push-to-talk key per setting value; `RemotePlayers.FirstPlayerWithin` replaces the per-frame list in `PlayerInteractions`; `UrpScenePost.MoodKey`, `MicroFauna.Richness` / `SurfaceKinds`, `MusicLibrary.ContextForBiome` remember the last biome → key; `MicroFaunaView` keeps its `RemoveAll` predicate; `GamepadInputSource.Connected` re-polls once a second; `HudUi` formats vitals, hotbar numbers / counts, the time-of-day read-out and the playtime only when their inputs changed; `VegaPanel`'s typewriter substrings once per revealed character.

**Measured** (Development player, `PerfProbe -perfProfile`, High / VD 8, the persisted PerfProbe save, walk phase; report by `ProfilerCaptureReport`):

| | before (PR 12) | after |
|---|---:|---:|
| total garbage | 7.0 MB/s, 20 400 allocs/s | 4.4 MB/s, 13 400 allocs/s |
| `GroundScatter.Setup` + `Random` | 440 KB/s, 2000/s | 46 KB/s, 52/s |
| `SampleKit` (ReadMono / Comb) | 340 KB/s | 26 KB/s once (source decode), pool warm-up |
| `RingBand` randoms, `VoiceChat`, `PlayersWithin`, `ToLowerInvariant` sites, `MicroFaunaView` | ~220 KB/s, ~3000/s | absent |
| `HudUi.LateUpdate` | 31 KB/s, 666/s | 17 KB/s, 265/s |
| PerfProbe walk collections | 19 per 10 s | 11 per 10 s |

The remaining sources are the next bundles: the chunk-build dispatch (#1550), the IMGUI overlays (#1553), the receive path (#1555); the outlined HUD text rebuilds (#1552) did not occur in this capture, so they are situational and get their own look.

**Verification:** Development player built and the capture + report run end to end; `dotnet build` of Client.Core and `dotnet format` on the changed shared file; TODO.md entry added.

closes #1551
closes #1554
closes #1556

🤖 Generated with [Claude Code](https://claude.com/claude-code)
