### PR TITLE
perf(client): the IMGUI overlays (WeatherFx, FinaleView) exist only while they draw — ImguiOverlay without a layout pass (#1553)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -243,6 +243,27 @@ is read from the module stat (16) instead of being dead, and the station deploy 
 persisted ids after a restart (id collision). Tests: `PlayerStationReportsTests` (7), `DropLootTests` (+2).
 Locales: 9 new keys + 2 rewordings, EN/DE hand-written, 12 MT via translate_locale.
 
+### ★ Client garbage, part 2: the IMGUI overlays exist only while they draw (#1553, 2026-09-04, branch perf/1553-imgui-overlays)
+
+**Why.** PR bundle 14 of the performance package (#1501). Every enabled behaviour with an `OnGUI` makes Unity run the
+IMGUI event loop for it every frame — a Layout and a Repaint pass, each allocating a `GUILayoutGroup` plus the event
+plumbing — whether or not it draws anything. `WeatherFx` (rain streaks, frost, droplets, lightning, the underwater
+wash) and `FinaleView` (duel, banner, hack bar) are on screen a fraction of the time, yet cost 146 KB/s and 1600
+allocations/s in clear weather.
+
+**What ships.** `ImguiOverlay`, the one `OnGUI` in the client: a component the owner attaches with a draw delegate,
+`useGUILayout = false` (both owners draw with absolute `GUI` calls), and `RepaintOnly` for the weather washes. Each
+owner syncs the overlay's `enabled` from `LateUpdate` — `WeatherFx` while anything is fading, falling or flashing or
+precipitation is on under an open sky; `FinaleView` while the duel, the resolution banner or the hack bar is visible.
+A disabled behaviour gets no `OnGUI` at all, so a quiet frame costs nothing. The former `OnGUI` bodies are unchanged
+as `DrawOverlay`.
+
+**Measured (walk capture, machine quiet).** `GUILayoutUtility.Begin` / `GUILayoutGroup` gone (146 KB/s, 1624/s → 0).
+The remaining 1.3 MB/s and ~6800 allocs/s in the `GUI.Repaint` scope are NOT ours: they persist with both overlays
+disabled and have no managed frame above `ScriptableRenderContext.Submit` — that is the Development player's own
+watermark / IMGUI overlay, absent from the release build. Total walk garbage 4.4 → 4.1 MB/s (per frame: 75 → 65
+allocations, of which ~36 are the dev watermark).
+
 ### ★ Client garbage, part 1: hash-based ground scatter, pooled voice bakes, and the per-frame tail (#1551 #1554 #1556, 2026-09-04, branch perf/1551-1554-1556-small-allocs)
 
 **Why.** PR bundle 13 of the performance package (#1501), the first three follow-ups of the #1537 attribution: the

--- a/client/Assets/BlocksBeyondTheStars/Scripts/FinaleView.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/FinaleView.cs
@@ -66,7 +66,20 @@ namespace BlocksBeyondTheStars.Client
         /// world, core not yet hacked, no duel up. Gates the touch ATTACK/hold button (#1042).</summary>
         public bool BreachAvailable => FinaleActive && OnGuardianWorld && !_hacked && !_duelActive;
 
-        private void Awake() => Instance = this;
+        private ImguiOverlay _overlay; // #1553: on-demand OnGUI — see ImguiOverlay
+
+        private void Awake()
+        {
+            Instance = this;
+            _overlay = ImguiOverlay.Attach(gameObject, DrawOverlay, repaintOnly: false); // the duel has buttons
+        }
+
+        private void LateUpdate()
+        {
+            _overlay.Sync(_duelActive
+                          || (_won && Time.time < _resolveVisibleUntil)
+                          || Time.time < _hackBarVisibleUntil);
+        }
 
         private void Update()
         {
@@ -155,7 +168,7 @@ namespace BlocksBeyondTheStars.Client
 
         private string L(string key, string fallback) => Game?.Localizer?.Get(key) ?? fallback;
 
-        private void OnGUI()
+        private void DrawOverlay()
         {
             EnsureStyles();
 

--- a/client/Assets/BlocksBeyondTheStars/Scripts/ImguiOverlay.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/ImguiOverlay.cs
@@ -1,0 +1,61 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using UnityEngine;
+
+namespace BlocksBeyondTheStars.Client
+{
+    /// <summary>
+    /// The one place an <c>OnGUI</c> lives (#1553). Every enabled behaviour with an <c>OnGUI</c> makes Unity run
+    /// the IMGUI event loop for it every frame — a Layout and a Repaint pass, each allocating a
+    /// <c>GUILayoutGroup</c> and the event plumbing — whether or not it draws anything. The weather washes and
+    /// the finale panels are on screen a fraction of the time, so their owners keep this component DISABLED
+    /// until they have something to show (<see cref="Sync"/>), and it skips the layout pass outright
+    /// (<c>useGUILayout = false</c>; the owners draw with absolute <c>GUI</c> calls).
+    /// </summary>
+    public sealed class ImguiOverlay : MonoBehaviour
+    {
+        /// <summary>The owner's draw routine, called from <c>OnGUI</c> — for every IMGUI event, or only for
+        /// Repaint when <see cref="RepaintOnly"/> is set (pure texture overlays never need Layout / mouse events).</summary>
+        public System.Action Draw;
+
+        /// <summary>Skip everything but the Repaint event (the weather overlay: nothing to click).</summary>
+        public bool RepaintOnly;
+
+        /// <summary>Attaches an overlay to <paramref name="host"/>, disabled until the owner syncs it on.</summary>
+        public static ImguiOverlay Attach(GameObject host, System.Action draw, bool repaintOnly)
+        {
+            var overlay = host.AddComponent<ImguiOverlay>();
+            overlay.Draw = draw;
+            overlay.RepaintOnly = repaintOnly;
+            overlay.useGUILayout = false;
+            overlay.enabled = false;
+            return overlay;
+        }
+
+        /// <summary>Enables the overlay only while <paramref name="wanted"/>; a disabled behaviour gets no
+        /// <c>OnGUI</c> calls at all, so an idle overlay costs nothing.</summary>
+        public void Sync(bool wanted)
+        {
+            if (enabled != wanted)
+            {
+                enabled = wanted;
+            }
+        }
+
+        private void Awake()
+        {
+            useGUILayout = false;
+        }
+
+        private void OnGUI()
+        {
+            if (RepaintOnly && Event.current.type != EventType.Repaint)
+            {
+                return;
+            }
+
+            Draw?.Invoke();
+        }
+    }
+}

--- a/client/Assets/BlocksBeyondTheStars/Scripts/ImguiOverlay.cs.meta
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/ImguiOverlay.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7a1d4290c6547854f8cecca97d837466

--- a/client/Assets/BlocksBeyondTheStars/Scripts/WeatherFx.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/WeatherFx.cs
@@ -54,6 +54,27 @@ namespace BlocksBeyondTheStars.Client
         private readonly float[] _boltJitter = new float[12];
         private readonly System.Random _boltRng = new System.Random(91);
 
+        // #1553: the IMGUI overlay is a separate behaviour that only exists (enabled) while something is on
+        // screen — an always-on OnGUI ran Unity's Layout + Repaint event loop every frame, even in clear
+        // weather (1.6 k allocations/s for the two handlers in the #1537 capture).
+        private ImguiOverlay _overlay;
+
+        private void Awake()
+        {
+            _overlay = ImguiOverlay.Attach(gameObject, DrawOverlay, repaintOnly: true);
+        }
+
+        private void LateUpdate()
+        {
+            // Mirrors the early-outs of DrawOverlay: anything fading, falling or flashing keeps the overlay
+            // alive; a quiet clear-sky frame leaves it off.
+            bool anyWash = _underwater > 0.01f || _frost > 0.01f || (_wet > 0.01f && _dropInit) || _flash > 0.01f || _boltTimer > 0.01f;
+            var env = Game?.Environment;
+            bool precipitation = env != null && !Game.SpaceViewActive && Game.ExposedToSky
+                                 && !string.IsNullOrEmpty(env.Precipitation) && env.Precipitation != "none";
+            _overlay.Sync(anyWash || precipitation);
+        }
+
         private void Init()
         {
             var rng = new System.Random(7);
@@ -345,15 +366,10 @@ namespace BlocksBeyondTheStars.Client
             return def?.Key == "water";
         }
 
-        private void OnGUI()
+        /// <summary>The screen overlay, drawn by <see cref="ImguiOverlay"/> on Repaint only: everything below is
+        /// GUI.DrawTexture (up to ~300 streaks + drops in rain), which has no effect in any other event (#1516).</summary>
+        private void DrawOverlay()
         {
-            // IMGUI calls OnGUI once per event; everything below is GUI.DrawTexture (up to ~300 streaks + drops in
-            // rain), which only has an effect during the Repaint event — skip the Layout pass entirely (#1516).
-            if (Event.current.type != EventType.Repaint)
-            {
-                return;
-            }
-
             // Subtle blue submerged wash, drawn before (and independent of) the weather overlay so it shows
             // even underwater in a cave or at night. Hidden in space and while the menu is open.
             if (_underwater > 0.01f && Game != null && !Game.SpaceViewActive && !Game.MenuOpen)


### PR DESCRIPTION
PR bundle 14 of the performance package #1501 — follow-up #1553 of the #1537 attribution.

**Problem.** Every enabled behaviour with an `OnGUI` makes Unity run the IMGUI event loop for it every frame — a Layout and a Repaint pass, each allocating a `GUILayoutGroup` plus the event plumbing — whether or not it draws anything. `WeatherFx` (rain streaks, frost, droplets, lightning, underwater wash) and `FinaleView` (duel, banner, hack bar) are on screen a fraction of the time, yet cost 146 KB/s and 1600 allocations/s in clear weather.

**Fix.** `ImguiOverlay` is now the one `OnGUI` in the client: a component the owner attaches with a draw delegate, `useGUILayout = false` (both owners draw with absolute `GUI` calls, no `GUILayout`), and `RepaintOnly` for the weather washes. Each owner syncs the overlay's `enabled` from `LateUpdate`:
- `WeatherFx`: while anything is fading, falling or flashing (underwater / frost / wet / flash / bolt > 0.01) or precipitation is on under an open sky;
- `FinaleView`: while the duel, the resolution banner or the hack bar is visible (the duel has buttons, so it keeps all events).

A disabled behaviour gets no `OnGUI` at all, so a quiet frame costs nothing. The former `OnGUI` bodies are unchanged as `DrawOverlay`.

**Verification of the open question in #1553.** The 1.4 MB/s in the `GUI.Repaint` scope with no managed frame above `ScriptableRenderContext.Submit` persists with both overlays disabled (1.3 MB/s, ~6800 allocs/s, ~36 per frame) — that is the Development player's own watermark / IMGUI overlay, not game code, and it is absent from the release build.

**Measured** (Development player, `PerfProbe -perfProfile`, High / VD 8, walk phase, machine quiet):

| | before (PR 13) | after |
|---|---:|---:|
| `GUILayoutUtility.Begin` + `GUILayoutGroup..ctor` | 128 KB/s, 1423/s | absent |
| total walk garbage | 4.4 MB/s, 13 400/s | 4.1 MB/s, 12 400/s |
| allocations per frame | 75 | 65 (of which ~36 the dev watermark) |

**Verification:** Development player built, capture + report end to end; TODO.md entry added.

closes #1553

🤖 Generated with [Claude Code](https://claude.com/claude-code)
