### PR TITLE
perf(client): UiOutline — text outlines rebuild without garbage; PerfProbe names the texts that change (#1552)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -283,6 +283,29 @@ is read from the module stat (16) instead of being dead, and the station deploy 
 persisted ids after a restart (id collision). Tests: `PlayerStationReportsTests` (7), `DropLootTests` (+2).
 Locales: 9 new keys + 2 rewordings, EN/DE hand-written, 12 MT via translate_locale.
 
+### ★ Client garbage, part 3: text outlines rebuild without garbage, and PerfProbe names the texts that change (#1552, 2026-09-04, branch perf/1552-outline-text-rebuilds)
+
+**Why.** PR bundle 15 of the performance package (#1501). The #1537 capture showed ~2 MB/s in uGUI `Outline.ModifyMesh`
++ `CanvasRenderer.SplitUIVertexStreams` at 3.6 rebuilds/s — ~550 KB per rebuild of one outlined HUD line — but the
+profiler cannot say which text. `Outline` expands the glyph quads into a triangle stream, appends four shifted copies
+and hands the stream back through `AddUIVertexTriangleStream`, which splits it into nine attribute lists per rebuild.
+
+**What ships.** `PerfProbe` runs a text-change census per phase: every second it re-scans the scene's `Text`
+components, per frame it compares each text's string with the last one seen, and at the end of the phase it logs the
+changed texts with change rate, average length, whether a mesh effect (outline) is attached and the hierarchy path.
+That named the culprit at once: the VEGA objective chip (`VegaPanel/Panel/Text`, outlined, ~60–80 characters) rebuilds
+3–8 times a second while walking because its progress counter ticks with the distance. `UiOutline` replaces `Outline`
+in `UiKit.AddOutline`: it reads the glyph quads straight out of the `VertexHelper` into one retained scratch list and
+writes the four offset copies plus the original back as quads — no stream expansion, no split, nothing on the heap once
+the lists have grown (the general non-quad path stays for completeness). Same look (four diagonal copies, alpha
+multiplied by the glyph alpha) and the same field names.
+
+**Measured (walk capture, the chip rebuilding ~4/s).** The outline's share is gone: `Outline.ModifyMesh` 911 KB/s +
+`SplitUIVertexStreams` 946 KB/s → `UiOutline` 1.8 KB/s (one-time list growth). What remains per rebuild is Unity's own
+`TextGenerator` vertex list (133 KB/s at 3.9 rebuilds/s, ~34 KB each) — proportional to the text length, so a
+separate counter text for the chip would shave most of it; left for a later pass. Total walk garbage now 4.0 MB/s
+(12 500 allocs/s), with the Development watermark's ~1.5 MB/s inside that number.
+
 ### ★ Client garbage, part 2: the IMGUI overlays exist only while they draw (#1553, 2026-09-04, branch perf/1553-imgui-overlays)
 
 **Why.** PR bundle 14 of the performance package (#1501). Every enabled behaviour with an `OnGUI` makes Unity run the

--- a/client/Assets/BlocksBeyondTheStars/Scripts/PerfProbe.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/PerfProbe.cs
@@ -9,6 +9,7 @@ using System.Text;
 using UnityEngine;
 using UnityEngine.Rendering;
 using UnityEngine.Rendering.Universal;
+using UnityEngine.UI;
 
 namespace BlocksBeyondTheStars.Client
 {
@@ -516,6 +517,7 @@ namespace BlocksBeyondTheStars.Client
             int gc0 = GC.CollectionCount(0), gc1 = GC.CollectionCount(1), gc2 = GC.CollectionCount(2);
             long mem = GC.GetTotalMemory(false);
 
+            var census = new TextChangeCensus();
             float t = 0f;
             yield return null; // don't count the setup frame
             while (t < seconds)
@@ -523,8 +525,11 @@ namespace BlocksBeyondTheStars.Client
                 float dt = Time.unscaledDeltaTime;
                 samples.Add(dt * 1000f);
                 t += dt;
+                census.Tick();
                 yield return null;
             }
+
+            census.Report(name, t);
 
             var r = new PhaseResult
             {
@@ -553,6 +558,100 @@ namespace BlocksBeyondTheStars.Client
             r.p99Ms = Percentile(samples, 0.99f);
             r.maxMs = max;
             done(r);
+        }
+
+        /// <summary>
+        /// #1552: which uGUI texts change (and therefore rebuild their mesh) during a phase. A text with an
+        /// <see cref="Outline"/> costs five vertex copies per rebuild, so the census names every text that changed,
+        /// with its change count, average length and whether it is outlined — the profiler capture only shows
+        /// <c>Outline.ModifyMesh</c> without the object. Once a second the scene is re-scanned for new texts.
+        /// </summary>
+        private sealed class TextChangeCensus
+        {
+            private sealed class Entry
+            {
+                public string Last;
+                public int Changes;
+                public long Chars;
+                public bool Outlined;
+                public string Path;
+            }
+
+            private readonly Dictionary<Text, Entry> _entries = new Dictionary<Text, Entry>();
+            private Text[] _texts = Array.Empty<Text>();
+            private float _rescanAt;
+
+            public void Tick()
+            {
+                if (Time.unscaledTime >= _rescanAt)
+                {
+                    _rescanAt = Time.unscaledTime + 1f;
+                    _texts = UnityEngine.Object.FindObjectsByType<Text>(FindObjectsInactive.Exclude, FindObjectsSortMode.None);
+                }
+
+                foreach (var text in _texts)
+                {
+                    if (text == null)
+                    {
+                        continue;
+                    }
+
+                    string now = text.text;
+                    if (!_entries.TryGetValue(text, out var e))
+                    {
+                        e = new Entry { Last = now, Outlined = text.GetComponent<BaseMeshEffect>() != null, Path = PathOf(text.transform) };
+                        _entries[text] = e;
+                        continue;
+                    }
+
+                    if (!ReferenceEquals(now, e.Last) && !string.Equals(now, e.Last, StringComparison.Ordinal))
+                    {
+                        e.Changes++;
+                        e.Chars += now?.Length ?? 0;
+                        e.Last = now;
+                    }
+                }
+            }
+
+            public void Report(string phase, float seconds)
+            {
+                var changed = new List<Entry>();
+                foreach (var e in _entries.Values)
+                {
+                    if (e.Changes > 0)
+                    {
+                        changed.Add(e);
+                    }
+                }
+
+                changed.Sort((a, b) => (b.Changes * (b.Outlined ? 5L : 1L) * Math.Max(1, b.Chars / Math.Max(1, b.Changes)))
+                    .CompareTo(a.Changes * (a.Outlined ? 5L : 1L) * Math.Max(1, a.Chars / Math.Max(1, a.Changes))));
+                var sb = new StringBuilder();
+                sb.Append($"[PerfProbe] text-rebuilds '{phase}': {changed.Count} of {_entries.Count} texts changed in {seconds:0.0}s");
+                int shown = 0;
+                foreach (var e in changed)
+                {
+                    if (shown++ >= 12)
+                    {
+                        break;
+                    }
+
+                    sb.Append('\n').Append($"  {e.Changes / Math.Max(0.001f, seconds),6:0.0}/s  avg {e.Chars / Math.Max(1, e.Changes),4} chars  {(e.Outlined ? "OUTLINE" : "plain  ")}  {e.Path}");
+                }
+
+                Debug.Log(sb.ToString());
+            }
+
+            private static string PathOf(Transform tr)
+            {
+                string path = tr.name;
+                for (var p = tr.parent; p != null && path.Length < 120; p = p.parent)
+                {
+                    path = p.name + "/" + path;
+                }
+
+                return path;
+            }
         }
 
         private static float Percentile(List<float> sorted, float p)

--- a/client/Assets/BlocksBeyondTheStars/Scripts/UiKit.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/UiKit.cs
@@ -814,7 +814,7 @@ namespace BlocksBeyondTheStars.Client
                 return;
             }
 
-            var o = g.gameObject.AddComponent<Outline>();
+            var o = g.gameObject.AddComponent<UiOutline>(); // #1552: allocation-free rebuilds (see UiOutline)
             o.effectColor = new Color(0f, 0f, 0f, 0.85f);
             o.effectDistance = new Vector2(1.2f, -1.2f);
         }

--- a/client/Assets/BlocksBeyondTheStars/Scripts/UiOutline.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/UiOutline.cs
@@ -1,0 +1,132 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace BlocksBeyondTheStars.Client
+{
+    /// <summary>
+    /// A text outline that rebuilds without garbage (#1552). uGUI's <see cref="Outline"/> expands the glyph quads
+    /// into a triangle stream, appends four shifted copies and hands the stream back through
+    /// <c>AddUIVertexTriangleStream</c>, which splits it into nine attribute lists — ~550 KB of allocations per
+    /// rebuild of a 60-character HUD line, and the VEGA objective chip rebuilt three times a second while its
+    /// counter ticked. This effect reads the glyph quads straight out of the <see cref="VertexHelper"/> into one
+    /// retained scratch list and writes the four offset copies plus the original back as quads, so a rebuild
+    /// touches no heap at all once the lists have grown. Same look as <see cref="Outline"/> (four diagonal
+    /// copies, alpha multiplied by the glyph alpha), same field names, so <see cref="UiKit.AddOutline"/> is the
+    /// only caller that changed.
+    /// </summary>
+    public sealed class UiOutline : BaseMeshEffect
+    {
+        public Color effectColor = new Color(0f, 0f, 0f, 0.5f);
+        public Vector2 effectDistance = new Vector2(1f, -1f);
+
+        private static readonly List<UIVertex> _scratch = new List<UIVertex>(1024);
+        private static readonly List<UIVertex> _stream = new List<UIVertex>(1024);
+
+        public override void ModifyMesh(VertexHelper vh)
+        {
+            if (!IsActive())
+            {
+                return;
+            }
+
+            int n = vh.currentVertCount;
+            if (n == 0)
+            {
+                return;
+            }
+
+            // Text (and every other quad-based Graphic) fills the helper with 4 vertices + 6 indices per quad in
+            // AddUIVertexQuad order; anything else goes through the general (allocating) stream path.
+            bool quads = n % 4 == 0 && vh.currentIndexCount == n / 4 * 6;
+            if (!quads)
+            {
+                ModifyStream(vh);
+                return;
+            }
+
+            _scratch.Clear();
+            var v = default(UIVertex);
+            for (int i = 0; i < n; i++)
+            {
+                vh.PopulateUIVertex(ref v, i);
+                _scratch.Add(v);
+            }
+
+            vh.Clear();
+            float dx = effectDistance.x, dy = effectDistance.y;
+            AddQuads(vh, dx, dy, true);
+            AddQuads(vh, dx, -dy, true);
+            AddQuads(vh, -dx, dy, true);
+            AddQuads(vh, -dx, -dy, true);
+            AddQuads(vh, 0f, 0f, false); // the glyphs themselves, on top
+        }
+
+        private void AddQuads(VertexHelper vh, float dx, float dy, bool tint)
+        {
+            int start = vh.currentVertCount;
+            int n = _scratch.Count;
+            for (int i = 0; i < n; i++)
+            {
+                var v = _scratch[i];
+                if (tint)
+                {
+                    var p = v.position;
+                    p.x += dx;
+                    p.y += dy;
+                    v.position = p;
+                    Color32 c = effectColor;
+                    c.a = (byte)(c.a * v.color.a / 255);
+                    v.color = c;
+                }
+
+                vh.AddVert(v);
+            }
+
+            for (int q = 0; q < n; q += 4)
+            {
+                int b = start + q;
+                vh.AddTriangle(b, b + 1, b + 2);
+                vh.AddTriangle(b + 2, b + 3, b);
+            }
+        }
+
+        /// <summary>The general path for non-quad geometry — what <see cref="Outline"/> does, kept for completeness.</summary>
+        private void ModifyStream(VertexHelper vh)
+        {
+            _stream.Clear();
+            vh.GetUIVertexStream(_stream);
+            int n = _stream.Count;
+            _scratch.Clear();
+            _scratch.AddRange(_stream);
+            _stream.Clear();
+            float dx = effectDistance.x, dy = effectDistance.y;
+            AppendShifted(dx, dy, n);
+            AppendShifted(dx, -dy, n);
+            AppendShifted(-dx, dy, n);
+            AppendShifted(-dx, -dy, n);
+            _stream.AddRange(_scratch);
+            vh.Clear();
+            vh.AddUIVertexTriangleStream(_stream);
+        }
+
+        private void AppendShifted(float dx, float dy, int n)
+        {
+            for (int i = 0; i < n; i++)
+            {
+                var v = _scratch[i];
+                var p = v.position;
+                p.x += dx;
+                p.y += dy;
+                v.position = p;
+                Color32 c = effectColor;
+                c.a = (byte)(c.a * v.color.a / 255);
+                v.color = c;
+                _stream.Add(v);
+            }
+        }
+    }
+}

--- a/client/Assets/BlocksBeyondTheStars/Scripts/UiOutline.cs.meta
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/UiOutline.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6026093fd1fff1f4985573312e01a8d4


### PR DESCRIPTION
PR bundle 15 of the performance package #1501 — follow-up #1552 of the #1537 attribution.

**Finding the text.** The profiler shows `Outline.ModifyMesh` but not the object, so `PerfProbe` now runs a text-change census per phase: every second it re-scans the scene's `Text` components, per frame it compares each text's string with the last one seen, and at the end of the phase it logs the changed texts with change rate, average length, whether a mesh effect (outline) is attached and the hierarchy path. Result on the PerfProbe save, walking:

```
[PerfProbe] text-rebuilds 'walk': 7 of 58 texts changed in 10,0s
     7,9/s  avg   80 chars  OUTLINE  VegaPanel/Panel/Text
     1,0/s  avg   30 chars  plain    HudUI/Panel/Text
     ...
```

The VEGA objective chip rebuilds 3–8 times a second because its progress counter ticks with the walked distance — and it is outlined.

**Fix.** `UiOutline` replaces uGUI's `Outline` in `UiKit.AddOutline`. `Outline` expands the glyph quads into a triangle stream, appends four shifted copies and hands the stream back through `AddUIVertexTriangleStream`, which splits it into nine attribute lists per rebuild (~550 KB of garbage for one 60-character line). `UiOutline` reads the glyph quads straight out of the `VertexHelper` into one retained scratch list and writes the four offset copies plus the original back as quads — no stream expansion, no split, nothing on the heap once the lists have grown. The general non-quad path (stream based) stays for any non-quad Graphic. Same look: four diagonal copies, effect alpha multiplied by the glyph alpha, same field names, so `AddOutline` is the only caller that changed. `UiNav`'s selection frame keeps the stock `Outline` (an Image, rebuilt on selection only).

**Measured** (Development player, `PerfProbe -perfProfile`, High / VD 8, walk phase, the chip rebuilding ~4/s):

| | before (PR 12 capture, 3.6 rebuilds/s) | after (3.9 rebuilds/s) |
|---|---:|---:|
| `Outline.ModifyMesh` + `SplitUIVertexStreams` | 911 + 946 KB/s | absent; `UiOutline` 1.8 KB/s once (list growth) |
| `TextGenerator.GetVerticesInternal` (Unity's own text mesh) | 122 KB/s | 133 KB/s |
| total walk garbage | 7.0 MB/s (PR 12) / 4.1 MB/s (PR 14) | 4.0 MB/s, 12 500 allocs/s |

What remains per rebuild is Unity's `TextGenerator` vertex list, proportional to the text length (~34 KB for the chip line). A separate counter text for the chip would shave most of it — noted in TODO.md, not done here.

**Verification:** Development player built, capture + census + report end to end; TODO.md entry added.

closes #1552

🤖 Generated with [Claude Code](https://claude.com/claude-code)
