### PR TITLE
perf(client): the chunk-build dispatch runs on pooled jobs — rented block copy, recycled Neighbourhood, no Task or closure per build (#1550)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -283,6 +283,33 @@ is read from the module stat (16) instead of being dead, and the station deploy 
 persisted ids after a restart (id collision). Tests: `PlayerStationReportsTests` (7), `DropLootTests` (+2).
 Locales: 9 new keys + 2 rewordings, EN/DE hand-written, 12 MT via translate_locale.
 
+### ★ Client garbage, part 4: the chunk-build dispatch runs on pooled jobs — no clone, no closures, no Task per build (#1550, 2026-09-04, branch perf/1550-dispatch-pool)
+
+**Why.** PR bundle 16 of the performance package (#1501). The largest client-side source in the #1537 attribution: every
+mesh dispatch cloned the 8 KB block array, allocated a `Neighbourhood`, five closures / delegates, the shape-dictionary
+copies, a light list, a paint-design snapshot closure, and a `Task` with its execution-context capture — ~1.8 MB/s
+and ~2400 objects/s at ~140 builds/s while walking.
+
+**What ships.** A pooled `MeshJob` (GameBootstrap) carries everything a build needs: the block copy is rented from
+`ArrayPool<ushort>` (4096 is a pool bucket, so the length is exact) and returned in `DrainBuiltChunks`; the
+`ChunkMesher.Neighbourhood` is recycled (`Reset` / `Clear`) and binds its three lookup delegates once per instance;
+the shape-dictionary copies come from a pool; the light list is reused through a new fill-a-list overload of
+`ClientWorld.LightSourcesNear`; the flora-tint delegate is bound once per job; `PaintDesignAtlas.Snapshot` returns one
+closure per published (copy-on-write) map instead of one per dispatch; and the job runs through a single static
+`ThreadPool.UnsafeQueueUserWorkItem` callback instead of `Task.Run` (WebGL keeps the inline path). Every exit of
+`DrainBuiltChunks` recycles the job. `PerfProbe` now prints the mesh builds per phase.
+
+**Tried and dropped.** Deferring the FIRST build of a far chunk until its six neighbours are present (to avoid the
+"built with open seams, rebuilt when the last neighbour lands" double) did not reduce the builds — 1809 vs 1444 per
+walk phase — because a neighbour arrival pulls a never-built chunk straight into `_dirty`; reverted, the frontier
+streams exactly as before.
+
+**Measured (walk capture, machine quiet).** `Array.Clone`, `Neighbourhood..ctor`, `DispatchChunkBuild`, `Task.*`,
+`ExecutionContext.Capture`, `UnitySynchronizationContext` all absent; the `GameBootstrap.Update` scope 2.46 MB/s →
+0.52 MB/s; total walk garbage 4.0 → 2.5 MB/s and 12 500 → 10 300 allocs/s (of which the Development watermark is
+~1.5 MB/s / 7800 allocs/s, i.e. ~60 % of what is left). PerfProbe walk collections 14 → 9 per 10 s. What remains
+of the game's own garbage is the receive path (#1555, ~0.6 MB/s) and the sampler's pool warm-up.
+
 ### ★ Client garbage, part 3: text outlines rebuild without garbage, and PerfProbe names the texts that change (#1552, 2026-09-04, branch perf/1552-outline-text-rebuilds)
 
 **Why.** PR bundle 15 of the performance package (#1501). The #1537 capture showed ~2 MB/s in uGUI `Outline.ModifyMesh`

--- a/client/Assets/BlocksBeyondTheStars/Scripts/ChunkMesher.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/ChunkMesher.cs
@@ -153,14 +153,46 @@ namespace BlocksBeyondTheStars.Client
             public const int SpanX = 5, SpanY = 7, SpanZ = 5, LoX = -2, LoY = -2, LoZ = -2;
             private readonly ChunkData[] _chunks = new ChunkData[SpanX * SpanY * SpanZ];
             private readonly Dictionary<int, int>[] _shapes = new Dictionary<int, int>[SpanX * SpanY * SpanZ];
-            private readonly int _ox, _oy, _oz;
+            private int _ox, _oy, _oz;
+
+            // #1550: the three lookups BuildGeometry takes, bound once per instance — a pooled neighbourhood is
+            // reused across builds, so no delegate is allocated per dispatch.
+            public readonly System.Func<int, int, int, BlockId> BlockFn;
+            public readonly System.Func<int, int, int, bool> LoadedFn;
+            public readonly System.Func<int, int, int, int> ShapeFn;
 
             public Neighbourhood(ChunkCoord center)
+            {
+                BlockFn = Block;
+                LoadedFn = Loaded;
+                ShapeFn = Shape;
+                Reset(center);
+            }
+
+            /// <summary>Re-centres an empty (cleared) neighbourhood for the next build.</summary>
+            public void Reset(ChunkCoord center)
             {
                 var origin = WorldConstants.ChunkOrigin(center);
                 _ox = origin.X;
                 _oy = origin.Y;
                 _oz = origin.Z;
+            }
+
+            /// <summary>Drops every chunk reference and hands the shape-dictionary copies back to
+            /// <paramref name="shapePool"/> (cleared), so the instance can go back to its pool.</summary>
+            public void Clear(Stack<Dictionary<int, int>> shapePool)
+            {
+                for (int s = 0; s < _chunks.Length; s++)
+                {
+                    _chunks[s] = null;
+                    var sh = _shapes[s];
+                    if (sh != null)
+                    {
+                        _shapes[s] = null;
+                        sh.Clear();
+                        shapePool?.Push(sh);
+                    }
+                }
             }
 
             private static int Slot(int dx, int dy, int dz) => ((dy - LoY) * SpanZ + (dz - LoZ)) * SpanX + (dx - LoX);

--- a/client/Assets/BlocksBeyondTheStars/Scripts/GameBootstrap.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/GameBootstrap.cs
@@ -1607,8 +1607,90 @@ namespace BlocksBeyondTheStars.Client
         // _meshGen + WorldEpoch discard a build superseded by a newer edit / world change (same pattern as the
         // collider bake above).
         private readonly Dictionary<ChunkCoord, int> _meshGen = new Dictionary<ChunkCoord, int>();
-        private readonly System.Collections.Concurrent.ConcurrentQueue<(ChunkCoord Coord, ChunkMeshData Data, int Gen, int Epoch, string Error)> _builtChunks
-            = new System.Collections.Concurrent.ConcurrentQueue<(ChunkCoord Coord, ChunkMeshData Data, int Gen, int Epoch, string Error)>();
+
+        // #1550: everything a build needs lives in a pooled MeshJob — the 8 KB block copy is rented, the
+        // neighbourhood (with its three delegates) and the shape-dictionary copies are recycled, the light
+        // list is reused, and the job runs on the thread pool through one static callback. Before this every
+        // dispatch allocated the clone, a neighbourhood, five closures/delegates, a Task and its context —
+        // ~1.8 MB/s and 2400 objects/s at 141 builds/s while walking.
+        private readonly Stack<MeshJob> _jobPool = new Stack<MeshJob>();
+        private readonly Stack<ChunkMesher.Neighbourhood> _hoodPool = new Stack<ChunkMesher.Neighbourhood>();
+        private readonly Stack<Dictionary<int, int>> _shapeDictPool = new Stack<Dictionary<int, int>>();
+        private static readonly System.Threading.WaitCallback RunMeshJob = o => ((MeshJob)o).Run();
+
+        /// <summary>Builds dispatched since start-up (PerfProbe reports the per-phase delta).</summary>
+        public static int MeshBuildsDispatched { get; private set; }
+
+        private sealed class MeshJob
+        {
+            public GameBootstrap Owner;
+            public ChunkCoord Coord;
+            public ChunkData Center;
+            public ushort[] Borrowed;
+            public ChunkMesher.Neighbourhood Hood;
+            public readonly List<(Vector3i Pos, int Rgb)> Lights = new List<(Vector3i Pos, int Rgb)>();
+            public Dictionary<ushort, Color> FloraDict;
+            public GameContent Content;
+            public BlockTextureAtlas Atlas;
+            public System.Func<int, Rect?> DesignUv;
+            public int Gen, Epoch;
+            public ChunkMeshData Data;
+            public string Error;
+            public readonly System.Func<BlockId, Color> FloraTintFn;
+
+            public MeshJob()
+            {
+                // Bound once: reads the job's CURRENT flora map (RebuildFloraTints replaces the map wholesale,
+                // so the reference captured at dispatch stays immutable for the build).
+                FloraTintFn = id => FloraDict != null && FloraDict.TryGetValue(id.Value, out var c) ? c : Color.black;
+            }
+
+            public void Run()
+            {
+                try
+                {
+                    Data = ChunkMesher.BuildGeometry(Center, Content, Hood.BlockFn, Atlas, FloraTintFn, null, Lights, Hood.ShapeFn, DesignUv, Hood.LoadedFn);
+                }
+                catch (System.Exception ex)
+                {
+                    // Carry the fault back to the main thread: DrainBuiltChunks re-dirties the chunk (it left
+                    // _dirty at dispatch — swallowing here made a failed chunk a permanent hole, #421 M10) and
+                    // logs rate-limited. A teardown race is filtered there by the epoch/gen guards.
+                    Data = null;
+                    Error = ex.ToString();
+                }
+
+                Owner._builtChunks.Enqueue(this);
+            }
+        }
+
+        private void RecycleJob(MeshJob job)
+        {
+            if (job.Borrowed != null)
+            {
+                System.Buffers.ArrayPool<ushort>.Shared.Return(job.Borrowed);
+                job.Borrowed = null;
+            }
+
+            if (job.Hood != null)
+            {
+                job.Hood.Clear(_shapeDictPool);
+                _hoodPool.Push(job.Hood);
+                job.Hood = null;
+            }
+
+            job.Lights.Clear();
+            job.Center = null;
+            job.FloraDict = null;
+            job.Content = null;
+            job.Atlas = null;
+            job.DesignUv = null;
+            job.Data = null;
+            job.Error = null;
+            _jobPool.Push(job);
+        }
+        private readonly System.Collections.Concurrent.ConcurrentQueue<MeshJob> _builtChunks
+            = new System.Collections.Concurrent.ConcurrentQueue<MeshJob>();
 
         // Failed-build retry bookkeeping (#421 M10): a build that faulted on the worker re-enters _dirty (the
         // coord was already removed at dispatch, so dropping it silently would leave a permanent un-meshed,
@@ -3018,9 +3100,12 @@ namespace BlocksBeyondTheStars.Client
             }
 
             int circ = Circumference;
+            var job = _jobPool.Count > 0 ? _jobPool.Pop() : new MeshJob { Owner = this };
+            job.Coord = coord;
 
             // Centre chunk: a private deep copy, so the worker reads its blocks/modifiers/shapes consistently.
-            var center = CopyChunk(chunk);
+            // The block array is rented (#1550) and goes back to the pool in DrainBuiltChunks.
+            job.Center = CopyChunk(chunk, out job.Borrowed);
 
             // Block reads reach up to ~±18 blocks (the coloured-light flood-fill) and a vertical band a few chunks
             // tall (the skylight column scan) → capture chunk REFERENCES over a ±2 horizontal / -2..+4 vertical
@@ -3030,8 +3115,10 @@ namespace BlocksBeyondTheStars.Client
             // each slot holds the CANONICAL chunk of its offset, and the mesher's block reads resolve with a shift
             // and a mask. Shape reads reach ±1 block (the neighbour-shape face test) → the sparse shape dicts are
             // deep-copied per slot on the main thread (the worker must NOT read a live ChunkData._shapes
-            // concurrently with an edit).
-            var hood = new ChunkMesher.Neighbourhood(coord);
+            // concurrently with an edit). #1550: the neighbourhood and the dictionary copies are pooled.
+            var hood = _hoodPool.Count > 0 ? _hoodPool.Pop() : new ChunkMesher.Neighbourhood(coord);
+            hood.Reset(coord);
+            job.Hood = hood;
             for (int dx = -2; dx <= 2; dx++)
                 for (int dy = -2; dy <= 4; dy++)
                     for (int dz = -2; dz <= 2; dz++)
@@ -3039,7 +3126,7 @@ namespace BlocksBeyondTheStars.Client
                         ChunkData nch;
                         if (dx == 0 && dy == 0 && dz == 0)
                         {
-                            nch = center;
+                            nch = job.Center;
                         }
                         else
                         {
@@ -3055,7 +3142,7 @@ namespace BlocksBeyondTheStars.Client
                         Dictionary<int, int> copy = null;
                         if (nch.Shapes is { Count: > 0 } src)
                         {
-                            copy = new Dictionary<int, int>(src.Count);
+                            copy = _shapeDictPool.Count > 0 ? _shapeDictPool.Pop() : new Dictionary<int, int>(src.Count);
                             foreach (var s in src)
                             {
                                 copy[s.Key] = s.Value;
@@ -3065,53 +3152,26 @@ namespace BlocksBeyondTheStars.Client
                         hood.Set(dx, dy, dz, nch, copy);
                     }
 
-            var lights = World.LightSourcesNear(coord, ChunkMesher.LightRadius);
-            var floraDict = _floraTintByBlock; // RebuildFloraTints REPLACES this map, so the captured ref is immutable
-
-            System.Func<int, int, int, BlockId> worldBlock = hood.Block;
-            // Companion to worldBlock: worldBlock cannot distinguish "air" from "chunk we don't have" (both come
-            // back as Air), and the fluid rules need that difference — see ChunkMesher's Loaded (#987). Answers
-            // from the SAME captured neighbourhood, so it is exactly as thread-safe, and every caller stays
-            // within it (face tests read ±1 block, the shore scan ±12 → at most one chunk out).
-            System.Func<int, int, int, bool> worldLoaded = hood.Loaded;
-            System.Func<int, int, int, int> worldShape = hood.Shape;
-            System.Func<BlockId, Color> floraTint = id =>
-                floraDict != null && floraDict.TryGetValue(id.Value, out var c) ? c : Color.black;
-
-            int gen = (_meshGen.TryGetValue(coord, out var g) ? g : 0) + 1;
-            _meshGen[coord] = gen;
-            int epoch = WorldEpoch;
-            var content = Content;
-            var atlas = Atlas;
-            // Paint-design lookup snapshot (#819): captures an immutable id → UV map, safe on the worker thread.
-            var designUv = PaintAtlas?.Snapshot();
-            var capturedCoord = coord;
-
-            void Build()
-            {
-                ChunkMeshData data = null;
-                string error = null;
-                try
-                {
-                    data = ChunkMesher.BuildGeometry(center, content, worldBlock, atlas, floraTint, null, lights, worldShape, designUv, worldLoaded);
-                }
-                catch (System.Exception ex)
-                {
-                    // Carry the fault back to the main thread: DrainBuiltChunks re-dirties the chunk (it left
-                    // _dirty at dispatch — swallowing here made a failed chunk a permanent hole, #421 M10) and
-                    // logs rate-limited. A teardown race is filtered there by the epoch/gen guards.
-                    error = ex.ToString();
-                }
-
-                _builtChunks.Enqueue((capturedCoord, data, gen, epoch, error));
-            }
+            World.LightSourcesNear(coord, ChunkMesher.LightRadius, job.Lights);
+            job.FloraDict = _floraTintByBlock; // RebuildFloraTints REPLACES this map, so the captured ref is immutable
+            job.Gen = (_meshGen.TryGetValue(coord, out var g) ? g : 0) + 1;
+            _meshGen[coord] = job.Gen;
+            job.Epoch = WorldEpoch;
+            job.Content = Content;
+            job.Atlas = Atlas;
+            // Paint-design lookup snapshot (#819): an immutable id → UV map, safe on the worker thread.
+            job.DesignUv = PaintAtlas?.Snapshot();
+            job.Data = null;
+            job.Error = null;
+            MeshBuildsDispatched++;
 
 #if UNITY_WEBGL && !UNITY_EDITOR
             // WebGL: no worker threads — build inline on the main thread. DrainBuiltChunks still uploads the
             // result next frame, exactly as it does for the async path on every other platform.
-            Build();
+            job.Run();
 #else
-            System.Threading.Tasks.Task.Run(Build);
+            // One static callback + the job as state: no Task, no closure, no execution-context capture.
+            System.Threading.ThreadPool.UnsafeQueueUserWorkItem(RunMeshJob, job);
 #endif
 
             return true;
@@ -3119,9 +3179,24 @@ namespace BlocksBeyondTheStars.Client
 
         /// <summary>Deep-copies a chunk (block array + the sparse colour-modifier and shape dictionaries) so a
         /// worker thread can read it without racing a live edit on the main thread.</summary>
-        private static ChunkData CopyChunk(ChunkData src)
+        private static ChunkData CopyChunk(ChunkData src, out ushort[] borrowed)
         {
-            var copy = ChunkData.FromRaw(src.Coord, src.ToArray());
+            // #1550: the 8 KB block copy comes from the shared pool (4096 is a pool bucket, so the length is
+            // exact; a mismatch falls back to a plain array that is simply not returned).
+            var blocks = System.Buffers.ArrayPool<ushort>.Shared.Rent(WorldConstants.BlocksPerChunk);
+            if (blocks.Length != WorldConstants.BlocksPerChunk)
+            {
+                System.Buffers.ArrayPool<ushort>.Shared.Return(blocks);
+                blocks = new ushort[WorldConstants.BlocksPerChunk];
+                borrowed = null;
+            }
+            else
+            {
+                borrowed = blocks;
+            }
+
+            src.RawBlocks.CopyTo(blocks);
+            var copy = ChunkData.FromRaw(src.Coord, blocks);
             if (src.Modifiers is { Count: > 0 } mods)
             {
                 foreach (var kv in mods)
@@ -3147,6 +3222,7 @@ namespace BlocksBeyondTheStars.Client
         {
             while (_builtChunks.TryDequeue(out var built))
             {
+                var job = built; // recycled on every exit path below (#1550)
                 if (built.Data == null)
                 {
                     // Failed build (#421 M10): the coord already left _dirty at dispatch, so dropping it here
@@ -3173,6 +3249,7 @@ namespace BlocksBeyondTheStars.Client
                         }
                     }
 
+                    RecycleJob(job);
                     continue;
                 }
 
@@ -3180,6 +3257,7 @@ namespace BlocksBeyondTheStars.Client
                     || !_meshGen.TryGetValue(built.Coord, out var gen) || gen != built.Gen)
                 {
                     built.Data.Release(); // superseded by a newer edit / a world change — recycle the buffers
+                    RecycleJob(job);
                     continue;
                 }
 
@@ -3188,6 +3266,7 @@ namespace BlocksBeyondTheStars.Client
                 // The upload copied everything into the Unity meshes (+ GroundScatter's matrices), so the
                 // pooled geometry buffers can go back for the next build.
                 built.Data.Release();
+                RecycleJob(job);
             }
         }
 

--- a/client/Assets/BlocksBeyondTheStars/Scripts/PaintDesignAtlas.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/PaintDesignAtlas.cs
@@ -173,8 +173,19 @@ namespace BlocksBeyondTheStars.Client
         public System.Func<int, Rect?> Snapshot()
         {
             var map = _uvById;
-            return id => map.TryGetValue(id, out var r) ? r : (Rect?)null;
+            if (!ReferenceEquals(map, _snapshotMap))
+            {
+                // #1550: the map is copy-on-write, so one closure per published map serves every dispatch
+                // until the next design registers (was a closure per chunk build).
+                _snapshotMap = map;
+                _snapshot = id => map.TryGetValue(id, out var r) ? r : (Rect?)null;
+            }
+
+            return _snapshot;
         }
+
+        private Dictionary<int, Rect> _snapshotMap;
+        private System.Func<int, Rect?> _snapshot;
 
         /// <summary>True when at least one live (non-wiped) design is registered.</summary>
         public bool HasAny => _uvById.Count > 0;

--- a/client/Assets/BlocksBeyondTheStars/Scripts/PerfProbe.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/PerfProbe.cs
@@ -493,6 +493,7 @@ namespace BlocksBeyondTheStars.Client
             public int gcGen1;
             public int gcGen2;
             public long managedMemDeltaBytes;
+            public int meshBuilds;
         }
 
         [Serializable]
@@ -516,6 +517,7 @@ namespace BlocksBeyondTheStars.Client
             var samples = new List<float>(Mathf.CeilToInt(seconds) * 300); // generous: fits 300 FPS without regrowth
             int gc0 = GC.CollectionCount(0), gc1 = GC.CollectionCount(1), gc2 = GC.CollectionCount(2);
             long mem = GC.GetTotalMemory(false);
+            int builds0 = GameBootstrap.MeshBuildsDispatched;
 
             var census = new TextChangeCensus();
             float t = 0f;
@@ -540,6 +542,7 @@ namespace BlocksBeyondTheStars.Client
                 gcGen1 = GC.CollectionCount(1) - gc1,
                 gcGen2 = GC.CollectionCount(2) - gc2,
                 managedMemDeltaBytes = GC.GetTotalMemory(false) - mem,
+                meshBuilds = GameBootstrap.MeshBuildsDispatched - builds0,
             };
 
             float sum = 0f, max = 0f;
@@ -690,7 +693,7 @@ namespace BlocksBeyondTheStars.Client
                 txt.AppendLine($"[{ph.name}] {ph.frames} frames / {ph.seconds:0.0}s — avg {ph.avgMs:0.00} ms ({1000f / Mathf.Max(0.001f, ph.avgMs):0} FPS), "
                              + $"p50 {ph.p50Ms:0.00}, p95 {ph.p95Ms:0.00}, p99 {ph.p99Ms:0.00}, max {ph.maxMs:0.0} ms; "
                              + $">33ms: {ph.framesOver33Ms}, >100ms: {ph.framesOver100Ms}; "
-                             + $"GC {ph.gcGen0}/{ph.gcGen1}/{ph.gcGen2}, managed Δ {ph.managedMemDeltaBytes / (1024f * 1024f):0.0} MB");
+                             + $"GC {ph.gcGen0}/{ph.gcGen1}/{ph.gcGen2}, managed Δ {ph.managedMemDeltaBytes / (1024f * 1024f):0.0} MB, mesh builds {ph.meshBuilds}");
             }
 
             // The summary always goes to the log FIRST: in the browser the console (captured over the

--- a/src/BlocksBeyondTheStars.Client.Core/ClientWorld.cs
+++ b/src/BlocksBeyondTheStars.Client.Core/ClientWorld.cs
@@ -199,9 +199,17 @@ namespace BlocksBeyondTheStars.Client
         public List<(Vector3i Pos, int Rgb)> LightSourcesNear(ChunkCoord coord, int radius)
         {
             var result = new List<(Vector3i, int)>();
+            LightSourcesNear(coord, radius, result);
+            return result;
+        }
+
+        /// <summary>Same as <see cref="LightSourcesNear(ChunkCoord, int)"/>, appending into a caller-owned list
+        /// (#1550: the mesher dispatch reuses one list per pooled job).</summary>
+        public void LightSourcesNear(ChunkCoord coord, int radius, List<(Vector3i Pos, int Rgb)> result)
+        {
             if (_lightSources.Count == 0)
             {
-                return result;
+                return;
             }
 
             coord = WorldConstants.CanonicalChunk(coord, _circumference);
@@ -243,7 +251,6 @@ namespace BlocksBeyondTheStars.Client
                         }
                     }
 
-            return result;
         }
 
         /// <summary>Re-indexes a chunk's light sources (placed glow blocks + dedicated light blocks) into the


### PR DESCRIPTION
PR bundle 16 of the performance package #1501 — follow-up #1550 of the #1537 attribution, the largest client-side source.

**Before.** Every mesh dispatch cloned the 8 KB block array, allocated a `Neighbourhood`, five closures / delegates, the shape-dictionary copies, a light list, a paint-design snapshot closure and a `Task` with its execution-context capture: ~1.8 MB/s and ~2400 objects/s at ~140 builds/s while walking.

**Now.** A pooled `MeshJob` carries everything a build needs:
- the block copy is rented from `ArrayPool<ushort>` (4096 is a pool bucket, so the length is exact; a mismatch falls back to a plain array) and returned in `DrainBuiltChunks`;
- `ChunkMesher.Neighbourhood` is recycled (`Reset` / `Clear`) and binds its three lookup delegates once per instance; the shape-dictionary copies come from a pool;
- the light list is reused through a new fill-a-list overload of `ClientWorld.LightSourcesNear`;
- the flora-tint delegate is bound once per job (it reads the job's captured map, which `RebuildFloraTints` replaces wholesale);
- `PaintDesignAtlas.Snapshot` returns one closure per published copy-on-write map instead of one per dispatch;
- the job runs through one static `ThreadPool.UnsafeQueueUserWorkItem` callback instead of `Task.Run` (no Task, no closure, no context capture); WebGL keeps the inline path.

Every exit of `DrainBuiltChunks` (failed, superseded, applied) recycles the job. `PerfProbe` prints the mesh builds per phase.

**Tried and dropped.** Deferring the first build of a far chunk until its six neighbours are present (to avoid "built with open seams, rebuilt when the last neighbour lands") did not reduce the builds — 1809 vs 1444 per walk phase — because a neighbour's arrival pulls a never-built chunk straight into the dirty set. Reverted; the streaming frontier behaves exactly as before.

**Measured** (Development player, `PerfProbe -perfProfile`, High / VD 8, walk phase, machine quiet):

| | before (PR 15) | after |
|---|---:|---:|
| `Array.Clone` ← `CopyChunk` | 945 KB/s, 121/s | absent |
| `Neighbourhood..ctor` | 329 KB/s, 235/s | absent |
| `DispatchChunkBuild` own (closures, delegates, dict copies, tuple) | 106 KB/s, 918/s | absent |
| `Task.Run` + `ExecutionContext.Capture` + `UnitySynchronizationContext` | ~95 KB/s, ~640/s | absent (`ThreadPool.QueueUserWorkItemHelper` 5 KB/s, 127/s) |
| `PaintDesignAtlas.Snapshot` | 17.5 KB/s, 235/s | 4 KB/s |
| `GameBootstrap.Update` scope | 2.46 MB/s | 0.52 MB/s |
| total walk garbage | 4.0 MB/s, 12 500/s | 2.5 MB/s, 10 300/s (the dev watermark is ~1.5 MB/s of that) |
| PerfProbe walk collections | 14 per 10 s | 9 per 10 s |

What remains of the game's own garbage is the receive path (#1555, ~0.6 MB/s) and the sampler's pool warm-up.

**Verification:** Development player built, capture + report end to end; `ChunkMesherGoldenEditModeTests` (EditMode) green — the mesher itself is untouched, only the neighbourhood construction changed; `dotnet build` + `dotnet format` on the shared `ClientWorld` change; TODO.md entry added.

closes #1550

🤖 Generated with [Claude Code](https://claude.com/claude-code)
