### PR TITLE
perf(client,net): chunks decode into pooled arrays that live with the chunk; the codec interns short strings (#1555)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -283,6 +283,31 @@ is read from the module stat (16) instead of being dead, and the station deploy 
 persisted ids after a restart (id collision). Tests: `PlayerStationReportsTests` (7), `DropLootTests` (+2).
 Locales: 9 new keys + 2 rewordings, EN/DE hand-written, 12 MT via translate_locale.
 
+### ★ Client garbage, part 5: chunks decode into pooled arrays that live with the chunk, the codec interns short strings (#1555, 2026-09-04, branch perf/1555-receive-path)
+
+**Why.** PR bundle 17 of the performance package (#1501). After the dispatch pooling the receive path was the largest
+game-side source left: `ChunkBlocksRle.Decode` allocated the 8 KB block array of every arriving chunk (~0.4–0.5 MB/s
+while walking), MessagePack decoded the same NPC names / role keys / item ids into fresh strings on every entity list
+(~280 strings/s), and `NpcView` built a set per list.
+
+**What ships.** `ChunkBlocksRle.DecodeInto` / `ChunkDataMessage.DecodeBlocksInto` decode into a caller-owned array
+(clearing it first — pooled memory is not zeroed); the client rents that array from a new `ChunkArrayPool` (a
+bounded stack of chunk-sized arrays; `ArrayPool.Shared` keeps only a few arrays per bucket, so the stored chunks ran
+it dry) and keeps it for the chunk's lifetime — unload or replacement retires it, and it returns to the pool after a
+two-second grace period because a mesh job in flight may still read the old `ChunkData` through its neighbourhood.
+The dispatch copies (#1550) now come from the same pool. `InterningStringFormatter` sits in front of the contractless
+resolver: strings of at most 64 UTF-8 bytes are looked up in a per-thread FNV-keyed cache (verified by re-encoding,
+bounded, reset when full), longer ones decode as before; encoding is untouched, so the wire format and every round-trip
+test are unchanged — only the identity of equal short strings, which nothing depends on. `NpcView` reuses its `seen`
+set. The LiteNetLib packet copy (`GetRemainingBytes`, ~25 KB/s) and the RLE array MessagePack allocates per chunk
+(~40 KB/s) stay: the transport interface hands out owned `byte[]`s and the RLE array is the message's own field.
+
+**Measured (walk capture, machine quiet).** `ChunkBlocksRle.Decode` 490 KB/s → gone; `String.CreateStringFromEncoding`
+(12 KB/s, 280/s) → gone (`InterningStringFormatter` 2 KB/s); what the pool still allocates (`ChunkArrayPool.Rent`
+~340 KB/s) is the world growing ahead of the player faster than it unloads behind — live chunk data, not garbage.
+Total walk allocations 2.5 → 2.3 MB/s and 10 300 → 9 300 per second (the Development watermark is 1.4 MB/s of
+that); PerfProbe walk collections 9 → 5–8 per 10 s. Tests: `InterningStringFormatterTests` (4).
+
 ### ★ Client garbage, part 4: the chunk-build dispatch runs on pooled jobs — no clone, no closures, no Task per build (#1550, 2026-09-04, branch perf/1550-dispatch-pool)
 
 **Why.** PR bundle 16 of the performance package (#1501). The largest client-side source in the #1537 attribution: every

--- a/client/Assets/BlocksBeyondTheStars/Scripts/GameBootstrap.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/GameBootstrap.cs
@@ -1618,6 +1618,51 @@ namespace BlocksBeyondTheStars.Client
         private readonly Stack<Dictionary<int, int>> _shapeDictPool = new Stack<Dictionary<int, int>>();
         private static readonly System.Threading.WaitCallback RunMeshJob = o => ((MeshJob)o).Run();
 
+        // #1555: a chunk's block array is rented from the shared pool when it arrives and returned once the chunk
+        // is unloaded or replaced — after a grace period, because a mesh job in flight may still read the old
+        // ChunkData through its neighbourhood (builds take milliseconds; two seconds is far beyond that).
+        private readonly Dictionary<ChunkCoord, ushort[]> _chunkArrays = new Dictionary<ChunkCoord, ushort[]>();
+
+        /// <summary>The pool behind every chunk-sized block array on the client (#1555): the stored chunks, the
+        /// dispatch copies. <c>ArrayPool.Shared</c> keeps only a few arrays per size bucket, and the stored
+        /// chunks hold hundreds of them for minutes, so it ran dry and both callers allocated afresh. Main thread
+        /// only. Bounded so a teardown cannot pin more than ~4 MB.</summary>
+        private static class ChunkArrayPool
+        {
+            private const int MaxKept = 512;
+            private static readonly Stack<ushort[]> _free = new Stack<ushort[]>();
+
+            public static ushort[] Rent() => _free.Count > 0 ? _free.Pop() : new ushort[WorldConstants.BlocksPerChunk];
+
+            public static void Return(ushort[] array)
+            {
+                if (array != null && array.Length == WorldConstants.BlocksPerChunk && _free.Count < MaxKept)
+                {
+                    _free.Push(array);
+                }
+            }
+        }
+        private readonly Queue<(ushort[] Array, float RetiredAt)> _retiredChunkArrays = new Queue<(ushort[], float)>();
+        private const float ChunkArrayRetireSeconds = 2f;
+
+        private void RetireChunkArray(ChunkCoord canonical)
+        {
+            if (_chunkArrays.TryGetValue(canonical, out var old))
+            {
+                _chunkArrays.Remove(canonical);
+                _retiredChunkArrays.Enqueue((old, Time.unscaledTime));
+            }
+        }
+
+        private void ReturnRetiredChunkArrays()
+        {
+            float now = Time.unscaledTime;
+            while (_retiredChunkArrays.Count > 0 && now - _retiredChunkArrays.Peek().RetiredAt >= ChunkArrayRetireSeconds)
+            {
+                ChunkArrayPool.Return(_retiredChunkArrays.Dequeue().Array);
+            }
+        }
+
         /// <summary>Builds dispatched since start-up (PerfProbe reports the per-phase delta).</summary>
         public static int MeshBuildsDispatched { get; private set; }
 
@@ -1668,7 +1713,7 @@ namespace BlocksBeyondTheStars.Client
         {
             if (job.Borrowed != null)
             {
-                System.Buffers.ArrayPool<ushort>.Shared.Return(job.Borrowed);
+                ChunkArrayPool.Return(job.Borrowed);
                 job.Borrowed = null;
             }
 
@@ -1758,6 +1803,8 @@ namespace BlocksBeyondTheStars.Client
 
             Localizer = Content.CreateLocalizer(Locale);
             World = new ClientWorld();
+            _chunkArrays.Clear(); // #1555: a new world — the old arrays are unreachable and simply garbage
+            _retiredChunkArrays.Clear();
             // Index dedicated light blocks (+ placed glow blocks) as coloured light sources for the mesher.
             World.SetBlockLightResolver(id => ChunkMesher.BlockLightColor(Content, new BlockId(id), 0));
 
@@ -2477,6 +2524,7 @@ namespace BlocksBeyondTheStars.Client
 
             // Upload + assign chunk geometry whose async build finished (A2), then assign collision meshes whose
             // async bake finished (both cheap on the main thread — the heavy work ran on worker threads).
+            ReturnRetiredChunkArrays(); // #1555
             DrainBuiltChunks();
             DrainBakedColliders();
 
@@ -2661,6 +2709,7 @@ namespace BlocksBeyondTheStars.Client
                 _meshGen.Remove(coord);
                 _meshFailCounts.Remove(coord);
                 World.RemoveChunk(coord);
+                RetireChunkArray(WorldConstants.CanonicalChunk(coord, Circumference)); // #1555
             }
         }
 
@@ -2675,15 +2724,21 @@ namespace BlocksBeyondTheStars.Client
             // the RLE payload (usual) or the dense array — and returns null for an undecodable RLE stream, so
             // this only fires on a genuinely truncated/corrupt payload; the warning is the diagnostic to watch.
             int expected = WorldConstants.BlocksPerChunk;
-            var blocks = m.DecodeBlocks(expected);
-            if (blocks == null || blocks.Length != expected)
+            // #1555: decode straight into a pooled array that the chunk keeps until it unloads.
+            var blocks = ChunkArrayPool.Rent();
+            if (!m.DecodeBlocksInto(blocks, expected))
             {
+                ChunkArrayPool.Return(blocks);
+
                 Debug.LogWarning($"[Chunk] Dropped malformed chunk {coord}: expected {expected} blocks, got "
-                    + (m.BlocksRle != null && m.BlocksRle.Length > 0 ? $"an undecodable RLE payload ({m.BlocksRle.Length} entries)" : $"{blocks?.Length ?? 0}") + ".");
+                    + (m.BlocksRle != null && m.BlocksRle.Length > 0 ? $"an undecodable RLE payload ({m.BlocksRle.Length} entries)" : $"{m.Blocks?.Length ?? 0}") + ".");
                 return;
             }
 
             World.StoreChunk(coord, blocks, m.ModIndex, m.ModTint, m.ModGlow, m.ShapeIndex, m.ShapeData);
+            var canonical = WorldConstants.CanonicalChunk(coord, Circumference);
+            RetireChunkArray(canonical); // a re-sent chunk replaces its array; the old one goes back after the grace period
+            _chunkArrays[canonical] = blocks;
             MarkChunkAndNeighborsDirty(coord);
             _lastChunkArrivalTime = Time.time; // feed the view-settle gate (#390)
 
@@ -3181,20 +3236,9 @@ namespace BlocksBeyondTheStars.Client
         /// worker thread can read it without racing a live edit on the main thread.</summary>
         private static ChunkData CopyChunk(ChunkData src, out ushort[] borrowed)
         {
-            // #1550: the 8 KB block copy comes from the shared pool (4096 is a pool bucket, so the length is
-            // exact; a mismatch falls back to a plain array that is simply not returned).
-            var blocks = System.Buffers.ArrayPool<ushort>.Shared.Rent(WorldConstants.BlocksPerChunk);
-            if (blocks.Length != WorldConstants.BlocksPerChunk)
-            {
-                System.Buffers.ArrayPool<ushort>.Shared.Return(blocks);
-                blocks = new ushort[WorldConstants.BlocksPerChunk];
-                borrowed = null;
-            }
-            else
-            {
-                borrowed = blocks;
-            }
-
+            // #1550: the 8 KB block copy comes from the chunk-array pool and goes back in DrainBuiltChunks.
+            var blocks = ChunkArrayPool.Rent();
+            borrowed = blocks;
             src.RawBlocks.CopyTo(blocks);
             var copy = ChunkData.FromRaw(src.Coord, blocks);
             if (src.Modifiers is { Count: > 0 } mods)

--- a/client/Assets/BlocksBeyondTheStars/Scripts/NpcView.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/NpcView.cs
@@ -118,9 +118,12 @@ namespace BlocksBeyondTheStars.Client
             _npcs.Clear();
         }
 
+        private readonly HashSet<int> _seenScratch = new HashSet<int>(); // #1555: one set, not one per list
+
         private void OnNpcs(NpcList m)
         {
-            var seen = new HashSet<int>();
+            var seen = _seenScratch;
+            seen.Clear();
             foreach (var nd in m.Npcs)
             {
                 seen.Add(nd.Id);

--- a/src/BlocksBeyondTheStars.Networking/ChunkBlocksRle.cs
+++ b/src/BlocksBeyondTheStars.Networking/ChunkBlocksRle.cs
@@ -65,12 +65,21 @@ public static class ChunkBlocksRle
     /// wrong-length dense payload is handled.</summary>
     public static ushort[]? Decode(ushort[] rle, int expectedLength)
     {
-        if (rle.Length == 0 || (rle.Length & 1) != 0)
+        var dense = new ushort[expectedLength];
+        return DecodeInto(rle, dense, expectedLength) ? dense : null;
+    }
+
+    /// <summary>Decodes into a caller-owned array (#1555: the client rents it for the chunk's lifetime; a pooled
+    /// array is not zeroed, so the first <paramref name="expectedLength"/> cells are cleared here). Same
+    /// validation and result as <see cref="Decode"/>; false when the stream is malformed.</summary>
+    public static bool DecodeInto(ushort[] rle, ushort[] dense, int expectedLength)
+    {
+        if (rle.Length == 0 || (rle.Length & 1) != 0 || dense.Length < expectedLength)
         {
-            return null;
+            return false;
         }
 
-        var dense = new ushort[expectedLength];
+        Array.Clear(dense, 0, expectedLength);
         int pos = 0;
         for (int i = 0; i < rle.Length; i += 2)
         {
@@ -78,7 +87,7 @@ public static class ChunkBlocksRle
             int count = rle[i + 1];
             if (count == 0 || pos + count > expectedLength)
             {
-                return null;
+                return false;
             }
 
             if (value == 0)
@@ -94,6 +103,6 @@ public static class ChunkBlocksRle
             }
         }
 
-        return pos == expectedLength ? dense : null;
+        return pos == expectedLength;
     }
 }

--- a/src/BlocksBeyondTheStars.Networking/InterningStringFormatter.cs
+++ b/src/BlocksBeyondTheStars.Networking/InterningStringFormatter.cs
@@ -1,0 +1,118 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Text;
+using MessagePack;
+using MessagePack.Formatters;
+
+namespace BlocksBeyondTheStars.Networking;
+
+/// <summary>
+/// The codec's string formatter (#1555): short strings are interned per decoding thread, so the same NPC name,
+/// role key, biome key or item id that arrives in every entity list several times a second is decoded to
+/// ONE string instance instead of a fresh one per message — the client saw ~280 string allocations per second
+/// from the entity lists alone. Long strings (chat, descriptions) are decoded as before. Encoding is untouched,
+/// so the wire format and every existing round-trip test stay the same; only the identity of equal short
+/// strings changes, which no caller depends on.
+/// </summary>
+public sealed class InterningStringFormatter : IMessagePackFormatter<string?>
+{
+    public static readonly InterningStringFormatter Instance = new();
+
+    /// <summary>Strings longer than this many UTF-8 bytes are not worth a cache lookup (and are rarely repeated).</summary>
+    public const int MaxInternedBytes = 64;
+
+    /// <summary>Per-thread cache ceiling; a full cache is simply dropped and refilled (a bounded, allocation-free reset).</summary>
+    public const int MaxEntries = 4096;
+
+    [ThreadStatic]
+    private static Dictionary<long, string>? _cache;
+
+    private InterningStringFormatter()
+    {
+    }
+
+    public void Serialize(ref MessagePackWriter writer, string? value, MessagePackSerializerOptions options)
+        => writer.Write(value);
+
+    public string? Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
+    {
+        var sequence = reader.ReadStringSequence();
+        if (sequence is null)
+        {
+            return null;
+        }
+
+        var seq = sequence.Value;
+        if (seq.Length == 0)
+        {
+            return string.Empty;
+        }
+
+        if (seq.Length > MaxInternedBytes)
+        {
+            return DecodeSlow(seq);
+        }
+
+        Span<byte> bytes = stackalloc byte[MaxInternedBytes];
+        seq.CopyTo(bytes);
+        bytes = bytes.Slice(0, (int)seq.Length);
+
+        // 64-bit FNV-1a over the UTF-8 bytes; a collision only costs a re-decode (the entry is verified).
+        ulong h = 14695981039346656037UL;
+        for (int i = 0; i < bytes.Length; i++)
+        {
+            h = (h ^ bytes[i]) * 1099511628211UL;
+        }
+
+        long key = unchecked((long)h);
+        var cache = _cache ??= new Dictionary<long, string>();
+        if (cache.TryGetValue(key, out var hit) && SameBytes(hit, bytes))
+        {
+            return hit;
+        }
+
+        string s = Encoding.UTF8.GetString(bytes);
+        if (cache.Count >= MaxEntries)
+        {
+            cache.Clear();
+        }
+
+        cache[key] = s;
+        return s;
+    }
+
+    private static bool SameBytes(string candidate, ReadOnlySpan<byte> bytes)
+    {
+        if (candidate.Length > bytes.Length)
+        {
+            return false; // a UTF-8 string never has more chars than bytes
+        }
+
+        Span<byte> encoded = stackalloc byte[MaxInternedBytes];
+        int n = Encoding.UTF8.GetBytes(candidate.AsSpan(), encoded);
+        return n == bytes.Length && encoded.Slice(0, n).SequenceEqual(bytes);
+    }
+
+    private static string DecodeSlow(in ReadOnlySequence<byte> seq)
+    {
+        if (seq.IsSingleSegment)
+        {
+            return Encoding.UTF8.GetString(seq.First.Span);
+        }
+
+        var rented = ArrayPool<byte>.Shared.Rent((int)seq.Length);
+        try
+        {
+            seq.CopyTo(rented);
+            return Encoding.UTF8.GetString(rented, 0, (int)seq.Length);
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(rented);
+        }
+    }
+}

--- a/src/BlocksBeyondTheStars.Networking/Messages.cs
+++ b/src/BlocksBeyondTheStars.Networking/Messages.cs
@@ -842,6 +842,25 @@ public sealed class ChunkDataMessage
     public ushort[]? DecodeBlocks(int expectedLength)
         => BlocksRle.Length > 0 ? ChunkBlocksRle.Decode(BlocksRle, expectedLength) : Blocks;
 
+    /// <summary>Decodes into a caller-owned array of at least <paramref name="expectedLength"/> cells (#1555:
+    /// the client keeps chunk arrays in a pool). False when the payload is malformed or the dense array has
+    /// the wrong length — the same cases in which <see cref="DecodeBlocks"/> yields null or a wrong length.</summary>
+    public bool DecodeBlocksInto(ushort[] into, int expectedLength)
+    {
+        if (BlocksRle.Length > 0)
+        {
+            return ChunkBlocksRle.DecodeInto(BlocksRle, into, expectedLength);
+        }
+
+        if (Blocks == null || Blocks.Length != expectedLength || into.Length < expectedLength)
+        {
+            return false;
+        }
+
+        System.Array.Copy(Blocks, into, expectedLength);
+        return true;
+    }
+
     // Sparse per-voxel colour modifiers (dyed surface tint / glow light colour), parallel arrays
     // keyed by local cell index. Empty for the overwhelming majority of chunks (no colour edits).
     public int[] ModIndex { get; set; } = System.Array.Empty<int>();

--- a/src/BlocksBeyondTheStars.Networking/NetCodec.cs
+++ b/src/BlocksBeyondTheStars.Networking/NetCodec.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Text.Json;
 using BlocksBeyondTheStars.Networking.Messages;
 using MessagePack;
+using MessagePack.Formatters;
 using MessagePack.Resolvers;
 
 namespace BlocksBeyondTheStars.Networking;
@@ -36,9 +37,15 @@ public static class NetCodec
     /// without compression hands the LZ4 ext block to the plain formatter and fails.</summary>
     public const int CompressionMinLengthBytes = 256;
 
+    // #1555: short strings (entity names, role/biome/item keys) are interned per decoding thread — the same
+    // text arrives in every entity list several times a second. Encoding is unchanged.
+    private static readonly IFormatterResolver Resolver = CompositeResolver.Create(
+        new IMessagePackFormatter[] { InterningStringFormatter.Instance },
+        new IFormatterResolver[] { ContractlessStandardResolver.Instance });
+
     private static readonly MessagePackSerializerOptions Options =
         MessagePackSerializerOptions.Standard
-            .WithResolver(ContractlessStandardResolver.Instance)
+            .WithResolver(Resolver)
             .WithSecurity(MessagePackSecurity.UntrustedData)
             .WithCompression(MessagePackCompression.Lz4BlockArray)
             .WithCompressionMinLength(CompressionMinLengthBytes);

--- a/tests/BlocksBeyondTheStars.Tests/InterningStringFormatterTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/InterningStringFormatterTests.cs
@@ -1,0 +1,56 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using BlocksBeyondTheStars.Networking;
+using BlocksBeyondTheStars.Networking.Messages;
+using Xunit;
+
+namespace BlocksBeyondTheStars.Tests;
+
+/// <summary>#1555: the codec interns short strings per decoding thread and leaves long ones alone.</summary>
+public sealed class InterningStringFormatterTests
+{
+    [Fact]
+    public void ShortStrings_DecodeToTheSameInstanceAcrossMessages()
+    {
+        var first = (ChatMessage)NetCodec.Decode(NetCodec.Encode(new ChatMessage { Sender = "Vega", Text = "hello" }))!;
+        var second = (ChatMessage)NetCodec.Decode(NetCodec.Encode(new ChatMessage { Sender = "Vega", Text = "hello" }))!;
+
+        Assert.Equal("Vega", first.Sender);
+        Assert.Same(first.Sender, second.Sender);
+        Assert.Same(first.Text, second.Text);
+    }
+
+    [Fact]
+    public void LongStrings_AreNotInterned_AndStillRoundTrip()
+    {
+        string text = new string('x', InterningStringFormatter.MaxInternedBytes + 1);
+        var first = (ChatMessage)NetCodec.Decode(NetCodec.Encode(new ChatMessage { Sender = "a", Text = text }))!;
+        var second = (ChatMessage)NetCodec.Decode(NetCodec.Encode(new ChatMessage { Sender = "a", Text = text }))!;
+
+        Assert.Equal(text, first.Text);
+        Assert.Equal(text, second.Text);
+        Assert.NotSame(first.Text, second.Text);
+    }
+
+    [Fact]
+    public void EqualBytesDifferentContent_NeverCollideSilently()
+    {
+        // Two different short strings with the same length must decode to their own content whatever the hash does.
+        var a = (ChatMessage)NetCodec.Decode(NetCodec.Encode(new ChatMessage { Sender = "ab", Text = "über" }))!;
+        var b = (ChatMessage)NetCodec.Decode(NetCodec.Encode(new ChatMessage { Sender = "ba", Text = "ubér" }))!;
+
+        Assert.Equal("ab", a.Sender);
+        Assert.Equal("ba", b.Sender);
+        Assert.Equal("über", a.Text);
+        Assert.Equal("ubér", b.Text);
+    }
+
+    [Fact]
+    public void EmptyAndNullStrings_RoundTrip()
+    {
+        var m = (ChatMessage)NetCodec.Decode(NetCodec.Encode(new ChatMessage { Sender = string.Empty, Text = "" }))!;
+        Assert.Equal(string.Empty, m.Sender);
+        Assert.Equal(string.Empty, m.Text);
+    }
+}


### PR DESCRIPTION
PR bundle 17 of the performance package #1501 — follow-up #1555 of the #1537 attribution: the receive path, the largest game-side source left after the dispatch pooling.

**What ships**
- `ChunkBlocksRle.DecodeInto` / `ChunkDataMessage.DecodeBlocksInto` decode into a caller-owned array (cleared first — pooled memory is not zeroed). `Decode` / `DecodeBlocks` keep their behaviour on top of them.
- The client rents that array from a new `ChunkArrayPool` (a bounded stack of chunk-sized arrays — `ArrayPool.Shared` keeps only a few arrays per size bucket, and the stored chunks hold hundreds for minutes, so it ran dry) and keeps it for the chunk's lifetime: unload or replacement retires it, and it returns to the pool after a two-second grace period because a mesh job in flight may still read the old `ChunkData` through its neighbourhood. The #1550 dispatch copies now come from the same pool.
- `InterningStringFormatter` in front of the contractless resolver: strings of at most 64 UTF-8 bytes are looked up in a per-thread FNV-keyed cache (verified by re-encoding, bounded to 4096 entries, reset when full); longer ones decode as before. Encoding is untouched, so the wire format and every round-trip test are unchanged — only the identity of equal short strings, which nothing depends on.
- `NpcView.OnNpcs` reuses its `seen` set.

**Left as is (and why):** the LiteNetLib packet copy (`NetDataReader.GetRemainingBytes`, ~25 KB/s) — the transport interface hands out owned `byte[]`s and the inbox queues them; and the RLE array MessagePack allocates per chunk (~40 KB/s) — it is the message's own field.

**Measured** (Development player, `PerfProbe -perfProfile`, High / VD 8, walk phase, machine quiet):

| | before (PR 16) | after |
|---|---:|---:|
| `ChunkBlocksRle.Decode` | 490 KB/s, 61/s | absent |
| `String.CreateStringFromEncoding` (entity-list strings) | 12 KB/s, 280/s | absent (`InterningStringFormatter` 2 KB/s, 0.3/s) |
| `ChunkArrayPool.Rent` | — | ~340 KB/s: the world growing ahead of the player faster than it unloads behind — live chunk data, not garbage |
| total walk allocations | 2.5 MB/s, 10 300/s | 2.3 MB/s, 9 300/s (the dev watermark is ~1.4 MB/s of that) |
| PerfProbe walk collections | 9 per 10 s | 5–8 per 10 s |

**Verification:** `InterningStringFormatterTests` (4: interning across messages, long strings not interned, no silent collisions, empty strings) plus the codec / chunk-payload / protocol suites (46 green); `dotnet format`; Development player built, capture + report end to end; TODO.md entry added.

closes #1555

🤖 Generated with [Claude Code](https://claude.com/claude-code)
