### PR TITLE
feat(net): protocol v5 — the world stream (chunks, block changes) on its own LiteNetLib channel, ordered by a world id (#1534)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ the richer, screenshot-laden versions live there. `(#123)` references the pull r
 
 ## [Unreleased]
 
-⚠️ **Compatibility:** the network protocol version moves to **4** (#1533 #1534 #1535 — LZ4-compressed entity
+⚠️ **Compatibility:** the network protocol version moves to **5** (#1533 #1534 #1535 — chunks and block changes on a second LiteNetLib channel with a world id, so a lost chunk no longer stalls presence and chat; — LZ4-compressed entity
 lists and chunks, a sequenced presence beat, and inventory updates that no longer re-send the unchanged
 blueprint list). Updated servers reject older game versions at join with a clear "protocol mismatch" message —
 update the game (desktop installs auto-update; the browser version is always current).

--- a/TODO.md
+++ b/TODO.md
@@ -283,6 +283,33 @@ is read from the module stat (16) instead of being dead, and the station deploy 
 persisted ids after a restart (id collision). Tests: `PlayerStationReportsTests` (7), `DropLootTests` (+2).
 Locales: 9 new keys + 2 rewordings, EN/DE hand-written, 12 MT via translate_locale.
 
+### ★ Protocol v5: the world stream on its own LiteNetLib channel, ordered by a world id (#1534, 2026-09-04, branch perf/1534-second-channel) — ⚠ RELEASE NOTE: older game versions cannot join a v5 server
+
+**Why.** PR bundle 18 of the performance package (#1501), part B of #1534 (part A — the presence beat on a Sequenced
+delivery — shipped with v4). Every server→client message shared ONE reliable-ordered LiteNetLib channel, so a lost
+fragment of a 1–12 KB chunk stalled every presence / creature / NPC update queued behind it for a resend round trip
+(head-of-line blocking — avatar and creature stutter on lossy Wi-Fi). Part B was deferred because chunks on a second
+channel can overtake or trail the JoinAccepted / WorldReset that introduces their world.
+
+**What ships.** `DeliveryMode.ReliableOrderedBulk`: the world stream — chunks and `BlockChanged` — on LiteNetLib
+channel 1 (`ChannelsCount = 2` on both peers; transports without channels treat it as ReliableOrdered). The ordering
+problem is solved with a world id: the server numbers every world once per run (`WorldIdOf`), stamps it on
+`ChunkDataMessage` (cache-stable: the payload cache is per world), `BlockChanged`, `WorldReset` and `JoinAccepted`,
+and `NetworkClient` orders the two channels with it — world-stream payloads that arrive before the JoinAccepted are
+held as raw bytes and replayed after it; after a world switch a message of the world just left is dropped and one of a
+world not announced yet is parked until its WorldReset arrives (both bounded at 512). Messages without an id (0) pass
+as before, so the loopback and JSON paths — single ordered streams — never take either branch. `Protocol.Version`
+5; a v4 peer would drop channel-1 packets, so the join-time version check keeps the two apart (CHANGELOG note
+extended).
+
+**Verification.** `ProtocolV5Tests` (version + channel mapping; a real UDP localhost LiteNetLib server ↔ client
+exchanging bulk and ordinary payloads on two channels, order kept within the bulk channel),
+`ProtocolV5ClientOrderingTests` (5: held before join, dropped for the world just left, parked for an unannounced world,
+id-less accepted, disconnect resets), the codec / chunk-payload / integration / WebSocket suites and the full fast
+tier green; the Development player joins the bundled v5 server over LiteNetLib and streams a world as before
+(PerfProbe run). Not measured: the packet-loss case itself — LiteNetLib's loss simulation is a DEBUG-build feature of
+the library, absent from the NuGet package; the mechanism (a second reliable queue) is the whole fix.
+
 ### ★ Client garbage, part 5: chunks decode into pooled arrays that live with the chunk, the codec interns short strings (#1555, 2026-09-04, branch perf/1555-receive-path)
 
 **Why.** PR bundle 17 of the performance package (#1501). After the dispatch pooling the receive path was the largest

--- a/src/BlocksBeyondTheStars.Client.Core/NetworkClient.cs
+++ b/src/BlocksBeyondTheStars.Client.Core/NetworkClient.cs
@@ -214,6 +214,7 @@ namespace BlocksBeyondTheStars.Client
             {
                 bool wasConnected = Connected;
                 Connected = false;
+                ResetWorldOrdering();
                 if (wasConnected)
                 {
                     Disconnected?.Invoke();
@@ -244,6 +245,98 @@ namespace BlocksBeyondTheStars.Client
 
         /// <summary>Payloads still waiting to be dispatched (diagnostics / tests).</summary>
         public int PendingPayloads => _inbox.Count;
+
+        // ---- World-stream ordering (#1534, protocol v5) ----
+        // Chunks and block changes arrive on their own transport channel, so they can overtake or trail the
+        // JoinAccepted / WorldReset that introduces their world. Every such message carries the server's WorldId:
+        // before the join the world stream is held back as raw payloads and replayed after JoinAccepted; after a
+        // world switch a message of the world just left is dropped, one of a world not announced yet waits for
+        // its WorldReset. Transports without channels (loopback, WebSocket) never trigger either path.
+        private const int MaxHeldWorldStream = 512;
+        private bool _joined;
+        private int _previousWorldId;
+        private int _futureWorldId;
+        private readonly Queue<byte[]> _heldBeforeJoin = new();
+        private readonly Queue<object> _futureWorld = new();
+
+        /// <summary>The WorldId of the last JoinAccepted / WorldReset (0 before the join or on a v4 server).</summary>
+        public int CurrentWorldId { get; private set; }
+
+        /// <summary>World-stream messages parked for a world the client has not been told about yet (diagnostics / tests).</summary>
+        public int PendingFutureWorldMessages => _futureWorld.Count;
+
+        private void ResetWorldOrdering()
+        {
+            _joined = false;
+            CurrentWorldId = 0;
+            _previousWorldId = 0;
+            _futureWorldId = 0;
+            _heldBeforeJoin.Clear();
+            _futureWorld.Clear();
+        }
+
+        private void AdoptWorld(int worldId)
+        {
+            _previousWorldId = CurrentWorldId;
+            CurrentWorldId = worldId;
+        }
+
+        /// <summary>True when a world-stream message belongs to the current world (or carries no id — a v4-era
+        /// path). A message of the world just left is dropped; one of an unannounced world is parked.</summary>
+        private bool AcceptWorldStream(int worldId, object message)
+        {
+            if (worldId == 0 || worldId == CurrentWorldId)
+            {
+                return true;
+            }
+
+            if (worldId == _previousWorldId)
+            {
+                return false; // the stream of the world we just left, still draining on its channel
+            }
+
+            if (_futureWorldId != worldId)
+            {
+                _futureWorld.Clear();
+                _futureWorldId = worldId;
+            }
+
+            if (_futureWorld.Count < MaxHeldWorldStream)
+            {
+                _futureWorld.Enqueue(message);
+            }
+
+            return false;
+        }
+
+        private void ReplayFutureWorld()
+        {
+            if (_futureWorldId != CurrentWorldId)
+            {
+                return;
+            }
+
+            _futureWorldId = 0;
+            while (_futureWorld.Count > 0)
+            {
+                switch (_futureWorld.Dequeue())
+                {
+                    case ChunkDataMessage c: ChunkReceived?.Invoke(c); break;
+                    case BlockChanged b: BlockChanged?.Invoke(b); break;
+                }
+            }
+        }
+
+        private void ReplayHeldBeforeJoin()
+        {
+            while (_heldBeforeJoin.Count > 0)
+            {
+                OnPayload(_heldBeforeJoin.Dequeue());
+            }
+        }
+
+        private static bool IsWorldStreamPayload(byte[] payload)
+            => NetCodec.IsMessageType<ChunkDataMessage>(payload) || NetCodec.IsMessageType<BlockChanged>(payload);
 
         private void EnqueuePayload(byte[] payload) => _inbox.Enqueue(payload);
 
@@ -736,6 +829,17 @@ namespace BlocksBeyondTheStars.Client
                     chunks++;
                 }
 
+                if (!_joined && IsWorldStreamPayload(payload))
+                {
+                    // #1534: the world stream overtook the JoinAccepted on the other channel — park it.
+                    if (_heldBeforeJoin.Count < MaxHeldWorldStream)
+                    {
+                        _heldBeforeJoin.Enqueue(payload);
+                    }
+
+                    continue;
+                }
+
                 OnPayload(payload);
             }
         }
@@ -751,10 +855,15 @@ namespace BlocksBeyondTheStars.Client
         {
             switch (NetCodec.Decode(payload))
             {
-                case JoinAccepted m: JoinAccepted?.Invoke(m); break;
+                case JoinAccepted m:
+                    _joined = true;
+                    AdoptWorld(m.WorldId);
+                    JoinAccepted?.Invoke(m);
+                    ReplayHeldBeforeJoin();
+                    break;
                 case JoinRejected m: JoinRejected?.Invoke(m); break;
-                case ChunkDataMessage m: ChunkReceived?.Invoke(m); break;
-                case BlockChanged m: BlockChanged?.Invoke(m); break;
+                case ChunkDataMessage m: if (AcceptWorldStream(m.WorldId, m)) { ChunkReceived?.Invoke(m); } break;
+                case BlockChanged m: if (AcceptWorldStream(m.WorldId, m)) { BlockChanged?.Invoke(m); } break;
                 case InventoryUpdate m: InventoryUpdated?.Invoke(m); break;
                 case PlayerStateUpdate m: PlayerStateUpdated?.Invoke(m); break;
                 case CraftResult m: CraftCompleted?.Invoke(m); break;
@@ -811,7 +920,11 @@ namespace BlocksBeyondTheStars.Client
                 case CustomShapeList m: CustomShapeListReceived?.Invoke(m); break;
                 case OwnedShips m: OwnedShipsReceived?.Invoke(m); break;
                 case WorldEnvironment m: WorldEnvironmentReceived?.Invoke(m); break;
-                case WorldReset m: WorldResetReceived?.Invoke(m); break;
+                case WorldReset m:
+                    AdoptWorld(m.WorldId);
+                    WorldResetReceived?.Invoke(m);
+                    ReplayFutureWorld();
+                    break;
                 case NpcList m: NpcsReceived?.Invoke(m); break;
                 case DoorList m: DoorsReceived?.Invoke(m); break;
                 case DataCubeList m: DataCubesReceived?.Invoke(m); break;

--- a/src/BlocksBeyondTheStars.GameServer/GameServer.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServer.cs
@@ -2373,7 +2373,7 @@ public sealed partial class GameServer
     private void StreamChunkNow(PlayerSession session, ChunkCoord coord)
     {
         var chunk = _world.GetOrLoadChunk(coord);
-        SendEncoded(session.ConnectionId, ChunkPayloadFor(chunk, coord));
+        SendEncoded(session.ConnectionId, ChunkPayloadFor(chunk, coord), DeliveryMode.ReliableOrderedBulk); // #1534: the world-stream channel
         session.SentChunks.Add(coord);
         MarkExploredCell(session, coord); // #1113: the planet map remembers this across sessions
     }
@@ -2404,6 +2404,7 @@ public sealed partial class GameServer
             Cx = coord.X,
             Cy = coord.Y,
             Cz = coord.Z,
+            WorldId = ActiveWorldId, // #1534: the payload cache is per world, so this is stable per entry
         };
         var rle = ChunkBlocksRle.Encode(chunk.RawBlocks);
         if (rle.Length < WorldConstants.BlocksPerChunk)
@@ -3293,6 +3294,7 @@ public sealed partial class GameServer
             PlanetType = joinBodyType,
             PlanetName = planetName,
             SystemName = systemName,
+            WorldId = WorldIdOf(state.CurrentLocationId), // #1534
             CumulativePlaytimeSeconds = _meta.CumulativePlaytimeSeconds,
             TerrainContinents = _meta.Description.TerrainContinents,
         });
@@ -6323,8 +6325,45 @@ public sealed partial class GameServer
         return list.ToArray();
     }
 
+    // #1534 (v5): every world is numbered once per server run; the world stream (chunks, block changes) carries
+    // the number and rides its own transport channel, and JoinAccepted / WorldReset tell the client which number
+    // is current — that is how the client orders the two channels. The numbering is per process (not persisted).
+    private readonly Dictionary<string, int> _worldIds = new(StringComparer.Ordinal);
+
+    private int WorldIdOf(string? locationId)
+    {
+        if (string.IsNullOrEmpty(locationId))
+        {
+            return 0;
+        }
+
+        if (!_worldIds.TryGetValue(locationId, out int id))
+        {
+            id = _worldIds.Count + 1;
+            _worldIds[locationId] = id;
+        }
+
+        return id;
+    }
+
+    private int ActiveWorldId => WorldIdOf(_worlds.Active?.LocationId);
+
     private void Send(PlayerSession session, object message)
-        => _transport.Send(session.ConnectionId, NetCodec.Encode(message), DeliveryMode.ReliableOrdered);
+    {
+        var mode = DeliveryMode.ReliableOrdered;
+        switch (message)
+        {
+            case WorldReset reset:
+                reset.WorldId = WorldIdOf(session.CurrentLocationId); // the stream that follows is this world's
+                break;
+            case BlockChanged change:
+                change.WorldId = WorldIdOf(session.CurrentLocationId);
+                mode = DeliveryMode.ReliableOrderedBulk;
+                break;
+        }
+
+        _transport.Send(session.ConnectionId, NetCodec.Encode(message), mode);
+    }
 
     /// <summary>Sends an already-encoded payload (so a broadcast encodes the message once and reuses the same
     /// bytes for every recipient instead of re-serializing per send). The payload is read-only after encoding.</summary>
@@ -6424,10 +6463,17 @@ public sealed partial class GameServer
     {
         // Encode ONCE and reuse the bytes for every recipient — re-encoding per send made a 4-player world
         // serialize the same block-change / entity / environment message 4× (the biggest steady-state GC cost).
+        var mode = DeliveryMode.ReliableOrdered;
+        if (message is BlockChanged change)
+        {
+            change.WorldId = ActiveWorldId; // #1534: the recipients are exactly the active world's players
+            mode = DeliveryMode.ReliableOrderedBulk;
+        }
+
         var payload = NetCodec.Encode(message);
         foreach (var s in JoinedInActiveWorld())
         {
-            SendEncoded(s.ConnectionId, payload);
+            SendEncoded(s.ConnectionId, payload, mode);
         }
     }
 

--- a/src/BlocksBeyondTheStars.Networking/Messages.cs
+++ b/src/BlocksBeyondTheStars.Networking/Messages.cs
@@ -808,6 +808,9 @@ public sealed class JoinAccepted
     public string PlanetName { get; set; } = string.Empty;
     public string SystemName { get; set; } = string.Empty;
 
+    /// <summary>The server's id of the joined world (#1534, v5) — see <see cref="ChunkDataMessage.WorldId"/>.</summary>
+    public int WorldId { get; set; }
+
     /// <summary>Total seconds this world has been played (server-accumulated, see
     /// <c>WorldMetadata.CumulativePlaytimeSeconds</c>); shown alongside the per-session timer in the HUD.</summary>
     public long CumulativePlaytimeSeconds { get; set; }
@@ -827,6 +830,10 @@ public sealed class ChunkDataMessage
     public int Cx { get; set; }
     public int Cy { get; set; }
     public int Cz { get; set; }
+
+    /// <summary>The server's id of the world this chunk belongs to (#1534, v5): the world stream travels on its own
+    /// channel, so the client matches it against the WorldId of the last JoinAccepted / WorldReset. 0 = unknown.</summary>
+    public int WorldId { get; set; }
 
     /// <summary>Dense per-cell block ids. Empty when <see cref="BlocksRle"/> carries the payload instead —
     /// the server sends whichever representation is smaller (a rare unrunnable chunk ships dense).</summary>
@@ -889,6 +896,9 @@ public sealed class BlockChanged
 
     /// <summary>Packed shape descriptor of the placed block (shape index + orientation; see ShapeCode); 0 = plain cube.</summary>
     public int Shape { get; set; }
+
+    /// <summary>The world this change belongs to (#1534, v5) — see <see cref="ChunkDataMessage.WorldId"/>.</summary>
+    public int WorldId { get; set; }
 }
 
 /// <summary>A harvested surface plant has begun regrowing on its (now bare) cell: the server broadcasts this
@@ -1357,6 +1367,9 @@ public sealed class WorldReset
 
     /// <summary>True when the arrival was a hyperspace jump to a different star system (drives the client warp animation).</summary>
     public bool Hyperjump { get; set; }
+
+    /// <summary>The server's id of the world whose stream follows (#1534, v5) — see <see cref="ChunkDataMessage.WorldId"/>.</summary>
+    public int WorldId { get; set; }
 }
 
 /// <summary>The player's current vitals are respawning at the ship heal-tank (Medbay).</summary>

--- a/src/BlocksBeyondTheStars.Networking/Protocol.cs
+++ b/src/BlocksBeyondTheStars.Networking/Protocol.cs
@@ -15,8 +15,13 @@ public static class Protocol
     /// v4 (#1533/#1535): MessagePack bodies above NetCodec.CompressionMinLengthBytes are LZ4 block arrays — a
     /// v3 reader hands the LZ4 ext block to the plain formatter and silently drops every entity list and
     /// chunk; and InventoryUpdate.BlueprintsUnchanged lets the server omit the unlocked-blueprint list, which
-    /// a v3 client would read as "no blueprints" and grey out its whole tech tree.</summary>
-    public const int Version = 4;
+    /// a v3 client would read as "no blueprints" and grey out its whole tech tree.
+    /// v5 (#1534): chunks and block changes travel as DeliveryMode.ReliableOrderedBulk — a second LiteNetLib
+    /// channel (ChannelsCount = 2 on both peers; a v4 peer drops channel-1 packets) — so a lost chunk fragment
+    /// no longer stalls presence, creatures and chat behind its resend. ChunkDataMessage, BlockChanged,
+    /// WorldReset and JoinAccepted carry a WorldId, which lets the client order the two channels: world-stream
+    /// messages of a world it has not been told about yet wait, those of the world it just left are dropped.</summary>
+    public const int Version = 5;
 
     public const int DefaultGameplayPort = 31415;
     public const int DefaultAdminPort = 31416;
@@ -35,6 +40,11 @@ public enum DeliveryMode
 
     /// <summary>Best-effort, may drop/reorder — for frequent position updates.</summary>
     Unreliable,
+
+    /// <summary>Guaranteed, in-order delivery on its OWN queue (#1534): the world stream (chunks, block changes)
+    /// stays ordered against itself but a lost chunk fragment no longer holds back everything else. Transports
+    /// without channels treat it exactly as <see cref="ReliableOrdered"/>.</summary>
+    ReliableOrderedBulk,
 
     /// <summary>Best-effort, never duplicated, arrives in order (an older packet behind a newer one is dropped)
     /// — for the presence beat (#1534): a lost fragment of a chunk on the reliable stream no longer holds every

--- a/src/BlocksBeyondTheStars.Networking/Transport/LiteNetLibTransport.cs
+++ b/src/BlocksBeyondTheStars.Networking/Transport/LiteNetLibTransport.cs
@@ -7,15 +7,22 @@ using LiteNetLib;
 namespace BlocksBeyondTheStars.Networking.Transport;
 
 /// <summary>Maps our <see cref="DeliveryMode"/> onto LiteNetLib delivery methods.</summary>
-internal static class DeliveryMapping
+public static class DeliveryMapping
 {
     public static DeliveryMethod ToLiteNetLib(this DeliveryMode mode) => mode switch
     {
         DeliveryMode.ReliableOrdered => DeliveryMethod.ReliableOrdered,
+        DeliveryMode.ReliableOrderedBulk => DeliveryMethod.ReliableOrdered,
         DeliveryMode.Unreliable => DeliveryMethod.Unreliable,
         DeliveryMode.Sequenced => DeliveryMethod.Sequenced, // #1534: its own queue — not behind chunk resends
         _ => DeliveryMethod.ReliableOrdered,
     };
+
+    /// <summary>The LiteNetLib channel: the world stream (chunks, block changes) rides channel 1, everything
+    /// else channel 0 (#1534). Both peers run <see cref="ChannelCount"/> channels — protocol v5.</summary>
+    public static byte Channel(this DeliveryMode mode) => mode == DeliveryMode.ReliableOrderedBulk ? (byte)1 : (byte)0;
+
+    public const byte ChannelCount = 2;
 }
 
 /// <summary>
@@ -53,6 +60,7 @@ public sealed class LiteNetLibServerTransport : IServerTransport
             // server also runs an app-level heartbeat on top.
             DisconnectTimeout = 10000,
             PingInterval = 1000,
+            ChannelsCount = DeliveryMapping.ChannelCount, // #1534
         };
 
         _listener.ConnectionRequestEvent += request =>
@@ -103,12 +111,12 @@ public sealed class LiteNetLibServerTransport : IServerTransport
     {
         if (_peers.TryGetValue(connectionId, out var peer))
         {
-            peer.Send(payload, mode.ToLiteNetLib());
+            peer.Send(payload, mode.Channel(), mode.ToLiteNetLib());
         }
     }
 
     public void Broadcast(byte[] payload, DeliveryMode mode)
-        => _manager.SendToAll(payload, mode.ToLiteNetLib());
+        => _manager.SendToAll(payload, mode.Channel(), mode.ToLiteNetLib());
 
     /// <summary>Disconnects one native peer (kick). LiteNetLib flushes the reliable queue before the
     /// disconnect packet, so a message sent just before this still reaches the client.</summary>
@@ -143,7 +151,7 @@ public sealed class LiteNetLibClientTransport : IClientTransport
     public LiteNetLibClientTransport()
     {
         // Explicit, matching the server side (#964) — see the note there.
-        _manager = new NetManager(_listener) { AutoRecycle = true, DisconnectTimeout = 10000, PingInterval = 1000 };
+        _manager = new NetManager(_listener) { AutoRecycle = true, DisconnectTimeout = 10000, PingInterval = 1000, ChannelsCount = DeliveryMapping.ChannelCount };
 
         _listener.PeerConnectedEvent += peer =>
         {
@@ -170,7 +178,7 @@ public sealed class LiteNetLibClientTransport : IClientTransport
         _manager.Connect(host, port, ConnectionKey);
     }
 
-    public void Send(byte[] payload, DeliveryMode mode) => _serverPeer?.Send(payload, mode.ToLiteNetLib());
+    public void Send(byte[] payload, DeliveryMode mode) => _serverPeer?.Send(payload, mode.Channel(), mode.ToLiteNetLib());
 
     public void Poll() => _manager.PollEvents();
 

--- a/tests/BlocksBeyondTheStars.Client.Tests/ProtocolV5ClientOrderingTests.cs
+++ b/tests/BlocksBeyondTheStars.Client.Tests/ProtocolV5ClientOrderingTests.cs
@@ -1,0 +1,146 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using BlocksBeyondTheStars.Client;
+using BlocksBeyondTheStars.Networking;
+using BlocksBeyondTheStars.Networking.Messages;
+using BlocksBeyondTheStars.Networking.Transport;
+using BlocksBeyondTheStars.Shared.World;
+using Xunit;
+
+namespace BlocksBeyondTheStars.Client.Tests;
+
+/// <summary>#1534 (protocol v5): chunks and block changes arrive on their own transport channel, so the client
+/// orders them against JoinAccepted / WorldReset by WorldId — held before the join, dropped for the world just
+/// left, parked for a world not announced yet.</summary>
+public sealed class ProtocolV5ClientOrderingTests
+{
+    /// <summary>An in-memory client transport: the test hands it server payloads in any order it likes.</summary>
+    private sealed class ScriptedClientTransport : IClientTransport
+    {
+        public event Action? Connected;
+        public event Action? Disconnected;
+        public event Action<byte[]>? PayloadReceived;
+
+        public void Connect(string host, int port) => Connected?.Invoke();
+
+        public void Send(byte[] payload, DeliveryMode mode)
+        {
+        }
+
+        public void Poll()
+        {
+        }
+
+        public void Disconnect() => Disconnected?.Invoke();
+
+        public void Dispose()
+        {
+        }
+
+        public void Deliver(object message) => PayloadReceived?.Invoke(NetCodec.Encode(message));
+    }
+
+    private static ChunkDataMessage Chunk(int worldId, int cx)
+        => new() { Cx = cx, Cy = 0, Cz = 0, WorldId = worldId, Blocks = new ushort[WorldConstants.BlocksPerChunk] };
+
+    [Fact]
+    public void WorldStream_ArrivingBeforeJoinAccepted_IsReplayedAfterIt()
+    {
+        var transport = new ScriptedClientTransport();
+        var client = new NetworkClient(transport);
+        var order = new List<string>();
+        client.JoinAccepted += _ => order.Add("join");
+        client.ChunkReceived += c => order.Add("chunk" + c.Cx);
+        client.BlockChanged += b => order.Add("block" + b.X);
+
+        transport.Deliver(Chunk(worldId: 1, cx: 7));
+        transport.Deliver(new BlockChanged { X = 3, WorldId = 1 });
+        client.Poll();
+        Assert.Empty(order); // held: nothing dispatched before the join
+
+        transport.Deliver(new JoinAccepted { WorldId = 1 });
+        client.Poll();
+
+        Assert.Equal(new[] { "join", "chunk7", "block3" }, order);
+        Assert.Equal(1, client.CurrentWorldId);
+    }
+
+    [Fact]
+    public void WorldStream_OfTheWorldJustLeft_IsDropped()
+    {
+        var transport = new ScriptedClientTransport();
+        var client = new NetworkClient(transport);
+        var chunks = new List<int>();
+        client.ChunkReceived += c => chunks.Add(c.Cx);
+
+        transport.Deliver(new JoinAccepted { WorldId = 1 });
+        transport.Deliver(Chunk(1, 1));
+        transport.Deliver(new WorldReset { WorldId = 2 });
+        transport.Deliver(Chunk(1, 99)); // a straggler from world 1, still draining on its channel
+        transport.Deliver(Chunk(2, 2));
+        client.Poll();
+
+        Assert.Equal(new[] { 1, 2 }, chunks);
+        Assert.Equal(2, client.CurrentWorldId);
+        Assert.Equal(0, client.PendingFutureWorldMessages);
+    }
+
+    [Fact]
+    public void WorldStream_OfAnUnannouncedWorld_WaitsForItsWorldReset()
+    {
+        var transport = new ScriptedClientTransport();
+        var client = new NetworkClient(transport);
+        var order = new List<string>();
+        client.ChunkReceived += c => order.Add("chunk" + c.Cx);
+        client.BlockChanged += b => order.Add("block" + b.X);
+        client.WorldResetReceived += _ => order.Add("reset");
+
+        transport.Deliver(new JoinAccepted { WorldId = 1 });
+        transport.Deliver(Chunk(2, 5));                       // the new world's stream overtook its WorldReset
+        transport.Deliver(new BlockChanged { X = 9, WorldId = 2 });
+        client.Poll();
+        Assert.Empty(order);
+        Assert.Equal(2, client.PendingFutureWorldMessages);
+
+        transport.Deliver(new WorldReset { WorldId = 2 });
+        client.Poll();
+
+        Assert.Equal(new[] { "reset", "chunk5", "block9" }, order);
+        Assert.Equal(0, client.PendingFutureWorldMessages);
+    }
+
+    [Fact]
+    public void WorldStream_WithoutAWorldId_IsAcceptedAsBefore()
+    {
+        var transport = new ScriptedClientTransport();
+        var client = new NetworkClient(transport);
+        var chunks = new List<int>();
+        client.ChunkReceived += c => chunks.Add(c.Cx);
+
+        transport.Deliver(new JoinAccepted { WorldId = 3 });
+        transport.Deliver(Chunk(worldId: 0, cx: 4)); // e.g. a path that does not number worlds
+        client.Poll();
+
+        Assert.Equal(new[] { 4 }, chunks);
+    }
+
+    [Fact]
+    public void Disconnect_ResetsTheOrderingState()
+    {
+        var transport = new ScriptedClientTransport();
+        var client = new NetworkClient(transport);
+        var chunks = new List<int>();
+        client.ChunkReceived += c => chunks.Add(c.Cx);
+
+        transport.Connect("x", 1);
+        transport.Deliver(new JoinAccepted { WorldId = 1 });
+        client.Poll();
+        transport.Disconnect();
+        Assert.Equal(0, client.CurrentWorldId);
+
+        transport.Deliver(Chunk(1, 8)); // before the next join: held again, not dispatched
+        client.Poll();
+        Assert.Empty(chunks);
+    }
+}

--- a/tests/BlocksBeyondTheStars.Client.Tests/ReceiveBudgetTests.cs
+++ b/tests/BlocksBeyondTheStars.Client.Tests/ReceiveBudgetTests.cs
@@ -47,6 +47,9 @@ public sealed class ReceiveBudgetTests
 
     private static byte[] Message(string text) => NetCodec.Encode(new ServerMessage { Text = text });
 
+    // #1534 (v5): the world stream is held back until the JoinAccepted has been dispatched.
+    private static byte[] Join() => NetCodec.Encode(new JoinAccepted { WorldId = 1 });
+
     [Fact]
     public void ChunkBacklog_IsPacedAcrossFrames_AndNothingIsLost()
     {
@@ -56,6 +59,7 @@ public sealed class ReceiveBudgetTests
         int received = 0;
         client.ChunkReceived += _ => received++;
 
+        transport.Pending.Enqueue(Join());
         int queued = (client.MaxChunksPerPoll * 3) + 5;
         for (int i = 0; i < queued; i++)
         {
@@ -108,6 +112,7 @@ public sealed class ReceiveBudgetTests
         client.ChunkReceived += m => order.Add("chunk" + m.Cx);
         client.BlockChanged += _ => order.Add("block");
 
+        transport.Pending.Enqueue(Join());
         transport.Pending.Enqueue(Chunk(0));
         transport.Pending.Enqueue(Chunk(1));
         transport.Pending.Enqueue(Chunk(2));                                  // over the cap → next frame

--- a/tests/BlocksBeyondTheStars.Tests/ProtocolV4Tests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/ProtocolV4Tests.cs
@@ -50,10 +50,11 @@ public sealed class ProtocolV4Tests : IDisposable
         };
 
     [Fact]
-    public void Version_IsFour()
+    public void Version_IsFive()
     {
-        Assert.Equal(4, Protocol.Version);
-        Assert.Equal(4, new JoinRequest().ProtocolVersion);
+        // v4 = LZ4 + BlueprintsUnchanged (this file); v5 = the second LiteNetLib channel + WorldId (ProtocolV5Tests).
+        Assert.Equal(5, Protocol.Version);
+        Assert.Equal(5, new JoinRequest().ProtocolVersion);
     }
 
     [Fact]

--- a/tests/BlocksBeyondTheStars.Tests/ProtocolV5Tests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/ProtocolV5Tests.cs
@@ -1,0 +1,63 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using System.Diagnostics;
+using BlocksBeyondTheStars.Networking;
+using BlocksBeyondTheStars.Networking.Transport;
+using Xunit;
+
+namespace BlocksBeyondTheStars.Tests;
+
+/// <summary>#1534 (protocol v5): the world stream (chunks, block changes) rides its own LiteNetLib channel. The
+/// client-side ordering against JoinAccepted / WorldReset is covered in the client test project
+/// (<c>ProtocolV5ClientOrderingTests</c>).</summary>
+public sealed class ProtocolV5Tests
+{
+    [Fact]
+    public void Version_IsFive_AndBulkIsItsOwnChannel()
+    {
+        Assert.Equal(5, Protocol.Version);
+        Assert.Equal(1, DeliveryMode.ReliableOrderedBulk.Channel());
+        Assert.Equal(0, DeliveryMode.ReliableOrdered.Channel());
+        Assert.Equal(0, DeliveryMode.Sequenced.Channel());
+        Assert.Equal(LiteNetLib.DeliveryMethod.ReliableOrdered, DeliveryMode.ReliableOrderedBulk.ToLiteNetLib());
+    }
+
+    [Fact]
+    public void LiteNetLib_DeliversBulkAndOrdinaryPayloads_OnTwoChannels()
+    {
+        int port = 34000 + Random.Shared.Next(1000);
+        using var server = new LiteNetLibServerTransport(1);
+        using var client = new LiteNetLibClientTransport();
+        int? connectionId = null;
+        var received = new List<byte>();
+        server.ClientConnected += id => connectionId = id;
+        client.PayloadReceived += p => received.Add(p[0]);
+
+        server.Start(port);
+        client.Connect("127.0.0.1", port);
+        var sw = Stopwatch.StartNew();
+        while (connectionId == null && sw.ElapsedMilliseconds < 5000)
+        {
+            server.Poll();
+            client.Poll();
+            Thread.Sleep(10);
+        }
+
+        Assert.NotNull(connectionId);
+        server.Send(connectionId!.Value, new byte[] { 1, 10, 20 }, DeliveryMode.ReliableOrderedBulk);
+        server.Send(connectionId.Value, new byte[] { 2, 30, 40 }, DeliveryMode.ReliableOrdered);
+        server.Send(connectionId.Value, new byte[] { 3, 50, 60 }, DeliveryMode.ReliableOrderedBulk);
+        while (received.Count < 3 && sw.ElapsedMilliseconds < 5000)
+        {
+            server.Poll();
+            client.Poll();
+            Thread.Sleep(10);
+        }
+
+        Assert.Equal(3, received.Count);
+        Assert.Contains((byte)2, received);
+        // The bulk channel keeps its own order.
+        Assert.True(received.IndexOf(1) < received.IndexOf(3));
+    }
+}


### PR DESCRIPTION
PR bundle 18 of the performance package #1501 — part B of #1534 (part A, the presence beat on a Sequenced delivery, shipped with protocol v4 in #1548).

⚠ **Protocol version 5** — older game versions cannot join an updated server (the join-time version check says so); CHANGELOG note extended. Ship server and client together.

**Problem.** Every server→client message shared one reliable-ordered LiteNetLib channel, so a lost fragment of a 1–12 KB chunk stalled every presence / creature / NPC update queued behind it for a resend round trip (head-of-line blocking — avatar and creature stutter on lossy Wi-Fi). Part B was deferred because chunks on a second channel can overtake or trail the JoinAccepted / WorldReset that introduces their world.

**What ships.**
- `DeliveryMode.ReliableOrderedBulk`: the world stream — `ChunkDataMessage` and `BlockChanged` — on LiteNetLib channel 1 (`ChannelsCount = 2` on both peers); transports without channels treat it exactly as `ReliableOrdered`.
- A world id resolves the cross-channel ordering: the server numbers every world once per run (`WorldIdOf`) and stamps it on `ChunkDataMessage` (the payload cache is per world, so the entry stays valid), `BlockChanged`, `WorldReset` and `JoinAccepted`.
- `NetworkClient` orders the two channels with it: world-stream payloads that arrive before the JoinAccepted are held as raw bytes and replayed right after it; after a world switch a message of the world just left is dropped, one of a world not announced yet is parked until its WorldReset arrives (both bounded at 512, cleared on disconnect). Messages without an id pass as before, so the loopback and JSON paths — single ordered streams — never take either branch.

**Verification.**
- `ProtocolV5Tests`: version + channel mapping; a real UDP localhost LiteNetLib server ↔ client exchanging bulk and ordinary payloads on two channels, order kept within the bulk channel.
- `ProtocolV5ClientOrderingTests` (5): held before join, dropped for the world just left, parked for an unannounced world, id-less accepted, disconnect resets.
- Codec / chunk-payload / integration / WebSocket suites and the full fast tier green; `dotnet format`.
- The Development player joins the bundled v5 server over LiteNetLib and streams a world as before (PerfProbe run, walk GC unchanged).
- Not measured: the packet-loss case itself — LiteNetLib's loss simulation is a DEBUG-build feature of the library, absent from the NuGet package; the mechanism (a second reliable queue) is the whole fix.

closes #1534

🤖 Generated with [Claude Code](https://claude.com/claude-code)
