### PR TITLE
perf(net,webgl): the in-process loopback passes message objects, the browser WebSocket bridge moves bytes through the WASM heap (#1531)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -283,6 +283,39 @@ is read from the module stat (16) instead of being dead, and the station deploy 
 persisted ids after a restart (id collision). Tests: `PlayerStationReportsTests` (7), `DropLootTests` (+2).
 Locales: 9 new keys + 2 rewordings, EN/DE hand-written, 12 MT via translate_locale.
 
+### ★ Browser transports without copies: the in-process loopback passes message objects, the WebSocket bridge moves bytes through the WASM heap (#1531, 2026-09-04, branch perf/1531-object-loopback) — ⚠ WebGL-only paths, verified headless only; a WebGL build + browser session is the real test
+
+**Why.** PR bundle 19 of the performance package (#1501), the two remaining parts of #1531 (the encode-once
+part shipped in PR 9). The browser singleplayer runs the real server in-process, yet every server→client
+message was JSON-serialised, parsed and deserialised on the render thread — three payload-sized allocations
+per message, sixteen chunks per tick during streaming — on the device class where the heap is the crash
+budget (the tablet OOM path). And the browser WebSocket client moved every frame through four base64 copies
+(btoa, string marshal, FromBase64String, atob).
+
+**What ships.** `IObjectServerTransport` / `IObjectClientTransport`: a transport may carry decoded message
+objects; `LoopbackLink.PassObjects` (opt-in — the tests that read the wire as bytes keep working; the browser
+host and the client harness switch it on) queues server→client messages as objects in the same queue as
+bytes, so the send order holds across both kinds. The server prefers the object path on every send site
+(`Send`, `SendTo`, `Broadcast`, `BroadcastToWorld`, the radio audience, the presence beat, the chunk stream —
+which hands over a cached `ChunkDataMessage` per chunk version, `WorldManager.ChunkMessages`, instead of the
+encoded payload). `NetworkClient`'s inbox holds bytes or objects; the receive budget, the pre-join hold and
+the world-id ordering (#1534) treat both alike. Client→server stays encoded on purpose: intents are tiny, and
+the server must never hold a reference into a client-owned object (it stores design arrays and pixel payloads
+— the round trip is its deep copy). The contract that makes the object path safe: the server builds every
+message fresh for the send or caches it read-only, and the client treats received messages as read-only
+(the chunk blocks are copied into the pooled array since #1555). In the browser WebSocket client
+(`BrowserWebSocketClientTransport` + `BbsWebSocket.jslib`) outbound frames go as pointer + length straight
+out of `HEAPU8` (`WebSocket.send` copies synchronously), inbound frames are parked per socket as views and
+`Poll` pulls each one into an exact-size managed array — one copy, the one the array needs anyway; only
+open / close / error still travel as SendMessage strings.
+
+**Verification.** `LoopbackObjectPassingTests` (object mode: join + chunk stream with zero server→client
+encodes; byte mode still works; a re-streamed cached chunk message stays intact), the whole client test
+project in object mode through the harness, the server integration / transport / protocol suites in byte
+mode. NOT verified: the WebGL build itself (`#if UNITY_WEBGL` code and the jslib compile only on a WebGL
+build — Marcel tests one after the desktop playtest, on his go). Nothing changes for desktop or the hosted
+LiteNetLib / WebSocket servers: their transports do not implement the object interfaces.
+
 ### ★ Protocol v5: the world stream on its own LiteNetLib channel, ordered by a world id (#1534, 2026-09-04, branch perf/1534-second-channel) — ⚠ RELEASE NOTE: older game versions cannot join a v5 server
 
 **Why.** PR bundle 18 of the performance package (#1501), part B of #1534 (part A — the presence beat on a Sequenced

--- a/client/Assets/BlocksBeyondTheStars/Scripts/BrowserLocalServer.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/BrowserLocalServer.cs
@@ -158,7 +158,9 @@ namespace BlocksBeyondTheStars.Client
                 BlocksBeyondTheStars.Networking.NetCodec.UseJsonEncoding = true;
 #endif
 
-                Link = new LoopbackLink();
+                // #1531: server→client messages cross the loopback as OBJECTS — no JSON round trip on the render
+                // thread (the UseJsonEncoding flag above still covers the client→server intents).
+                Link = new LoopbackLink { PassObjects = true };
                 _server = new SvGameServer(config, content, new LoopbackServerTransport(Link), _repo,
                     new UnityGameLogger(), aiProvider: new BlocksBeyondTheStars.GameServer.NullAiMissionProvider());
                 _repo.Flushed += PersistBlob; // server autosaves + shutdown both end in Flush()

--- a/client/Assets/BlocksBeyondTheStars/Scripts/BrowserWebSocketClientTransport.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/BrowserWebSocketClientTransport.cs
@@ -16,6 +16,13 @@ namespace BlocksBeyondTheStars.Client
     /// WebGL client transport. Browsers cannot use the native LiteNetLib UDP socket, so the
     /// WebGL player talks to the authoritative .NET server through a browser WebSocket while
     /// still exchanging the same NetCodec payloads as native clients.
+    /// <para>#1531: payloads cross the managed/JS boundary through the WASM heap. Outbound, the managed
+    /// array's pointer and length go to <c>BbsWsSendBytes</c>, which copies straight out of the heap into
+    /// the socket. Inbound, the JS side parks each frame; <see cref="Poll"/> asks for the pending length,
+    /// allocates the exact array and lets <c>BbsWsReadPending</c> copy the frame into it — one copy, the
+    /// one the managed array needs anyway, instead of the four base64 copies (btoa / string marshal /
+    /// FromBase64String / atob) per message before. Open, close and error still arrive as SendMessage
+    /// strings, which is fine for events that happen once per connection.</para>
     /// </summary>
     public sealed class BrowserWebSocketClientTransport : IClientTransport
     {
@@ -31,7 +38,13 @@ namespace BlocksBeyondTheStars.Client
         private static extern void BbsWsConnect(int id, string url);
 
         [DllImport("__Internal")]
-        private static extern void BbsWsSendBase64(int id, string payload);
+        private static extern void BbsWsSendBytes(int id, byte[] data, int length);
+
+        [DllImport("__Internal")]
+        private static extern int BbsWsPendingLength(int id);
+
+        [DllImport("__Internal")]
+        private static extern int BbsWsReadPending(int id, byte[] buffer, int capacity);
 
         [DllImport("__Internal")]
         private static extern void BbsWsDisconnect(int id);
@@ -58,9 +71,7 @@ namespace BlocksBeyondTheStars.Client
                 return;
             }
 
-            // The JavaScript bridge sends binary WebSocket frames. Base64 is only the
-            // WebGL interop envelope between managed C# and the browser runtime.
-            BbsWsSendBase64(_socketId, Convert.ToBase64String(payload));
+            BbsWsSendBytes(_socketId, payload, payload.Length);
         }
 
         public void Poll()
@@ -68,6 +79,31 @@ namespace BlocksBeyondTheStars.Client
             while (_events.TryDequeue(out var action))
             {
                 action();
+            }
+
+            if (_socketId == 0)
+            {
+                return;
+            }
+
+            // Drain every frame the socket parked since the last frame, oldest first.
+            for (int guard = 0; guard < 4096; guard++)
+            {
+                int length = BbsWsPendingLength(_socketId);
+                if (length <= 0)
+                {
+                    break;
+                }
+
+                var payload = new byte[length];
+                int got = BbsWsReadPending(_socketId, payload, payload.Length);
+                if (got != length)
+                {
+                    Debug.LogWarning($"Browser WebSocket: dropped a frame the bridge could not hand over ({got}/{length} bytes).");
+                    break;
+                }
+
+                PayloadReceived?.Invoke(payload);
             }
         }
 
@@ -95,27 +131,6 @@ namespace BlocksBeyondTheStars.Client
 
         internal void QueueDisconnected()
             => _events.Enqueue(() => Disconnected?.Invoke());
-
-        internal void QueuePayload(string base64)
-        {
-            if (string.IsNullOrEmpty(base64))
-            {
-                return;
-            }
-
-            byte[] payload;
-            try
-            {
-                payload = Convert.FromBase64String(base64);
-            }
-            catch (FormatException ex)
-            {
-                Debug.LogWarning($"Dropped malformed WebSocket payload: {ex.Message}");
-                return;
-            }
-
-            _events.Enqueue(() => PayloadReceived?.Invoke(payload));
-        }
 
         internal void QueueError(string message)
             => _events.Enqueue(() => Debug.LogWarning("Browser WebSocket error: " + message));
@@ -194,15 +209,6 @@ namespace BlocksBeyondTheStars.Client
                 if (Transports.TryGetValue(id, out var transport))
                 {
                     transport.QueueError(message);
-                }
-            }
-
-            public void HandleMessage(string payload)
-            {
-                Split(payload, out int id, out string message);
-                if (Transports.TryGetValue(id, out var transport))
-                {
-                    transport.QueuePayload(message);
                 }
             }
 

--- a/client/Assets/Plugins/BbsWebSocket.jslib
+++ b/client/Assets/Plugins/BbsWebSocket.jslib
@@ -1,6 +1,12 @@
 // Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // WebGL browser WebSocket bridge for BrowserWebSocketClientTransport.
+//
+// #1531: bytes cross the managed/JS boundary through the WASM heap, not through base64 strings. Outbound:
+// C# hands a pointer + length and the socket copies straight out of HEAPU8. Inbound: frames are parked per
+// socket as Uint8Array views; C# polls the pending length, allocates the exact array and BbsWsReadPending
+// copies the frame into it (one copy, the one the managed array needs anyway). Only open/close/error still
+// go through SendMessage strings.
 mergeInto(LibraryManager.library, {
   $BbsWsSendUnityMessage: function (objectName, methodName, payload) {
     if (typeof SendMessage === "function") {
@@ -16,22 +22,18 @@ mergeInto(LibraryManager.library, {
     console.error("Unity SendMessage bridge is not available for " + objectName + "." + methodName);
   },
 
-  $BbsWsSendBytesToUnity__deps: ["$BbsWsSendUnityMessage"],
-  $BbsWsSendBytesToUnity: function (id, bytes) {
-    var binary = "";
-    var chunkSize = 0x8000;
-    for (var offset = 0; offset < bytes.length; offset += chunkSize) {
-      var chunk = bytes.subarray(offset, offset + chunkSize);
-      binary += String.fromCharCode.apply(null, chunk);
-    }
-
-    BbsWsSendUnityMessage("BbsWebSocketBridge", "HandleMessage", String(id) + "|" + btoa(binary));
+  $BbsWsPark: function (id, bytes) {
+    var queues = Module.BbsInbound = Module.BbsInbound || {};
+    var q = queues[id] = queues[id] || [];
+    q.push(bytes);
   },
 
-  BbsWsConnect__deps: ["$BbsWsSendUnityMessage", "$BbsWsSendBytesToUnity"],
+  BbsWsConnect__deps: ["$BbsWsSendUnityMessage", "$BbsWsPark"],
   BbsWsConnect: function (id, urlPtr) {
     var url = UTF8ToString(urlPtr);
     Module.BbsSockets = Module.BbsSockets || {};
+    Module.BbsInbound = Module.BbsInbound || {};
+    Module.BbsInbound[id] = [];
 
     try {
       var socket = new WebSocket(url);
@@ -53,18 +55,17 @@ mergeInto(LibraryManager.library, {
 
       socket.onmessage = function (event) {
         if (event.data instanceof ArrayBuffer) {
-          BbsWsSendBytesToUnity(id, new Uint8Array(event.data));
+          BbsWsPark(id, new Uint8Array(event.data)); // a view over the frame's own buffer — no copy
           return;
         }
 
         if (ArrayBuffer.isView(event.data)) {
-          BbsWsSendBytesToUnity(id, new Uint8Array(event.data.buffer, event.data.byteOffset, event.data.byteLength));
+          BbsWsPark(id, new Uint8Array(event.data.buffer, event.data.byteOffset, event.data.byteLength));
           return;
         }
 
         if (typeof event.data === "string") {
-          var bytes = new TextEncoder().encode(event.data);
-          BbsWsSendBytesToUnity(id, bytes);
+          BbsWsPark(id, new TextEncoder().encode(event.data));
           return;
         }
 
@@ -75,7 +76,7 @@ mergeInto(LibraryManager.library, {
 
         var reader = new FileReader();
         reader.onload = function () {
-          BbsWsSendBytesToUnity(id, new Uint8Array(reader.result));
+          BbsWsPark(id, new Uint8Array(reader.result));
         };
         reader.onerror = function () {
           BbsWsSendUnityMessage("BbsWebSocketBridge", "HandleError", String(id) + "|message decode failed");
@@ -88,25 +89,47 @@ mergeInto(LibraryManager.library, {
     }
   },
 
-  BbsWsSendBase64__deps: ["$BbsWsSendUnityMessage"],
-  BbsWsSendBase64: function (id, payloadPtr) {
+  // Sends `length` bytes starting at `ptr` in the WASM heap. WebSocket.send copies the view's bytes
+  // synchronously, so the managed array may be reused the moment this returns.
+  BbsWsSendBytes: function (id, ptr, length) {
     var socket = Module.BbsSockets && Module.BbsSockets[id];
-    if (!socket || socket.readyState !== WebSocket.OPEN) {
+    if (!socket || socket.readyState !== WebSocket.OPEN || length <= 0) {
       return;
     }
 
-    var payload = UTF8ToString(payloadPtr);
-    var binary = atob(payload);
-    var bytes = new Uint8Array(binary.length);
-    for (var i = 0; i < binary.length; i++) {
-      bytes[i] = binary.charCodeAt(i);
+    socket.send(HEAPU8.subarray(ptr, ptr + length));
+  },
+
+  // Length of the oldest parked inbound frame, 0 when none.
+  BbsWsPendingLength: function (id) {
+    var q = Module.BbsInbound && Module.BbsInbound[id];
+    return q && q.length > 0 ? q[0].length : 0;
+  },
+
+  // Copies the oldest parked frame into the managed array at `ptr` (capacity `capacity` bytes) and drops it.
+  // Returns the frame length, or -1 when the array is too small (the frame stays parked).
+  BbsWsReadPending: function (id, ptr, capacity) {
+    var q = Module.BbsInbound && Module.BbsInbound[id];
+    if (!q || q.length === 0) {
+      return 0;
     }
 
-    socket.send(bytes);
+    var frame = q[0];
+    if (frame.length > capacity) {
+      return -1;
+    }
+
+    HEAPU8.set(frame, ptr);
+    q.shift();
+    return frame.length;
   },
 
   BbsWsDisconnect__deps: ["$BbsWsSendUnityMessage"],
   BbsWsDisconnect: function (id) {
+    if (Module.BbsInbound) {
+      delete Module.BbsInbound[id];
+    }
+
     var socket = Module.BbsSockets && Module.BbsSockets[id];
     if (!socket) {
       return;

--- a/src/BlocksBeyondTheStars.Client.Core/NetworkClient.cs
+++ b/src/BlocksBeyondTheStars.Client.Core/NetworkClient.cs
@@ -221,6 +221,10 @@ namespace BlocksBeyondTheStars.Client
                 }
             };
             _transport.PayloadReceived += EnqueuePayload;
+            if (_transport is IObjectClientTransport objects)
+            {
+                objects.MessageReceived += EnqueueMessage; // #1531: the loopback hands decoded messages over
+            }
         }
 
         // ---- Receive budget (#963) ----
@@ -230,7 +234,9 @@ namespace BlocksBeyondTheStars.Client
         // of traffic inside a single frame: a multi-second freeze, then a long stutter while the resulting
         // mesh backlog drained at a few chunks per frame. The server has always budgeted its SENDING
         // (ChunkStreamPerTick / ChunkStreamBudgetMs); this is the receive-side counterpart.
-        private readonly Queue<byte[]> _inbox = new();
+        // #1531: an entry is either an encoded byte[] (socket transports) or a decoded message object (the
+        // in-process loopback); one queue keeps the server's send order across both kinds.
+        private readonly Queue<object> _inbox = new();
 
         /// <summary>Max payloads dispatched per <see cref="Poll"/>. Generous — a healthy frame never queues
         /// anywhere near this — so normal play behaves exactly as before and only a backlog is paced.</summary>
@@ -256,7 +262,7 @@ namespace BlocksBeyondTheStars.Client
         private bool _joined;
         private int _previousWorldId;
         private int _futureWorldId;
-        private readonly Queue<byte[]> _heldBeforeJoin = new();
+        private readonly Queue<object> _heldBeforeJoin = new();
         private readonly Queue<object> _futureWorld = new();
 
         /// <summary>The WorldId of the last JoinAccepted / WorldReset (0 before the join or on a v4 server).</summary>
@@ -331,14 +337,32 @@ namespace BlocksBeyondTheStars.Client
         {
             while (_heldBeforeJoin.Count > 0)
             {
-                OnPayload(_heldBeforeJoin.Dequeue());
+                DispatchItem(_heldBeforeJoin.Dequeue());
             }
         }
 
-        private static bool IsWorldStreamPayload(byte[] payload)
-            => NetCodec.IsMessageType<ChunkDataMessage>(payload) || NetCodec.IsMessageType<BlockChanged>(payload);
+        private static bool IsWorldStreamItem(object item)
+            => item is ChunkDataMessage or BlocksBeyondTheStars.Networking.Messages.BlockChanged
+               || (item is byte[] payload && (NetCodec.IsMessageType<ChunkDataMessage>(payload) || NetCodec.IsMessageType<BlockChanged>(payload)));
+
+        private static bool IsChunkItem(object item)
+            => item is ChunkDataMessage || (item is byte[] payload && IsChunkPayload(payload));
+
+        private void DispatchItem(object item)
+        {
+            if (item is byte[] payload)
+            {
+                OnPayload(payload);
+            }
+            else
+            {
+                Dispatch(item);
+            }
+        }
 
         private void EnqueuePayload(byte[] payload) => _inbox.Enqueue(payload);
+
+        private void EnqueueMessage(object message) => _inbox.Enqueue(message);
 
         public void Connect(string host, int port) => _transport.Connect(host, port);
 
@@ -817,30 +841,30 @@ namespace BlocksBeyondTheStars.Client
             {
                 // Chunks are capped separately; stop once that cap is hit and the next payload is a chunk,
                 // rather than reordering the stream (block edits must not overtake the chunk they patch).
-                if (chunks >= MaxChunksPerPoll && IsChunkPayload(_inbox.Peek()))
+                if (chunks >= MaxChunksPerPoll && IsChunkItem(_inbox.Peek()))
                 {
                     break;
                 }
 
-                var payload = _inbox.Dequeue();
+                var item = _inbox.Dequeue();
                 dispatched++;
-                if (IsChunkPayload(payload))
+                if (IsChunkItem(item))
                 {
                     chunks++;
                 }
 
-                if (!_joined && IsWorldStreamPayload(payload))
+                if (!_joined && IsWorldStreamItem(item))
                 {
                     // #1534: the world stream overtook the JoinAccepted on the other channel — park it.
                     if (_heldBeforeJoin.Count < MaxHeldWorldStream)
                     {
-                        _heldBeforeJoin.Enqueue(payload);
+                        _heldBeforeJoin.Enqueue(item);
                     }
 
                     continue;
                 }
 
-                OnPayload(payload);
+                DispatchItem(item);
             }
         }
 
@@ -851,9 +875,11 @@ namespace BlocksBeyondTheStars.Client
         private void Send(object message, DeliveryMode mode = DeliveryMode.ReliableOrdered)
             => _transport.Send(NetCodec.Encode(message), mode);
 
-        private void OnPayload(byte[] payload)
+        private void OnPayload(byte[] payload) => Dispatch(NetCodec.Decode(payload));
+
+        private void Dispatch(object? message)
         {
-            switch (NetCodec.Decode(payload))
+            switch (message)
             {
                 case JoinAccepted m:
                     _joined = true;

--- a/src/BlocksBeyondTheStars.GameServer/GameServer.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServer.cs
@@ -69,6 +69,10 @@ public sealed partial class GameServer
     private readonly ServerConfig _config;
     private readonly GameContent _content;
     private readonly IServerTransport _transport;
+
+    /// <summary>#1531: set when the transport can carry message objects (the in-process loopback) — every send
+    /// site below prefers it, skipping the codec entirely. Null for socket transports.</summary>
+    private readonly IObjectServerTransport? _objectTransport;
     private readonly IWorldRepository _repo;
     private readonly IGameLogger _log;
     private readonly IAiMissionProvider _ai;
@@ -189,6 +193,7 @@ public sealed partial class GameServer
         _config = config;
         _content = content;
         _transport = transport;
+        _objectTransport = transport as IObjectServerTransport;
         _repo = repo;
         _log = logger ?? new NullGameLogger();
         // Everything the AI writes for players passes the world's content screen (#1221). Wrapped HERE,
@@ -2373,7 +2378,15 @@ public sealed partial class GameServer
     private void StreamChunkNow(PlayerSession session, ChunkCoord coord)
     {
         var chunk = _world.GetOrLoadChunk(coord);
-        SendEncoded(session.ConnectionId, ChunkPayloadFor(chunk, coord), DeliveryMode.ReliableOrderedBulk); // #1534: the world-stream channel
+        if (_objectTransport != null)
+        {
+            // #1531: the cached chunk MESSAGE goes over as an object — no RLE encode, no codec, no decode.
+            _objectTransport.SendMessage(session.ConnectionId, ChunkMessageFor(chunk, coord), DeliveryMode.ReliableOrderedBulk);
+        }
+        else
+        {
+            SendEncoded(session.ConnectionId, ChunkPayloadFor(chunk, coord), DeliveryMode.ReliableOrderedBulk); // #1534: the world-stream channel
+        }
         session.SentChunks.Add(coord);
         MarkExploredCell(session, coord); // #1113: the planet map remembers this across sessions
     }
@@ -2389,22 +2402,16 @@ public sealed partial class GameServer
     /// the client accepts both representations (ChunkDataMessage.DecodeBlocks), dense only for a degenerate
     /// chunk. Decisive on the browser JSON path — ~15-25 KB of JSON numbers per chunk shrink to usually a few
     /// hundred bytes — and it trims native payloads and VPS egress too.</summary>
-    private byte[] ChunkPayloadFor(ChunkData chunk, ChunkCoord coord)
+    /// <summary>The chunk as a wire message: RLE when it runs (nearly always), dense otherwise, plus the sparse
+    /// modifier / shape arrays. Fresh per chunk version; both caches below hold the result read-only.</summary>
+    private ChunkDataMessage BuildChunkMessage(ChunkData chunk, ChunkCoord coord)
     {
-        var cache = _worlds.Active.ChunkPayloads;
-        bool json = NetCodec.UseJsonEncoding;
-        if (cache.TryGetValue(coord, out var hit) && hit.Version == chunk.Version && hit.Json == json)
-        {
-            ChunkPayloadCacheHits++;
-            return hit.Payload;
-        }
-
         var msg = new ChunkDataMessage
         {
             Cx = coord.X,
             Cy = coord.Y,
             Cz = coord.Z,
-            WorldId = ActiveWorldId, // #1534: the payload cache is per world, so this is stable per entry
+            WorldId = ActiveWorldId, // #1534: the caches are per world, so this is stable per entry
         };
         var rle = ChunkBlocksRle.Encode(chunk.RawBlocks);
         if (rle.Length < WorldConstants.BlocksPerChunk)
@@ -2417,6 +2424,42 @@ public sealed partial class GameServer
         }
 
         PackChunkModifiers(chunk, msg); // dyed-block / coloured-light cells, if any
+        return msg;
+    }
+
+    /// <summary>#1531: the object-path twin of <see cref="ChunkPayloadFor"/> — the decoded message, cached per
+    /// chunk version, handed to the loopback client as is (the client copies the blocks it keeps).</summary>
+    private ChunkDataMessage ChunkMessageFor(ChunkData chunk, ChunkCoord coord)
+    {
+        var cache = _worlds.Active.ChunkMessages;
+        if (cache.TryGetValue(coord, out var hit) && hit.Version == chunk.Version)
+        {
+            ChunkPayloadCacheHits++;
+            return hit.Message;
+        }
+
+        var msg = BuildChunkMessage(chunk, coord);
+        ChunkPayloadEncodes++;
+        if (cache.Count >= ChunkPayloadCacheCap)
+        {
+            cache.Clear();
+        }
+
+        cache[coord] = (chunk.Version, msg);
+        return msg;
+    }
+
+    private byte[] ChunkPayloadFor(ChunkData chunk, ChunkCoord coord)
+    {
+        var cache = _worlds.Active.ChunkPayloads;
+        bool json = NetCodec.UseJsonEncoding;
+        if (cache.TryGetValue(coord, out var hit) && hit.Version == chunk.Version && hit.Json == json)
+        {
+            ChunkPayloadCacheHits++;
+            return hit.Payload;
+        }
+
+        var msg = BuildChunkMessage(chunk, coord);
         var payload = NetCodec.Encode(msg);
         ChunkPayloadEncodes++;
         if (cache.Count >= ChunkPayloadCacheCap)
@@ -6362,6 +6405,12 @@ public sealed partial class GameServer
                 break;
         }
 
+        if (_objectTransport != null)
+        {
+            _objectTransport.SendMessage(session.ConnectionId, message, mode); // #1531: no codec on the loopback
+            return;
+        }
+
         _transport.Send(session.ConnectionId, NetCodec.Encode(message), mode);
     }
 
@@ -6371,10 +6420,26 @@ public sealed partial class GameServer
         => _transport.Send(connectionId, payload, mode);
 
     private void SendTo(int connectionId, object message)
-        => _transport.Send(connectionId, NetCodec.Encode(message), DeliveryMode.ReliableOrdered);
+    {
+        if (_objectTransport != null)
+        {
+            _objectTransport.SendMessage(connectionId, message, DeliveryMode.ReliableOrdered);
+            return;
+        }
+
+        _transport.Send(connectionId, NetCodec.Encode(message), DeliveryMode.ReliableOrdered);
+    }
 
     private void Broadcast(object message)
-        => _transport.Broadcast(NetCodec.Encode(message), DeliveryMode.ReliableOrdered);
+    {
+        if (_objectTransport != null)
+        {
+            _objectTransport.BroadcastMessage(message, DeliveryMode.ReliableOrdered);
+            return;
+        }
+
+        _transport.Broadcast(NetCodec.Encode(message), DeliveryMode.ReliableOrdered);
+    }
 
     // ---------------- Radio reach (tiered comms: text chat + voice) ----------------
 
@@ -6418,6 +6483,16 @@ public sealed partial class GameServer
     /// <see cref="DeliveryMode.Unreliable"/> (latency over delivery — a dropped 20 ms frame is inaudible).</summary>
     private void SendToRadioAudience(PlayerSession sender, object message, DeliveryMode mode)
     {
+        if (_objectTransport != null)
+        {
+            foreach (var s in RadioAudience(sender))
+            {
+                _objectTransport.SendMessage(s.ConnectionId, message, mode);
+            }
+
+            return;
+        }
+
         var payload = NetCodec.Encode(message);
         foreach (var s in RadioAudience(sender))
         {
@@ -6429,7 +6504,7 @@ public sealed partial class GameServer
     /// not hear their own relayed frames (text chat, by contrast, echoes the sender's own line into their log).</summary>
     private void SendToRadioAudienceExcept(PlayerSession sender, object message, DeliveryMode mode)
     {
-        var payload = NetCodec.Encode(message);
+        byte[]? payload = _objectTransport == null ? NetCodec.Encode(message) : null;
         foreach (var s in RadioAudience(sender))
         {
             if (s.ConnectionId == sender.ConnectionId)
@@ -6437,7 +6512,14 @@ public sealed partial class GameServer
                 continue;
             }
 
-            _transport.Send(s.ConnectionId, payload, mode);
+            if (_objectTransport != null)
+            {
+                _objectTransport.SendMessage(s.ConnectionId, message, mode);
+            }
+            else
+            {
+                _transport.Send(s.ConnectionId, payload!, mode);
+            }
         }
     }
 
@@ -6468,6 +6550,16 @@ public sealed partial class GameServer
         {
             change.WorldId = ActiveWorldId; // #1534: the recipients are exactly the active world's players
             mode = DeliveryMode.ReliableOrderedBulk;
+        }
+
+        if (_objectTransport != null)
+        {
+            foreach (var s in JoinedInActiveWorld())
+            {
+                _objectTransport.SendMessage(s.ConnectionId, message, mode); // #1531: the object itself, once per recipient
+            }
+
+            return;
         }
 
         var payload = NetCodec.Encode(message);

--- a/src/BlocksBeyondTheStars.GameServer/GameServerPresence.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerPresence.cs
@@ -447,8 +447,16 @@ public sealed partial class GameServer
                     continue; // unchanged and recent — the client keeps rendering the pose it has
                 }
 
-                payload ??= NetCodec.Encode(presence);
-                SendEncoded(viewer.ConnectionId, payload, DeliveryMode.Sequenced); // #1534: never behind a chunk resend
+                if (_objectTransport != null)
+                {
+                    _objectTransport.SendMessage(viewer.ConnectionId, presence, DeliveryMode.Sequenced); // #1531
+                }
+                else
+                {
+                    payload ??= NetCodec.Encode(presence);
+                    SendEncoded(viewer.ConnectionId, payload, DeliveryMode.Sequenced); // #1534: never behind a chunk resend
+                }
+
                 subject.PresenceSentTo[viewer.ConnectionId] = (hash, beat);
             }
 

--- a/src/BlocksBeyondTheStars.GameServer/WorldManager.cs
+++ b/src/BlocksBeyondTheStars.GameServer/WorldManager.cs
@@ -128,6 +128,10 @@ internal sealed class LoadedWorld
     /// co-located players and a re-stream after a sweep reuse the bytes instead of re-encoding.</summary>
     public Dictionary<ChunkCoord, (long Version, bool Json, byte[] Payload)> ChunkPayloads { get; } = new();
 
+    /// <summary>#1531: the same per-version cache for the decoded chunk MESSAGE, handed over as an object on the
+    /// in-process loopback (no encoding at all). Read-only once cached — the client never writes into it.</summary>
+    public Dictionary<ChunkCoord, (long Version, BlocksBeyondTheStars.Networking.Messages.ChunkDataMessage Message)> ChunkMessages { get; } = new();
+
     /// <summary>#1530: the per-world fauna jitter of <c>WorldCreatureCap</c> (a pure function of seed + location,
     /// documented "stable per world") — hashed once instead of an interpolated string 15× per second.</summary>
     public double? FaunaJitter { get; set; }

--- a/src/BlocksBeyondTheStars.Networking/Transport/ITransport.cs
+++ b/src/BlocksBeyondTheStars.Networking/Transport/ITransport.cs
@@ -47,3 +47,22 @@ public interface IClientTransport : IDisposable
 
     void Disconnect();
 }
+
+/// <summary>#1531: a server transport that can hand decoded message OBJECTS to its peer instead of encoded bytes —
+/// the in-process loopback, where sender and receiver share the heap. The server prefers this path whenever the
+/// transport offers it; every other transport keeps the byte path. Contract: a message handed over is never
+/// mutated by the sender afterwards (built fresh per send, or cached read-only), and the receiver treats it as
+/// read-only.</summary>
+public interface IObjectServerTransport
+{
+    void SendMessage(int connectionId, object message, DeliveryMode mode);
+
+    void BroadcastMessage(object message, DeliveryMode mode);
+}
+
+/// <summary>#1531: the client side of the object path — decoded messages arrive through
+/// <see cref="MessageReceived"/> in the same order as byte payloads through <c>PayloadReceived</c>.</summary>
+public interface IObjectClientTransport
+{
+    event Action<object>? MessageReceived;
+}

--- a/src/BlocksBeyondTheStars.Networking/Transport/LoopbackTransport.cs
+++ b/src/BlocksBeyondTheStars.Networking/Transport/LoopbackTransport.cs
@@ -10,6 +10,14 @@ namespace BlocksBeyondTheStars.Networking.Transport;
 /// <see cref="LoopbackClientTransport"/>. Enables singleplayer (the client hosts the
 /// server in-process) and deterministic tests using the exact same server logic as
 /// multiplayer — no sockets involved.
+/// <para>#1531: server→client traffic passes the message OBJECTS themselves (<see cref="PassObjects"/>)
+/// instead of encoding and decoding them — sender and receiver share the process, and the
+/// JSON round trip the browser singleplayer had to use (IL2CPP cannot run MessagePack's runtime formatters)
+/// cost three payload-sized allocations per message on the render thread. Client→server stays encoded:
+/// intents are tiny, and the server must never keep a reference into a client-owned object (it stores
+/// design arrays, pixel payloads and the like — the round trip is its deep copy). Every message a server
+/// hands over is built fresh for that send or cached read-only (the chunk message cache), and the client
+/// treats received messages as read-only — that contract is what makes the object path safe.</para>
 /// </summary>
 public sealed class LoopbackLink
 {
@@ -17,7 +25,16 @@ public sealed class LoopbackLink
 
     private readonly object _gate = new();
     private readonly Queue<byte[]> _clientToServer = new();
-    private readonly Queue<byte[]> _serverToClient = new();
+    private readonly Queue<object> _serverToClient = new();
+
+    /// <summary>Hand server→client messages over as objects. Off by default so every test that reads the wire
+    /// as bytes keeps working; the browser singleplayer host and the client harness switch it on.</summary>
+    public bool PassObjects { get; set; }
+
+    /// <summary>Diagnostics / tests: how many server→client messages went over as objects, and as bytes.</summary>
+    public long ObjectsToClient { get; private set; }
+
+    public long BytesToClient { get; private set; }
 
     internal bool ConnectRequested;
     internal bool ConnectAcknowledgedByServer;
@@ -33,7 +50,26 @@ public sealed class LoopbackLink
 
     internal void EnqueueToClient(byte[] payload)
     {
-        lock (_gate) { _serverToClient.Enqueue(payload); }
+        lock (_gate)
+        {
+            _serverToClient.Enqueue(payload);
+            BytesToClient++;
+        }
+    }
+
+    internal void EnqueueMessageToClient(object message)
+    {
+        if (!PassObjects)
+        {
+            EnqueueToClient(NetCodec.Encode(message));
+            return;
+        }
+
+        lock (_gate)
+        {
+            _serverToClient.Enqueue(message);
+            ObjectsToClient++;
+        }
     }
 
     internal List<byte[]> DrainToServer()
@@ -46,18 +82,18 @@ public sealed class LoopbackLink
         }
     }
 
-    internal List<byte[]> DrainToClient()
+    internal List<object> DrainToClient()
     {
         lock (_gate)
         {
-            var list = new List<byte[]>(_serverToClient);
+            var list = new List<object>(_serverToClient);
             _serverToClient.Clear();
             return list;
         }
     }
 }
 
-public sealed class LoopbackServerTransport : IServerTransport
+public sealed class LoopbackServerTransport : IServerTransport, IObjectServerTransport
 {
     private readonly LoopbackLink _link;
 
@@ -72,6 +108,11 @@ public sealed class LoopbackServerTransport : IServerTransport
     public void Send(int connectionId, byte[] payload, DeliveryMode mode) => _link.EnqueueToClient(payload);
 
     public void Broadcast(byte[] payload, DeliveryMode mode) => _link.EnqueueToClient(payload);
+
+    /// <summary>#1531: the object path — no encoding at all when the link passes objects.</summary>
+    public void SendMessage(int connectionId, object message, DeliveryMode mode) => _link.EnqueueMessageToClient(message);
+
+    public void BroadcastMessage(object message, DeliveryMode mode) => _link.EnqueueMessageToClient(message);
 
     /// <summary>Server-side hang-up (kick). The loopback has exactly one client, so the id only has to
     /// match it; the disconnect surfaces on the next <see cref="Poll"/> like a client-side one.</summary>
@@ -108,13 +149,14 @@ public sealed class LoopbackServerTransport : IServerTransport
     public void Dispose() { }
 }
 
-public sealed class LoopbackClientTransport : IClientTransport
+public sealed class LoopbackClientTransport : IClientTransport, IObjectClientTransport
 {
     private readonly LoopbackLink _link;
 
     public event Action? Connected;
     public event Action? Disconnected;
     public event Action<byte[]>? PayloadReceived;
+    public event Action<object>? MessageReceived;
 
     public LoopbackClientTransport(LoopbackLink link) => _link = link;
 
@@ -130,9 +172,17 @@ public sealed class LoopbackClientTransport : IClientTransport
             Connected?.Invoke();
         }
 
-        foreach (var payload in _link.DrainToClient())
+        // One queue for both kinds keeps the server's send order — a byte payload never overtakes an object.
+        foreach (var item in _link.DrainToClient())
         {
-            PayloadReceived?.Invoke(payload);
+            if (item is byte[] payload)
+            {
+                PayloadReceived?.Invoke(payload);
+            }
+            else
+            {
+                MessageReceived?.Invoke(item);
+            }
         }
 
         // The server can hang up too (a kick, #497) — the client has to notice, or it sits in a world

--- a/tests/BlocksBeyondTheStars.Client.Tests/ClientServerHarness.cs
+++ b/tests/BlocksBeyondTheStars.Client.Tests/ClientServerHarness.cs
@@ -45,7 +45,11 @@ public sealed class ClientServerHarness : IDisposable
     /// <summary>Builds the full in-process stack. <paramref name="repository"/> lets a test swap the
     /// persistence backend (e.g. the browser singleplayer's <see cref="MemoryWorldRepository"/>); the
     /// caller keeps ownership of an injected repository — the default SQLite one is disposed here.</summary>
-    public ClientServerHarness(GameContent content, Action<ServerConfig>? configure = null, IWorldRepository? repository = null)
+    /// <summary>The in-memory wire (#1531: <c>PassObjects</c> decides whether server→client messages go over as
+    /// objects — the default, what the browser singleplayer runs — or encoded like on a socket).</summary>
+    public LoopbackLink Link => _link;
+
+    public ClientServerHarness(GameContent content, Action<ServerConfig>? configure = null, IWorldRepository? repository = null, bool passObjects = true)
     {
         _root = Path.Combine(Path.GetTempPath(), "bbts_client_" + Guid.NewGuid().ToString("N"));
 
@@ -63,7 +67,7 @@ public sealed class ClientServerHarness : IDisposable
 
         _ownsRepo = repository is null;
         _repo = repository ?? new SqliteWorldRepository(new SaveGamePaths(_root, config.WorldName));
-        _link = new LoopbackLink();
+        _link = new LoopbackLink { PassObjects = passObjects };
         Server = new SvGameServer(config, content, new LoopbackServerTransport(_link), _repo);
         Server.Start();
 

--- a/tests/BlocksBeyondTheStars.Client.Tests/LoopbackObjectPassingTests.cs
+++ b/tests/BlocksBeyondTheStars.Client.Tests/LoopbackObjectPassingTests.cs
@@ -1,0 +1,60 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using BlocksBeyondTheStars.Shared.Content;
+using BlocksBeyondTheStars.Shared.World;
+using Xunit;
+
+namespace BlocksBeyondTheStars.Client.Tests;
+
+/// <summary>#1531: the in-process loopback hands server→client messages over as objects — the whole join and
+/// world stream arrive without a single server→client encode — while the byte mode still works for the tests
+/// that want the codec in the loop. Client→server stays encoded in both modes.</summary>
+public sealed class LoopbackObjectPassingTests
+{
+    private static GameContent LoadContent() => ContentLoader.LoadFromDirectory(ClientTestPaths.DataDir());
+
+    [Fact]
+    public void ObjectMode_JoinsAndStreamsChunks_WithoutEncodingAnythingToTheClient()
+    {
+        using var h = new ClientServerHarness(LoadContent());
+        h.Join();
+
+        Assert.NotNull(h.JoinAccepted);
+        Assert.True(h.PumpUntil(() => h.Chunks.Count >= 4, maxTicks: 60), "chunks should stream over the object path");
+        Assert.True(h.Link.ObjectsToClient > 0);
+        Assert.Equal(0, h.Link.BytesToClient);
+
+        // The world view was filled from the objects exactly as it would be from decoded payloads.
+        var first = h.Chunks.Values.First();
+        Assert.True(h.World.TryGetChunk(new ChunkCoord(first.Cx, first.Cy, first.Cz), out _));
+    }
+
+    [Fact]
+    public void ByteMode_JoinsAndStreamsChunks_ThroughTheCodec()
+    {
+        using var h = new ClientServerHarness(LoadContent(), passObjects: false);
+        h.Join();
+
+        Assert.NotNull(h.JoinAccepted);
+        Assert.True(h.PumpUntil(() => h.Chunks.Count >= 4, maxTicks: 60), "chunks should stream over the byte path");
+        Assert.True(h.Link.BytesToClient > 0);
+        Assert.Equal(0, h.Link.ObjectsToClient);
+    }
+
+    [Fact]
+    public void ObjectMode_ARestreamedChunk_IsTheSameCachedInstance_AndStillReadOnlyForTheClient()
+    {
+        using var h = new ClientServerHarness(LoadContent());
+        h.Join();
+        Assert.True(h.PumpUntil(() => h.Chunks.Count >= 1, maxTicks: 60));
+
+        // The server caches the chunk message per version; the client must never have written into it —
+        // the RLE payload it received still decodes to the blocks the world view holds.
+        var m = h.Chunks.Values.First();
+        var again = m.DecodeBlocks(WorldConstants.BlocksPerChunk);
+        Assert.NotNull(again);
+        Assert.True(h.World.TryGetChunk(new ChunkCoord(m.Cx, m.Cy, m.Cz), out var stored));
+        Assert.Equal(again, stored.ToArray());
+    }
+}


### PR DESCRIPTION
PR bundle 19 of the performance package #1501 — the two remaining parts of #1531 (the encode-once part shipped with PR 9, #1547).

⚠ **WebGL-only paths, verified headless only.** The `#if UNITY_WEBGL` transport and the jslib compile only on a WebGL build; the desktop player and the hosted LiteNetLib / WebSocket servers are untouched by construction (their transports do not implement the new interfaces). A WebGL build + browser session follows after the desktop playtest, on request.

**Object-passing loopback (browser singleplayer).** The in-process server ran the real simulation, yet every server→client message was JSON-serialised, parsed and deserialised on the render thread — three payload-sized allocations per message, sixteen chunks per tick while streaming — on the device class where the heap is the crash budget.
- `IObjectServerTransport` / `IObjectClientTransport`: a transport may carry decoded message objects. `LoopbackLink.PassObjects` (opt-in; `BrowserLocalServer` and `ClientServerHarness` switch it on, byte-reading tests keep working) queues server→client messages as objects in the same queue as bytes, so the send order holds across both kinds.
- The server prefers the object path on every send site (`Send`, `SendTo`, `Broadcast`, `BroadcastToWorld`, the radio audience, the presence beat, and the chunk stream, which hands over a cached `ChunkDataMessage` per chunk version — `WorldManager.ChunkMessages` — instead of the encoded payload).
- `NetworkClient`'s inbox holds bytes or objects; the receive budget, the pre-join hold and the world-id ordering (#1534) treat both alike.
- Client→server stays encoded on purpose: intents are tiny, and the server must never hold a reference into a client-owned object (it stores design arrays and pixel payloads — the round trip is its deep copy).
- The contract that makes the object path safe: every message the server hands over is built fresh for that send (verified: the entity lists, presence, block changes are `new` per send) or cached read-only (the chunk message cache), and the client treats received messages as read-only (the chunk blocks are copied into the pooled array since #1555).

**HEAP bridge (browser WebSocket client).** `BrowserWebSocketClientTransport` + `BbsWebSocket.jslib`: outbound frames go as pointer + length straight out of `HEAPU8` (`WebSocket.send` copies synchronously, so the managed array is free the moment the call returns); inbound frames are parked per socket as `Uint8Array` views and `Poll` pulls each one into an exact-size managed array through `BbsWsReadPending` — one copy, the one the array needs anyway, instead of btoa / string marshal / FromBase64String / atob. Open, close and error still travel as SendMessage strings (once per connection).

**Verification.**
- `LoopbackObjectPassingTests` (3): object mode joins and streams chunks with zero server→client encodes; byte mode still joins through the codec; a re-streamed cached chunk message stays intact for the client's world view.
- The whole client test project (476 + 3) runs the harness in object mode; the server integration / transport / protocol suites run the loopback in byte mode.
- `dotnet format`; TODO.md entry added.

closes #1531

🤖 Generated with [Claude Code](https://claude.com/claude-code)
