### PR TITLE
fix(client): water shows the bed again — the screen-space water holds the opaque-texture request the on-demand copy dropped (#1577)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -283,6 +283,17 @@ is read from the module stat (16) instead of being dead, and the station deploy 
 persisted ids after a restart (id collision). Tests: `PlayerStationReportsTests` (7), `DropLootTests` (+2).
 Locales: 9 new keys + 2 rewordings, EN/DE hand-written, 12 MT via translate_locale.
 
+### ★ Water opaque from outside since the on-demand opaque copy — the water shader holds its own request (#1577, 2026-09-05, branch fix/1577-water-opaque)
+
+**Why.** Playtest regression from #1520 (PR #1542): the camera opaque texture became on-demand for the heat-haze and
+thermal quads, but the screen-space water in `BlockAtlasTransparent` (Medium+) composites the bed from that texture for
+refraction — without it the water rendered a milky opaque surface and the bed was invisible from above.
+
+**What ships.** `ClientSettings` holds a standing opaque-texture request for the water for as long as the preset
+enables screen-space water (`_Sc_ScreenFx` = 1), through the same `RequestOpaqueTexture` mechanism; Low stays
+without the copy, the haze / thermal requests are unchanged. The #1520 saving therefore applies only below Medium; a
+finer gate (request only while water is in view) is a possible follow-up.
+
 ### ★ Browser transports without copies: the in-process loopback passes message objects, the WebSocket bridge moves bytes through the WASM heap (#1531, 2026-09-04, branch perf/1531-object-loopback) — ⚠ WebGL-only paths, verified headless only; a WebGL build + browser session is the real test
 
 **Why.** PR bundle 19 of the performance package (#1501), the two remaining parts of #1531 (the encode-once

--- a/client/Assets/BlocksBeyondTheStars/Scripts/ClientSettings.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/ClientSettings.cs
@@ -1033,13 +1033,16 @@ namespace BlocksBeyondTheStars.Client
                 // which also disables every dependent effect for free (the features early-out without the textures).
                 bool wantsScreenSpace = Preset >= QualityPreset.Medium;
                 urp.supportsCameraDepthTexture = wantsScreenSpace;
-                // #1520: the opaque colour copy (an MSAA resolve + a half-res blit EVERY frame at Medium+) has
-                // exactly two consumers — the heat-haze and thermal-vision screen quads — and they are inactive
-                // in deserts, caves, space and most of the time on temperate worlds. So the asset no longer
-                // requests the copy; the two effects request it per camera while they are active
-                // (RequestOpaqueTexture), still gated to the presets that had it.
+                // #1520: the opaque colour copy (an MSAA resolve + a half-res blit EVERY frame at Medium+) is
+                // requested per camera by its consumers instead of by the asset (RequestOpaqueTexture), still
+                // gated to the presets that had it. The heat-haze and thermal-vision quads hold a request only
+                // while they are visible. #1577: the screen-space WATER (BlockAtlasTransparent, Medium+) is the
+                // third consumer — it composites the bed from the opaque copy for refraction, and without the
+                // texture it rendered a milky opaque surface — so the water's request is held for as long as the
+                // preset enables screen-space water. (A finer gate — only while water is in view — is open.)
                 urp.supportsCameraOpaqueTexture = false;
                 _opaqueTexturePresetAllows = wantsScreenSpace;
+                RequestOpaqueTexture(wantsScreenSpace, ref _waterOpaqueHeld);
                 ApplyOpaqueTextureRequest();
 
                 // Tell the shaders whether the depth/opaque textures exist this preset. The water shader uses it to
@@ -1067,6 +1070,7 @@ namespace BlocksBeyondTheStars.Client
         private static UniversalAdditionalCameraData _activeCameraData;
         private static bool _opaqueTexturePresetAllows;
         private static int _opaqueTextureRequests;
+        private static bool _waterOpaqueHeld; // #1577: the water shader's standing request at Medium+
 
         /// <summary>#1520: a screen-space effect that samples <c>_CameraOpaqueTexture</c> (heat haze, thermal
         /// vision) holds a request while it is visible; the camera copies the opaque colour only while at least


### PR DESCRIPTION
Playtest regression (2026-09-05) from #1520 / PR #1542: the camera opaque texture became on-demand for the heat-haze and thermal quads, but the screen-space water in `BlockAtlasTransparent` (Medium+) composites the bed from that texture for refraction — without it the water rendered a milky opaque surface and the bed was invisible from above.

**Fix.** `ClientSettings` holds a standing opaque-texture request for the water for as long as the preset enables screen-space water (`_Sc_ScreenFx` = 1), through the same `RequestOpaqueTexture` mechanism. Low stays without the copy; the haze / thermal requests are unchanged. The #1520 saving therefore applies only below Medium; a finer gate (request only while water is in view) is a possible follow-up, noted in TODO.md.

**Verification.** Marcel's playtest with the rebuilt release client (water bed visible from above at Medium/High); no test covers the render-pipeline setting.

closes #1577

🤖 Generated with [Claude Code](https://claude.com/claude-code)