### PR TITLE
fix(client): ship/vox meshes add their MeshCollider before the non-readable render mesh; weather logs precipitation changes (playtest 2026-09-05)

### DIFF
--- a/client/Assets/BlocksBeyondTheStars/Scripts/LandedShipView.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/LandedShipView.cs
@@ -230,9 +230,12 @@ namespace BlocksBeyondTheStars.Client
                 var go = new GameObject($"ShipChunk {cx},{cy},{cz}");
                 go.transform.SetParent(root.transform, false);
                 go.transform.localPosition = new Vector3(origin.X, origin.Y, origin.Z);
+                // The collider FIRST: a MeshCollider added after the MeshFilter adopts the render mesh and tries to
+                // cook it — since #1528 that mesh is uploaded non-readable, so the cook logs an error per chunk
+                // (playtest 2026-09-05) before the real collider mesh replaces it.
+                go.AddComponent<MeshCollider>().sharedMesh = collider; // walk on the wings, stand in the cabin
                 go.AddComponent<MeshFilter>().sharedMesh = mesh;
                 go.AddComponent<MeshRenderer>().sharedMaterials = mats;
-                go.AddComponent<MeshCollider>().sharedMesh = collider; // walk on the wings, stand in the cabin
             }
         }
     }

--- a/client/Assets/BlocksBeyondTheStars/Scripts/SpaceView.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/SpaceView.cs
@@ -3322,9 +3322,9 @@ namespace BlocksBeyondTheStars.Client
                 var go = new GameObject($"VoxChunk {cx},{cy},{cz}");
                 go.transform.SetParent(parent, false);
                 go.transform.localPosition = new Vector3(origin.X, origin.Y, origin.Z) - centre;
+                go.AddComponent<MeshCollider>().sharedMesh = collider; // S2/S3: hull/ore collision (suit + future) — added FIRST, see LandedShipView
                 go.AddComponent<MeshFilter>().sharedMesh = mesh;
                 go.AddComponent<MeshRenderer>().sharedMaterials = mats;
-                go.AddComponent<MeshCollider>().sharedMesh = collider; // S2/S3: hull/ore collision (suit + future)
             }
         }
 

--- a/client/Assets/BlocksBeyondTheStars/Scripts/WeatherFx.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/WeatherFx.cs
@@ -1,3 +1,13 @@
+            bool wanted = anyWash || precipitation;
+            if (wanted != _loggedOverlay)
+            {
+                // Playtest 2026-09-05 diagnostics: when the screen overlay switches on/off and why.
+                _loggedOverlay = wanted;
+                Debug.Log($"[WeatherFx] overlay {(wanted ? "on" : "off")} (precip '{env?.Precipitation}', weather {env?.Weather}, exposed {Game?.ExposedToSky}, wash {anyWash})");
+            }
+
+            _overlay.Sync(wanted);
+        }
 // Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
@@ -58,6 +68,7 @@ namespace BlocksBeyondTheStars.Client
         // screen — an always-on OnGUI ran Unity's Layout + Repaint event loop every frame, even in clear
         // weather (1.6 k allocations/s for the two handlers in the #1537 capture).
         private ImguiOverlay _overlay;
+        private bool _loggedOverlay; // diagnostics: last overlay state written to the log
 
         private void Awake()
         {

--- a/client/Assets/BlocksBeyondTheStars/Scripts/WeatherFx3D.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/WeatherFx3D.cs
@@ -35,6 +35,7 @@ namespace BlocksBeyondTheStars.Client
         // second so block edits and freshly streamed chunks are picked up.
         private readonly Dictionary<long, bool> _skyOpen = new Dictionary<long, bool>(256);
         private float _skyCacheTimer;
+        private string _loggedPrecip = "none"; // diagnostics: last precipitation kind written to the log
 
         // Saved global fog state so storm fog restores cleanly when the weather clears / we leave the world.
         private bool _fogSaved;
@@ -130,6 +131,14 @@ namespace BlocksBeyondTheStars.Client
             }
 
             var s = StyleFor(precip, env.Weather == "storm");
+            if (!ReferenceEquals(precip, _loggedPrecip) && precip != _loggedPrecip)
+            {
+                // Playtest 2026-09-05 ("no rain in a thunderstorm"): one line per precipitation change so the
+                // Player.log says what the client was told and how many drops it tried to show.
+                _loggedPrecip = precip;
+                Debug.Log($"[Weather3D] precipitation '{precip}' (weather {env.Weather}, intensity {env.Intensity:0.00}, exposed {Game?.ExposedToSky})");
+            }
+
             Color drop = ShaderColor.Srgb(s.Color);
             if (_mat.color != drop) { _mat.color = drop; } // all drops share one material → one precip form at a time
             // Intensity comes from the SMOOTHED client value (#900), so an episode's swell and fade shows


### PR DESCRIPTION
Two playtest follow-ups of the performance package (2026-09-05).

**Collider error per ship chunk (desktop + browser logs).** `LandedShipView.BuildShip` and `SpaceView`'s vox chunks added the `MeshCollider` after the `MeshFilter`; a MeshCollider added that way adopts the filter's mesh and tries to cook it — since #1528 the render mesh is uploaded non-readable, so Unity logged `CollisionMeshData couldn't be created because the mesh has been marked as non-accessible` once per chunk before the real collider mesh replaced it. Harmless for play (the collider mesh followed immediately), but a dozen error lines per ship build. The collider is now added first, with its own mesh.

**"No rain in a thunderstorm" (desktop, not reproduced).** `WeatherFx3D` (the 3D drops, untouched by the package) and `WeatherFx` (the 2D streaks, `rain` only — a drizzle storm never had them) now log one line per precipitation change and per overlay on/off, so the next storm leaves evidence in Player.log. In the browser session the same code rained as expected.

No behaviour change beyond the log lines and the component order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)