### PR TITLE
fix(client): WeatherFx compiles again — the overlay diagnostics block sits in LateUpdate, not at the top of the file (hotfix for #1579)

### DIFF
--- a/client/Assets/BlocksBeyondTheStars/Scripts/WeatherFx.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/WeatherFx.cs
@@ -1,13 +1,3 @@
-            bool wanted = anyWash || precipitation;
-            if (wanted != _loggedOverlay)
-            {
-                // Playtest 2026-09-05 diagnostics: when the screen overlay switches on/off and why.
-                _loggedOverlay = wanted;
-                Debug.Log($"[WeatherFx] overlay {(wanted ? "on" : "off")} (precip '{env?.Precipitation}', weather {env?.Weather}, exposed {Game?.ExposedToSky}, wash {anyWash})");
-            }
-
-            _overlay.Sync(wanted);
-        }
 // Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
@@ -83,7 +73,15 @@ namespace BlocksBeyondTheStars.Client
             var env = Game?.Environment;
             bool precipitation = env != null && !Game.SpaceViewActive && Game.ExposedToSky
                                  && !string.IsNullOrEmpty(env.Precipitation) && env.Precipitation != "none";
-            _overlay.Sync(anyWash || precipitation);
+            bool wanted = anyWash || precipitation;
+            if (wanted != _loggedOverlay)
+            {
+                // Playtest 2026-09-05 diagnostics: when the screen overlay switches on/off and why.
+                _loggedOverlay = wanted;
+                Debug.Log($"[WeatherFx] overlay {(wanted ? "on" : "off")} (precip '{env?.Precipitation}', weather {env?.Weather}, exposed {Game?.ExposedToSky}, wash {anyWash})");
+            }
+
+            _overlay.Sync(wanted);
         }
 
         private void Init()


### PR DESCRIPTION
Hotfix for #1579: the patch that added the overlay diagnostics to `WeatherFx` inserted the block at the top of the file as well, which broke the Unity script compile (`CS1022` / `CS1529`) — PR CI does not compile the Unity client, so it went unnoticed until the local player build. The block is now only where it belongs, in `LateUpdate`. Verified by a local release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)