### PR TITLE
feat(client): HUD hull/shield rows show value / max — a shield generator built on the ground no longer looks dead at "Schild 55" (#1585)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -110,6 +110,17 @@ Per-item detail lives in the dated work log below. **Since 2026-07 versions are 
 #1144, #1146, #1147), all 28 sub-issues #1102–#1129 done. The whole package is UNRELEASED pending the big
 playtest; the post-epic implementation audit spawned the follow-up fix round #1149–#1156.
 
+### ★ HUD hull/shield rows read "value / max" — a shield generator built on the ground no longer looks dead at "Shield 55" (#1585, 2026-09-05, branch fix/hud-vitals-value-max)
+
+**Why.** Lyxette (v2026.9.2): "Schildgenerator, da bleibt es bei 55 als Leistungswert". The generator WAS installed
+and counted (`shieldMax` 135 = starter 25 + baseline 30 + generator 80), but the shield only charges in flight, so the
+landed HUD showed the bare charge "Schild 55" against a 41 % bar — indistinguishable from a broken module.
+
+**What ships.** `HudUi.SetVital` takes an optional `max`; the hull and shield rows pass `HullMax` / `ShieldMax` and
+render "Hülle 200 / 200", "Schild 55 / 135". The suit rows (health, O2, energy, hunger) keep their bare value; the
+flight instrument line (HULL/SHD while piloting) is untouched. The #1554 string-rebuild guard now also keys on the
+rounded max. Companion: server-side shield top-up on module build / repair is #1586.
+
 ### ★ Lyxette round 7 — the station's west wing is station again, the box follows the whole build, the pads survive a station visit, R repairs the ship, hyperjumps arrive with a name (#1558–#1568, 2026-09-04, branch fix/lyxette-reports-2026-09-04)
 Eight F1 reports from the night and afternoon of 2026-09-04 (v2026.8.26 → v2026.9.1). **X wrap in the station world
 (#1558):** `HandleMove` wrapped X for EVERY world (only Z was gated by `onSurface`); a player station's void world

--- a/client/Assets/BlocksBeyondTheStars/Scripts/HudUi.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/HudUi.cs
@@ -85,7 +85,7 @@ namespace BlocksBeyondTheStars.Client
         private readonly System.Collections.Generic.List<RectTransform> _compassBeacons = new();
         private readonly System.Collections.Generic.List<RectTransform> _compassMarkers = new(); // named markers + pings (#1217)
 
-        private struct VitalRow { public Image Fill; public Text Label; public GameObject Go; public bool Warn; public Color BaseColor; public string LastLabel; public int LastValue; }
+        private struct VitalRow { public Image Fill; public Text Label; public GameObject Go; public bool Warn; public Color BaseColor; public string LastLabel; public int LastValue; public int LastMax; }
         private VitalRow[] _vitals;
         private float _lowVitalBeepTimer; // shared low-vitals alarm cadence (#753)
 
@@ -721,8 +721,11 @@ namespace BlocksBeyondTheStars.Client
             if (ship)
             {
                 var c = Game.ShipCombat;
-                SetVital(4, loc.Get("ui.hud.hull"), c.Hull, c.HullMax > 0 ? c.Hull / c.HullMax : 0f, HullC, true);
-                SetVital(5, loc.Get("ui.hud.shield"), c.Shield, c.ShieldMax > 0 ? c.Shield / c.ShieldMax : 0f, ShieldC, true);
+                // #1585: hull and shield spell out "value / max". The shield only charges in flight, so a
+                // freshly built generator on the ground reads "Shield 55" against a 41 % bar — which looks like
+                // a dead module unless the max (135) stands next to it. The suit rows keep their bare value.
+                SetVital(4, loc.Get("ui.hud.hull"), c.Hull, c.HullMax > 0 ? c.Hull / c.HullMax : 0f, HullC, true, c.HullMax);
+                SetVital(5, loc.Get("ui.hud.shield"), c.Shield, c.ShieldMax > 0 ? c.Shield / c.ShieldMax : 0f, ShieldC, true, c.ShieldMax);
             }
             else
             {
@@ -923,7 +926,7 @@ namespace BlocksBeyondTheStars.Client
             return new VitalRow { Fill = fill, Label = label, Go = go };
         }
 
-        private void SetVital(int i, string label, float value, float frac, Color color, bool active)
+        private void SetVital(int i, string label, float value, float frac, Color color, bool active, float max = 0f)
         {
             var v = _vitals[i];
             if (v.Go.activeSelf != active) v.Go.SetActive(active);
@@ -937,13 +940,15 @@ namespace BlocksBeyondTheStars.Client
             v.Fill.color = color;
             v.Fill.fillAmount = Mathf.Clamp01(frac);
             int shown = Mathf.RoundToInt(value);
-            if (shown != v.LastValue || !ReferenceEquals(label, v.LastLabel) || v.LastLabel == null)
+            int shownMax = max > 0f ? Mathf.RoundToInt(max) : 0; // 0 = no "/ max" suffix (#1585)
+            if (shown != v.LastValue || shownMax != v.LastMax || !ReferenceEquals(label, v.LastLabel) || v.LastLabel == null)
             {
-                // #1554: 10 Hz × 6 rows of interpolated strings — only when the rounded value or label changed.
+                // #1554: 10 Hz × 6 rows of interpolated strings — only when the rounded value, max or label changed.
                 v.LastValue = shown;
+                v.LastMax = shownMax;
                 v.LastLabel = label;
                 _vitals[i] = v;
-                v.Label.text = $"{label}  {shown}";
+                v.Label.text = shownMax > 0 ? $"{label}  {shown} / {shownMax}" : $"{label}  {shown}";
             }
         }
 


### PR DESCRIPTION
## Summary
- `HudUi.SetVital` takes an optional `max`; the hull and shield vitals rows pass `HullMax` / `ShieldMax` and read **"Hülle 200 / 200"**, **"Schild 55 / 135"** instead of a bare charge value.
- Suit rows (health, O2, energy, hunger) unchanged; flight instrument line (HULL/SHD while piloting) untouched.
- The #1554 string-rebuild guard also keys on the rounded max, so the label still only rebuilds on a change.

## Why
Lyxette (v2026.9.2) reported the shield generator "stays at 55". The generator was installed and counted (max 135), but the shield only charges in flight, so the landed HUD showed a lone "Schild 55" against a 41 % bar — it looked like a dead module. Companion server-side top-up: #1586.

## Verification
- PR CI never compiles `client/Assets` — a local Unity player build is run before merge (see AGENTS.md).

closes #1585

🤖 Generated with [Claude Code](https://claude.com/claude-code)