### PR TITLE
fix(ship): a switched-in ship launches into the orbit it is ON — SwitchShip parks the new hull where the pilot is, EnterSpace keys the flight by the pilot's body (#1584)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -110,6 +110,17 @@ Per-item detail lives in the dated work log below. **Since 2026-07 versions are 
 #1144, #1146, #1147), all 28 sub-issues #1102–#1129 done. The whole package is UNRELEASED pending the big
 playtest; the post-epic implementation audit spawned the follow-up fix round #1149–#1156.
 
+### ★ HUD hull/shield rows read "value / max" — a shield generator built on the ground no longer looks dead at "Shield 55" (#1585, 2026-09-05, branch fix/hud-vitals-value-max)
+
+**Why.** Lyxette (v2026.9.2): "Schildgenerator, da bleibt es bei 55 als Leistungswert". The generator WAS installed
+and counted (`shieldMax` 135 = starter 25 + baseline 30 + generator 80), but the shield only charges in flight, so the
+landed HUD showed the bare charge "Schild 55" against a 41 % bar — indistinguishable from a broken module.
+
+**What ships.** `HudUi.SetVital` takes an optional `max`; the hull and shield rows pass `HullMax` / `ShieldMax` and
+render "Hülle 200 / 200", "Schild 55 / 135". The suit rows (health, O2, energy, hunger) keep their bare value; the
+flight instrument line (HULL/SHD while piloting) is untouched. The #1554 string-rebuild guard now also keys on the
+rounded max. Companion: server-side shield top-up on module build / repair is #1586.
+
 ### ★ Lyxette round 7 — the station's west wing is station again, the box follows the whole build, the pads survive a station visit, R repairs the ship, hyperjumps arrive with a name (#1558–#1568, 2026-09-04, branch fix/lyxette-reports-2026-09-04)
 Eight F1 reports from the night and afternoon of 2026-09-04 (v2026.8.26 → v2026.9.1). **X wrap in the station world
 (#1558):** `HandleMove` wrapped X for EVERY world (only Z was gated by `onSurface`); a player station's void world

--- a/TODO.md
+++ b/TODO.md
@@ -110,6 +110,22 @@ Per-item detail lives in the dated work log below. **Since 2026-07 versions are 
 #1144, #1146, #1147), all 28 sub-issues #1102–#1129 done. The whole package is UNRELEASED pending the big
 playtest; the post-epic implementation audit spawned the follow-up fix round #1149–#1156.
 
+### ★ A switched-in ship launches into the orbit it is ON — SwitchShip parks the new hull where the pilot is, EnterSpace keys the flight by the pilot's body (#1584, 2026-09-05, branch fix/1584-switched-ship-location)
+
+**Why.** Lyxette (v2026.9.2): "Port Nou im falschen System" — launched from a planet in another system and found the
+home system's station, escape pod and asteroid ring in orbit. `EnterSpace` keyed the flight instance by the SHIP's
+remembered body (`space:sys3-p1-m1`) while the pilot stood on `sys1-p4`; only the active ship's location was ever
+updated, and `SwitchShip` never touched the switched-in ship's — the starter still "believed" it was parked at the
+home moon. The star map and flight names followed the pilot, the scenery followed the ship; docking at that station
+was a free cross-system teleport, and `RecoverToShip` re-homed a dead pilot to the stale body.
+
+**What ships.** `SwitchShip` syncs the new active ship's `CurrentLocationId` to the pilot's body (landed / on foot)
+or to the orbit's anchor body (in space) — persisted with the fleet. `EnterSpace` keys the instance by
+`session.CurrentLocationId` and writes it back into the ship, which also covers claimed wrecks, shipyard purchases
+and custom ships that start with the planet-type placeholder. No load-time repair of persisted fleets: the next switch
+or launch corrects a stale record on its own. Four regression tests in `LanPlaytestRegressionTests` (switch landed,
+launch with a stale record, death in that orbit, switch in space); all four fail without the fix.
+
 ### ★ HUD hull/shield rows read "value / max" — a shield generator built on the ground no longer looks dead at "Shield 55" (#1585, 2026-09-05, branch fix/hud-vitals-value-max)
 
 **Why.** Lyxette (v2026.9.2): "Schildgenerator, da bleibt es bei 55 als Leistungswert". The generator WAS installed

--- a/client/Assets/BlocksBeyondTheStars/Scripts/HudUi.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/HudUi.cs
@@ -85,7 +85,7 @@ namespace BlocksBeyondTheStars.Client
         private readonly System.Collections.Generic.List<RectTransform> _compassBeacons = new();
         private readonly System.Collections.Generic.List<RectTransform> _compassMarkers = new(); // named markers + pings (#1217)
 
-        private struct VitalRow { public Image Fill; public Text Label; public GameObject Go; public bool Warn; public Color BaseColor; public string LastLabel; public int LastValue; }
+        private struct VitalRow { public Image Fill; public Text Label; public GameObject Go; public bool Warn; public Color BaseColor; public string LastLabel; public int LastValue; public int LastMax; }
         private VitalRow[] _vitals;
         private float _lowVitalBeepTimer; // shared low-vitals alarm cadence (#753)
 
@@ -721,8 +721,11 @@ namespace BlocksBeyondTheStars.Client
             if (ship)
             {
                 var c = Game.ShipCombat;
-                SetVital(4, loc.Get("ui.hud.hull"), c.Hull, c.HullMax > 0 ? c.Hull / c.HullMax : 0f, HullC, true);
-                SetVital(5, loc.Get("ui.hud.shield"), c.Shield, c.ShieldMax > 0 ? c.Shield / c.ShieldMax : 0f, ShieldC, true);
+                // #1585: hull and shield spell out "value / max". The shield only charges in flight, so a
+                // freshly built generator on the ground reads "Shield 55" against a 41 % bar — which looks like
+                // a dead module unless the max (135) stands next to it. The suit rows keep their bare value.
+                SetVital(4, loc.Get("ui.hud.hull"), c.Hull, c.HullMax > 0 ? c.Hull / c.HullMax : 0f, HullC, true, c.HullMax);
+                SetVital(5, loc.Get("ui.hud.shield"), c.Shield, c.ShieldMax > 0 ? c.Shield / c.ShieldMax : 0f, ShieldC, true, c.ShieldMax);
             }
             else
             {
@@ -923,7 +926,7 @@ namespace BlocksBeyondTheStars.Client
             return new VitalRow { Fill = fill, Label = label, Go = go };
         }
 
-        private void SetVital(int i, string label, float value, float frac, Color color, bool active)
+        private void SetVital(int i, string label, float value, float frac, Color color, bool active, float max = 0f)
         {
             var v = _vitals[i];
             if (v.Go.activeSelf != active) v.Go.SetActive(active);
@@ -937,13 +940,15 @@ namespace BlocksBeyondTheStars.Client
             v.Fill.color = color;
             v.Fill.fillAmount = Mathf.Clamp01(frac);
             int shown = Mathf.RoundToInt(value);
-            if (shown != v.LastValue || !ReferenceEquals(label, v.LastLabel) || v.LastLabel == null)
+            int shownMax = max > 0f ? Mathf.RoundToInt(max) : 0; // 0 = no "/ max" suffix (#1585)
+            if (shown != v.LastValue || shownMax != v.LastMax || !ReferenceEquals(label, v.LastLabel) || v.LastLabel == null)
             {
-                // #1554: 10 Hz × 6 rows of interpolated strings — only when the rounded value or label changed.
+                // #1554: 10 Hz × 6 rows of interpolated strings — only when the rounded value, max or label changed.
                 v.LastValue = shown;
+                v.LastMax = shownMax;
                 v.LastLabel = label;
                 _vitals[i] = v;
-                v.Label.text = $"{label}  {shown}";
+                v.Label.text = shownMax > 0 ? $"{label}  {shown} / {shownMax}" : $"{label}  {shown}";
             }
         }
 

--- a/src/BlocksBeyondTheStars.GameServer/GameServerShips.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerShips.cs
@@ -134,6 +134,7 @@ public sealed partial class GameServer
 
         _activeShipId = shipId;
         RecomputeShipCombatStats(); // _ship now resolves to the newly active ship
+        SyncSwitchedShipLocation(ship);
         if (_current is { Joined: true })
         {
             // The HUD hull/shield rows only ever read this message — without it they kept showing the
@@ -179,6 +180,33 @@ public sealed partial class GameServer
 
         BroadcastOwnedShips();
         return true;
+    }
+
+    /// <summary>
+    /// The switched-in hull is placed wherever the pilot IS — on this pad, or floating in this orbit — so its
+    /// remembered body must say so (#1584). Only the ACTIVE ship's location was ever updated (landing,
+    /// hyperjump, respawn), so a ship last flown elsewhere kept "believing" it was parked there: the next
+    /// launch keyed the flight instance by that stale body (Lyxette found the home system's Port Nou, escape pod
+    /// and asteroid ring in orbit over a planet three systems away), and a death re-homed the clone to it.
+    /// </summary>
+    private void SyncSwitchedShipLocation(ShipState ship)
+    {
+        if (_current is null)
+        {
+            return;
+        }
+
+        if (_playerInstance.TryGetValue(_current.State.PlayerId, out var flightId) && _spaceInstances.ContainsKey(flightId))
+        {
+            // In space: the orbit's anchor body. A legacy instance key (planet-type placeholder) is no body — the
+            // pilot's own body is the next best truth.
+            string anchor = flightId.StartsWith("space:", StringComparison.Ordinal) ? flightId.Substring("space:".Length) : flightId;
+            ship.CurrentLocationId = _galaxy?.FindBody(anchor) is not null ? anchor : _current.CurrentLocationId;
+        }
+        else if (!string.IsNullOrEmpty(_current.CurrentLocationId))
+        {
+            ship.CurrentLocationId = _current.CurrentLocationId; // landed / on foot: this body
+        }
     }
 
     /// <summary>

--- a/src/BlocksBeyondTheStars.GameServer/GameServerSpaceCombat.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerSpaceCombat.cs
@@ -532,11 +532,17 @@ public sealed partial class GameServer
         string locationId = session is not null && !string.IsNullOrEmpty(session.CurrentLocationId)
             ? session.CurrentLocationId
             : string.IsNullOrEmpty(_ship.CurrentLocationId) ? _meta.ActiveLocationId : _ship.CurrentLocationId;
+        // The ambient-hostility shading keeps its documented rule (see CreateSpaceInstance): a ship that has never
+        // flown still carries its type placeholder, which resolves to no system — its first launch stays shaded
+        // Standard. A ship with a real (even stale) body is shaded by the system it actually launches in.
+        string hostilityAnchorId = _galaxy?.FindBody(_ship.CurrentLocationId) is null && !string.IsNullOrEmpty(_ship.CurrentLocationId)
+            ? _ship.CurrentLocationId
+            : locationId;
         _ship.CurrentLocationId = locationId;
         string instanceId = "space:" + locationId;
         if (!_spaceInstances.TryGetValue(instanceId, out var instance))
         {
-            instance = CreateSpaceInstance(instanceId);
+            instance = CreateSpaceInstance(instanceId, hostilityAnchorId);
             _spaceInstances[instanceId] = instance;
         }
 
@@ -668,7 +674,10 @@ public sealed partial class GameServer
         }
     }
 
-    private SpaceInstance CreateSpaceInstance(string instanceId)
+    /// <param name="instanceId">The flight instance key, <c>space:</c> + the body the pilot launches from (#1584).</param>
+    /// <param name="hostilityAnchorId">The body id that shades the ambient hostiles — the launch body, or a
+    /// never-flown ship's type placeholder (which resolves to no system and so to the Standard shading).</param>
+    private SpaceInstance CreateSpaceInstance(string instanceId, string? hostilityAnchorId = null)
     {
         var instance = new SpaceInstance { Id = instanceId, Kind = "orbit" };
 
@@ -728,13 +737,15 @@ public sealed partial class GameServer
                 // hammered the ship the instant it launched (continuous damage → destroyed → respawn at base).
                 // #547: the system archetype shades the ambient hostility — Desolate space is truly empty
                 // (no drones, no UFO), a Pirate Haven runs one extra drone when NPC enemies are on at all.
-                // Deliberately keyed on the RAW anchor id (not the resolved start-body fallback above):
-                // a never-launched ship carries its type placeholder here, which never resolves — so the
+                // Deliberately keyed on the RAW hostility anchor (not the resolved start-body fallback above):
+                // a never-launched ship passes its type placeholder here, which never resolves — so the
                 // first launch has always been shaded Standard, and changing that would silently raise
-                // the fresh-start difficulty in pirate-space starts.
-                var archetype = SystemArchetypeOf(_galaxy?.FindBody(anchorId)?.SystemId);
+                // the fresh-start difficulty in pirate-space starts. Since #1584 the instance itself is keyed
+                // by the pilot's body, so EnterSpace hands the ship's pre-launch record in separately.
+                string hostilityId = hostilityAnchorId ?? anchorId;
+                var archetype = SystemArchetypeOf(_galaxy?.FindBody(hostilityId)?.SystemId);
                 int drones = ActivityCount(Rules.SpaceNpcEnemies);
-                bool remnantSpace = RemnantSpaceHostile(archetype, anchorId);
+                bool remnantSpace = RemnantSpaceHostile(archetype, hostilityId);
                 if (archetype == SystemArchetype.Desolate || !remnantSpace)
                 {
                     drones = 0;

--- a/src/BlocksBeyondTheStars.GameServer/GameServerSpaceCombat.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerSpaceCombat.cs
@@ -323,6 +323,9 @@ public sealed partial class GameServer
     /// <summary>True while the player is flying in a space instance.</summary>
     public bool InSpace(string playerId) => _playerInstance.ContainsKey(playerId);
 
+    /// <summary>Test hook: the id of the flight instance the player is in (null on a surface).</summary>
+    public string? SpaceInstanceIdForTest(string playerId) => _playerInstance.TryGetValue(playerId, out var id) ? id : null;
+
     /// <summary>The acting pilot's OWN position in the instance (#994). Instances are shared per body and
     /// <see cref="SpaceInstance.ShipPosition"/> is last-writer-wins across all pilots, so range checks and
     /// aim for player-triggered actions must read the pilot's pose instead. Falls back to the shared field
@@ -520,7 +523,16 @@ public sealed partial class GameServer
             }
         }
 
-        string locationId = string.IsNullOrEmpty(_ship.CurrentLocationId) ? _meta.ActiveLocationId : _ship.CurrentLocationId;
+        // #1584: the flight instance is keyed by the body the PILOT launches from, not by the body the ship
+        // remembers. The ship's record only ever followed the ACTIVE ship (landing, hyperjump, respawn), so a
+        // switched-in hull, a claimed wreck or a shipyard purchase could still carry another body — or the
+        // creation placeholder — and the launch put the pilot into THAT orbit (home-system station, pod and
+        // asteroids over a planet three systems away). The pilot is aboard, so the ship is physically here;
+        // write it back so a later death re-homes to this body too.
+        string locationId = session is not null && !string.IsNullOrEmpty(session.CurrentLocationId)
+            ? session.CurrentLocationId
+            : string.IsNullOrEmpty(_ship.CurrentLocationId) ? _meta.ActiveLocationId : _ship.CurrentLocationId;
+        _ship.CurrentLocationId = locationId;
         string instanceId = "space:" + locationId;
         if (!_spaceInstances.TryGetValue(instanceId, out var instance))
         {

--- a/tests/BlocksBeyondTheStars.Tests/LanPlaytestRegressionTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/LanPlaytestRegressionTests.cs
@@ -687,6 +687,112 @@ public sealed class LanPlaytestRegressionTests : IDisposable
         Assert.Contains(transport.Sent, x => x.Conn == ann.ConnectionId && x.Msg is InventoryUpdate); // the hold still refreshes
     }
 
+    // ---------------- #1584 (Lyxette, v2026.9.2): a switched-in ship launched into its OLD orbit ----------------
+
+    /// <summary>Two real galaxy bodies other than the start world, reached by real travels so every ship record
+    /// carries a proper body id. Returns the server with the STARTER last flown at A and the pilot standing on B
+    /// aboard a hauler.</summary>
+    private (SvGameServer Server, PlayerSession Pilot, string BodyA, string BodyB, string StarterId)
+        StarterLastFlownAtA_PilotOnBWithHauler(string name, RecordingTransport transport)
+    {
+        var server = NewServer(name, transport);
+        var ann = server.AddLocalPlayer("Ann");
+        ann.State.InstantBuild = true;
+        ann.State.UnlockedBlueprints.Add("ship_hauler");
+        server.SetInstantTravelForTest(true);
+        var planets = server.Galaxy.AllBodies().Where(b =>
+                b.Kind == CelestialKind.Planet
+                && !string.IsNullOrEmpty(b.PlanetType)
+                && _content.GetPlanet(b.PlanetType!) is not null
+                && b.Id != ann.CurrentLocationId)
+            .Take(2).ToArray();
+        var (bodyA, bodyB) = (planets[0].Id, planets[1].Id);
+
+        server.RequestLandingPadsForTest(ann, ann.CurrentLocationId); // serves Ann → server.Ship is her starter
+        string starterId = server.OwnedShips.Single().Key;
+        server.Ship.Modules.Add("jump_generator");
+        Assert.True(server.QuickTravelForTest("Ann", bodyA)); // the starter's last flight ends on A
+        Assert.Equal(bodyA, server.Ship.CurrentLocationId);
+
+        var (ok, haulerId) = server.CraftShip("Ann", "hauler");
+        Assert.True(ok);
+        Assert.True(server.SwitchShip(haulerId));
+        server.Ship.Modules.Add("jump_generator");
+        Assert.True(server.QuickTravelForTest("Ann", bodyB)); // …and the hauler carries her on to B
+        Assert.Equal(bodyB, ann.CurrentLocationId);
+        Assert.Equal(bodyA, server.OwnedShips[starterId].CurrentLocationId); // the starter still remembers A
+        return (server, ann, bodyA, bodyB, starterId);
+    }
+
+    [Fact]
+    public void SwitchShipWhileLanded_ParksTheSwitchedInShipOnThisBody()
+    {
+        // "Port Nou im falschen System": the starter, last flown at a home-system moon, was switched back in on a
+        // planet three systems away, launched — and its orbit was the moon's, station, pod and asteroids included.
+        var transport = new RecordingTransport();
+        var (server, ann, bodyA, bodyB, starterId) = StarterLastFlownAtA_PilotOnBWithHauler("switch_loc", transport);
+        ann.State.AboardShip = true;
+
+        Assert.True(server.SwitchShip(starterId));
+
+        Assert.Equal(bodyB, server.Ship.CurrentLocationId); // the hull stands on THIS pad, so it is parked here
+        Assert.NotEqual(bodyA, server.OwnedShips[starterId].CurrentLocationId);
+    }
+
+    [Fact]
+    public void EnterSpace_KeysTheFlightByThePilotsBody_EvenWhenTheShipRemembersAnother()
+    {
+        // The launch half must hold on its own: a stale fleet record (persisted before the switch sync existed,
+        // a claimed wreck, a shipyard purchase with its creation placeholder) may still name another body.
+        var transport = new RecordingTransport();
+        var (server, ann, bodyA, bodyB, starterId) = StarterLastFlownAtA_PilotOnBWithHauler("launch_loc", transport);
+        ann.State.AboardShip = true;
+        Assert.True(server.SwitchShip(starterId));
+        server.Ship.CurrentLocationId = bodyA; // the stale record the sync did not reach
+
+        server.EnterSpace("Ann");
+
+        Assert.True(server.InSpace("Ann"));
+        Assert.Equal("space:" + bodyB, server.SpaceInstanceIdForTest("Ann"));
+        Assert.Equal(bodyB, server.Ship.CurrentLocationId);
+        var state = transport.Sent.Where(x => x.Conn == ann.ConnectionId).Select(x => x.Msg).OfType<SpaceState>().Last();
+        Assert.Equal(server.Galaxy.FindBody(bodyB)!.Name, state.BodyName); // the scenery and the names agree
+    }
+
+    [Fact]
+    public void DyingInThatOrbit_RehomesTheCloneToThePilotsBody_NotTheShipsOldOne()
+    {
+        // Side effect of the same stale record: RecoverToShip re-homed a dead pilot to the ship's remembered body —
+        // a silent cross-system teleport on death.
+        var transport = new RecordingTransport();
+        var (server, ann, bodyA, bodyB, starterId) = StarterLastFlownAtA_PilotOnBWithHauler("death_loc", transport);
+        ann.State.AboardShip = true;
+        Assert.True(server.SwitchShip(starterId));
+        server.Ship.CurrentLocationId = bodyA;
+        server.EnterSpace("Ann");
+
+        server.KillPlayerForTest(ann, "@srv.death.wildlife");
+
+        Assert.False(server.InSpace("Ann"));
+        Assert.Equal(bodyB, ann.CurrentLocationId);
+        Assert.Equal(bodyB, server.Ship.CurrentLocationId);
+    }
+
+    [Fact]
+    public void SwitchShipInSpace_ParksTheSwitchedInShipAtTheOrbitsAnchor()
+    {
+        var transport = new RecordingTransport();
+        var (server, ann, bodyA, bodyB, starterId) = StarterLastFlownAtA_PilotOnBWithHauler("switch_space", transport);
+        ann.State.AboardShip = true;
+        server.EnterSpace("Ann"); // the hauler lifts off B
+        Assert.Equal("space:" + bodyB, server.SpaceInstanceIdForTest("Ann"));
+
+        Assert.True(server.SwitchShip(starterId)); // rebuilt in THIS orbit
+
+        Assert.Equal(bodyB, server.Ship.CurrentLocationId);
+        Assert.NotEqual(bodyA, server.OwnedShips[starterId].CurrentLocationId);
+    }
+
     // ---------------- #1346: the ship blip survives a death respawn ----------------
 
     /// <summary>Since #1308 the client clears its ship marker on EVERY WorldReset; a reset that is not followed


### PR DESCRIPTION
## Summary
- **SwitchShip** syncs the switched-in ship's `CurrentLocationId` to where the pilot physically is: the pilot's body when landed / on foot, the orbit's anchor body when in space. Persisted with the fleet, so it survives reloads.
- **EnterSpace** keys the flight instance by `session.CurrentLocationId` (the body the pilot launches from) and writes it back into the ship — covers every path that forgets the sync (claimed wrecks, shipyard purchases, custom ships with the planet-type placeholder).
- **RecoverToShip** therefore re-homes a dead pilot to the body they actually launched from, not to the ship's stale record.
- No load-time repair of persisted fleets: the next switch or launch corrects a stale record on its own.
- Test hook `SpaceInstanceIdForTest`.

## Why
Lyxette (v2026.9.2): "Port Nou im falschen System" — launched from a planet in another system and found the home system's station, escape pod and asteroid ring in orbit (`space.instanceId = space:sys3-p1-m1` next to `currentLocation = sys1-p4`). The starter had last been flown at the home moon, was switched back in three systems away, and still "believed" it was parked at the moon. Docking at that station was a free cross-system teleport; a death in that orbit would have woken the clone on the moon.

## Tests
Four regression tests in `LanPlaytestRegressionTests` (§ #1584): switch while landed parks the ship on this body; launch with a stale record → `space:<pilot's body>` and the record synced; death in that orbit re-homes to the pilot's body; switch in space parks at the orbit's anchor. **All four fail without the fix** (verified by disabling the two hunks) and pass with it. Targeted ship/travel/death suites (107 tests) green; full non-Slow suite run locally.

Stacked on #1587 (the diff against main shows only this change once #1587 lands).

closes #1584

🤖 Generated with [Claude Code](https://claude.com/claude-code)