### PR TITLE
feat(client): first-person field of view 80° by default, a 50–100° setting, and a held item that keeps its size (#1589 #1590 #1591)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ the richer, screenshot-laden versions live there. `(#123)` references the pull r
 
 ## [Unreleased]
 
+### 👁️ A wider view (#1589 #1590 #1591)
+
+- **The world no longer feels oversized.** The first-person camera now looks through a 70° field of view
+  instead of the narrow 60° it silently used before, so blocks take up about a fifth less of your screen and a wall
+  only fills the view when you are really standing at it (#1589).
+- **Field of view setting.** Settings → Controls has a new *Field of view* stepper, 50° to 100°. It applies
+  right away, even from the pause menu; wider shows more of the world and costs a little frame rate (#1590).
+- **A smaller tool in hand.** The drill, block or hand you hold is a fifth smaller and stays the same size on
+  screen whatever field of view you pick (#1591).
+
 ## [2026.9.2] — 2026-09-05
 
 The tune-up release. Nothing new to build or discover this time — instead the whole game went in for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,8 @@ the richer, screenshot-laden versions live there. `(#123)` references the pull r
 
 ### 👁️ A wider view (#1589 #1590 #1591)
 
-- **The world no longer feels oversized.** The first-person camera now looks through a 70° field of view
-  instead of the narrow 60° it silently used before, so blocks take up about a fifth less of your screen and a wall
+- **The world no longer feels oversized.** The first-person camera now looks through an 80° field of view
+  instead of the narrow 60° it silently used before, so blocks take up about a third less of your screen and a wall
   only fills the view when you are really standing at it (#1589).
 - **Field of view setting.** Settings → Controls has a new *Field of view* stepper, 50° to 100°. It applies
   right away, even from the pause menu; wider shows more of the world and costs a little frame rate (#1590).

--- a/TODO.md
+++ b/TODO.md
@@ -110,6 +110,28 @@ Per-item detail lives in the dated work log below. **Since 2026-07 versions are 
 #1144, #1146, #1147), all 28 sub-issues #1102–#1129 done. The whole package is UNRELEASED pending the big
 playtest; the post-epic implementation audit spawned the follow-up fix round #1149–#1156.
 
+### ★ First-person scale: field of view 70° by default, a 50–100° setting, a smaller held item that keeps its size (#1589 #1590 #1591, 2026-09-05, branch feat/fov-setting)
+
+**Why.** Playtest 2026-09-05: "the blocks feel huge — one right in front of you fills the whole view". The world is
+scaled normally (1 m blocks, 1.8 m player, eye at 1.6 m); the camera was the culprit. `WorldRig` creates the camera in
+code and never set its field of view, so Unity's 60° default applied — every block drew about a fifth larger on screen
+than at the 70° first-person block games use (a block filled the screen from 0.87 m instead of 0.71 m).
+
+**What ships.** (#1589) `ClientSettings.FieldOfView`, default **70°**, applied in `WorldRig`; everything derived from
+the camera FOV (walking kick, binocular zoom = base / magnification, heat shimmer, thermal vision, photo camera) already
+reads it live. (#1590) A **Field of view** stepper in Settings → Controls, 50–100° in 5° steps, live from the pause
+menu through `PlayerController.SetBaseFov`, with a one-line hint about the frame-rate cost; locale keys
+`ui.settings.fov` / `ui.settings.fov_hint` in all 14 locales. (#1591) The held item is 20 % smaller (`Viewmodel`
+mesh scale 0.9 → 0.72) and the viewmodel holder is scaled by `tan(fov/2) / tan(30°)` (x/y offsets likewise) so the tool
+keeps the same screen size and corner at every FOV value.
+
+**Performance.** Streaming is radius-based and unchanged; only frustum culling lets more chunks through: ≈ +12 %
+rendered chunks outdoors at 70° (up to +21 % in ships/caves), ≈ +40 % at the 100° cap — hence the hint and the cap.
+Per-pixel cost is unchanged.
+
+**Verification.** Local Unity build (client scripts are not compiled by PR CI); server/shared test suite
+(locale parity across the 14 files).
+
 ### ★ Sky domes sit at the far plane — opaque geometry beyond 0.45 × far no longer gets stars painted over it (#1582, 2026-09-05, branch fix/1582-sky-dome-depth)
 
 **Why.** Since #1513 (v2026.9.2) the three sky domes (`Starfield`, `NebulaField`, `AtmosphereDome`) draw at

--- a/TODO.md
+++ b/TODO.md
@@ -110,14 +110,15 @@ Per-item detail lives in the dated work log below. **Since 2026-07 versions are 
 #1144, #1146, #1147), all 28 sub-issues #1102–#1129 done. The whole package is UNRELEASED pending the big
 playtest; the post-epic implementation audit spawned the follow-up fix round #1149–#1156.
 
-### ★ First-person scale: field of view 70° by default, a 50–100° setting, a smaller held item that keeps its size (#1589 #1590 #1591, 2026-09-05, branch feat/fov-setting)
+### ★ First-person scale: field of view 80° by default, a 50–100° setting, a smaller held item that keeps its size (#1589 #1590 #1591, 2026-09-05, branch feat/fov-setting)
 
 **Why.** Playtest 2026-09-05: "the blocks feel huge — one right in front of you fills the whole view". The world is
 scaled normally (1 m blocks, 1.8 m player, eye at 1.6 m); the camera was the culprit. `WorldRig` creates the camera in
 code and never set its field of view, so Unity's 60° default applied — every block drew about a fifth larger on screen
 than at the 70° first-person block games use (a block filled the screen from 0.87 m instead of 0.71 m).
 
-**What ships.** (#1589) `ClientSettings.FieldOfView`, default **70°**, applied in `WorldRig`; everything derived from
+**What ships.** (#1589) `ClientSettings.FieldOfView`, default **80°** (trial value chosen in the review — 70° was the
+first candidate; at 80° a block at 2 m covers 30 % of the screen height instead of 43 %), applied in `WorldRig`; everything derived from
 the camera FOV (walking kick, binocular zoom = base / magnification, heat shimmer, thermal vision, photo camera) already
 reads it live. (#1590) A **Field of view** stepper in Settings → Controls, 50–100° in 5° steps, live from the pause
 menu through `PlayerController.SetBaseFov`, with a one-line hint about the frame-rate cost; locale keys
@@ -126,7 +127,8 @@ mesh scale 0.9 → 0.72) and the viewmodel holder is scaled by `tan(fov/2) / tan
 keeps the same screen size and corner at every FOV value.
 
 **Performance.** Streaming is radius-based and unchanged; only frustum culling lets more chunks through: ≈ +12 %
-rendered chunks outdoors at 70° (up to +21 % in ships/caves), ≈ +40 % at the 100° cap — hence the hint and the cap.
+rendered chunks outdoors at 70°, ≈ +23 % at the 80° default (up to +45 % in ships/caves), ≈ +40 % at the 100° cap —
+hence the hint and the cap.
 Per-pixel cost is unchanged.
 
 **Verification.** Local Unity build (client scripts are not compiled by PR CI); server/shared test suite

--- a/client/Assets/BlocksBeyondTheStars/Scripts/ClientSettings.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/ClientSettings.cs
@@ -255,11 +255,12 @@ namespace BlocksBeyondTheStars.Client
 
         /// <summary>Vertical field of view of the first-person camera in degrees (#1589/#1590). The camera used
         /// to run on Unity's 60° default, which drew every block about a fifth larger on screen than the 70°
-        /// most first-person block games use — "the blocks feel huge". 70 is the new default; the setting
-        /// steps 50–100 (a wider view shows more chunks, so the cap keeps weak machines honest). An older
-        /// settings file without the field simply gets the default.</summary>
+        /// most first-person block games use — "the blocks feel huge". The default is 80 — a trial value chosen
+        /// in the 2026-09-05 review (70 was the first candidate; at 80 a block at 2 m covers 30 % of the screen
+        /// height instead of 43 %); the setting steps 50–100 (a wider view shows more chunks, so the cap keeps weak machines
+        /// honest). An older settings file without the field simply gets the default.</summary>
         public float FieldOfView = FieldOfViewDefault;
-        public const float FieldOfViewDefault = 70f;
+        public const float FieldOfViewDefault = 80f;
         public const float FieldOfViewMin = 50f;
         public const float FieldOfViewMax = 100f;
         public const float FieldOfViewStep = 5f;

--- a/client/Assets/BlocksBeyondTheStars/Scripts/ClientSettings.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/ClientSettings.cs
@@ -253,6 +253,20 @@ namespace BlocksBeyondTheStars.Client
         public float MouseSensitivity = 2f;
         public bool InvertY = false;
 
+        /// <summary>Vertical field of view of the first-person camera in degrees (#1589/#1590). The camera used
+        /// to run on Unity's 60° default, which drew every block about a fifth larger on screen than the 70°
+        /// most first-person block games use — "the blocks feel huge". 70 is the new default; the setting
+        /// steps 50–100 (a wider view shows more chunks, so the cap keeps weak machines honest). An older
+        /// settings file without the field simply gets the default.</summary>
+        public float FieldOfView = FieldOfViewDefault;
+        public const float FieldOfViewDefault = 70f;
+        public const float FieldOfViewMin = 50f;
+        public const float FieldOfViewMax = 100f;
+        public const float FieldOfViewStep = 5f;
+
+        /// <summary>The stored field of view clamped to the supported range (a hand-edited file can hold anything).</summary>
+        public float ClampedFieldOfView => Mathf.Clamp(FieldOfView, FieldOfViewMin, FieldOfViewMax);
+
         // Controller (#1219). All of these are pad-only: with no pad connected they change nothing, and the
         // mouse/keyboard path never reads them. The shipped values are the constants the code used before
         // they were settings, so an existing client_settings.json behaves exactly as it did.

--- a/client/Assets/BlocksBeyondTheStars/Scripts/PlayerController.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/PlayerController.cs
@@ -299,10 +299,26 @@ namespace BlocksBeyondTheStars.Client
             {
                 _viewmodel = Camera.gameObject.AddComponent<Viewmodel>();
                 _viewmodel.Game = Game;
-                _baseFov = Camera.fieldOfView;
+                _baseFov = Camera.fieldOfView; // WorldRig applied the settings value (#1589) before this runs
+                _viewmodel.SetReferenceFov(_baseFov);
             }
 
             ApplyCameraMode();
+        }
+
+        /// <summary>The player's field-of-view setting (#1590), pushed live from the settings screen. Only the
+        /// BASE value changes: <see cref="UpdateCameraFeel"/> owns the camera and eases toward it every frame,
+        /// with the walking kick and the binocular zoom staying relative to it. When nothing is zoomed the camera
+        /// is written directly, so a stepper press from the pause menu shows the new view at once instead of
+        /// drifting there over a second; the viewmodel re-scales so the held item keeps its screen size (#1591).</summary>
+        public void SetBaseFov(float fov)
+        {
+            _baseFov = fov;
+            _viewmodel?.SetReferenceFov(fov);
+            if (Camera != null && !(_optic != null && _optic.Raised))
+            {
+                Camera.fieldOfView = fov;
+            }
         }
 
         private void ApplyCameraMode()

--- a/client/Assets/BlocksBeyondTheStars/Scripts/UiSettings.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/UiSettings.cs
@@ -160,6 +160,16 @@ namespace BlocksBeyondTheStars.Client
                 () => { S.MouseSensitivity = Mathf.Clamp(S.MouseSensitivity - 0.5f, 0.5f, 6f); ApplyLiveWorld(); Rebuild(); },
                 () => { S.MouseSensitivity = Mathf.Clamp(S.MouseSensitivity + 0.5f, 0.5f, 6f); ApplyLiveWorld(); Rebuild(); },
                 S.MouseSensitivity.ToString("0.0"));
+            // Field of view (#1590): 50–100° in 5° steps, live from the pause menu (ApplyLiveWorld → SetBaseFov).
+            // The hint says what the trade-off is — a wider view renders more chunks.
+            Stepper(ref y, L("ui.settings.fov"),
+                (S.ClampedFieldOfView - ClientSettings.FieldOfViewMin) / (ClientSettings.FieldOfViewMax - ClientSettings.FieldOfViewMin),
+                ClientSettings.FieldOfViewMin, ClientSettings.FieldOfViewMax,
+                () => { S.FieldOfView = Mathf.Clamp(S.ClampedFieldOfView - ClientSettings.FieldOfViewStep, ClientSettings.FieldOfViewMin, ClientSettings.FieldOfViewMax); ApplyLiveWorld(); Rebuild(); },
+                () => { S.FieldOfView = Mathf.Clamp(S.ClampedFieldOfView + ClientSettings.FieldOfViewStep, ClientSettings.FieldOfViewMin, ClientSettings.FieldOfViewMax); ApplyLiveWorld(); Rebuild(); },
+                Mathf.RoundToInt(S.ClampedFieldOfView) + "°");
+            UiKit.AddText(_content, _x + CtrlX, y, _rowW - CtrlX, 24, L("ui.settings.fov_hint"), 14, UiKit.CyanDim, TextAnchor.MiddleLeft);
+            y += 28f;
             Toggle(ref y, L("ui.settings.invert_y"), S.InvertY, () => { S.InvertY = !S.InvertY; ApplyLiveWorld(); Rebuild(); });
             Toggle(ref y, L("ui.settings.camera_motion"), S.CameraMotion, () => { S.CameraMotion = !S.CameraMotion; ApplyLiveWorld(); Rebuild(); });
 
@@ -585,6 +595,7 @@ namespace BlocksBeyondTheStars.Client
                 pc.MouseSensitivity = S.MouseSensitivity;
                 pc.InvertY = S.InvertY;
                 pc.CameraMotion = S.CameraMotion;
+                pc.SetBaseFov(S.ClampedFieldOfView);
             }
 
             FindAnyObjectByType<VisorHud>()?.ApplyPreset(S.Preset, S.ReducedEffects);

--- a/client/Assets/BlocksBeyondTheStars/Scripts/Viewmodel.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/Viewmodel.cs
@@ -18,6 +18,18 @@ namespace BlocksBeyondTheStars.Client
         private static readonly Vector3 RestPos = new Vector3(0.26f, -0.22f, 0.52f);
         private static readonly Vector3 RestEuler = new Vector3(6f, -10f, 4f);
 
+        /// <summary>Held-item mesh scale. 0.9 filled about a quarter of the screen height with a block in hand and
+        /// added to the "everything is huge" feel of first person; 20 % smaller (#1591).</summary>
+        private const float ItemScale = 0.72f;
+
+        /// <summary>The vertical field of view the rest pose was tuned at. The holder is scaled by
+        /// tan(fov/2) / tan(ReferenceFov/2) so the held item keeps the same screen size and corner whatever the
+        /// player's FOV setting (#1590/#1591) — a wide view would otherwise leave a tiny tool, a narrow one a
+        /// giant fist. Only the base FOV drives this (see <see cref="SetReferenceFov"/>); the walking kick and the
+        /// binocular zoom do not resize the hands.</summary>
+        private const float ReferenceFov = 60f;
+        private float _fovScale = 1f;
+
         private Transform _holder;
         private HeldItem.Kind _kind = HeldItem.Kind.None;
         private bool _visible = true;
@@ -37,9 +49,26 @@ namespace BlocksBeyondTheStars.Client
             var go = new GameObject("Viewmodel");
             _holder = go.transform;
             _holder.SetParent(transform, false); // transform = the camera
-            _holder.localPosition = RestPos;
+            _holder.localPosition = Compensated(RestPos);
             _holder.localEulerAngles = RestEuler;
+            _holder.localScale = Vector3.one * _fovScale;
         }
+
+        /// <summary>Base field of view of the owning camera (degrees); re-scales the holder so the held item
+        /// stays the same size on screen. Called by the controller at start and on every settings change.</summary>
+        public void SetReferenceFov(float fov)
+        {
+            _fovScale = Mathf.Tan(fov * 0.5f * Mathf.Deg2Rad) / Mathf.Tan(ReferenceFov * 0.5f * Mathf.Deg2Rad);
+            if (_holder != null)
+            {
+                _holder.localScale = Vector3.one * _fovScale;
+                _holder.localPosition = Compensated(RestPos);
+            }
+        }
+
+        /// <summary>A camera-local offset with x/y scaled to the FOV factor and depth kept: a point at (x, y, z)
+        /// lands on the same screen position when x/y grow by the same factor as tan(fov/2).</summary>
+        private Vector3 Compensated(Vector3 local) => new Vector3(local.x * _fovScale, local.y * _fovScale, local.z);
 
         /// <summary>Sets the held item (rebuilds only when it changes — call from the controller).</summary>
         public void SetHeldItem(HeldItem.Kind kind, Color tint, string blockKey = null)
@@ -55,7 +84,7 @@ namespace BlocksBeyondTheStars.Client
             var mesh = HeldItem.Build(_holder, kind, tint, blockKey);
             if (mesh != null)
             {
-                mesh.transform.localScale = Vector3.one * 0.9f;
+                mesh.transform.localScale = Vector3.one * ItemScale;
             }
 
             ApplyVisible();
@@ -209,7 +238,7 @@ namespace BlocksBeyondTheStars.Client
                 }
             }
 
-            _holder.localPosition = posOff;
+            _holder.localPosition = Compensated(posOff);
             _holder.localEulerAngles = rot;
         }
     }

--- a/client/Assets/BlocksBeyondTheStars/Scripts/WorldRig.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/WorldRig.cs
@@ -106,7 +106,7 @@ namespace BlocksBeyondTheStars.Client
             // ~6 cm sat behind it and was clipped into a hollow open tube whenever a swing raised it into
             // view (#1428). 0.1 matches the avatar/ship preview rigs; reversed-Z depth keeps precision fine.
             cam.nearClipPlane = 0.1f;
-            // Field of view from the settings (default 70°, #1589/#1590). Left unset, a code-created camera runs
+            // Field of view from the settings (default 80°, #1589/#1590). Left unset, a code-created camera runs
             // on Unity's 60°, which is why the blocks used to feel oversized in first person. PlayerController
             // reads this as its base FOV at Start (the walking kick and the binocular zoom are relative to it).
             cam.fieldOfView = shell.Settings.ClampedFieldOfView;

--- a/client/Assets/BlocksBeyondTheStars/Scripts/WorldRig.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/WorldRig.cs
@@ -106,6 +106,10 @@ namespace BlocksBeyondTheStars.Client
             // ~6 cm sat behind it and was clipped into a hollow open tube whenever a swing raised it into
             // view (#1428). 0.1 matches the avatar/ship preview rigs; reversed-Z depth keeps precision fine.
             cam.nearClipPlane = 0.1f;
+            // Field of view from the settings (default 70°, #1589/#1590). Left unset, a code-created camera runs
+            // on Unity's 60°, which is why the blocks used to feel oversized in first person. PlayerController
+            // reads this as its base FOV at Start (the walking kick and the binocular zoom are relative to it).
+            cam.fieldOfView = shell.Settings.ClampedFieldOfView;
 
             // URP look wiring: a code-created URP camera has post-processing OFF by default, so the global
             // UrpScenePost Volume (bloom/tonemap/vignette/teal-orange grade/lens flare) and SMAA would never run

--- a/data/locales/de.json
+++ b/data/locales/de.json
@@ -1975,6 +1975,8 @@
   "ui.settings.music_style.synth": "Ambient-Synth",
   "ui.settings.music_style.tracks": "Musik-Tracks",
   "ui.settings.mouse_sensitivity": "Maus-Empfindlichkeit",
+  "ui.settings.fov": "Sichtfeld",
+  "ui.settings.fov_hint": "Weiter zeigt mehr von der Welt und kostet etwas Bildrate.",
   "ui.settings.invert_y": "Vertikale Sicht invertieren",
   "ui.settings.camera_motion": "Kamerabewegung (Wippen/Wackeln)",
   "ui.settings.comfort": "Komfort & Wohlbefinden",

--- a/data/locales/en.json
+++ b/data/locales/en.json
@@ -1975,6 +1975,8 @@
   "ui.settings.music_style.synth": "Ambient synth",
   "ui.settings.music_style.tracks": "Music tracks",
   "ui.settings.mouse_sensitivity": "Mouse sensitivity",
+  "ui.settings.fov": "Field of view",
+  "ui.settings.fov_hint": "Wider shows more of the world and costs a little frame rate.",
   "ui.settings.invert_y": "Invert vertical look",
   "ui.settings.camera_motion": "Camera motion (bob/shake)",
   "ui.settings.comfort": "Comfort & wellbeing",

--- a/data/locales/es.json
+++ b/data/locales/es.json
@@ -1975,6 +1975,8 @@
   "ui.settings.music_style.synth": "Sintetizador ambiental",
   "ui.settings.music_style.tracks": "Pistas musicales",
   "ui.settings.mouse_sensitivity": "Sensibilidad del ratón",
+  "ui.settings.fov": "Campo de visión",
+  "ui.settings.fov_hint": "Más amplio muestra más del mundo y cuesta un poco de rendimiento.",
   "ui.settings.invert_y": "Invertir eje vertical",
   "ui.settings.camera_motion": "Movimiento de cámara (balanceo/temblor)",
   "ui.settings.comfort": "Comodidad y bienestar",

--- a/data/locales/fr.json
+++ b/data/locales/fr.json
@@ -1975,6 +1975,8 @@
   "ui.settings.music_style.synth": "Synthé ambiant",
   "ui.settings.music_style.tracks": "Pistes musicales",
   "ui.settings.mouse_sensitivity": "Sensibilité de la souris",
+  "ui.settings.fov": "Champ de vision",
+  "ui.settings.fov_hint": "Un angle plus large montre plus du monde, mais réduit un peu les images par seconde.",
   "ui.settings.invert_y": "Inverser l'axe vertical",
   "ui.settings.camera_motion": "Mouvement caméra (balancement/secousse)",
   "ui.settings.comfort": "Confort et bien-être",

--- a/data/locales/it.json
+++ b/data/locales/it.json
@@ -1975,6 +1975,8 @@
   "ui.settings.music_style.synth": "Synth ambient",
   "ui.settings.music_style.tracks": "Tracce musicali",
   "ui.settings.mouse_sensitivity": "Sensibilità mouse",
+  "ui.settings.fov": "Campo visivo",
+  "ui.settings.fov_hint": "Un angolo più ampio mostra più del mondo ma può ridurre leggermente il framerate.",
   "ui.settings.invert_y": "Inverti verticale",
   "ui.settings.camera_motion": "Movimento camera (onde/trema)",
   "ui.settings.comfort": "Comfort e benessere",

--- a/data/locales/ja.json
+++ b/data/locales/ja.json
@@ -1975,6 +1975,8 @@
   "ui.settings.music_style.synth": "アンビエント・シンセ",
   "ui.settings.music_style.tracks": "楽曲トラック",
   "ui.settings.mouse_sensitivity": "マウス感度",
+  "ui.settings.fov": "視野",
+  "ui.settings.fov_hint": "広くすると世界がより多く見えますが、フレームレートが少し落ちます。",
   "ui.settings.invert_y": "上下視点反転",
   "ui.settings.camera_motion": "カメラ動作（揺れ/振動）",
   "ui.settings.comfort": "快適性",

--- a/data/locales/ko.json
+++ b/data/locales/ko.json
@@ -1975,6 +1975,8 @@
   "ui.settings.music_style.synth": "앰비언트 신스",
   "ui.settings.music_style.tracks": "음악 트랙",
   "ui.settings.mouse_sensitivity": "마우스 감도",
+  "ui.settings.fov": "시야(FOV)",
+  "ui.settings.fov_hint": "넓게 설정하면 더 많은 세계가 보이지만 프레임률이 조금 떨어질 수 있어요.",
   "ui.settings.invert_y": "수직 시선 반전",
   "ui.settings.camera_motion": "카메라 동작 (흔들림)",
   "ui.settings.comfort": "편의 & 웰빙",

--- a/data/locales/nl.json
+++ b/data/locales/nl.json
@@ -1975,6 +1975,8 @@
   "ui.settings.music_style.synth": "Ambient synth",
   "ui.settings.music_style.tracks": "Muziektracks",
   "ui.settings.mouse_sensitivity": "Muisgevoeligheid",
+  "ui.settings.fov": "Gezichtsveld",
+  "ui.settings.fov_hint": "Breder toont meer van de wereld en kost ietsje meer frames.",
   "ui.settings.invert_y": "Verticaal omkeren",
   "ui.settings.camera_motion": "Camerabeweging (bob/schud)",
   "ui.settings.comfort": "Comfort & welzijn",

--- a/data/locales/pl.json
+++ b/data/locales/pl.json
@@ -1975,6 +1975,8 @@
   "ui.settings.music_style.synth": "Ambient synth",
   "ui.settings.music_style.tracks": "Ścieżki muzyczne",
   "ui.settings.mouse_sensitivity": "Czułość myszy",
+  "ui.settings.fov": "Pole widzenia",
+  "ui.settings.fov_hint": "Szersze pokazuje więcej świata, ale może trochę obniżyć liczbę klatek.",
   "ui.settings.invert_y": "Odwróć pionowy widok",
   "ui.settings.camera_motion": "Ruch kamery (kołysanie/odbijanie)",
   "ui.settings.comfort": "Komfort i dobre samopoczucie",

--- a/data/locales/pt.json
+++ b/data/locales/pt.json
@@ -1975,6 +1975,8 @@
   "ui.settings.music_style.synth": "Synth ambiente",
   "ui.settings.music_style.tracks": "Faixas musicais",
   "ui.settings.mouse_sensitivity": "Sensibilidade do mouse",
+  "ui.settings.fov": "Campo de visão",
+  "ui.settings.fov_hint": "Mais amplo mostra mais do mundo e custa um pouco no desempenho.",
   "ui.settings.invert_y": "Inverter olhar vertical",
   "ui.settings.camera_motion": "Movimento da câmera (balanço/tremer)",
   "ui.settings.comfort": "Conforto & bem-estar",

--- a/data/locales/ru.json
+++ b/data/locales/ru.json
@@ -1975,6 +1975,8 @@
   "ui.settings.music_style.synth": "Амбиентный синт",
   "ui.settings.music_style.tracks": "Трековая музыка",
   "ui.settings.mouse_sensitivity": "Чувствительность мыши",
+  "ui.settings.fov": "Поле зрения",
+  "ui.settings.fov_hint": "Шире показывает больше мира, но немного снижает FPS.",
   "ui.settings.invert_y": "Инвертировать вертикаль",
   "ui.settings.camera_motion": "Движение камеры (качка/тряска)",
   "ui.settings.comfort": "Комфорт и самочувствие",

--- a/data/locales/tr.json
+++ b/data/locales/tr.json
@@ -1975,6 +1975,8 @@
   "ui.settings.music_style.synth": "Ortam synth",
   "ui.settings.music_style.tracks": "Müzik parçaları",
   "ui.settings.mouse_sensitivity": "Fare hassasiyeti",
+  "ui.settings.fov": "Görüş alanı",
+  "ui.settings.fov_hint": "Daha geniş alan daha fazla dünya gösterir ve biraz FPS maliyeti olur.",
   "ui.settings.invert_y": "Dikey bakışı tersine çevir",
   "ui.settings.camera_motion": "Kamera hareketi (sallanma/titreşim)",
   "ui.settings.comfort": "Konfor & iyi hissetme",

--- a/data/locales/uk.json
+++ b/data/locales/uk.json
@@ -1975,6 +1975,8 @@
   "ui.settings.music_style.synth": "Амбієнтний синт",
   "ui.settings.music_style.tracks": "Музичні треки",
   "ui.settings.mouse_sensitivity": "Чутливість миші",
+  "ui.settings.fov": "Кут огляду",
+  "ui.settings.fov_hint": "Ширший показує більше світу, але трохи знижує FPS.",
   "ui.settings.invert_y": "Інвертувати вертикальний вигляд",
   "ui.settings.camera_motion": "Рух камери (гойдання/тряска)",
   "ui.settings.comfort": "Комфорт і самопочуття",

--- a/data/locales/zh.json
+++ b/data/locales/zh.json
@@ -1975,6 +1975,8 @@
   "ui.settings.music_style.synth": "氛围 合成器",
   "ui.settings.music_style.tracks": "音乐 曲目",
   "ui.settings.mouse_sensitivity": "鼠标 灵敏度",
+  "ui.settings.fov": "视野",
+  "ui.settings.fov_hint": "更宽能看到更多世界，但会稍微影响帧率。",
   "ui.settings.invert_y": "垂直视角反转",
   "ui.settings.camera_motion": "镜头运动（晃动）",
   "ui.settings.comfort": "舒适与健康",


### PR DESCRIPTION
## Why
Playtest 2026-09-05: "the blocks feel huge — one right in front of you fills the whole view". The world is scaled normally (1 m blocks, 1.8 m player, eye at 1.6 m); the camera was the culprit. `WorldRig` creates the camera in code and never set its field of view, so Unity's 60° default applied. Every block drew about a fifth larger on screen than at the 70° first-person block games use; a block filled the screen from 0.87 m.

## What
- **#1589 — default field of view.** `ClientSettings.FieldOfView` (default **80°**, a trial value chosen in review; clamped 50–100), applied in `WorldRig`. Everything derived from the camera FOV (walking kick, binocular zoom = base / magnification, heat shimmer, thermal vision, photo camera `CopyFrom`) already reads it live.
- **#1590 — setting.** Settings → Controls: a *Field of view* stepper under *Mouse sensitivity*, 50–100° in 5° steps, with a one-line frame-rate hint. Applies live from the pause menu via `PlayerController.SetBaseFov` (base value only; the camera-feel code keeps owning the camera). Locale keys `ui.settings.fov` / `ui.settings.fov_hint` in all 14 locales (en/de by hand, the rest via `translate_locale.py`).
- **#1591 — held item.** `Viewmodel` mesh scale 0.9 → 0.72 (20 % smaller); the holder is scaled by `tan(fov/2) / tan(30°)` and its x/y offsets likewise, so the tool keeps the same screen size and corner at every FOV value.
- TODO.md work-log entry, CHANGELOG *Unreleased* section.

| Distance to block face | 60° (before) | 80° (now) |
|---|---|---|
| 1 m | 87 % of screen height | 60 % |
| 2 m | 43 % | 30 % |
| block fills the screen from | 0.87 m | 0.60 m |

## Performance
Chunk streaming is radius-based and unchanged; only frustum culling lets more chunks through: ≈ +23 % rendered chunks outdoors at 80° (up to +45 % in ships/caves), ≈ +40 % at the 100° cap — hence the hint and the cap. Per-pixel cost (SSAO, weather, water, visor) is unchanged.

## Verification
- Local Unity build on this tree: `Build Finished, Result: Success` (client scripts are not compiled by PR CI); the compiled `BlocksBeyondTheStars.Client.dll` contains `SetBaseFov` / `SetReferenceFov`.
- Server/shared test suite (non-Slow): 2643 passed, 0 failed (locale parity across the 14 files included).
- Played by Marcel: 70° first, then the 80° build — 80° approved.

closes #1589, closes #1590, closes #1591

🤖 Generated with [Claude Code](https://claude.com/claude-code)
