### PR TITLE
fix: restore shield after ship repair

### DIFF
--- a/src/BlocksBeyondTheStars.GameServer/GameServerShipRepair.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerShipRepair.cs
@@ -269,9 +269,13 @@ public sealed partial class GameServer
         }
 
         SendInventory(session);
+        var (missingAfter, _) = ComputeShipRepairCost(live, design);
+        if (missingAfter == 0 && _ship.Hull >= _shipHullMax)
+        {
+            _ship.Shield = _shipShieldMax;
+        }
         SendShipCombatStatus(session);
 
-        var (missingAfter, _) = ComputeShipRepairCost(live, design);
         string note = Localize(session.Locale, "srv.repair.result")
             .Replace("{hull}", ((int)System.Math.Round(hullGained)).ToString());
         if (cellsRepaired > 0)
@@ -388,6 +392,32 @@ public sealed partial class GameServer
 
         Serve(session);
         _ship.Hull = System.Math.Max(0f, System.Math.Min(_shipHullMax, hull));
+    }
+
+    /// <summary>Test hook: current shield / max for a player.</summary>
+    public (float Shield, float ShieldMax) ShipShieldForTest(string playerId)
+    {
+        var session = FindSessionByPlayerId(playerId);
+        if (session is null)
+        {
+            return (0f, 0f);
+        }
+
+        Serve(session);
+        return (_ship.Shield, _shipShieldMax);
+    }
+
+    /// <summary>Test hook: set the shield to a chosen value (clamped to [0, max]).</summary>
+    public void SetShipShieldForTest(string playerId, float shield)
+    {
+        var session = FindSessionByPlayerId(playerId);
+        if (session is null)
+        {
+            return;
+        }
+
+        Serve(session);
+        _ship.Shield = System.Math.Max(0f, System.Math.Min(_shipShieldMax, shield));
     }
 
     /// <summary>Test hook: the repair readout exactly as the cockpit would receive it (null when the player

--- a/src/BlocksBeyondTheStars.GameServer/GameServerSpaceCombat.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerSpaceCombat.cs
@@ -463,6 +463,12 @@ public sealed partial class GameServer
         ResizeCargo(_ship);
         RecomputeShipCombatStats();
 
+        if (module.Stats.ContainsKey("shield") ||
+            module.Stats.ContainsKey("shield_regen"))
+        {
+            _ship.Shield = _shipShieldMax;
+        }
+
         Send(session, new ServerMessage
         {
             Text = Localize(session.Locale, "srv.module.built")

--- a/tests/BlocksBeyondTheStars.Tests/ShipFleetTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/ShipFleetTests.cs
@@ -248,6 +248,52 @@ public sealed class ShipFleetTests : IDisposable
         }
     }
 
+    [Fact]
+    public void BuildShieldGenerator_RestoresShieldToMax()
+    {
+        var server = Started(out var repo);
+        using (repo)
+        {
+            var pilot = server.AddLocalPlayer("Pilot");
+            pilot.State.AboardShip = true;
+            pilot.State.InstantBuild = true;
+            pilot.State.UnlockedBlueprints.Add("shield_generator");
+
+            var (_, shieldMaxBefore) = server.ShipShieldForTest("Pilot");
+            server.SetShipShieldForTest("Pilot", shieldMaxBefore - 10f);
+
+            Assert.True(server.BuildModuleForTest("Pilot", "shield_generator"));
+
+            var (shield, shieldMax) = server.ShipShieldForTest("Pilot");
+            Assert.Equal(shieldMax, shield);
+            Assert.Equal(135f, shieldMax);
+        }
+    }
+
+    [Fact]
+    public void BuildNonShieldModule_DoesNotChangeShield()
+    {
+        var server = Started(out var repo);
+        using (repo)
+        {
+            var pilot = server.AddLocalPlayer("Pilot");
+            pilot.State.AboardShip = true;
+            pilot.State.InstantBuild = true;
+            pilot.State.UnlockedBlueprints.Add("cargo_expansion_1");
+
+            var (_, shieldMax) = server.ShipShieldForTest("Pilot");
+            server.SetShipShieldForTest("Pilot", shieldMax - 10f);
+
+            var (shieldBefore, _) = server.ShipShieldForTest("Pilot");
+
+            Assert.True(server.BuildModuleForTest("Pilot", "cargo_hold_1"));
+
+            var (shieldAfter, actualShieldMax) = server.ShipShieldForTest("Pilot");
+            Assert.Equal(shieldBefore, shieldAfter);
+            Assert.Equal(shieldMax, actualShieldMax);
+        }
+    }
+
     public void Dispose()
     {
         try

--- a/tests/BlocksBeyondTheStars.Tests/ShipRepairTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/ShipRepairTests.cs
@@ -130,7 +130,7 @@ public sealed class ShipRepairTests : IDisposable
             Assert.Equal(actualShieldMax, shield);
         }
     }
-    
+
     [Fact]
     public void ShipRepairStatus_ListsTheBreachCells_AndClearsThemOnceRepaired()
     {

--- a/tests/BlocksBeyondTheStars.Tests/ShipRepairTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/ShipRepairTests.cs
@@ -101,6 +101,37 @@ public sealed class ShipRepairTests : IDisposable
     }
 
     [Fact]
+    public void RepairShipAll_WhenFullyRepaired_RestoresShield()
+    {
+        var server = Started(out var repo);
+        using (repo)
+        {
+            var player = server.AddLocalPlayer("Host");
+
+            var (_, hullMax) = server.ShipHullForTest("Host");
+            var (_, shieldMax) = server.ShipShieldForTest("Host");
+
+            // Simulate a damaged ship with a partially depleted shield.
+            server.SetShipHullForTest("Host", hullMax - 10f);
+            server.SetShipShieldForTest("Host", shieldMax - 10f);
+
+            player.State.Inventory.Add("iron_plate", 5, 99);
+
+            Assert.True(server.RepairShipForTest(
+                "Host",
+                new RepairShipIntent { Mode = "all" }));
+
+            var (hull, actualHullMax) = server.ShipHullForTest("Host");
+            Assert.True(
+                Math.Abs(actualHullMax - hull) < 0.01f,
+                $"hull {hull} should be back at max {actualHullMax}");
+
+            var (shield, actualShieldMax) = server.ShipShieldForTest("Host");
+            Assert.Equal(actualShieldMax, shield);
+        }
+    }
+    
+    [Fact]
     public void ShipRepairStatus_ListsTheBreachCells_AndClearsThemOnceRepaired()
     {
         // #1368: the readout carries the missing design cells (structure-local) so the client can outline every


### PR DESCRIPTION
## Summary

- Restore the ship's shield to its maximum when a repair completes and the hull is fully repaired.
- Send the updated `ShipCombatStatus` after the repair.
- Add a focused regression test covering shield restoration.

This PR is deliberately kept small and focused on the ship-repair behavior only.