### PR TITLE
fix(client): shade is shade, not a cave — depth-aware skylight, dappled sun through the shadow map, SSAO 0.5→0.3, star light normalised, cave floor 0.32, shadow fade (#1608 #1609 #1610 #1611 #1612)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -24,6 +24,24 @@ envelope at the WebSocket edge; deterministic seed world-gen; SQLite default per
 
 ---
 
+### ★ Planet lighting: shade is shade, not a cave — depth-aware skylight, dappled sun through the shadow map, de-stacked AO, star light normalised, caves a touch brighter, shadow fade (#1608 #1609 #1610 #1611 #1612, 2026-09-05, branch fix/shade-skylight-lighting)
+Marcel: "auf manchen Welten immer noch recht dunkel; im Schatten braucht es die Lampe, um eine Textur zu erkennen".
+Analysis: the URP shadow map is mild (shadowStrength 0.7 → ×0.73); what crushed shade was the mesher SKYLIGHT —
+`ChunkMesher.Top()` counts any non-air block (leaves, flora, glass) as the column top, so under any canopy / overhang
+≥ 5 wide the 5×5 open fraction is 0 and `BlockAtlas.shader` lit the face like a cave (ambient at the 0.26 floor, the
+direct-sun term zeroed BEFORE the shadow map, no night fill) — ~24 % of a lit face at noon, ~4 % in a crevice once
+vertex AO × normal-map cavity × after-opaque SSAO stacked on top. Open ground: `_Sc_Light` is the raw star colour, so
+late-K / M stars (about a fifth of all systems) lit every face at 64–74 % of a sun-like star all day. Changes:
+**#1608** `Skylight()` takes a shade floor from the depth below the column top (0.55 within 6 blocks, fading to 0 by
+14 — deep caves unchanged) and the URP pass gates the direct sun + specular by `saturate(sky*2)`, so the foliage
+alpha-clip holes cast real sun spots under trees; **#1609** SSAO intensity 0.5 → 0.3 on the High + Medium renderers;
+**#1610** `Sky.ApplyLighting` lifts the block light so its sRGB luma never drops below 93 % of the sun-like anchor
+(≈ 85 % linear), hue untouched, the sun disc / rays / grade keep the raw colour, `_sun.color` follows so Lit props
+match; **#1611** occluded ambient floor 0.26 → 0.32 (URP + Built-in passes); **#1612** the dead `_Sc_GradeTint` /
+`_Sc_GradeParams` uploads dropped (no shader read them) and the shadow sample blended to lit with
+`GetMainLightShadowFade`. Verification: local Unity build; the .NET suite is untouched (the mesher lives in
+`client/Assets` only). Playtest open: jungle at noon under canopy, an M-star world, a cave at 12+ blocks.
+
 ### ★ Hyperspace chart: a stars-only galaxy tab on the flight chart, jump-from-chart, real star colours, the finale out past the frontier (#1603 #1604 #1605, 2026-09-05, branch feat/hyperspace-chart-1603)
 
 **Why.** Marcel, 2026-09-05: "like the planet chart in space, I want a hyperspace map of the star systems — as a

--- a/client/Assets/BlocksBeyondTheStars/Scripts/ChunkMesher.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/ChunkMesher.cs
@@ -353,9 +353,18 @@ namespace BlocksBeyondTheStars.Client
             // old hard 0/1 edge into a gradient, so a cave MOUTH (some open neighbours) is softly lit and
             // overhang shadows feather, while a DEEP cave (no open neighbours) stays ~0 and still needs a lamp.
             const int SkyKernel = 2; // 5x5 (radius 2)
+            // Shade vs. underground (#1608): a cell just below its column top — under a tree canopy, an overhang,
+            // a roof — used to get the same 0 as a cell twenty blocks down a cave, so every shaded patch lit like
+            // a cave (ambient at the cave floor, no direct sun, no night fill) and needed the lamp at noon. The
+            // depth below the top now sets a floor: full shade (ShadeFloor) within ShadeDepthFull blocks of the
+            // cover, fading to the old 0 by ShadeDepthNone blocks, so deep caves stay dark and still need a lamp.
+            const int ShadeDepthFull = 6;
+            const int ShadeDepthNone = 14;
+            const float ShadeFloor = 0.55f;
             float Skylight(int wx, int wy, int wz)
             {
-                if (wy > Top(wx, wz))
+                int top = Top(wx, wz);
+                if (wy > top)
                 {
                     return 1f; // open straight up to the sky
                 }
@@ -373,7 +382,14 @@ namespace BlocksBeyondTheStars.Client
 
                 // Linear fraction: a mouth (≈half its neighbourhood open) lands mid-bright and softly lit, a
                 // couple of blocks deeper falls off to the dark cave floor — a smooth gradient, deep stays ~0.
-                return open / (float)total;
+                float fraction = open / (float)total;
+
+                // Depth below the cover (1 = directly under it) → the shade floor; deep = the plain fraction.
+                int depth = top - wy + 1;
+                float shade = depth <= ShadeDepthFull
+                    ? ShadeFloor
+                    : ShadeFloor * Mathf.Clamp01((ShadeDepthNone - depth) / (float)(ShadeDepthNone - ShadeDepthFull));
+                return Mathf.Max(fraction, shade);
             }
 
             // A cell in a chunk the client does not hold is NOT open air — the streamer either has not sent it

--- a/client/Assets/BlocksBeyondTheStars/Scripts/MenuBackground.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/MenuBackground.cs
@@ -201,7 +201,6 @@ namespace BlocksBeyondTheStars.Client
         {
             Shader.SetGlobalColor("_Sc_Light", Color.white);
             Shader.SetGlobalVector("_Sc_SunDir", SunDir); // light the voxel ship from the VISIBLE sun, not a third direction
-            Shader.SetGlobalColor("_Sc_GradeTint", new Color(0f, 0f, 0f, 0f));
             Shader.SetGlobalColor("_Sc_FloraTint", new Color(0f, 0f, 0f, 0f));
             Shader.SetGlobalColor("_Sc_LampColor", new Color(0f, 0f, 0f, 0f)); // suit headlamp off
             Shader.SetGlobalFloat("_Sc_Indoor", 0f);

--- a/client/Assets/BlocksBeyondTheStars/Scripts/Sky.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/Sky.cs
@@ -31,8 +31,6 @@ namespace BlocksBeyondTheStars.Client
         private static readonly int SunDirId = Shader.PropertyToID("_Sc_SunDir");
         private static readonly int SkyId = Shader.PropertyToID("_Sc_Sky");
         private static readonly int ColorId = Shader.PropertyToID("_Color");
-        private static readonly int GradeTintId = Shader.PropertyToID("_Sc_GradeTint");
-        private static readonly int GradeParamsId = Shader.PropertyToID("_Sc_GradeParams");
         private static readonly int IndoorId = Shader.PropertyToID("_Sc_Indoor");
         private static readonly int FloraTintId = Shader.PropertyToID("_Sc_FloraTint");
         private static readonly int LampColorId = Shader.PropertyToID("_Sc_LampColor");
@@ -45,6 +43,10 @@ namespace BlocksBeyondTheStars.Client
         /// of the horizon (|sin(sunAngle)| ≤ band). 0.34 ≈ the sun within ~20° of the horizon — a civil+nautical
         /// dusk wide enough to read as a real sunset. Larger = a longer, softer golden hour.</summary>
         private const float TwilightBand = 0.34f;
+
+        /// <summary>sRGB luma of the server star ramp's sun-like anchor (FFF1CE, <c>GameServerWeather.StarRamp</c>) —
+        /// the reference the block light is normalised against (#1610).</summary>
+        private const float SunLikeLuma = 0.947f;
 
         private Light _sun;
         private Transform _sunDisc;     // visible glowing sun billboard in the sky
@@ -147,8 +149,7 @@ namespace BlocksBeyondTheStars.Client
             if (Game.SpaceViewActive)
             {
                 Shader.SetGlobalColor(LightId, new Color(1f, 1f, 1f, 1f));   // neutral, full-bright
-                Shader.SetGlobalColor(GradeTintId, new Color(0f, 0f, 0f, 0f)); // colour grade off
-                UrpScenePost.Instance?.ApplyGrade(Color.white, 1f, 1f);        // …and off on the URP volume too
+                UrpScenePost.Instance?.ApplyGrade(Color.white, 1f, 1f);        // colour grade off on the URP volume
                 UrpScenePost.Instance?.SetMoodLut(null);                       // …and drop the biome mood LUT in space
                 Shader.SetGlobalColor(LampColorId, new Color(0f, 0f, 0f, 0f));
                 Shader.SetGlobalFloat(IndoorId, 0f);
@@ -260,8 +261,17 @@ namespace BlocksBeyondTheStars.Client
             // takes on the golden-hour cast, then cools back to its true colour high in the sky. Kept off on stations.
             Color warmSun = constantLight ? sunColor : Color.Lerp(sunColor, sunColor * new Color(1f, 0.72f, 0.5f), twilight * 0.7f);
 
+            // #1610: the star colour should TINT the world, not dim it. The ramp's cool / red anchors carry 20–36 %
+            // less luma than the sun-like one, so about a fifth of all systems lit every face darker all day long.
+            // Lift the block light so its sRGB luma never drops below 93 % of the sun-like anchor (≈ 85 % once the
+            // value goes linear); the hue is untouched, and the sun disc / god-rays / grade keep the raw star colour.
+            // Measured on the RAW star (not warmSun) so the golden-hour warming still dims dusk as before.
+            float starLuma = 0.299f * sunColor.r + 0.587f * sunColor.g + 0.114f * sunColor.b;
+            float lift = starLuma > 0.001f ? Mathf.Max(1f, SunLikeLuma * 0.93f / starLuma) : 1f;
+            Color litSun = constantLight ? warmSun : warmSun * lift;
+
             // Stations use a clean neutral interior light (not the system sun's tint).
-            Color tint = constantLight ? new Color(0.95f, 0.96f, 1f) : warmSun * (brightness * weatherDim);
+            Color tint = constantLight ? new Color(0.95f, 0.96f, 1f) : litSun * (brightness * weatherDim);
 
             // A lightning strike lights the WORLD for a moment (#900), not just the screen: the block light
             // global is pushed toward a cold white, so the whole landscape flares out of a dark storm.
@@ -339,7 +349,7 @@ namespace BlocksBeyondTheStars.Client
 
             if (_sun != null)
             {
-                _sun.color = warmSun;
+                _sun.color = litSun; // Lit-shaded props / creatures follow the same normalised light as the blocks
                 _sun.intensity = brightness;
                 _sun.transform.rotation = Quaternion.Euler(time * 360f - 90f, 160f, 0f);
                 // The lit block shader reads the sun direction from this global (direction TO the sun).
@@ -372,8 +382,8 @@ namespace BlocksBeyondTheStars.Client
             // light, atmospheric wash — raised from 0.25 so the per-system sun colour clearly reads).
             Color blended = tint * Color.Lerp(Color.white, norm, 0.4f);
             blended.a = 0.7f; // grade strength
-            Shader.SetGlobalColor(GradeTintId, ShaderColor.Srgb(blended));
-            Shader.SetGlobalVector(GradeParamsId, new Vector4(sat, contrast, 0f, 0f));
+            // #1612: the old _Sc_GradeTint / _Sc_GradeParams shader globals are gone — no shader read them since
+            // the grade moved onto the URP volume below.
             // ApplyGrade keeps the sRGB value: URP's ColorAdjustments colorFilter converts internally.
             UrpScenePost.Instance?.ApplyGrade(blended, sat, contrast); // URP colour grade (ColorAdjustments)
             UrpScenePost.Instance?.SetMoodLut(biome); // WS4: layer the per-biome cinematic mood LUT on top
@@ -535,7 +545,6 @@ namespace BlocksBeyondTheStars.Client
             // Clear the tint so other scenes (menu) aren't affected.
             Shader.SetGlobalColor(LightId, new Color(1f, 1f, 1f, 0f));
             Shader.SetGlobalColor(LampColorId, new Color(0f, 0f, 0f, 0f)); // headlamp off
-            Shader.SetGlobalColor(GradeTintId, new Color(0f, 0f, 0f, 0f)); // colour grade off (menu/space)
             UrpScenePost.Instance?.SetMoodLut(null); // drop the biome mood LUT (menu/space)
             Shader.SetGlobalFloat(IndoorId, 0f); // interior fill off (menu/space)
             Shader.SetGlobalColor(FloraTintId, new Color(0f, 0f, 0f, 0f)); // flora tint off (menu/space)

--- a/client/Assets/BlocksBeyondTheStars/Shaders/BlockAtlas.shader
+++ b/client/Assets/BlocksBeyondTheStars/Shaders/BlockAtlas.shader
@@ -177,13 +177,24 @@ Shader "BlocksBeyondTheStars/BlockAtlas"
                 // #1518: the lookup only feeds terms multiplied by ndl*sky, so a face turned away from the sun
                 // or without skylight (caves, interiors — about half of all voxel faces) skips the soft-shadow
                 // tent filter entirely; the branch is per-face coherent and the result is identical.
-                float shadow = (ndl * sky > 0.0) ? MainLightRealtimeShadow(TransformWorldToShadowCoord(i.wp)) : 0.0;
+                // #1612: blended toward "lit" by the URP shadow-distance fade, so the shadow map's edge dissolves
+                // instead of marching across the terrain as a hard line at the preset distance (40/70/110 m).
+                float shadow = (ndl * sky > 0.0)
+                    ? lerp(MainLightRealtimeShadow(TransformWorldToShadowCoord(i.wp)), 1.0, GetMainLightShadowFade(i.wp))
+                    : 0.0;
 
                 // Per-vertex AO (mesher, in .b) widened to a visible contact-shadow range, then multiplied by
                 // the texture-scale cavity AO (normal map alpha). Diffuse-only — spec/reflection stay crisp.
                 float faceAo = lerp(0.62, 1.0, i.mat.b) * lerp(1.0, nrm.a, 0.6);
-                float amb = lerp(0.26, 0.78, sky); // #1457: sky-lit faces turned away from the sun sat at 0.70 — a shade too dark by day
-                float3 col = albedo * (light * (amb + 0.5 * ndl * sky * shadow) + 0.05) * faceAo;
+                // #1611: the fully occluded (cave / interior) end of the ambient sat at 0.26 — lifted to 0.32 so a
+                // cave wall keeps a faint readable texture while still clearly asking for the lamp.
+                float amb = lerp(0.32, 0.78, sky); // #1457: sky-lit faces turned away from the sun sat at 0.70 — a shade too dark by day
+                // #1608: the shadow map owns "is the sun blocked". The mesher skylight gates the direct sun (and the
+                // specular below) at half weight only — saturate(sky*2) — so partially covered ground keeps the sun
+                // spots the foliage alpha-clip punches through a canopy (dappled light), instead of the skylight
+                // zeroing them before the shadow map ever gets a say.
+                float sunOpen = saturate(sky * 2.0);
+                float3 col = albedo * (light * (amb + 0.5 * ndl * sunOpen * shadow) + 0.05) * faceAo;
                 col += albedo * (_Sc_Indoor * 0.5 * (1.0 - sky)) * faceAo;
 
                 // Night/atmosphere ambient floor: a faint cool fill on open-sky faces, strongest when the sun
@@ -206,7 +217,7 @@ Shader "BlocksBeyondTheStars/BlockAtlas"
                 float dterm = nh * nh * (r2 - 1.0) + 1.00001;
                 float specTerm = r2 / ((dterm * dterm) * max(0.1, lh * lh) * (rough * 4.0 + 2.0));
                 float3 F0 = lerp(float3(0.04, 0.04, 0.04), albedo, metal);
-                col += light * F0 * (specTerm * ndl * sky * shadow);
+                col += light * F0 * (specTerm * ndl * sunOpen * shadow);
 
                 // Environment reflection of the sky colour, roughness-aware: metals reflect strongly (tinted by
                 // F0) even head-on, dielectrics mostly at grazing angles (Fresnel). Additive, faded by skylight.
@@ -550,7 +561,7 @@ Shader "BlocksBeyondTheStars/BlockAtlas"
                 // (outdoors ~0.70, a readable cave floor of 0.24). The directional adds the sunny side on top.
                 // A small flat term (sun/sky-independent) guarantees a minimum readable level, so blocks in a
                 // dark hole or deep cave are dim but never pure black.
-                float amb = lerp(0.26, 0.78, sky); // #1457: sky-lit faces turned away from the sun sat at 0.70 — a shade too dark by day
+                float amb = lerp(0.32, 0.78, sky); // #1457 (0.70 → 0.78); #1611 (0.26 → 0.32): occluded faces keep a faint readable texture
                 fixed3 col = albedo * (light * (amb + 0.5 * ndl * sky) + 0.05) * faceAo;
 
                 // Ship interior fill: a neutral, day/night-independent fill on skylight-occluded faces only

--- a/client/Assets/Settings/BlocksBeyondTheStarsURP_Renderer.asset
+++ b/client/Assets/Settings/BlocksBeyondTheStarsURP_Renderer.asset
@@ -19,7 +19,7 @@ MonoBehaviour:
     AfterOpaque: 1
     Source: 0
     NormalSamples: 1
-    Intensity: 0.5
+    Intensity: 0.3
     DirectLightingStrength: 0.25
     Radius: 0.3
     Samples: 1

--- a/client/Assets/Settings/BlocksBeyondTheStarsURP_Renderer_Medium.asset
+++ b/client/Assets/Settings/BlocksBeyondTheStarsURP_Renderer_Medium.asset
@@ -19,7 +19,7 @@ MonoBehaviour:
     AfterOpaque: 1
     Source: 0
     NormalSamples: 1
-    Intensity: 0.5
+    Intensity: 0.3
     DirectLightingStrength: 0.25
     Radius: 0.3
     Samples: 1


### PR DESCRIPTION
Closes #1608
Closes #1609
Closes #1610
Closes #1611
Closes #1612

## Why
Marcel: some worlds still read dark, and anything in shade needs the suit lamp before a texture is recognisable. The audit found that the URP shadow map is mild (shadowStrength 0.7 → ×0.73); what crushed shade was the **mesher skylight**: `ChunkMesher.Top()` counts any non-air block (leaves, flora, glass) as the column top, so under any canopy or overhang ≥ 5 blocks wide the 5×5 open fraction is 0 and `BlockAtlas.shader` lit the face like a cave — ambient at the 0.26 floor, the direct-sun term zeroed *before* the shadow map, no night fill. That is ~24 % of a lit face at noon, ~4 % in a crevice once vertex AO × normal-map cavity × after-opaque SSAO stacked on top. On open ground the raw star colour dims late-K / M systems to 64–74 % of a sun-like one.

## What
- **#1608** `Skylight()` takes a shade floor from the depth below the column top (0.55 within 6 blocks, fading to 0 by 14 — deep caves unchanged). The URP pass gates the direct sun + specular by `saturate(sky*2)`, so the foliage alpha-clip holes cast real sun spots under trees (dappled light).
- **#1609** SSAO intensity 0.5 → 0.3 on the High and Medium renderers (after-opaque SSAO hits the voxel shader).
- **#1610** `Sky.ApplyLighting` lifts the block light so its sRGB luma never drops below 93 % of the sun-like anchor (≈ 85 % linear); hue untouched, the sun disc / god-rays / grade keep the raw star colour, `_sun.color` follows so Lit props match.
- **#1611** Skylight-occluded ambient floor 0.26 → 0.32 (URP + Built-in passes).
- **#1612** Dead `_Sc_GradeTint` / `_Sc_GradeParams` uploads removed (no shader read them); the shadow sample is blended to lit with `GetMainLightShadowFade` so shadows fade out at the preset distance instead of ending in a hard line.
- TODO.md entry.

## Verification
- Local Unity build (PR CI does not compile `client/Assets`): see the PR comment / merge note.
- .NET suite untouched — the mesher lives in `client/Assets` only.
- Playtest open: jungle at noon under canopy, an M-star world, a cave at 12+ blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
