### PR TITLE
feat(worldgen): bigger galaxy by default — Universe-size tiers 6 / 12 / 20 / 32, Growing starts at 12, server default 12 (#1615 #1616 #1617)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ the richer, screenshot-laden versions live there. `(#123)` references the pull r
 
 ## [Unreleased]
 
+### ✨ A bigger sky (#1615 #1616 #1617)
+
+- **More stars in every new world.** A Normal world now starts with 12 star systems instead of 8, and the
+  other Universe-size tiers grew with it: Small 6, Large 20, Huge 32. A Growing world also starts at 12 and
+  keeps growing at the frontier as before. Existing saves keep the galaxy they were created with (#1615).
+- Dedicated servers that do not set a system count start with the same 12 systems (#1616).
+
 ### 🌌 A map of the stars (#1603 #1604 #1605)
 
 - **The system chart has a Hyperspace tab.** Press M while flying and switch tabs (LB/RB on a pad): the

--- a/TODO.md
+++ b/TODO.md
@@ -24,6 +24,19 @@ envelope at the WebSocket edge; deterministic seed world-gen; SQLite default per
 
 ---
 
+### ★ Bigger galaxy by default: Universe-size tiers 6 / 12 / 20 / 32, Growing starts at 12, server default 12 (#1615 #1616 #1617, 2026-09-05, branch feat/bigger-default-galaxy)
+Marcel: "mehr Inhalt im selben Spiel". Analysis first: the galaxy is POCO metadata (~12 bodies per system);
+worlds, space instances, ticks and the save (`block_edit` deltas only) all scale with OCCUPIED bodies, never
+with the system count — so 8 → 12 (Normal) and 18 → 32 (Huge) cost nothing in singleplayer or on the VPS. The
+only thing that grows is `StarMapData` (~15–20 KB at 8 → ~60–80 KB at 32, broadcast on landing / rename /
+lane / growth) — fine natively, worth a look on WebGL before ever going past 32. Decided: no jump fuel /
+distance cost for now, the denser hyperspace chart at 32 stars is fine, the official VPS world picks up the
+new default at the next release reset. Changes: `WorldCreationOptions` tier table 4/8/12/18 → 6/12/20/32
+(Normal still sends no explicit count), `WorldDescription.StarSystemCount` 8 → 12 (+ pin test
+`DefaultDescription_GeneratesTwelveSystems`), docs (WORLD_GENERATION, USER_MANUAL). No change to the
+`--systems` clamp (1..32) or the growth soft cap (48); the chart layout tests already run at 40 systems.
+- Playtest open: does a 12-system Normal galaxy read as "more to do" on the hyperspace chart, and is Huge (32) still legible?
+
 ### ★ Planet lighting: shade is shade, not a cave — depth-aware skylight, dappled sun through the shadow map, de-stacked AO, star light normalised, caves a touch brighter, shadow fade (#1608 #1609 #1610 #1611 #1612, 2026-09-05, branch fix/shade-skylight-lighting)
 Marcel: "auf manchen Welten immer noch recht dunkel; im Schatten braucht es die Lampe, um eine Textur zu erkennen".
 Analysis: the URP shadow map is mild (shadowStrength 0.7 → ×0.73); what crushed shade was the mesher SKYLIGHT —

--- a/client/Assets/BlocksBeyondTheStars/Scripts/UiWorldOptions.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/UiWorldOptions.cs
@@ -122,7 +122,7 @@ namespace BlocksBeyondTheStars.Client
             Row(false, shell.L("ui.worldopt.vaults"), freqSteps, () => opt.Vaults, v => opt.Vaults = v);
             Row(false, shell.L("ui.worldopt.stations"), freqSteps, () => opt.Stations, v => opt.Stations = v);
             Row(false, shell.L("ui.worldopt.exotic"), freqSteps, () => opt.Exotic, v => opt.Exotic = v);
-            // Five steps since #1123: the last one ("Growing") is a normal 8-system galaxy that appends a
+            // Five steps since #1123: the last one ("Growing") is a normal 12-system galaxy that appends a
             // new system whenever a player hyperjumps into one of the current outermost ones.
             Row(false, shell.L("ui.worldopt.universe"), L5("ui.worldopt.size"), () => opt.UniverseSize, v => opt.UniverseSize = v);
 

--- a/client/Assets/BlocksBeyondTheStars/Scripts/WorldCreationOptions.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/WorldCreationOptions.cs
@@ -182,14 +182,17 @@ namespace BlocksBeyondTheStars.Client
             if (UniverseSize != 1)
             {
                 // Klein / Normal / Groß / Riesig / Wachsend → systems + planets-per-system + moons.
-                // "Growing" (#1123) starts as the normal 8-system galaxy and appends a system whenever a
-                // player hyperjumps into one of the current outermost ones.
+                // Tiers 6 / 12 / 20 / 32 since #1615 (were 4 / 8 / 12 / 18): more to explore in the same game.
+                // System count is metadata only — worlds load per occupied body — so Huge stays inside the
+                // server's --systems clamp (32) and the growth soft cap (48). "Growing" (#1123) starts as
+                // the normal 12-system galaxy and appends a system whenever a player hyperjumps into one of
+                // the current outermost ones.
                 (int systems, int pMin, int pMax, int moons) = UniverseSize switch
                 {
-                    0 => (4, 2, 4, 2),
-                    2 => (12, 3, 8, 3),
-                    3 => (18, 3, 10, 4),
-                    _ => (8, 2, 6, 3),
+                    0 => (6, 2, 4, 2),
+                    2 => (20, 3, 8, 3),
+                    3 => (32, 3, 10, 4),
+                    _ => (12, 2, 6, 3),
                 };
                 Arg("systems", systems.ToString());
                 Arg("planets-min", pMin.ToString());

--- a/docs/developer/WORLD_GENERATION.md
+++ b/docs/developer/WORLD_GENERATION.md
@@ -39,7 +39,10 @@ SEED
 Built by [`UniverseGenerator.cs`](../../src/BlocksBeyondTheStars.WorldGeneration/UniverseGenerator.cs).
 The data shapes are in [`Galaxy.cs`](../../src/BlocksBeyondTheStars.Shared/World/Galaxy.cs).
 
-- **~8 star systems** per galaxy (`StarSystemCount`), each with a random 2D star-map position.
+- **12 star systems** per galaxy by default (`StarSystemCount`, #1616), each with a random 2D star-map
+  position. The launcher's Universe-size tiers send 6 / 12 / 20 / 32 (Small / Normal / Large / Huge, #1615);
+  "Growing" starts at 12 and appends systems at the frontier (#1123, soft cap 48). The CLI clamps
+  `--systems` to 1..32. The galaxy is metadata only — a system costs nothing until a player is in it.
 - Per system: **2–6 planets**, each with **0–3 moons**, plus **2–3 landable asteroids** and (rarely)
   **1–3 space stations**.
 - Each asteroid rolls one of five **families** (#515) — `asteroid` (stony), `asteroid_metallic`,

--- a/docs/user/USER_MANUAL.md
+++ b/docs/user/USER_MANUAL.md
@@ -1096,7 +1096,7 @@ separate unlock; admins can still disable it through server world rules.
 - **Visitors at the base** (Settings → world rules, world admin, off by default): bandit scouts look at a
   founded base from its edge while the owner is home — never inside, never destructive; see § Bases. Gated
   on the **Bandits** slider (no robbers, no scouts); the `dangerous` preset ships with it on.
-- **Growing galaxy** (world creation → Universe size → **"Growing"**): the galaxy starts at the normal 8
+- **Growing galaxy** (world creation → Universe size → **"Growing"**): the galaxy starts at the normal 12
   systems — but every time someone hyperjumps into one of the current **outermost** systems, deep-space
   telescopes report a **brand-new system beyond it**. The galaxy literally grows at your frontier, up to a
   generous cap ("the frontier is quiet"). Growth is permanent: new systems survive save/reload like any

--- a/src/BlocksBeyondTheStars.Shared/World/WorldDescription.cs
+++ b/src/BlocksBeyondTheStars.Shared/World/WorldDescription.cs
@@ -107,7 +107,11 @@ public static class FrequencyExtensions
 /// </summary>
 public sealed class WorldDescription
 {
-    public int StarSystemCount { get; set; } = 8;
+    /// <summary>Systems in a fixed galaxy. 12 since #1616 (was 8): the launcher's "Normal" tier sends no
+    /// explicit count, so this default IS a normal singleplayer world and every dedicated server without
+    /// <c>--systems</c>. The galaxy is metadata only (worlds load per occupied body), so the count is a
+    /// content knob, not a performance one; the CLI clamps it to 1..32.</summary>
+    public int StarSystemCount { get; set; } = 12;
 
     public int PlanetsPerSystemMin { get; set; } = 2;
     public int PlanetsPerSystemMax { get; set; } = 6;

--- a/tests/BlocksBeyondTheStars.Tests/UniverseTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/UniverseTests.cs
@@ -40,6 +40,18 @@ public sealed class UniverseTests : IDisposable
     }
 
     [Fact]
+    public void DefaultDescription_GeneratesTwelveSystems()
+    {
+        // #1616: the default (= the launcher's "Normal" tier + every dedicated server without --systems)
+        // grew from 8 to 12 systems. Pinned so a stray default change never silently shrinks new worlds.
+        var galaxy = new UniverseGenerator(42, new WorldDescription(), _content).Generate();
+
+        Assert.Equal(12, new WorldDescription().StarSystemCount);
+        Assert.Equal(12, galaxy.Systems.Count);
+        Assert.Equal(12, galaxy.Systems.Select(s => s.Id).Distinct().Count());
+    }
+
+    [Fact]
     public void BodyPositions_AreDeterministic_AndSpreadOut()
     {
         var desc = new WorldDescription { StarSystemCount = 4, PlanetsPerSystemMin = 3, PlanetsPerSystemMax = 5 };


### PR DESCRIPTION
## Summary

Marcel's call after the star-system-count analysis: **more content in the same game**. A Normal world now starts with 12 star systems instead of 8; the other Universe-size tiers grow with it.

| Tier | before | after |
|---|---|---|
| Small | 4 | 6 |
| Normal (default, also dedicated servers) | 8 | 12 |
| Large | 12 | 20 |
| Huge | 18 | 32 |
| Growing | 8 + growth | 12 + growth (soft cap 48 unchanged) |

Why it is safe: the galaxy is POCO metadata (~12 bodies per system). Worlds, space instances, ticks and the save (`block_edit` deltas only) scale with **occupied** bodies, never with the system count — singleplayer and VPS cost do not change. The only growing payload is `StarMapData` (~4× at 32 systems, still tens of KB). No jump fuel/distance cost, no clamp or cap change, no chart-box scaling (the chart layout tests already run at 40 systems). Existing saves keep the galaxy they were created with; the official VPS world picks the new default up at the next release reset.

## Changes

- `WorldCreationOptions.cs`: tier table 4/8/12/18 → 6/12/20/32 (Normal still sends no explicit count, Growing starts at 12); comment in `UiWorldOptions.cs`
- `WorldDescription.StarSystemCount` 8 → 12, plus pin test `DefaultDescription_GeneratesTwelveSystems`
- Docs: `WORLD_GENERATION.md` §2, `USER_MANUAL.md` (Growing galaxy), `CHANGELOG.md` Unreleased, `TODO.md` status entry

## Verification

- Server suite (non-Slow, Release): 2659 passed · client suite: 507 passed · `dotnet format --verify-no-changes` clean
- Local Unity build of this tree: see the merge comment (client script touched, PR CI does not compile `client/Assets`)

closes #1615
closes #1616
closes #1617

🤖 Generated with [Claude Code](https://claude.com/claude-code)