### PR TITLE
fix(client): VEGA continue key works right after the chat closes — release the EventSystem selection on close, InputCaptured needs an active + focused field (#1634)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -24,6 +24,20 @@ envelope at the WebSocket edge; deterministic seed world-gen; SQLite default per
 
 ---
 
+### ★ VEGA continue key works right after the chat closes — the hidden chat box no longer counts as "a text field has focus" (#1634, 2026-09-05, branch fix/vega-n-after-chat)
+
+Marcel (2026-09-05, local playtest): Enter → type → Esc closed the chat fine, but N would not dismiss the VEGA
+line that had popped up meanwhile — until the next click into the world. Cause: `ChatUi` never released the
+uGUI EventSystem selection on close, and uGUI never deselects a deactivated InputField by itself, so
+`VegaPanel.InputCaptured()` (#1041) kept seeing "an InputField is selected" and swallowed the continue key.
+
+- **Done:** `ChatUi` drops the EventSystem selection whenever the chat box closes (end-edit for Esc *and* Enter,
+  plus disable) if it still points at the box. `VegaPanel.InputCaptured()` now requires the selected InputField
+  to be active in the hierarchy **and** `isFocused` — a closed or unfocused field captures nothing, which also
+  covers the feedback dialog / beacon label closed without a click.
+- **Unchanged:** the pause-menu gate, pad Back / touch NEXT (#1041), N typed inside the chat box still types `n`.
+- **Verify:** Enter → type → Esc → N advances VEGA with no click in between; same with Enter (send).
+
 ### ★ Volcanoes on every lava-core world; sea-mount cones rise out of the sea as volcanic islands (#1631, 2026-09-05, branch feat/volcanoes-1631)
 
 Marcel (2026-09-05): ocean worlds should sometimes show volcanoes as mountains out of the water; volcanoes on

--- a/client/Assets/BlocksBeyondTheStars/Scripts/ChatUi.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/ChatUi.cs
@@ -217,6 +217,8 @@ namespace BlocksBeyondTheStars.Client
             {
                 Game.ChatTyping = false;
             }
+
+            ReleaseSelection();
         }
 
         private void OnChat(BlocksBeyondTheStars.Networking.Messages.ChatMessage m)
@@ -272,7 +274,21 @@ namespace BlocksBeyondTheStars.Client
             Game.ChatTyping = false;
             _input.text = string.Empty;
             _inputRow.gameObject.SetActive(false);
+            ReleaseSelection();
             RefreshLog();
+        }
+
+        /// <summary>Drops the EventSystem selection if it still points at the chat box. uGUI never
+        /// deselects a deactivated InputField on its own, so after Esc/Enter the hidden box stayed the
+        /// "selected" object until the next world click — and every "is a text field focused?" check
+        /// (the VEGA continue key first of all) kept answering yes (#1634).</summary>
+        private void ReleaseSelection()
+        {
+            var es = UnityEngine.EventSystems.EventSystem.current;
+            if (es != null && _input != null && es.currentSelectedGameObject == _input.gameObject)
+            {
+                es.SetSelectedGameObject(null);
+            }
         }
 
         /// <summary>Sends a finished chat line (also the touch/browser prompt path, which has no Enter key).</summary>

--- a/client/Assets/BlocksBeyondTheStars/Scripts/VegaPanel.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/VegaPanel.cs
@@ -379,7 +379,10 @@ namespace BlocksBeyondTheStars.Client
         /// field (chat, beacon label) currently has keyboard focus. Only a focused INPUT FIELD counts —
         /// uGUI also leaves an ordinary Button selected after any click, and with pad focus
         /// (<see cref="UiNavFocus"/>) something is selected most of the time; treating that as "captured"
-        /// left the panel stuck after the first HUD click / on a pad (#1041).</summary>
+        /// left the panel stuck after the first HUD click / on a pad (#1041). And only a field that is
+        /// ACTIVE and FOCUSED: uGUI keeps a closed InputField as the selected object (nothing deselects on
+        /// deactivate), so the chat box closed with Esc or Enter counted as "captured" until the next
+        /// world click — N did nothing on a VEGA line that arrived mid-chat (#1634).</summary>
         private bool InputCaptured()
         {
             if (Game != null && Game.MenuOpen)
@@ -388,7 +391,13 @@ namespace BlocksBeyondTheStars.Client
             }
 
             var selected = UnityEngine.EventSystems.EventSystem.current?.currentSelectedGameObject;
-            return selected != null && selected.GetComponent<InputField>() != null;
+            if (selected == null || !selected.activeInHierarchy)
+            {
+                return false;
+            }
+
+            var field = selected.GetComponent<InputField>();
+            return field != null && field.isFocused;
         }
 
         /// <summary>True while a VEGA line is on screen (typing or waiting for continue) — gates the touch


### PR DESCRIPTION
closes #1634

## What

Enter → type → Esc (or Enter) closed the chat fine, but **N would not dismiss a VEGA line** that had popped up meanwhile — until the next click into the world.

## Why

`ChatUi` never released the uGUI `EventSystem` selection on close, and uGUI never deselects a deactivated `InputField` by itself. `VegaPanel.InputCaptured()` (#1041) tested only "is an InputField selected?" — true for the hidden chat box — and swallowed the continue key every frame. The first pointer press that hits no Selectable deselects, which is why it healed on the next world click and rarely showed.

## Fix

- **`ChatUi`** — `ReleaseSelection()` on every close path (end-edit for Esc *and* Enter, plus `OnDisable`): nulls the EventSystem selection if it still points at the chat box.
- **`VegaPanel.InputCaptured()`** — the selected InputField must be `activeInHierarchy` **and** `isFocused`. A closed or unfocused field captures nothing; this also covers the feedback dialog / beacon label closed without a click.
- TODO.md entry.

Unchanged: the pause-menu gate, pad Back / touch NEXT (#1041), N typed inside the chat box still types `n`.

## Verification

- Local Unity build (client/Assets change — PR CI does not compile Unity code): see comment below.
- Manual: Enter → type → Esc → N advances VEGA with no click in between; same with Enter (send).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
