### PR TITLE
fix(client): visor HUD glow falls back to R8G8B8A8 where B10G11R11 render targets are unsupported (#1636)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -83,6 +83,16 @@ suite is touched (client/Assets only). Marcel approved the look on the screensho
 `PerfProbe` text-change tracker only sees legacy `Text`; a runtime `SpriteAtlas` for the remaining icon textures
 (Unity 6.4 API); PerfProbe A/B of the sub-canvas split.
 
+**WebGL verification + glow-target fallback (#1636, 2026-09-05, branch fix/visor-glow-format-fallback).** A local
+WebGL build of the HUD pass (`BBS_WEBGL_FAST_LOCAL`, served + captured headed) compiled clean and rendered the whole
+new HUD in the browser — SDF text, holo chrome, glow, icons — with no new console errors (only the known engine
+noise, #1099). The one real gap found in review: the glow chain's quarter-res blur targets were hard-wired to
+`B10G11R11_UFloatPack32`, which as a render target needs `EXT_color_buffer_float` under WebGL 2 — desktop browsers
+have it, older tablets do not, and the render graph would then fail the visor pass every frame. `VisorUrpCompositor`
+now picks the format once per session via `SystemInfo.IsFormatSupported` (render + linear) and falls back to
+`R8G8B8A8_UNorm`; the glow input is the LDR HUD RT and the threshold never exceeds 1, so nothing visible changes
+where the float format works. Not measured: browser frame times (another agent's Unity build was running).
+
 ### ★ Ocean landings: 2-D pad nudge, islet for every deep all-water pad, wider islets, dry-pad preference, blue seabed markers with depth (#1618 #1619 #1620 #1621 #1622, 2026-09-05, branch fix/ocean-pads-2d-nudge)
 
 Follow-up to #1453/#1454 after Marcel's 2026-09-05 impression that "the islets do not work": a 12-seed probe

--- a/client/Assets/BlocksBeyondTheStars/Scripts/VisorUrpCompositor.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/VisorUrpCompositor.cs
@@ -85,6 +85,37 @@ namespace BlocksBeyondTheStars.Client
             private readonly Material _mat;
             public RTHandle Hud;
 
+            // Quarter-res glow target format, chosen once per session. B10G11R11 is the compact HDR-ish choice on
+            // desktop, but as a RENDER target under WebGL 2 it needs EXT_color_buffer_float, which older mobile
+            // GPUs (and some tablets' browsers) do not expose — the render graph then fails to allocate the
+            // texture and the whole visor pass errors out every frame. The glow chain's input is the LDR ARGB32
+            // HUD RT and the threshold pass never writes values above 1, so plain 8-bit RGBA loses nothing
+            // visible; it is guaranteed on every WebGL 2 / GLES 3 device. Checked for render + bilinear sampling
+            // (the blur taps rely on linear filtering).
+            private static GraphicsFormat? _glowFormat;
+
+            private static GraphicsFormat GlowFormat
+            {
+                get
+                {
+                    if (_glowFormat.HasValue)
+                    {
+                        return _glowFormat.Value;
+                    }
+
+                    var preferred = GraphicsFormat.B10G11R11_UFloatPack32;
+                    bool ok = SystemInfo.IsFormatSupported(preferred, GraphicsFormatUsage.Render)
+                              && SystemInfo.IsFormatSupported(preferred, GraphicsFormatUsage.Linear);
+                    _glowFormat = ok ? preferred : GraphicsFormat.R8G8B8A8_UNorm;
+                    if (!ok)
+                    {
+                        Debug.Log("[VisorUrpCompositor] B10G11R11_UFloatPack32 render targets unsupported here — HUD glow uses R8G8B8A8_UNorm.");
+                    }
+
+                    return _glowFormat.Value;
+                }
+            }
+
             private sealed class PassData
             {
                 public TextureHandle Source, Hud, Glow;
@@ -117,7 +148,7 @@ namespace BlocksBeyondTheStars.Client
                     var gdesc = new TextureDesc(gw, gh)
                     {
                         name = "VisorHudGlowA",
-                        colorFormat = GraphicsFormat.B10G11R11_UFloatPack32,
+                        colorFormat = GlowFormat,
                         filterMode = FilterMode.Bilinear,
                         wrapMode = TextureWrapMode.Clamp,
                         clearBuffer = false,


### PR DESCRIPTION
## Summary

- `VisorUrpCompositor` picked `B10G11R11_UFloatPack32` for the quarter-res glow blur targets with no fallback. As a render target that format needs `EXT_color_buffer_float` under WebGL 2 (desktop browsers have it, older tablets don't) — there the render graph could not allocate the texture and the visor pass failed every frame.
- The format is now chosen once per session via `SystemInfo.IsFormatSupported` (render + linear sampling) and falls back to `R8G8B8A8_UNorm`. The glow input is the LDR ARGB32 HUD RT and the threshold pass never writes above 1, so the fallback looks identical where the float format works.
- TODO.md records the local WebGL verification of the HUD look pass (#1629): clean WebGL compile, whole new HUD rendering in the browser, no new console errors.

closes #1636

## Verification

- Local WebGL build of main (HUD pass) served + captured headed: HUD renders, only known engine noise in the console.
- Local Windows player build of this branch: see PR comment (client/Assets only — PR CI does not compile Unity code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)