### PR TITLE
test(client): view-distance streaming test wraps its probe columns at the longitude seam — main green again (#1640)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -24,6 +24,14 @@ envelope at the WebSocket edge; deterministic seed world-gen; SQLite default per
 
 ---
 
+### ★ CI: main green again — the view-distance streaming test wraps its probe columns at the longitude seam (#1640, 2026-09-05, branch fix/streaming-test-seam)
+
+Every push to `main` since #1632 failed the full tier on one `Slow` test (PR CI skips the Slow tier, so five
+merges went through green): `ClientViewDistance_ExtendsTheStreamedTerrain_OverTheWire` compared unwrapped chunk X,
+and the dry-pad preference (#1621) moved this seed's spawn pad to column 733 of 735 — "center + 2" named a column
+the server only ever streams canonically as 0. Test-only fix: both probe columns go through
+`WorldConstants.CanonicalChunkX(x, circumference)`, like the server's own chunk keys. Streaming was never wrong.
+
 ### ★ VEGA continue key works right after the chat closes — the hidden chat box no longer counts as "a text field has focus" (#1634, 2026-09-05, branch fix/vega-n-after-chat)
 
 Marcel (2026-09-05, local playtest): Enter → type → Esc closed the chat fine, but N would not dismiss the VEGA

--- a/tests/BlocksBeyondTheStars.Client.Tests/JoinAndStreamingTests.cs
+++ b/tests/BlocksBeyondTheStars.Client.Tests/JoinAndStreamingTests.cs
@@ -82,12 +82,18 @@ public sealed class JoinAndStreamingTests
 
         // A column 2 east is inside the client's radius-3 view but outside the host's radius-1 default — it only
         // reaches the client because the slider value travelled in the JoinRequest and drove server streaming.
+        // Both probe columns are wrapped at the longitude seam: streamed chunk keys are canonical, and the
+        // dry-pad preference (#1621) put this seed's spawn pad two columns short of the seam, where an
+        // unwrapped "center + 2" names a column that can never arrive.
+        int circumference = h.Server.World.Circumference;
+        int withinX = Shared.World.WorldConstants.CanonicalChunkX(center.X + 2, circumference);
+        int beyondX = Shared.World.WorldConstants.CanonicalChunkX(center.X + 5, circumference);
         bool gotWithinClientView = false;
         bool gotBeyondClientView = false;
         foreach (var key in h.Chunks.Keys)
         {
-            if (key.Item1 == center.X + 2) gotWithinClientView = true;
-            if (key.Item1 == center.X + 5) gotBeyondClientView = true; // beyond radius 3 + the one-ring load-ahead (4) — must never stream
+            if (key.Item1 == withinX) gotWithinClientView = true;
+            if (key.Item1 == beyondX) gotBeyondClientView = true; // beyond radius 3 + the one-ring load-ahead (4) — must never stream
         }
 
         Assert.True(gotWithinClientView, "client's radius-3 view should stream terrain past the host's radius-1 default");


### PR DESCRIPTION
closes #1640

## What

Main has been red for five pushes (since 3bdef058 / #1632) on exactly one test: `JoinAndStreamingTests.ClientViewDistance_ExtendsTheStreamedTerrain_OverTheWire`. PR CI never noticed — the test is tagged `Slow` and PRs skip that tier.

## Cause

The test expects a streamed chunk at `center.X + 2`, comparing **unwrapped** chunk X. Since the dry-pad preference (#1621) the harness seed's spawn pad sits at x ≈ 11736 → column 733 of 735; `735` never arrives because the server streams that column canonically as `0` (observed columns 729…734, 0…2). Streaming is correct; only the comparison ignored the seam.

## Fix

Test-only: both probe columns (`+2` inside the view, `+5` beyond it) go through `WorldConstants.CanonicalChunkX(x, h.Server.World.Circumference)`, the same canonicalisation the server applies to its chunk keys. TODO.md entry.

## Verification

- Local: `dotnet test tests/BlocksBeyondTheStars.Client.Tests --filter JoinAndStreamingTests` → 3/3 passed (was 2/3).
- `dotnet format --verify-no-changes` clean.
- The PR gate will **not** run this test (Slow tier); the next push to `main` after merging is the proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
