### PR TITLE
feat(worldgen): regional style pools, per-world scale, biome relief, 7 new styles, 11 archetypes, planet regimes — every new world rolls its own relief (#1645)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,20 @@ the richer, screenshot-laden versions live there. `(#123)` references the pull r
 
 ## [Unreleased]
 
+### 🏔️ Landscape variety, part 2 of 6 — every new world rolls its own relief (#1645)
+
+- **New worlds only.** A planet type used to have one landscape: every desert a dune sea, every highland a
+  mountain world. New worlds now roll one to three landscape styles from their type's pool and lay them
+  out as regions — a desert can be dune seas next to badlands next to flat country with buttes, a highland
+  mountains next to fjord coasts. Seven new styles join in: island archipelagos, fjordlands, chalk downs,
+  shattered rift country, terraces, drumlin fields and glacial trough highlands.
+- **Each world has its own wavelength.** Hill spacing and dune pitch vary from world to world of the same type.
+- **Biomes shape the ground.** Marsh biomes lie flatter, stone country rises rougher — on the same world.
+- **Rare whole-planet shapes:** tilted worlds (one hemisphere high, one low), three-storey stepped worlds
+  and a ridge girdling the equator. Three new regional landform types (moorland, knob-and-kettle, coastal
+  cliffs) join the blend.
+- Existing worlds are byte-identical (the generation-0 goldens prove it).
+
 ### 🏔️ Landscape variety, part 1 of 6 — the foundation (#1644)
 
 - **Nothing visible changes yet — every existing world stays byte-identical.** New worlds now carry a

--- a/TODO.md
+++ b/TODO.md
@@ -24,6 +24,21 @@ envelope at the WebSocket edge; deterministic seed world-gen; SQLite default per
 
 ---
 
+### ★ Landscape variety 2/6: regional style pools, per-world scale, biome relief, 7 new styles, 11 archetypes, planet regimes (#1645, 2026-09-05, branch landscape/1645-relief)
+
+Generation-1 worlds only (`w.Generation >= 1`; the eight classic goldens are byte-identical, three `*-gen1` groups
+pinned). `PlanetType.TerrainStyles` pools on 16 types → 1–3 styles per body laid out as REGIONS (`StyleOffset`: 70 %
+pure, 30 % offset-space blend band; the #703 hybrid fade on top). `WonderProfile.Scale` = TerrainScale × 0.75–1.35
+per body (relief fields only; biome/forest/pond masks keep the type scale). `Biome.ReliefMul` (mud 0.35, sand 0.8,
+stone 1.3–1.5) through the region-only biome field (`ReliefMulAt`, no altitude feedback). New styles `archipelago`,
+`fjordlands`, `downs`, `shattered`, `terraces`, `drumlins`, `glacial`; archetype pool 8 → 11 (moorland,
+knob-and-kettle, coastal cliffs); baseline regimes tilted (~8 %) / stepped (~3 %) / equatorial ridge (~3 %) in
+`WorldGenerator.Regimes.cs`. `LandscapeReliefTests` (pool coverage, identity purity, scale range, relief-mul
+monotonicity + continuity, style shape probes, determinism/seam/memo, regime rates). Docs: WORLD_GENERATION.md §12.1.
+**Playtest (Marcel):** one new desert + one new highland world — do the style regions read as one world?
+
+---
+
 ### ★ Landscape variety 1/6: terrain-generation flag, terrain tags, landmark + prop tables, WorldGenerator split (#1644, 2026-09-05, branch landscape/1644-infra)
 
 Foundation for the landscape-variety package (#1644–#1649), deliberately **invisible**: all seven worldgen

--- a/data/planets.json
+++ b/data/planets.json
@@ -3,12 +3,13 @@
     "key": "rocky", "baseTemperature": 12, "nameKey": "planet.rocky.name", "atmosphereHeight": 190, "cloudColor": 15593458, "cloudDensity": 0.35,
     "terrainTags": ["buttes", "hoodoos"],
     "baseHeight": 64, "amplitude": 14, "terrainScale": 48.0, "terrainStyle": "mesa",
+    "terrainStyles": ["mesa", "hills", "canyons", "downs"],
     "surfaceBlock": "dirt", "subSurfaceBlock": "dirt", "deepBlock": "stone", "surfaceDepth": 4,
     "caveThreshold": 0.74, "dataCacheRarity": 0.0012, "floraDensity": 0.03, "creatureAbundance": "few", "atmosphere": "toxic", "oxygenExtractability": 0.6, "spawnWeight": 14,
     "biomes": [
-      { "surfaceBlock": "sand",  "subSurfaceBlock": "sand" },
+      { "surfaceBlock": "sand",  "subSurfaceBlock": "sand", "reliefMul": 0.8 },
       { "surfaceBlock": "dirt",  "subSurfaceBlock": "dirt" },
-      { "surfaceBlock": "stone", "subSurfaceBlock": "stone" }
+      { "surfaceBlock": "stone", "subSurfaceBlock": "stone", "reliefMul": 1.5 }
     ],
     "ores": [
       { "block": "gold_ore", "rarity": 0.02, "minDepth": 20, "maxDepth": 2048 },
@@ -24,13 +25,14 @@
   {
     "key": "ice", "floraTheme": "tundra", "baseTemperature": -38, "nameKey": "planet.ice.name", "atmosphereHeight": 200, "cloudColor": 14478069, "cloudDensity": 0.5,
     "baseHeight": 60, "amplitude": 10, "terrainScale": 56.0,
+    "terrainStyles": ["hills", "flats", "glacial"],
     "surfaceBlock": "ice", "subSurfaceBlock": "ice", "deepBlock": "stone", "surfaceDepth": 5,
     "caveThreshold": 0.76, "dataCacheRarity": 0.0015, "floraDensity": 0.04, "creatureAbundance": "few", "atmosphere": "toxic", "oxygenExtractability": 0.5, "spawnWeight": 10,
     "weatherVolatility": 1.25, "seasonAmplitude": 0.3,
     "weatherEvents": { "blizzard": 3.0, "gale": 1.6, "ion_storm": 1.4, "fog": 0.8 },
     "biomes": [
       { "surfaceBlock": "ice",   "subSurfaceBlock": "ice" },
-      { "surfaceBlock": "stone", "subSurfaceBlock": "stone" }
+      { "surfaceBlock": "stone", "subSurfaceBlock": "stone", "reliefMul": 1.5 }
     ],
     "ores": [
       { "block": "iron_ore",   "rarity": 0.07, "minDepth": 4,  "maxDepth": 2048 },
@@ -70,6 +72,7 @@
     "key": "desert", "floraTheme": "desert", "baseTemperature": 44, "nameKey": "planet.desert.name", "atmosphereHeight": 190, "cloudColor": 15260080, "cloudDensity": 0.3,
     "terrainTags": ["buttes"],
     "baseHeight": 62, "amplitude": 10, "terrainScale": 60.0, "terrainStyle": "dunes",
+    "terrainStyles": ["dunes", "badlands", "flats", "downs"],
     "surfaceBlock": "sand", "subSurfaceBlock": "sand", "deepBlock": "stone", "surfaceDepth": 5,
     "caveThreshold": 0.81, "dataCacheRarity": 0.0012,
     "weather": "dynamic", "stormChance": 0.18, "dayLengthSeconds": 640, "worldRadius": 900, "floraDensity": 0.05, "creatureAbundance": "few", "atmosphere": "toxic", "oxygenExtractability": 0.5, "spawnWeight": 12, "waterAbundance": 0.0,
@@ -78,7 +81,7 @@
     "biomes": [
       { "surfaceBlock": "sand",  "subSurfaceBlock": "sand" },
       { "surfaceBlock": "dirt",  "subSurfaceBlock": "dirt" },
-      { "surfaceBlock": "stone", "subSurfaceBlock": "stone" }
+      { "surfaceBlock": "stone", "subSurfaceBlock": "stone", "reliefMul": 1.5 }
     ],
     "ores": [
       { "block": "gold_ore", "rarity": 0.02, "minDepth": 20, "maxDepth": 2048 },
@@ -92,13 +95,14 @@
   {
     "key": "jungle", "floraTheme": "tropical", "baseTemperature": 28, "nameKey": "planet.jungle.name", "atmosphereHeight": 240, "cloudColor": 15922422, "cloudDensity": 0.6,
     "baseHeight": 66, "amplitude": 16, "terrainScale": 44.0,
+    "terrainStyles": ["hills", "karst", "downs"],
     "surfaceBlock": "grass", "subSurfaceBlock": "dirt", "deepBlock": "stone", "surfaceDepth": 4,
     "caveThreshold": 0.70, "dataCacheRarity": 0.0015,
     "weather": "dynamic", "stormChance": 0.65, "dayLengthSeconds": 560, "worldRadius": 800, "floraDensity": 0.14, "treeDensity": 0.045, "creatureAbundance": "many", "atmosphere": "breathable", "spawnWeight": 8,
     "weatherVolatility": 1.35, "seasonAmplitude": 0.45,
     "weatherEvents": { "spore_bloom": 2.0, "drizzle": 1.6, "fog": 1.4, "gale": 0.5 },
     "biomes": [
-      { "surfaceBlock": "mud",   "subSurfaceBlock": "mud", "floraTheme": "swamp", "floraDensityMul": 1.3, "treeDensityMul": 0.7 },
+      { "surfaceBlock": "mud",   "subSurfaceBlock": "mud", "floraTheme": "swamp", "floraDensityMul": 1.3, "treeDensityMul": 0.7, "reliefMul": 0.35 },
       { "surfaceBlock": "grass", "subSurfaceBlock": "dirt", "floraDensityMul": 1.2 },
       { "surfaceBlock": "dirt",  "subSurfaceBlock": "dirt", "floraDensityMul": 0.9, "treeDensityMul": 0.6 }
     ],
@@ -115,6 +119,7 @@
     "key": "crystal", "floraTheme": "crystal", "exotic": true, "baseTemperature": 4, "nameKey": "planet.crystal.name", "atmosphereHeight": 150, "cloudColor": 15128304, "cloudDensity": 0.4,
     "terrainTags": ["crystal"],
     "baseHeight": 60, "amplitude": 18, "terrainScale": 50.0, "terrainStyle": "spires",
+    "terrainStyles": ["spires", "shattered"],
     "surfaceBlock": "crystal", "subSurfaceBlock": "stone", "deepBlock": "stone", "surfaceDepth": 3,
     "caveThreshold": 0.66, "dataCacheRarity": 0.0030,
     "weather": "clear", "stormChance": 0.0, "dayLengthSeconds": 480, "worldRadius": 600, "creatureAbundance": "few", "atmosphere": "none", "oxygenExtractability": 0.0, "spawnWeight": 6,
@@ -134,6 +139,7 @@
   {
     "key": "swamp", "floraTheme": "swamp", "baseTemperature": 22, "nameKey": "planet.swamp.name", "atmosphereHeight": 230, "cloudColor": 13159360, "cloudDensity": 0.75,
     "baseHeight": 58, "amplitude": 8, "terrainScale": 52.0, "terrainStyle": "flats",
+    "terrainStyles": ["flats", "downs"],
     "surfaceBlock": "mud", "subSurfaceBlock": "mud", "deepBlock": "stone", "surfaceDepth": 4,
     "caveThreshold": 0.66, "dataCacheRarity": 0.0015,
     "weather": "overcast", "stormChance": 0.5, "dayLengthSeconds": 600, "worldRadius": 750, "floraDensity": 0.10, "creatureAbundance": "many", "atmosphere": "breathable", "spawnWeight": 8,
@@ -157,10 +163,10 @@
     "caveThreshold": 0.73, "dataCacheRarity": 0.0015,
     "weather": "dynamic", "stormChance": 0.4, "dayLengthSeconds": 600, "worldRadius": 1000, "floraDensity": 0.10, "creatureAbundance": "many", "atmosphere": "breathable", "spawnWeight": 8,
     "biomes": [
-      { "surfaceBlock": "sand",  "subSurfaceBlock": "sand", "floraTheme": "desert", "floraDensityMul": 0.5, "treeDensityMul": 0.3 },
+      { "surfaceBlock": "sand",  "subSurfaceBlock": "sand", "floraTheme": "desert", "floraDensityMul": 0.5, "treeDensityMul": 0.3, "reliefMul": 0.8 },
       { "surfaceBlock": "grass", "subSurfaceBlock": "dirt", "floraTheme": "temperate", "floraDensityMul": 1.2 },
-      { "surfaceBlock": "mud",   "subSurfaceBlock": "mud", "floraTheme": "swamp", "floraDensityMul": 1.2 },
-      { "surfaceBlock": "stone", "subSurfaceBlock": "stone", "floraTheme": "alpine", "floraDensityMul": 0.6 }
+      { "surfaceBlock": "mud",   "subSurfaceBlock": "mud", "floraTheme": "swamp", "floraDensityMul": 1.2, "reliefMul": 0.35 },
+      { "surfaceBlock": "stone", "subSurfaceBlock": "stone", "floraTheme": "alpine", "floraDensityMul": 0.6, "reliefMul": 1.5 }
     ],
     "ores": [
       { "block": "silicate", "rarity": 0.05, "minDepth": 2, "maxDepth": 2048 },
@@ -175,6 +181,7 @@
   {
     "key": "ocean", "floraTheme": "temperate", "baseTemperature": 20, "nameKey": "planet.ocean.name", "atmosphereHeight": 230, "cloudColor": 13623026, "cloudDensity": 0.55,
     "baseHeight": 60, "amplitude": 20, "terrainScale": 60.0, "terrainStyle": "flats",
+    "terrainStyles": ["flats", "archipelago"],
     "surfaceBlock": "grass", "subSurfaceBlock": "dirt", "deepBlock": "stone", "surfaceDepth": 4,
     "caveThreshold": 0.72, "dataCacheRarity": 0.0015,
     "weather": "dynamic", "stormChance": 0.6, "dayLengthSeconds": 580, "worldRadius": 950, "floraDensity": 0.10, "creatureAbundance": "many", "atmosphere": "breathable", "spawnWeight": 12,
@@ -182,8 +189,8 @@
     "weatherEvents": { "gale": 2.2, "fog": 1.8, "drizzle": 1.4 },
     "waterAbundance": 1.2,
     "biomes": [
-      { "surfaceBlock": "sand",  "subSurfaceBlock": "sand" },
-      { "surfaceBlock": "mud",   "subSurfaceBlock": "mud" },
+      { "surfaceBlock": "sand",  "subSurfaceBlock": "sand", "reliefMul": 0.8 },
+      { "surfaceBlock": "mud",   "subSurfaceBlock": "mud", "reliefMul": 0.35 },
       { "surfaceBlock": "grass", "subSurfaceBlock": "dirt" }
     ],
     "ores": [
@@ -199,11 +206,12 @@
     "key": "savanna", "floraTheme": "savanna", "baseTemperature": 32, "nameKey": "planet.savanna.name", "atmosphereHeight": 210, "cloudColor": 15261109, "cloudDensity": 0.3,
     "terrainTags": ["buttes"],
     "baseHeight": 64, "amplitude": 10, "terrainScale": 58.0,
+    "terrainStyles": ["hills", "downs", "flats"],
     "surfaceBlock": "grass", "subSurfaceBlock": "dirt", "deepBlock": "stone", "surfaceDepth": 4,
     "caveThreshold": 0.77, "dataCacheRarity": 0.0013,
     "weather": "dynamic", "stormChance": 0.25, "dayLengthSeconds": 620, "worldRadius": 900, "floraDensity": 0.08, "treeDensity": 0.02, "creatureAbundance": "many", "atmosphere": "breathable", "spawnWeight": 10,
     "biomes": [
-      { "surfaceBlock": "sand",  "subSurfaceBlock": "sand", "floraTheme": "desert", "floraDensityMul": 0.4, "treeDensityMul": 0.2 },
+      { "surfaceBlock": "sand",  "subSurfaceBlock": "sand", "floraTheme": "desert", "floraDensityMul": 0.4, "treeDensityMul": 0.2, "reliefMul": 0.8 },
       { "surfaceBlock": "grass", "subSurfaceBlock": "dirt", "floraDensityMul": 1.0 },
       { "surfaceBlock": "dirt",  "subSurfaceBlock": "dirt", "floraDensityMul": 0.8, "treeDensityMul": 0.6 }
     ],
@@ -219,13 +227,14 @@
   {
     "key": "highland", "floraTheme": "alpine", "baseTemperature": 8, "nameKey": "planet.highland.name", "atmosphereHeight": 280, "cloudColor": 13292509, "cloudDensity": 0.45,
     "baseHeight": 72, "amplitude": 30, "terrainScale": 40.0, "terrainStyle": "mountains",
+    "terrainStyles": ["mountains", "fjordlands", "canyons"],
     "surfaceBlock": "stone", "subSurfaceBlock": "dirt", "deepBlock": "stone", "surfaceDepth": 3,
     "caveThreshold": 0.70, "dataCacheRarity": 0.0016,
     "weather": "dynamic", "stormChance": 0.4, "dayLengthSeconds": 600, "worldRadius": 850, "floraDensity": 0.05, "treeDensity": 0.012, "creatureAbundance": "few", "atmosphere": "breathable", "spawnWeight": 8,
     "biomes": [
       { "surfaceBlock": "grass", "subSurfaceBlock": "dirt" },
       { "surfaceBlock": "dirt",  "subSurfaceBlock": "dirt" },
-      { "surfaceBlock": "stone", "subSurfaceBlock": "stone" }
+      { "surfaceBlock": "stone", "subSurfaceBlock": "stone", "reliefMul": 1.5 }
     ],
     "ores": [
       { "block": "diamond_ore", "rarity": 0.010, "minDepth": 56, "maxDepth": 2048 },
@@ -266,6 +275,7 @@
     "key": "ashen", "floraTheme": "ashen", "exotic": true, "baseTemperature": 70, "nameKey": "planet.ashen.name", "atmosphereHeight": 170, "cloudColor": 7036501, "cloudDensity": 0.65,
     "terrainTags": ["volcanic"],
     "baseHeight": 58, "amplitude": 18, "terrainScale": 44.0, "terrainStyle": "mountains",
+    "terrainStyles": ["mountains", "shattered", "badlands"],
     "surfaceBlock": "ash", "subSurfaceBlock": "basalt", "deepBlock": "basalt", "surfaceDepth": 3,
     "caveThreshold": 0.72, "dataCacheRarity": 0.0020,
     "weather": "overcast", "stormChance": 0.3, "dayLengthSeconds": 540, "worldRadius": 720, "floraDensity": 0.05, "creatureAbundance": "few", "atmosphere": "toxic", "oxygenExtractability": 0.25, "spawnWeight": 5,
@@ -288,6 +298,7 @@
   {
     "key": "tundra", "floraTheme": "tundra", "baseTemperature": -22, "nameKey": "planet.tundra.name", "atmosphereHeight": 220, "cloudColor": 14606326, "cloudDensity": 0.5,
     "baseHeight": 62, "amplitude": 14, "terrainScale": 52.0, "terrainStyle": "hills",
+    "terrainStyles": ["hills", "downs", "drumlins"],
     "surfaceBlock": "snow", "subSurfaceBlock": "dirt", "deepBlock": "stone", "surfaceDepth": 4,
     "caveThreshold": 0.74, "dataCacheRarity": 0.0015,
     "weather": "dynamic", "stormChance": 0.5, "dayLengthSeconds": 620, "worldRadius": 820, "floraDensity": 0.05, "treeDensity": 0.008, "creatureAbundance": "few", "atmosphere": "breathable", "spawnWeight": 8,
@@ -296,7 +307,7 @@
     "biomes": [
       { "surfaceBlock": "dirt",  "subSurfaceBlock": "dirt", "floraDensityMul": 0.8 },
       { "surfaceBlock": "snow",  "subSurfaceBlock": "dirt", "floraDensityMul": 1.0 },
-      { "surfaceBlock": "stone", "subSurfaceBlock": "stone", "floraTheme": "alpine", "floraDensityMul": 0.6 }
+      { "surfaceBlock": "stone", "subSurfaceBlock": "stone", "floraTheme": "alpine", "floraDensityMul": 0.6, "reliefMul": 1.5 }
     ],
     "ores": [
       { "block": "iron_ore",   "rarity": 0.07, "minDepth": 4,  "maxDepth": 2048 },
@@ -311,6 +322,7 @@
   {
     "key": "fungal", "floraTheme": "fungal", "exotic": true, "baseTemperature": 18, "nameKey": "planet.fungal.name", "atmosphereHeight": 220, "cloudColor": 9337256, "cloudDensity": 0.6,
     "baseHeight": 60, "amplitude": 14, "terrainScale": 48.0, "terrainStyle": "hills",
+    "terrainStyles": ["hills", "karst", "downs"],
     "surfaceBlock": "mycelium", "subSurfaceBlock": "dirt", "deepBlock": "stone", "surfaceDepth": 4,
     "caveThreshold": 0.64, "dataCacheRarity": 0.0022,
     "weather": "overcast", "stormChance": 0.3, "dayLengthSeconds": 600, "worldRadius": 780, "floraDensity": 0.13, "creatureAbundance": "many", "atmosphere": "toxic", "oxygenExtractability": 0.5, "spawnWeight": 5,
@@ -318,7 +330,7 @@
     "weatherEvents": { "spore_bloom": 3.2, "ground_fog": 2.0, "acid_rain": 1.2, "drizzle": 1.3 },
     "biomes": [
       { "surfaceBlock": "mycelium", "subSurfaceBlock": "dirt" },
-      { "surfaceBlock": "mud",      "subSurfaceBlock": "mud" },
+      { "surfaceBlock": "mud",      "subSurfaceBlock": "mud", "reliefMul": 0.35 },
       { "surfaceBlock": "dirt",     "subSurfaceBlock": "dirt" }
     ],
     "ores": [
@@ -335,13 +347,14 @@
     "key": "corrupted", "floraTheme": "alien", "exotic": true, "baseTemperature": 24, "nameKey": "planet.corrupted.name", "atmosphereHeight": 230, "cloudColor": 8030298, "cloudDensity": 0.55,
     "terrainTags": ["buttes", "hoodoos"],
     "baseHeight": 64, "amplitude": 16, "terrainScale": 46.0, "terrainStyle": "canyons",
+    "terrainStyles": ["canyons", "shattered", "badlands"],
     "surfaceBlock": "alien_grass", "subSurfaceBlock": "dirt", "deepBlock": "stone", "surfaceDepth": 4,
     "caveThreshold": 0.70, "dataCacheRarity": 0.0026,
     "weather": "dynamic", "stormChance": 0.45, "dayLengthSeconds": 580, "worldRadius": 820, "floraDensity": 0.12, "creatureAbundance": "many", "atmosphere": "toxic", "oxygenExtractability": 0.45, "spawnWeight": 5, "floatingIslands": true,
     "biomes": [
       { "surfaceBlock": "alien_grass", "subSurfaceBlock": "dirt", "floraDensityMul": 1.2 },
-      { "surfaceBlock": "mud",         "subSurfaceBlock": "mud", "floraTheme": "swamp", "floraDensityMul": 1.0 },
-      { "surfaceBlock": "stone",       "subSurfaceBlock": "stone", "floraDensityMul": 0.5 }
+      { "surfaceBlock": "mud",         "subSurfaceBlock": "mud", "floraTheme": "swamp", "floraDensityMul": 1.0, "reliefMul": 0.35 },
+      { "surfaceBlock": "stone",       "subSurfaceBlock": "stone", "floraDensityMul": 0.5, "reliefMul": 1.3 }
     ],
     "ores": [
       { "block": "diamond_ore",  "rarity": 0.012, "minDepth": 52, "maxDepth": 2048 },
@@ -398,12 +411,13 @@
     "key": "tablelands", "floraTheme": "savanna", "baseTemperature": 24, "nameKey": "planet.tablelands.name", "atmosphereHeight": 200, "cloudColor": 15450749, "cloudDensity": 0.25,
     "terrainTags": ["buttes", "hoodoos"],
     "baseHeight": 62, "amplitude": 26, "terrainScale": 58.0, "terrainStyle": "tablelands",
+    "terrainStyles": ["tablelands", "terraces", "mesa"],
     "surfaceBlock": "granite", "subSurfaceBlock": "granite", "deepBlock": "stone", "surfaceDepth": 4,
     "caveThreshold": 0.74, "dataCacheRarity": 0.0012,
     "weather": "clear", "stormChance": 0.15, "dayLengthSeconds": 640, "worldRadius": 900, "floraDensity": 0.05, "waterAbundance": 0.35, "creatureAbundance": "few", "atmosphere": "breathable", "oxygenExtractability": 0.8, "spawnWeight": 6,
     "biomes": [
       { "surfaceBlock": "sand",    "subSurfaceBlock": "sand" },
-      { "surfaceBlock": "granite", "subSurfaceBlock": "granite" },
+      { "surfaceBlock": "granite", "subSurfaceBlock": "granite", "reliefMul": 1.3 },
       { "surfaceBlock": "grass",   "subSurfaceBlock": "dirt" }
     ],
     "ores": [
@@ -419,13 +433,14 @@
     "key": "badlands", "floraTheme": "desert", "baseTemperature": 38, "nameKey": "planet.badlands.name", "atmosphereHeight": 190, "cloudColor": 15593458, "cloudDensity": 0.2,
     "terrainTags": ["buttes", "hoodoos"],
     "baseHeight": 60, "amplitude": 16, "terrainScale": 40.0, "terrainStyle": "badlands",
+    "terrainStyles": ["badlands", "canyons", "terraces"],
     "surfaceBlock": "sand", "subSurfaceBlock": "granite", "deepBlock": "stone", "surfaceDepth": 3,
     "caveThreshold": 0.73, "dataCacheRarity": 0.0014,
     "weather": "clear", "stormChance": 0.2, "dayLengthSeconds": 600, "worldRadius": 850, "floraDensity": 0.03, "waterAbundance": 0.1, "creatureAbundance": "few", "atmosphere": "toxic", "oxygenExtractability": 0.5, "spawnWeight": 5,
     "biomes": [
       { "surfaceBlock": "sand",    "subSurfaceBlock": "sand" },
       { "surfaceBlock": "granite", "subSurfaceBlock": "granite" },
-      { "surfaceBlock": "stone",   "subSurfaceBlock": "stone" }
+      { "surfaceBlock": "stone",   "subSurfaceBlock": "stone", "reliefMul": 1.3 }
     ],
     "ores": [
       { "block": "copper_ore",   "rarity": 0.05, "minDepth": 4,  "maxDepth": 2048 },
@@ -440,13 +455,14 @@
   {
     "key": "karst", "floraTheme": "tropical", "exotic": true, "baseTemperature": 27, "nameKey": "planet.karst.name", "atmosphereHeight": 210, "cloudColor": 14210014, "cloudDensity": 0.5,
     "baseHeight": 60, "amplitude": 18, "terrainScale": 46.0, "terrainStyle": "karst",
+    "terrainStyles": ["karst", "hills", "downs"],
     "surfaceBlock": "grass", "subSurfaceBlock": "dirt", "deepBlock": "stone", "surfaceDepth": 4,
     "caveThreshold": 0.68, "dataCacheRarity": 0.0016,
     "weather": "dynamic", "stormChance": 0.35, "dayLengthSeconds": 580, "worldRadius": 850, "floraDensity": 0.12, "waterAbundance": 0.5, "creatureAbundance": "many", "atmosphere": "breathable", "spawnWeight": 4,
     "biomes": [
-      { "surfaceBlock": "mud",   "subSurfaceBlock": "mud" },
+      { "surfaceBlock": "mud",   "subSurfaceBlock": "mud", "reliefMul": 0.35 },
       { "surfaceBlock": "grass", "subSurfaceBlock": "dirt" },
-      { "surfaceBlock": "stone", "subSurfaceBlock": "stone" }
+      { "surfaceBlock": "stone", "subSurfaceBlock": "stone", "reliefMul": 1.5 }
     ],
     "ores": [
       { "block": "silicate",    "rarity": 0.05, "minDepth": 2,  "maxDepth": 2048 },

--- a/docs/developer/ARCHITECTURE.md
+++ b/docs/developer/ARCHITECTURE.md
@@ -97,7 +97,7 @@ feature files. It is **single-threaded and tick-driven** by design (`GameServer.
   backups via `CreateBackup`. See [SELF_HOSTING.md](SELF_HOSTING.md).
 - **WorldGen** — `WorldGeneration/WorldGenerator.cs` (+ its `WorldGenerator.*.cs` partials, one per
   seam: relief, landmarks, overhangs, underground, craters, calibration, fluids, columns, stamps, biomes,
-  flora — #1644) is **seed-deterministic**: given a seed,
+  flora — #1644; regimes + the generation-1 relief rolls — #1645) is **seed-deterministic**: given a seed,
   `PlanetType` and `ChunkCoord` it always yields the same blocks, so the procedural baseline is
   never stored. `UniverseGenerator` builds the galaxy of systems/bodies from the seed; flora,
   settlements, stations, creatures, wrecks and landing-pad flattening are all deterministic

--- a/docs/developer/WORLD_GENERATION.md
+++ b/docs/developer/WORLD_GENERATION.md
@@ -614,5 +614,49 @@ drama, grain, continents, the regional blend), `.Landmarks`, `.Overhangs`, `.Und
 `.Flora`. Pure moves; the core file keeps the constructor, the mode setters, the per-world profile and
 `SurfaceHeight`.
 
-Parts 2–6 (regional style pools, per-world scale, biome relief, new styles and landmarks, water bodies,
-paints, props, trees, data-only planet types, monument archetypes) are documented here as they land.
+### 12.1 Part 2 — relief variety (#1645, generation ≥ 1)
+
+Everything below reads `w.Generation >= 1`; a generation-0 world takes the classic value at every step
+(single type style, the type's `TerrainScale`, no multipliers, no regimes), so the eight classic golden
+groups stay byte-identical while three new groups (`varied-gen1`, `desert-gen1`, `highland-gen1`) pin the
+generation-1 relief.
+
+**Style pools, regionally mixed — `PlanetType.TerrainStyles`.** A styled type lists a pool
+(desert `[dunes, badlands, flats, downs]`, highland `[mountains, fjordlands, canyons]`, ocean
+`[flats, archipelago]`, tundra `[hills, downs, drumlins]`, …; 16 types carry one). `WonderFor` rolls 1–3
+of them per body (25 % / 45 % / 30 %, seeded Fisher–Yates like the biome subset) into
+`WonderProfile.Styles`. `StyleOffset` partitions the surface with a broad field (`Scale × 8`) into
+contiguous style regions — 70 % of each region is one pure style, the 30 % boundary band smoothstep-blends
+the two neighbours' OFFSETS (the archetype blend's method; decks and spires cannot be blended as
+parameters). The #703 hybrid fade stays on top and runs on every multi-style world; identity styles
+(`flats`, `spires`) stay pure only as the sole pick. An empty pool keeps the single `TerrainStyle`.
+
+**Per-world scale — `WonderProfile.Scale`.** `TerrainScale × 0.75–1.35`, one roll per body. Every relief
+field (base swell, styles, archetypes, the hybrid and region fields) reads `w.Scale`; the biome, forest
+and pond masks keep `planet.TerrainScale` so flora patch sizes do not move.
+
+**Biome relief — `Biome.ReliefMul`.** Multiplies the style/archetype relief (never the baseline or a
+landmark) under a biome: mud 0.35, sand 0.8, stone/granite 1.3–1.5 in `planets.json`. Read through the
+biome REGION field alone (`ReliefMulAt`, the same FBM `BiomeIndex` spreads, without its altitude share),
+so relief cannot feed back into its own multiplier; a ±10 % band around each region boundary lerps the
+two multipliers. `WonderProfile.ReliefMuls` is null (no extra sample) when no resolved biome differs from 1.
+
+**New styles** (cases in `StyledHeightOffset`): `archipelago` (flats + one island dome per 120-block
+hotspot cell, 60 % of cells, r 25–60), `fjordlands` (mountains with deep broad troughs that flood into
+fjords), `downs` (very smooth at `Scale × 2.5`), `shattered` (2–3 straight rifts per 900-block cell at
+fixed angles, 2.2 × amplitude deep), `terraces` (mesa quantisation, fine step, no roll), `drumlins`
+(rounded whalebacks along the grain), `glacial` (broad U-troughs along the grain). `KnownTerrainStyles`
+lists every style name; a test checks every pooled name against it.
+
+**Archetype pool 8 → 11.** `ArchetypePoolFor(w)` returns 11 from generation 1 — `moorland` (flats with
+pans the pond mask fills), `knob-and-kettle` (dense domes and pits), `coastal cliffs` (a relief step
+where the swell crosses zero). The subset roll depends on the pool size, so it stays 8 on generation 0.
+
+**Baseline regimes** (`WorldGenerator.Regimes.cs`, part of the baseline like the escarpment): `tilted`
+(~8 %, a latitude sine of 20–40 blocks — one hemisphere high, one low), `stepped` (~3 %, a second
+escarpment at its own latitude → three storeys; the first escarpment is forced on), `equatorial ridge`
+(~3 %, a 30–60-block wall 24–44 wide girdling the planet along X, meandering like the mega-rift).
+Never on sky, void or cratered worlds.
+
+Parts 3–6 (new landmarks, water bodies, paints, props, trees, data-only planet types, monument archetypes)
+are documented here as they land.

--- a/src/BlocksBeyondTheStars.Shared/Definitions/PlanetType.cs
+++ b/src/BlocksBeyondTheStars.Shared/Definitions/PlanetType.cs
@@ -20,6 +20,11 @@ public sealed class Biome
 
     /// <summary>Per-biome multiplier on tree density (1.0 = the planet's tree density; 0 = a treeless biome).</summary>
     public double TreeDensityMul { get; set; } = 1.0;
+
+    /// <summary>Per-biome multiplier on the RELIEF under it (#1645, terrain generation 1 only): a mud marsh at
+    /// 0.35 lies flat next to stone country at 1.5 on the same world. Applies to the style/archetype relief,
+    /// never to the baseline (continents, escarpments) or landmarks. 1.0 = the planet's relief.</summary>
+    public double ReliefMul { get; set; } = 1.0;
 }
 
 /// <summary>An ore vein generation rule for a planet type.</summary>
@@ -66,6 +71,13 @@ public sealed class PlanetType
     /// the surface). Other values reshape the heightmap: "flats", "hills", "mountains", "canyons",
     /// "mesa" (terraced plateaus + cliffs), "dunes" (parallel sand ridges), "spires" (sparse tall spikes).</summary>
     public string TerrainStyle { get; set; } = string.Empty;
+
+    /// <summary>The style POOL (#1645, terrain generation 1): a world of this type rolls 1–3 of these styles
+    /// and lays them out as regions blended in offset space, so one desert is a dune sea, the next badlands
+    /// with dune fields, the third flats with buttes. Empty = the single <see cref="TerrainStyle"/> (every
+    /// generation-0 world ignores the pool). Same style names as <see cref="TerrainStyle"/> plus the
+    /// generation-1 styles ("archipelago", "fjordlands", "downs", "shattered", "terraces", "drumlins", "glacial").</summary>
+    public List<string> TerrainStyles { get; set; } = new();
 
     /// <summary>Terrain feature tags this type opts into (#1644): "volcanic", "salt", "buttes", "hoodoos",
     /// "crystal", "wind", "wetland", "glacial", "inselbergs" (see <see cref="TerrainTag"/>). The generator gates

--- a/src/BlocksBeyondTheStars.WorldGeneration/WorldGenerator.Biomes.cs
+++ b/src/BlocksBeyondTheStars.WorldGeneration/WorldGenerator.Biomes.cs
@@ -17,13 +17,15 @@ public sealed partial class WorldGenerator
     /// and another sparse + arid within the same world).</summary>
     internal readonly struct BiomeResolved
     {
-        public BiomeResolved(BlockId surface, BlockId sub, double floraMul, double treeMul, FloraThemes.Theme theme)
+        public BiomeResolved(BlockId surface, BlockId sub, double floraMul, double treeMul, FloraThemes.Theme theme,
+            double reliefMul = 1.0)
         {
             Surface = surface;
             Sub = sub;
             FloraMul = floraMul;
             TreeMul = treeMul;
             Theme = theme;
+            ReliefMul = reliefMul;
         }
 
         public BlockId Surface { get; }
@@ -31,6 +33,9 @@ public sealed partial class WorldGenerator
         public double FloraMul { get; }
         public double TreeMul { get; }
         public FloraThemes.Theme Theme { get; }
+
+        /// <summary>Relief multiplier under this biome (#1645, generation 1 only; 1 = the planet's relief).</summary>
+        public double ReliefMul { get; }
     }
 
     /// <summary>
@@ -79,7 +84,7 @@ public sealed partial class WorldGenerator
             var b = planet.Biomes[order[i]];
             var theme = string.IsNullOrWhiteSpace(b.FloraTheme) ? planetTheme : FloraThemes.Resolve(b.FloraTheme);
             list.Add(new BiomeResolved(ResolveBlock(b.SurfaceBlock), ResolveBlock(b.SubSurfaceBlock),
-                b.FloraDensityMul, b.TreeDensityMul, theme));
+                b.FloraDensityMul, b.TreeDensityMul, theme, b.ReliefMul));
         }
 
         return list;

--- a/src/BlocksBeyondTheStars.WorldGeneration/WorldGenerator.Regimes.cs
+++ b/src/BlocksBeyondTheStars.WorldGeneration/WorldGenerator.Regimes.cs
@@ -1,0 +1,183 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using BlocksBeyondTheStars.Shared.Definitions;
+using BlocksBeyondTheStars.Shared.World;
+
+namespace BlocksBeyondTheStars.WorldGeneration;
+
+/// <summary>Generation-1 whole-planet baseline regimes and the per-world relief rolls (#1645): style pools,
+/// scale jitter, biome relief multipliers, tilted / stepped / ridged worlds (partial of <see cref="WorldGenerator"/>).</summary>
+public sealed partial class WorldGenerator
+{
+    // --- Baseline regimes: rare rolls that shape the WHOLE planet under styles and landmarks, like the
+    // escarpment (#702). Generation 1 only — the profile never sets them on a generation-0 world. ---
+    private const double TiltChance = 20 / 256.0;        // ~8 % of eligible worlds
+    private const double SteppedChance = 8 / 256.0;      // ~3 %: a second escarpment → three storeys
+    private const double EquatorRidgeChance = 8 / 256.0; // ~3 %: the Iapetus ridge
+    private const long SteppedSeedSalt = 0x57E99ED1;     // the second escarpment's own latitude / step / band
+
+    /// <summary>Solid ground with a real surface: the regimes never touch sky worlds, void interiors or
+    /// cratered regolith (whose flat identity is the point).</summary>
+    private bool RegimeGround(PlanetType planet)
+        => !planet.FloatingIslands && !planet.Void && !planet.Cratered && !_crateredWorld;
+
+    private bool HasTilt(PlanetType planet, long seed)
+        => RegimeGround(planet) && (Noise.Hash(seed ^ 0x71170001, 3, 5, 7) & 0xFF) < 256 * TiltChance;
+
+    private bool HasStepped(PlanetType planet, long seed)
+        => RegimeGround(planet) && (Noise.Hash(seed ^ 0x57E99ED0, 2, 6, 4) & 0xFF) < 256 * SteppedChance;
+
+    private bool HasEquatorRidge(PlanetType planet, long seed)
+        => RegimeGround(planet) && (Noise.Hash(seed ^ 0x0E9A70A1, 5, 3, 9) & 0xFF) < 256 * EquatorRidgeChance;
+
+    /// <summary>Tilted world: one hemisphere sits 20–40 blocks higher than the other, changing gradually
+    /// across the latitudes. A sine of the latitude (period = the north–south wrap) so the torus closes;
+    /// the biome altitude blend then reads the low half as lowlands and the high half as uplands.</summary>
+    private double TiltOffset(long seed, int worldZ)
+    {
+        ulong h = Noise.Hash(seed ^ 0x71170002, 1, 1, 1);
+        double amp = 20.0 + ((h >> 8) & 0x3FF) / 1023.0 * 20.0;     // 20..40
+        double phase = ((h >> 18) & 0x3FF) / 1023.0 * System.Math.PI * 2.0;
+        return amp * System.Math.Sin(System.Math.PI * 2.0 * worldZ / LatPeriod + phase);
+    }
+
+    private const double EquatorRidgeMeanderFrac = 0.06; // meander amplitude as a fraction of the latitude period
+    private const double EquatorRidgeMaxHalfWidth = 22.0;
+
+    /// <summary>The equatorial ridge's (positive) height contribution (#1645): a 30–60-block wall 24–44 wide
+    /// girdling the planet along X at a rolled latitude, meandering like the mega-rift (an X-only torus FBM,
+    /// so the ridge closes on itself after a circumnavigation). A cheap band reject keeps far columns free.</summary>
+    private double EquatorialRidgeOffset(long seed, int worldX, int worldZ)
+    {
+        ulong h = Noise.Hash(seed ^ 0x0E9A70A2, 4, 2, 8);
+        int period = LatPeriod;
+        double z0 = ((((h >> 8) & 0x3FF) / 1023.0) - 0.5) * period;
+        double halfWidth = 12.0 + ((h >> 18) & 0x3FF) / 1023.0 * (EquatorRidgeMaxHalfWidth - 12.0); // 12..22
+        double height = 30.0 + ((h >> 28) & 0x3FF) / 1023.0 * 30.0;                                 // 30..60
+
+        double band = period * EquatorRidgeMeanderFrac + EquatorRidgeMaxHalfWidth * 1.5;
+        double dz0 = WorldConstants.WrapDeltaZ(worldZ - z0, _circumference);
+        if (System.Math.Abs(dz0) > band)
+        {
+            return 0.0;
+        }
+
+        double meander = (FbmT(seed + 0x0E9A70A3, worldX, 0.0, _circumference / 6.0, octaves: 2) - 0.5)
+            * 2.0 * (period * EquatorRidgeMeanderFrac);
+        double dz = WorldConstants.WrapDeltaZ(worldZ - z0 - meander, _circumference);
+        double u = System.Math.Abs(dz) / halfWidth;
+        if (u >= 1.0)
+        {
+            return 0.0;
+        }
+
+        double t = 1.0 - u * u;              // rounded crest
+        return height * System.Math.Pow(t, 1.5);
+    }
+
+    /// <summary>The regimes rolled for this world (tests).</summary>
+    internal (bool Tilted, bool Stepped, bool EquatorRidge, bool Escarpment) RegimesForTest(PlanetType planet)
+    {
+        var w = WonderFor(planet);
+        return (w.Tilted, w.Stepped, w.EquatorRidge, w.Escarpment);
+    }
+
+    /// <summary>The tilt offset at a latitude (tests).</summary>
+    internal double TiltOffsetForTest(PlanetType planet, int worldZ) => TiltOffset(WonderFor(planet).Seed, worldZ);
+
+    /// <summary>The equatorial ridge offset at a column (tests).</summary>
+    internal double EquatorialRidgeOffsetForTest(PlanetType planet, int worldX, int worldZ)
+        => EquatorialRidgeOffset(WonderFor(planet).Seed, worldX, worldZ);
+
+    // --- Per-world relief rolls (#1645): the style pick, the scale jitter and the biome multipliers, resolved
+    // once in WonderFor. Generation-0 worlds take the classic values (single type style, type scale, no
+    // multipliers) so every existing world stays byte-identical. ---
+
+    /// <summary>The styles this world lays out as regions (#1645): 1–3 picks from the type's
+    /// <see cref="PlanetType.TerrainStyles"/> pool (Fisher–Yates seeded like the biome subset; a pool of one,
+    /// or no pool, keeps the type's single <see cref="PlanetType.TerrainStyle"/>). Lowered once.</summary>
+    private static string[] PickStyles(PlanetType planet, long seed, string loweredStyle)
+    {
+        var pool = new System.Collections.Generic.List<string>();
+        foreach (var s in planet.TerrainStyles)
+        {
+            if (string.IsNullOrWhiteSpace(s))
+            {
+                continue;
+            }
+
+            string lowered = s.Trim().ToLowerInvariant();
+            if (!pool.Contains(lowered))
+            {
+                pool.Add(lowered);
+            }
+        }
+
+        if (pool.Count == 0)
+        {
+            return loweredStyle.Length != 0 ? new[] { loweredStyle } : System.Array.Empty<string>();
+        }
+
+        if (pool.Count == 1)
+        {
+            return new[] { pool[0] };
+        }
+
+        // 25 % one style, 45 % two, 30 % three (capped by the pool) — most worlds mix, a quarter stay whole.
+        ulong u = Noise.Hash(seed ^ 0x57F00, 4, 4, 2);
+        double roll = (u & 0x3FF) / 1023.0;
+        int k = roll < 0.25 ? 1 : roll < 0.70 ? 2 : 3;
+        k = System.Math.Min(k, pool.Count);
+
+        var order = pool.ToArray();
+        var rng = new DeterministicRandom((seed ^ 0x57F07) * 2654435761L);
+        for (int i = order.Length - 1; i > 0; i--)
+        {
+            int j = rng.Range(0, i);
+            (order[i], order[j]) = (order[j], order[i]);
+        }
+
+        var picked = new string[k];
+        System.Array.Copy(order, picked, k);
+        return picked;
+    }
+
+    /// <summary>The per-world relief wavelength (#1645): the type's TerrainScale × 0.75–1.35, so two worlds of
+    /// one type roll different hill spacing / dune pitch.</summary>
+    private static double ScaleJitterFor(PlanetType planet, long seed)
+    {
+        ulong u = Noise.Hash(seed ^ 0x5CA1E, 3, 1, 4);
+        return planet.TerrainScale * (0.75 + 0.6 * ((u & 0x3FF) / 1023.0));
+    }
+
+    /// <summary>The resolved biomes' relief multipliers in biome order (#1645), or null when the world has a
+    /// single biome or every multiplier is 1 — the hot path then skips the extra field sample.</summary>
+    private double[]? ReliefMulsFor(PlanetType planet)
+    {
+        var biomes = ResolveBiomes(planet);
+        if (biomes.Count <= 1)
+        {
+            return null;
+        }
+
+        bool any = false;
+        var muls = new double[biomes.Count];
+        for (int i = 0; i < biomes.Count; i++)
+        {
+            muls[i] = biomes[i].ReliefMul;
+            any |= System.Math.Abs(muls[i] - 1.0) > 1e-9;
+        }
+
+        return any ? muls : null;
+    }
+
+    /// <summary>The styles this world lays out (tests): empty on an archetype-blend world.</summary>
+    internal string[] StylesForTest(PlanetType planet) => WonderFor(planet).Styles;
+
+    /// <summary>The relief wavelength of this world (tests).</summary>
+    internal double ScaleForTest(PlanetType planet) => WonderFor(planet).Scale;
+
+    /// <summary>Whether the style×archetype hybrid fade runs on this world (tests).</summary>
+    internal bool HybridEligibleForTest(PlanetType planet) => WonderFor(planet).HybridEligible;
+}

--- a/src/BlocksBeyondTheStars.WorldGeneration/WorldGenerator.Relief.cs
+++ b/src/BlocksBeyondTheStars.WorldGeneration/WorldGenerator.Relief.cs
@@ -16,7 +16,7 @@ public sealed partial class WorldGenerator
     /// <paramref name="h"/> is the base FBM swell in [-1,1]. Archetypes are explicit shapes rather than
     /// (amplitude, ridged) parameter pairs because the #576 additions — quantised decks, asymmetric
     /// gorges — cannot be expressed as parameters of one shared formula; the regional blend therefore
-    /// lerps computed OFFSETS, not parameters.</summary>
+    /// lerps computed OFFSETS, not parameters. Entries 8–10 exist on generation-1 worlds only (#1645).</summary>
     private double ArchetypeOffset(int archetype, PlanetType planet, WonderProfile w, long seed, double h, int worldX, int worldZ)
     {
         double amp = planet.Amplitude;
@@ -29,7 +29,7 @@ public sealed partial class WorldGenerator
             case 2: return h * amp * 1.00; // hills
             case 3: // mountains (lightly ridged; #700 — a directional share so ranges chain along the grain)
                 return (h * 0.58 + Ridge(h) * 0.12
-                        + OrientedRidge(seed, w.Grain, worldX, worldZ, planet.TerrainScale * 0.9) * 0.30)
+                        + OrientedRidge(seed, w.Grain, worldX, worldZ, w.Scale * 0.9) * 0.30)
                     * amp * 1.9;
             case 4: // canyons (strongly ridged)
                 return (h * 0.35 + Ridge(h) * 0.65) * amp * 1.3;
@@ -38,14 +38,14 @@ public sealed partial class WorldGenerator
                     double raw = h * amp * 1.05;
                     double step = System.Math.Max(5.0, amp * 0.5);
                     double deck = System.Math.Floor(raw / step) * step;
-                    double roll = FbmT(seed + 0x9D3C, worldX, worldZ, planet.TerrainScale * 0.5, octaves: 2);
+                    double roll = FbmT(seed + 0x9D3C, worldX, worldZ, w.Scale * 0.5, octaves: 2);
                     return deck + (roll - 0.5) * 2.0; // ±1-block texture so decks read as rock, not glass
                 }
 
             case 6: // extreme peaks (#576): the far tail of relief, well above the mountains archetype
                 {
                     // #700: the extreme crests follow the world's grain too — the tallest ranges chain.
-                    double or6 = OrientedRidge(seed, w.Grain, worldX, worldZ, planet.TerrainScale * 0.9);
+                    double or6 = OrientedRidge(seed, w.Grain, worldX, worldZ, w.Scale * 0.9);
                     double r = h * 0.25 + Ridge(h) * 0.45 + or6 * 0.30;
                     if (r > 0)
                     {
@@ -55,11 +55,33 @@ public sealed partial class WorldGenerator
                     return r * amp * 3.4;
                 }
 
-            default: // 7: rift gorges (#576): gentle ground gashed by deep ridged canyons
+            case 7: // rift gorges (#576): gentle ground gashed by deep ridged canyons
                 {
                     double g = Ridge(h);
                     double swell = h * amp * 0.3;
                     return g > 0 ? swell - System.Math.Pow(g, 2.2) * amp * 3.0 : swell;
+                }
+
+            case 8: // moorland (#1645): near-flat heath dimpled with shallow pans — the pond mask fills them
+                {
+                    double p = FbmT(seed + 0x3003, worldX, worldZ, w.Scale * 0.35, octaves: 2);
+                    double pan = p < 0.3 ? -(0.3 - p) / 0.3 * amp * 0.35 : 0.0;
+                    return h * amp * 0.3 + pan;
+                }
+
+            case 9: // knob-and-kettle (#1645): dense small domes and pits, glacial-drift country
+                {
+                    double k = FbmT(seed + 0x4E0B, worldX, worldZ, w.Scale * 0.3, octaves: 3);
+                    double c = k * 2.0 - 1.0;
+                    double sharp = System.Math.Sign(c) * System.Math.Pow(System.Math.Abs(c), 0.7);
+                    return h * amp * 0.4 + sharp * amp * 0.9;
+                }
+
+            default: // 10: coastal cliffs (#1645): a relief step where the swell crosses zero — cliff lines, not ramps
+                {
+                    double s = System.Math.Clamp((h + 0.05) / 0.10, 0.0, 1.0);
+                    s = s * s * (3.0 - 2.0 * s);
+                    return h * amp * 0.6 + (s - 0.5) * amp * 1.2;
                 }
         }
     }
@@ -92,7 +114,7 @@ public sealed partial class WorldGenerator
     private int RawSurfaceHeight(PlanetType planet, WonderProfile w, int worldX, int worldZ)
     {
         long seed = w.Seed;
-        double n = FbmT(seed, worldX, worldZ, planet.TerrainScale, octaves: 4);
+        double n = FbmT(seed, worldX, worldZ, w.Scale, octaves: 4);
         double h = (n - 0.5) * 2.0; // [-1, 1] base rolling terrain
 
         // Airless moons + landable asteroids (item 33): mostly flat regolith (a gentle undulation only — no
@@ -118,6 +140,23 @@ public sealed partial class WorldGenerator
             baseline += EscarpmentOffset(seed, worldX, worldZ);
         }
 
+        // Generation-1 baseline regimes (#1645): a second escarpment (three storeys), a tilted world, an
+        // equatorial ridge. Rare rolls, all part of the baseline like the escarpment.
+        if (w.Stepped)
+        {
+            baseline += EscarpmentOffset(seed ^ SteppedSeedSalt, worldX, worldZ);
+        }
+
+        if (w.Tilted)
+        {
+            baseline += TiltOffset(seed, worldZ);
+        }
+
+        if (w.EquatorRidge)
+        {
+            baseline += EquatorialRidgeOffset(seed, worldX, worldZ);
+        }
+
         // Salt polygons (#701): the cracked-plate ridge network of salt pans.
         if (w.SaltPolygons)
         {
@@ -133,13 +172,15 @@ public sealed partial class WorldGenerator
         // A planet may dictate an overall terrain SHAPE (item 21 V2) so worlds read structurally different —
         // mesas, dunes, spires, etc. — instead of every world using the same mixed blend. Since #703 a broad
         // fade field hands 20–40 % of most styled worlds to the archetype blend, so a dunes world has gravel
-        // plains between its dune seas instead of being dunes from pole to pole.
-        if (w.Style.Length != 0)
+        // plains between its dune seas instead of being dunes from pole to pole. Generation-1 worlds (#1645)
+        // roll 1–3 styles from the type's pool and lay them out as REGIONS (see StyleOffset).
+        double relief;
+        if (w.Styles.Length != 0)
         {
-            double styled = StyledHeightOffset(planet, w, seed, h, worldX, worldZ);
+            double styled = StyleOffset(planet, w, seed, h, worldX, worldZ);
             if (w.HybridEligible)
             {
-                double fade = FbmT(seed + 0x57FAD1, worldX, worldZ, planet.TerrainScale * 6.0, octaves: 2);
+                double fade = FbmT(seed + 0x57FAD1, worldX, worldZ, w.Scale * 6.0, octaves: 2);
                 if (fade < w.HybridB)
                 {
                     double arch = BlendedArchetypeOffset(planet, w, seed, h, worldX, worldZ);
@@ -155,13 +196,25 @@ public sealed partial class WorldGenerator
                 }
             }
 
-            return planet.BaseHeight + (int)System.Math.Round(baseline + styled * drama);
+            relief = styled;
+        }
+        else
+        {
+            // Regional terrain character: a large-scale field selects how rugged this area is (a blend across
+            // the world's archetype subset), so the surface varies between flat plains, hills, mountains — and,
+            // where the subset drew the #576 archetypes, terraced decks, extreme crests or rift gorges.
+            relief = BlendedArchetypeOffset(planet, w, seed, h, worldX, worldZ);
         }
 
-        // Regional terrain character: a large-scale field selects how rugged this area is (a blend across
-        // the world's archetype subset), so the surface varies between flat plains, hills, mountains — and,
-        // where the subset drew the #576 archetypes, terraced decks, extreme crests or rift gorges.
-        return planet.BaseHeight + (int)System.Math.Round(baseline + BlendedArchetypeOffset(planet, w, seed, h, worldX, worldZ) * drama);
+        // Biome relief (#1645, generation 1): a biome may damp or boost the relief under it (a mud marsh lies
+        // flatter than the stone country next to it). Read through the REGION field only — never the
+        // altitude share of the biome pick — so relief cannot feed back into its own multiplier.
+        if (w.ReliefMuls is { } muls)
+        {
+            relief *= ReliefMulAt(muls, seed, worldX, worldZ);
+        }
+
+        return planet.BaseHeight + (int)System.Math.Round(baseline + relief * drama);
     }
 
     /// <summary>Styles that hand a rolled 20–40 % of their surface to the archetype blend (#703). The
@@ -170,7 +223,15 @@ public sealed partial class WorldGenerator
     private static bool StyleHybridEligible(string loweredStyle) => loweredStyle switch
     {
         "mountains" or "canyons" or "mesa" or "dunes" or "hills" or "tablelands" or "badlands" or "karst" => true,
+        "fjordlands" or "downs" or "shattered" or "terraces" or "drumlins" or "glacial" => true, // #1645
         _ => false,
+    };
+
+    /// <summary>Every style name <see cref="StyledHeightOffset"/> knows (content validation + tests).</summary>
+    public static readonly string[] KnownTerrainStyles =
+    {
+        "flats", "hills", "mountains", "canyons", "mesa", "dunes", "spires", "tablelands", "badlands", "karst",
+        "archipelago", "fjordlands", "downs", "shattered", "terraces", "drumlins", "glacial", // #1645
     };
 
     /// <summary>The vertical band [<paramref name="bottom"/>..<paramref name="top"/>] of a floating sky island at
@@ -343,16 +404,124 @@ public sealed partial class WorldGenerator
         return -p.BasinDepth + m * (p.BasinDepth + p.Lift);
     }
 
+    // --- Regional style pools (#1645, generation 1): a world rolls 1–3 styles from its type's pool and a
+    // broad field (Scale × 8) partitions the surface into style regions. Inside a region the style is pure;
+    // across a boundary band the two neighbours' OFFSETS blend with a smoothstep (the archetype blend's
+    // method — shapes like decks or spires cannot be blended as parameters). ---
+    private const double StyleBlendHalf = 0.15; // half-width of the boundary band in region units (70 % pure)
+
+    /// <summary>The styled offset at a column: the single style directly (every generation-0 styled world,
+    /// and generation-1 worlds that rolled one style), else the regional blend of the rolled styles.</summary>
+    private double StyleOffset(PlanetType planet, WonderProfile w, long seed, double h, int worldX, int worldZ)
+    {
+        var styles = w.Styles;
+        if (styles.Length == 1)
+        {
+            return StyledHeightOffset(styles[0], planet, w, seed, h, worldX, worldZ);
+        }
+
+        double n = FbmT(seed + 0x57F1E5, worldX, worldZ, w.Scale * 8.0, octaves: 2);
+        double spread = System.Math.Clamp((n - 0.5) * 2.4 + 0.5, 0.0, 0.9999);
+        double pos = spread * styles.Length;
+        int i0 = (int)pos;
+        double t = pos - i0;
+        double o0 = StyledHeightOffset(styles[i0], planet, w, seed, h, worldX, worldZ);
+
+        // Boundary bands: the last 15 % of a region fades toward the next style, the first 15 % from the
+        // previous one — continuous across the integer boundary (0.5 on both sides).
+        if (t > 1.0 - StyleBlendHalf && i0 + 1 < styles.Length)
+        {
+            double f = (t - (1.0 - StyleBlendHalf)) / (2.0 * StyleBlendHalf);
+            f = f * f * (3.0 - 2.0 * f);
+            double o1 = StyledHeightOffset(styles[i0 + 1], planet, w, seed, h, worldX, worldZ);
+            return o0 + (o1 - o0) * f;
+        }
+
+        if (t < StyleBlendHalf && i0 > 0)
+        {
+            double f = (t + StyleBlendHalf) / (2.0 * StyleBlendHalf);
+            f = f * f * (3.0 - 2.0 * f);
+            double oPrev = StyledHeightOffset(styles[i0 - 1], planet, w, seed, h, worldX, worldZ);
+            return oPrev + (o0 - oPrev) * f;
+        }
+
+        return o0;
+    }
+
+    /// <summary>Which style region a column falls in on a multi-style world (tests): the index into
+    /// <see cref="WonderProfile.Styles"/> whose offset dominates here.</summary>
+    internal string StyleAtForTest(PlanetType planet, int worldX, int worldZ)
+    {
+        var w = WonderFor(planet);
+        if (w.Styles.Length == 0)
+        {
+            return string.Empty;
+        }
+
+        if (w.Styles.Length == 1)
+        {
+            return w.Styles[0];
+        }
+
+        double n = FbmT(w.Seed + 0x57F1E5, worldX, worldZ, w.Scale * 8.0, octaves: 2);
+        double spread = System.Math.Clamp((n - 0.5) * 2.4 + 0.5, 0.0, 0.9999);
+        return w.Styles[(int)(spread * w.Styles.Length)];
+    }
+
+    /// <summary>The biome relief multiplier at a column (#1645): the biome REGION field alone (the same field
+    /// <see cref="BiomeIndex"/> spreads, without its altitude share) picks the resolved biome whose
+    /// <c>ReliefMul</c> applies; a ±10 % band around each region boundary lerps the two multipliers so relief
+    /// never steps at a biome edge.</summary>
+    private double ReliefMulAt(double[] muls, long seed, int worldX, int worldZ)
+    {
+        double n = FbmT(seed ^ 0x0B10E, worldX, worldZ, 360.0, octaves: 3);
+        double spread = System.Math.Clamp((n - 0.5) * 2.4 + 0.5, 0.0, 0.9999);
+        double pos = spread * muls.Length;
+        int i0 = (int)pos;
+        double t = pos - i0;
+        const double band = 0.10;
+        if (t > 1.0 - band && i0 + 1 < muls.Length)
+        {
+            double f = (t - (1.0 - band)) / (2.0 * band);
+            return muls[i0] + (muls[i0 + 1] - muls[i0]) * f;
+        }
+
+        if (t < band && i0 > 0)
+        {
+            double f = (t + band) / (2.0 * band);
+            return muls[i0 - 1] + (muls[i0] - muls[i0 - 1]) * f;
+        }
+
+        return muls[i0];
+    }
+
+    /// <summary>The biome relief multiplier applied at a column (tests; 1.0 where the feature is off).</summary>
+    internal double ReliefMulAtForTest(PlanetType planet, int worldX, int worldZ)
+    {
+        var w = WonderFor(planet);
+        return w.ReliefMuls is { } muls ? ReliefMulAt(muls, w.Seed, worldX, worldZ) : 1.0;
+    }
+
+    /// <summary>One style's raw offset at a column (tests).</summary>
+    internal double StyledOffsetForTest(string style, PlanetType planet, int worldX, int worldZ)
+    {
+        var w = WonderFor(planet);
+        double n = FbmT(w.Seed, worldX, worldZ, w.Scale, octaves: 4);
+        return StyledHeightOffset(style, planet, w, w.Seed, (n - 0.5) * 2.0, worldX, worldZ);
+    }
+
     /// <summary>Height offset (blocks, added to BaseHeight) for a planet with an explicit <see cref="PlanetType.TerrainStyle"/>
     /// (item 21 V2). <paramref name="h"/> is the base FBM swell in [-1,1]. Each style reshapes it into a distinct
     /// landform so worlds look structurally different. Deterministic + seam-safe (all noise wraps on X).
-    /// Dispatches on the profile's pre-lowered style and pre-rolled grain (#712 — no per-column strings).</summary>
-    private double StyledHeightOffset(PlanetType planet, WonderProfile w, long seed, double h, int worldX, int worldZ)
+    /// Dispatches on a pre-lowered style and the profile's pre-rolled grain (#712 — no per-column strings).
+    /// The wavelength is the profile's <see cref="WonderProfile.Scale"/> (the type's TerrainScale on
+    /// generation-0 worlds, jittered per body from generation 1 — #1645).</summary>
+    private double StyledHeightOffset(string style, PlanetType planet, WonderProfile w, long seed, double h, int worldX, int worldZ)
     {
         double amp = planet.Amplitude;
         double Ridge(double v) => (1.0 - System.Math.Abs(v)) * 2.0 - 1.0; // smooth swell → sharp ridge/valley
 
-        switch (w.Style)
+        switch (style)
         {
             case "flats":
                 return h * amp * 0.22; // near-flat plains (salt flats, ocean floor, low islands)
@@ -364,7 +533,7 @@ public sealed partial class WorldGenerator
                 {
                     // #700: part of the ridging comes from an oriented field, so ranges form CHAINS along
                     // the world's grain instead of isotropic knots.
-                    double or = OrientedRidge(seed, w.Grain, worldX, worldZ, planet.TerrainScale * 0.9);
+                    double or = OrientedRidge(seed, w.Grain, worldX, worldZ, w.Scale * 0.9);
                     double r = h * 0.25 + Ridge(h) * 0.30 + or * 0.45; // sharp, rugged, directional
                     if (r > 0)
                     {
@@ -392,7 +561,7 @@ public sealed partial class WorldGenerator
                     double raw = h * amp * 1.15;
                     double step = System.Math.Max(3.0, amp * 0.30);
                     double deck = System.Math.Floor(raw / step) * step;
-                    double roll = FbmT(seed + 0x3E5A, worldX, worldZ, planet.TerrainScale * 0.5, octaves: 2);
+                    double roll = FbmT(seed + 0x3E5A, worldX, worldZ, w.Scale * 0.5, octaves: 2);
                     return deck + (roll - 0.5) * 2.0; // ±2-block texture on each deck
                 }
 
@@ -401,7 +570,7 @@ public sealed partial class WorldGenerator
                     // Parallel wind-blown ridges: a ridged mid-frequency field laid over a gentle base.
                     // Since #700 the field is sampled in the world's GRAIN — every desert rolls a wind
                     // direction and its dune crests march that way instead of blobbing isotropically.
-                    double d = GrainFbm(seed + 0x0D0E, w.Grain, worldX, worldZ, planet.TerrainScale * 0.45, octaves: 2);
+                    double d = GrainFbm(seed + 0x0D0E, w.Grain, worldX, worldZ, w.Scale * 0.45, octaves: 2);
                     double ridged = 1.0 - System.Math.Abs(d * 2.0 - 1.0); // 0..1 dune crests
                     return h * amp * 0.25 + ridged * amp * 0.85;
                 }
@@ -410,7 +579,7 @@ public sealed partial class WorldGenerator
                 {
                     // Mostly flat ground studded with sparse tall thin spikes (crystal needles / alien towers).
                     double basep = h * amp * 0.22;
-                    double mask = FbmT(seed + 0x591E, worldX, worldZ, planet.TerrainScale * 0.4, octaves: 2);
+                    double mask = FbmT(seed + 0x591E, worldX, worldZ, w.Scale * 0.4, octaves: 2);
                     if (mask > 0.72)
                     {
                         double t = (mask - 0.72) / 0.28; // 0..1 toward the spike centre
@@ -427,7 +596,7 @@ public sealed partial class WorldGenerator
                     double raw = h * amp * 1.2;
                     double step = System.Math.Max(8.0, amp * 0.45);
                     double deck = System.Math.Floor(raw / step) * step;
-                    double roll = FbmT(seed + 0x7B1D, worldX, worldZ, planet.TerrainScale * 0.5, octaves: 2);
+                    double roll = FbmT(seed + 0x7B1D, worldX, worldZ, w.Scale * 0.5, octaves: 2);
                     return deck + (roll - 0.5) * 3.0; // rough rock texture on each deck
                 }
 
@@ -435,7 +604,7 @@ public sealed partial class WorldGenerator
                 {
                     // Fine-ridged gully country (#579): dense sharp crests + broad eroded floors over a
                     // modest base swell — canyon geology at a smaller, busier wavelength.
-                    double fine = FbmT(seed + 0x0BAD, worldX, worldZ, planet.TerrainScale * 0.35, octaves: 3);
+                    double fine = FbmT(seed + 0x0BAD, worldX, worldZ, w.Scale * 0.35, octaves: 3);
                     double r = h * 0.3 + (1.0 - System.Math.Abs(fine * 2.0 - 1.0)) * 1.4 - 0.7;
                     if (r < 0)
                     {
@@ -450,7 +619,7 @@ public sealed partial class WorldGenerator
                     // Karst tower country (#579): steep stone towers with flat, walkable tops rising from
                     // rolling green ground — denser than spires, and capped instead of needle-pointed.
                     double basep = h * amp * 0.35;
-                    double mask = FbmT(seed + 0x4A85, worldX, worldZ, planet.TerrainScale * 0.5, octaves: 2);
+                    double mask = FbmT(seed + 0x4A85, worldX, worldZ, w.Scale * 0.5, octaves: 2);
                     if (mask > 0.62)
                     {
                         double t = System.Math.Min(1.0, (mask - 0.62) / 0.22); // capped → flat tower top
@@ -460,25 +629,134 @@ public sealed partial class WorldGenerator
                     return basep;
                 }
 
+            // ---- generation-1 styles (#1645) ----
+
+            case "archipelago":
+                {
+                    // Flats studded with a dense field of island domes: with the sea calibrated high, hundreds
+                    // of islets; on dry land, a knoll country. One dome per hotspot cell (cell ≈120, 60 % of cells).
+                    double basep = h * amp * 0.22;
+                    if (!TryGetHotspot(seed ^ 0x0A9C1, ArchipelagoCellSize, 0.6, 40.0, worldX, worldZ,
+                            out ulong hh, out double dx, out double dz))
+                    {
+                        return basep;
+                    }
+
+                    double radius = 25.0 + ((hh >> 16) & 0x3FF) / 1023.0 * 35.0;   // 25..60
+                    double height = amp * (1.2 + ((hh >> 26) & 0x3FF) / 1023.0 * 1.0); // 1.2..2.2 × amp
+                    double dist = System.Math.Sqrt(dx * dx + dz * dz);
+                    if (dist >= radius)
+                    {
+                        return basep;
+                    }
+
+                    double t = 1.0 - dist / radius;
+                    return basep + height * (t * t * (3.0 - 2.0 * t));
+                }
+
+            case "fjordlands":
+                {
+                    // Mountains whose valleys plunge steep and deep below the base: once the sea percentile
+                    // calibrates, the troughs flood into fjords between the ridges.
+                    double or = OrientedRidge(seed, w.Grain, worldX, worldZ, w.Scale * 0.9);
+                    double r = h * 0.25 + Ridge(h) * 0.30 + or * 0.45;
+                    r = r > 0 ? System.Math.Pow(r, 1.35) : -System.Math.Pow(-r, 0.7); // proud crests, broad deep troughs
+                    return r * amp * 2.1;
+                }
+
+            case "downs":
+                {
+                    // Chalk downs: very smooth, very long-wavelength rolling country.
+                    double d = FbmT(seed + 0xD0E5, worldX, worldZ, w.Scale * 2.5, octaves: 2);
+                    return (d - 0.5) * 2.0 * amp * 0.9;
+                }
+
+            case "shattered":
+                {
+                    // A crossing network of straight rifts to great depth, shards of upland between them: every
+                    // ~900-block cell carries 2–3 linear features through its hotspot at fixed angles.
+                    double basep = h * amp * 0.35;
+                    if (!TryGetHotspot(seed ^ 0x5A77E, ShatteredCellSize, 1.0, 60.0, worldX, worldZ,
+                            out ulong hh, out double dx, out double dz))
+                    {
+                        return basep;
+                    }
+
+                    int lines = 2 + (int)((hh >> 8) & 1UL);
+                    double deepest = 0.0;
+                    for (int k = 0; k < lines; k++)
+                    {
+                        double angle = ((hh >> (10 + 6 * k)) & 0x3F) / 63.0 * System.Math.PI;
+                        double halfWidth = 10.0 + ((hh >> (30 + 4 * k)) & 0xF) / 15.0 * 8.0; // 10..18
+                        double cos = System.Math.Cos(angle);
+                        double sin = System.Math.Sin(angle);
+                        double along = dx * cos + dz * sin;
+                        double across = -dx * sin + dz * cos;
+                        if (System.Math.Abs(across) > halfWidth || System.Math.Abs(along) > 400.0)
+                        {
+                            continue;
+                        }
+
+                        double wv = 1.0 - System.Math.Abs(across) / halfWidth;
+                        double wall = wv >= 0.45 ? 1.0 : (wv / 0.45) * (wv / 0.45) * (3.0 - 2.0 * (wv / 0.45));
+                        double endT = 1.0 - System.Math.Abs(along) / 400.0;
+                        double taper = endT >= 0.15 ? 1.0 : (endT / 0.15) * (endT / 0.15) * (3.0 - 2.0 * (endT / 0.15));
+                        deepest = System.Math.Max(deepest, wall * taper);
+                    }
+
+                    return basep - deepest * amp * 2.2;
+                }
+
+            case "terraces":
+                {
+                    // Rice-terrace country: the mesa quantisation with a fine step and no deck roll.
+                    double raw = h * amp * 1.0;
+                    double step = System.Math.Max(2.0, amp * 0.12);
+                    return System.Math.Floor(raw / step) * step;
+                }
+
+            case "drumlins":
+                {
+                    // Glacial drift: smoothed whaleback ridges all elongated along the world's grain.
+                    double d = GrainFbm(seed + 0xD8B1, w.Grain, worldX, worldZ, w.Scale * 0.5, octaves: 2);
+                    double ridged = 1.0 - System.Math.Abs(d * 2.0 - 1.0);
+                    ridged = ridged * ridged * (3.0 - 2.0 * ridged); // rounded, not sharp
+                    return h * amp * 0.45 + ridged * amp * 0.5;
+                }
+
+            case "glacial":
+                {
+                    // Broad U-shaped troughs along the grain between rounded ridges — an ice-carved highland;
+                    // the trough heads hold tarns once the sea/pond percentiles calibrate.
+                    double v = GrainFbm(seed + 0x61AC, w.Grain, worldX, worldZ, w.Scale * 1.6, octaves: 2);
+                    double u = System.Math.Abs(v * 2.0 - 1.0);          // 0 on the trough axis, 1 on the ridges
+                    double valley = u * u * (3.0 - 2.0 * u);            // flat floor, steep walls
+                    return h * amp * 0.5 + (valley - 0.5) * amp * 1.6;
+                }
+
             default:
                 return h * amp; // unknown style → plain base swell
         }
     }
 
+    private const double ArchipelagoCellSize = 120.0;
+    private const double ShatteredCellSize = 900.0;
+
     /// <summary>The blended archetype height offset for a column: a large-scale region field picks among
     /// the world's seed-chosen subset of archetypes (deterministic, seam-free across the X wrap) and
     /// smoothstep-blends the two neighbours' computed OFFSETS (#576 — shapes like quantised decks or
-    /// asymmetric gorges cannot be blended as parameters).</summary>
+    /// asymmetric gorges cannot be blended as parameters). Generation-1 worlds draw from the larger pool
+    /// (#1645: moorland, knob-and-kettle, coastal cliffs).</summary>
     private double BlendedArchetypeOffset(PlanetType planet, WonderProfile w, long seed, double h, int worldX, int worldZ)
     {
-        int pool = TerrainArchetypeCount;
+        int pool = ArchetypePoolFor(w);
         long s = seed ^ 0x7E44A1;
         ulong us = (ulong)(s < 0 ? -s : s);
         int count = 2 + (int)(us % (ulong)(pool - 1)); // this world uses 2..pool archetypes
         int rot = (int)((us >> 8) % (ulong)pool);       // …starting at a seed-rotated offset in the list
 
         // A broad field (much larger than the base terrain) picks a position across the subset + blends it.
-        double rug = FbmT(s, worldX, worldZ, planet.TerrainScale * 6.0, octaves: 3);
+        double rug = FbmT(s, worldX, worldZ, w.Scale * 6.0, octaves: 3);
         double pos = (rug < 0 ? 0 : (rug > 0.9999 ? 0.9999 : rug)) * count; // [0, count)
         int i0 = (int)pos;
         int i1 = i0 + 1 < count ? i0 + 1 : count - 1;
@@ -495,4 +773,10 @@ public sealed partial class WorldGenerator
 
         return o0 + (ArchetypeOffset(a1, planet, w, seed, h, worldX, worldZ) - o0) * f;
     }
+
+    /// <summary>The archetype pool a world draws from: the classic eight, or eleven from generation 1 (#1645).</summary>
+    private static int ArchetypePoolFor(WonderProfile w) => w.Generation >= 1 ? TerrainArchetypeCountGen1 : TerrainArchetypeCount;
+
+    /// <summary>The archetype pool size of this world (tests).</summary>
+    internal int ArchetypePoolForTest(PlanetType planet) => ArchetypePoolFor(WonderFor(planet));
 }

--- a/src/BlocksBeyondTheStars.WorldGeneration/WorldGenerator.cs
+++ b/src/BlocksBeyondTheStars.WorldGeneration/WorldGenerator.cs
@@ -359,6 +359,10 @@ public sealed partial class WorldGenerator
     // worlds whose subset drew the new entries, as terraced mesa country, jagged extremes or gorge lands.
     private const int TerrainArchetypeCount = 8;
 
+    /// <summary>The generation-1 archetype pool (#1645): the classic eight plus moorland, knob-and-kettle and
+    /// coastal cliffs. Generation-0 worlds keep drawing from the eight (the subset roll depends on the pool size).</summary>
+    private const int TerrainArchetypeCountGen1 = 11;
+
     // --- Per-world wonder profile (#712): every feature GATE, world roll and lowered string that the
     // #698–#709 wave added is constant for a given world, yet was re-derived per COLUMN — string
     // allocations (ToLowerInvariant), Noise.Hash world rolls and repeated planet-key hashing in the
@@ -380,6 +384,14 @@ public sealed partial class WorldGenerator
         public int SkyTiers;               // #707 (0 on non-floating worlds)
         public int Generation;             // #1644 terrain generation of this world (0 = classic generators)
         public TerrainTag Tags;            // #1644 the planet type's terrain tags, resolved at content load
+
+        // #1645 (generation 1): the styles laid out as regions (gen 0: the single type style, or empty), the
+        // per-world relief wavelength (gen 0: the type's TerrainScale exactly), the resolved biomes' relief
+        // multipliers (null = off) and the rare whole-planet baseline regimes.
+        public string[] Styles = System.Array.Empty<string>();
+        public double Scale;
+        public double[]? ReliefMuls;
+        public bool Tilted, Stepped, EquatorRidge;
 
         /// <summary>The landmark table rows active on this world, in precedence order (#1644) — what
         /// <see cref="SurfaceHeightUncached"/> loops instead of a hand-written if-chain.</summary>
@@ -593,6 +605,24 @@ public sealed partial class WorldGenerator
                     Tags = planet.Tags,
                 };
                 w.OverhangLandmarks = w.Arches || w.SeaStacks || w.Hoodoos;
+
+                // #1645 relief rolls: generation 0 takes the classic values verbatim (byte-identical worlds).
+                w.Scale = planet.TerrainScale;
+                w.Styles = w.Style.Length != 0 ? new[] { w.Style } : System.Array.Empty<string>();
+                if (_terrainGeneration >= 1)
+                {
+                    w.Scale = ScaleJitterFor(planet, seed);
+                    w.Styles = PickStyles(planet, seed, w.Style);
+                    w.ReliefMuls = ReliefMulsFor(planet);
+                    w.Tilted = HasTilt(planet, seed);
+                    w.Stepped = HasStepped(planet, seed);
+                    w.EquatorRidge = HasEquatorRidge(planet, seed);
+                    if (w.Stepped)
+                    {
+                        w.Escarpment = true; // three storeys = the classic escarpment plus a second one
+                    }
+                }
+
                 var offsets = new System.Collections.Generic.List<LandmarkOffsetFn>(LandmarkKinds.Length);
                 var paints = new System.Collections.Generic.List<LandmarkPaintFn>();
                 foreach (var kind in LandmarkKinds)
@@ -612,7 +642,11 @@ public sealed partial class WorldGenerator
                 w.ActiveLandmarks = offsets.ToArray();
                 w.ActivePaints = paints.ToArray();
                 w.AnyBands = planet.FloatingIslands || w.Arches || w.SeaStacks || w.Hoodoos || w.Cenotes;
-                w.HybridEligible = StyleHybridEligible(w.Style);
+                // #703 hybrid fade; #1645: on a multi-style world the fade runs whenever more than one style was
+                // rolled — identity styles (flats, spires) stay pure only as the sole pick.
+                w.HybridEligible = _terrainGeneration >= 1 && w.Styles.Length != 0
+                    ? (w.Styles.Length > 1 || StyleHybridEligible(w.Styles[0]))
+                    : StyleHybridEligible(w.Style);
                 ulong uh = Noise.Hash(seed ^ 0x57FADE, 2, 4, 8);
                 w.HybridA = 0.34 + (uh & 0xFF) / 255.0 * 0.08;
                 w.HybridB = w.HybridA + 0.08;

--- a/tests/BlocksBeyondTheStars.Tests/AtmosphereTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/AtmosphereTests.cs
@@ -37,6 +37,7 @@ public sealed class AtmosphereTests : IDisposable
             StartPlanet = planet,
             AutoSaveIntervalMinutes = 9999,
             PlaceStarterShip = false,
+            World = { TerrainGeneration = 0 }, // #1645: gameplay test on the classic relief — the player sits at a fixed (0, 64, 0), which generation-1 terrain may flood or bury
         };
         var server = new SvGameServer(config, _content, st, repo);
         server.Start();

--- a/tests/BlocksBeyondTheStars.Tests/CreatureTamingTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/CreatureTamingTests.cs
@@ -40,6 +40,7 @@ public sealed class CreatureTamingTests : IDisposable
             StartPlanet = "jungle", // "many" fauna
             AutoSaveIntervalMinutes = 9999,
             PlaceStarterShip = false,
+            World = { TerrainGeneration = 0 }, // #1645: gameplay test on the classic relief — the player sits at a fixed (0, 64, 0), which generation-1 terrain may flood or bury
         };
         var server = new SvGameServer(config, _content, st, repo);
         server.Start();

--- a/tests/BlocksBeyondTheStars.Tests/CreatureTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/CreatureTests.cs
@@ -41,6 +41,7 @@ public sealed class CreatureTests : IDisposable
             StartPlanet = planet,
             AutoSaveIntervalMinutes = 9999,
             PlaceStarterShip = false,
+            World = { TerrainGeneration = 0 }, // #1645: gameplay test on the classic relief — the player sits at a fixed (0, 64, 0), which generation-1 terrain may flood or bury
         };
         var server = new SvGameServer(config, _content, st, repo);
         server.Start();

--- a/tests/BlocksBeyondTheStars.Tests/LandscapeReliefTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/LandscapeReliefTests.cs
@@ -1,0 +1,441 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using BlocksBeyondTheStars.Shared.Content;
+using BlocksBeyondTheStars.Shared.Definitions;
+using BlocksBeyondTheStars.Shared.World;
+using BlocksBeyondTheStars.WorldGeneration;
+using Xunit;
+
+namespace BlocksBeyondTheStars.Tests;
+
+/// <summary>
+/// #1645 (landscape variety 2/6): relief variety on terrain-generation-1 worlds — regional style pools,
+/// per-world scale jitter, biome relief multipliers, the new styles, the larger archetype pool and the rare
+/// baseline regimes. Generation-0 worlds must take none of it (the goldens prove the bytes; these tests prove
+/// the rolls and the shapes).
+/// </summary>
+public sealed class LandscapeReliefTests
+{
+    private static readonly GameContent Content = ContentLoader.LoadFromDirectory(TestPaths.DataDir());
+
+    private static WorldGenerator Gen(long seed, int generation)
+    {
+        var gen = new WorldGenerator(seed, Content);
+        if (generation > 0)
+        {
+            gen.SetTerrainGeneration(generation);
+        }
+
+        return gen;
+    }
+
+    private static IEnumerable<PlanetType> PooledTypes()
+        => Content.Planets.Values.Where(p => p.TerrainStyles.Count > 1);
+
+    // ---------- generation 0 stays classic ----------
+
+    [Fact]
+    public void GenerationZero_KeepsTheSingleTypeStyle_TheTypeScale_AndNoRegimes()
+    {
+        foreach (var planet in Content.Planets.Values)
+        {
+            var gen = Gen(4711, 0);
+            var styles = gen.StylesForTest(planet);
+            string expected = planet.TerrainStyle?.ToLowerInvariant() ?? string.Empty;
+            if (expected.Length == 0)
+            {
+                Assert.Empty(styles);
+            }
+            else
+            {
+                Assert.Equal(new[] { expected }, styles);
+            }
+
+            Assert.Equal(planet.TerrainScale, gen.ScaleForTest(planet));
+            Assert.Equal(8, gen.ArchetypePoolForTest(planet));
+            Assert.Equal(1.0, gen.ReliefMulAtForTest(planet, 123, 456));
+            var (tilted, stepped, ridge, _) = gen.RegimesForTest(planet);
+            Assert.False(tilted || stepped || ridge, planet.Key);
+        }
+    }
+
+    // ---------- style pools ----------
+
+    [Fact]
+    public void EveryPoolEntry_AppearsOnSomeWorld_AndPicksAreOneToThree()
+    {
+        foreach (var planet in PooledTypes())
+        {
+            var seen = new HashSet<string>();
+            for (long s = 1; s <= 80; s++)
+            {
+                var styles = Gen(s * 7919 + 3, 1).StylesForTest(planet);
+                Assert.InRange(styles.Length, 1, Math.Min(3, planet.TerrainStyles.Count));
+                Assert.Equal(styles.Length, styles.Distinct().Count());
+                foreach (var st in styles)
+                {
+                    Assert.Contains(st, planet.TerrainStyles.Select(x => x.ToLowerInvariant()));
+                    seen.Add(st);
+                }
+            }
+
+            foreach (var pooled in planet.TerrainStyles)
+            {
+                Assert.Contains(pooled.ToLowerInvariant(), seen);
+            }
+        }
+    }
+
+    [Fact]
+    public void EveryPooledStyle_IsAStyleTheGeneratorKnows()
+    {
+        var known = WorldGenerator.KnownTerrainStyles.ToHashSet();
+        foreach (var planet in Content.Planets.Values)
+        {
+            if (!string.IsNullOrEmpty(planet.TerrainStyle))
+            {
+                Assert.Contains(planet.TerrainStyle.ToLowerInvariant(), known);
+            }
+
+            foreach (var s in planet.TerrainStyles)
+            {
+                Assert.Contains(s.ToLowerInvariant(), known);
+            }
+        }
+    }
+
+    [Fact]
+    public void IdentityStyles_StayPure_OnlyAsTheSolePick()
+    {
+        // ocean pool = flats + archipelago: a sole "flats" world never fades to the archetype blend; a mixed
+        // world does (the hybrid fade is what puts hills between the island fields).
+        var ocean = Content.Planets["ocean"];
+        bool sawSole = false, sawMixed = false;
+        for (long s = 1; s <= 120 && !(sawSole && sawMixed); s++)
+        {
+            var gen = Gen(s * 104729 + 11, 1);
+            var styles = gen.StylesForTest(ocean);
+            if (styles.Length == 1 && styles[0] == "flats")
+            {
+                Assert.False(gen.HybridEligibleForTest(ocean));
+                sawSole = true;
+            }
+            else if (styles.Length > 1)
+            {
+                Assert.True(gen.HybridEligibleForTest(ocean));
+                sawMixed = true;
+            }
+        }
+
+        Assert.True(sawSole && sawMixed, $"sole {sawSole}, mixed {sawMixed}");
+    }
+
+    [Fact]
+    public void StyleRegions_CoverEveryRolledStyle_OnAMultiStyleWorld()
+    {
+        var desert = Content.Planets["desert"];
+        WorldGenerator? gen = null;
+        for (long s = 1; s <= 200 && gen is null; s++)
+        {
+            var g = Gen(s * 6151 + 5, 1);
+            if (g.StylesForTest(desert).Length == 3)
+            {
+                gen = g;
+            }
+        }
+
+        Assert.NotNull(gen);
+        var counts = new Dictionary<string, int>();
+        int circ = WorldConstants.Circumference;
+        int period = WorldConstants.LatitudePeriodFor(circ);
+        for (int z = -period / 2; z < period / 2; z += 61)
+            for (int x = 0; x < circ; x += 67)
+            {
+                string st = gen!.StyleAtForTest(desert, x, z);
+                counts[st] = counts.GetValueOrDefault(st) + 1;
+            }
+
+        foreach (var st in gen!.StylesForTest(desert))
+        {
+            Assert.True(counts.GetValueOrDefault(st) > 0, $"style {st} has no region");
+        }
+    }
+
+    // ---------- scale jitter ----------
+
+    [Fact]
+    public void ScaleJitter_StaysInTheDesignedRange_AndVariesPerWorld()
+    {
+        var jungle = Content.Planets["jungle"];
+        var seen = new HashSet<double>();
+        for (long s = 1; s <= 60; s++)
+        {
+            double scale = Gen(s * 31 + 7, 1).ScaleForTest(jungle);
+            Assert.InRange(scale, jungle.TerrainScale * 0.75 - 1e-9, jungle.TerrainScale * 1.35 + 1e-9);
+            seen.Add(Math.Round(scale, 3));
+        }
+
+        Assert.True(seen.Count > 20, $"only {seen.Count} distinct scales");
+    }
+
+    // ---------- biome relief ----------
+
+    [Fact]
+    public void ReliefMul_DampsTheMarsh_AndBoostsTheStone()
+    {
+        // karst: mud 0.35 · grass 1.0 · stone 1.5 — the relief amplitude under the marsh regions must come out
+        // clearly smaller than under the stone regions on the same world (default mode: no continents, no
+        // escarpment baseline to confound the comparison).
+        var karst = Content.Planets["karst"];
+        double flatSum = 0, ruggedSum = 0;
+        int flatN = 0, ruggedN = 0;
+        for (long s = 1; s <= 6; s++)
+        {
+            var gen = Gen(s * 2003 + 1, 1);
+            var (tilted, stepped, ridge, esc) = gen.RegimesForTest(karst);
+            if (tilted || stepped || ridge || esc)
+            {
+                continue; // a baseline regime would shift the mean height; skip those seeds
+            }
+
+            for (int z = -1200; z < 1200; z += 23)
+                for (int x = 0; x < 2400; x += 29)
+                {
+                    double mul = gen.ReliefMulAtForTest(karst, x, z);
+                    double dev = Math.Abs(gen.SurfaceHeight(karst, x, z) - karst.BaseHeight);
+                    if (mul <= 0.5)
+                    {
+                        flatSum += dev;
+                        flatN++;
+                    }
+                    else if (mul >= 1.4)
+                    {
+                        ruggedSum += dev;
+                        ruggedN++;
+                    }
+                }
+        }
+
+        Assert.True(flatN > 200 && ruggedN > 200, $"samples flat {flatN}, rugged {ruggedN}");
+        double flat = flatSum / flatN, rugged = ruggedSum / ruggedN;
+        Assert.True(flat * 1.8 < rugged, $"marsh relief {flat:F2} vs stone relief {rugged:F2}");
+    }
+
+    [Fact]
+    public void ReliefMul_IsContinuous_AcrossBiomeRegionBoundaries()
+    {
+        var karst = Content.Planets["karst"];
+        var gen = Gen(99, 1);
+        double prev = gen.ReliefMulAtForTest(karst, 0, 0);
+        for (int x = 1; x < 6000; x++)
+        {
+            double cur = gen.ReliefMulAtForTest(karst, x, 0);
+            Assert.True(Math.Abs(cur - prev) < 0.2, $"relief multiplier jumps {prev:F3} → {cur:F3} at x={x}");
+            prev = cur;
+        }
+    }
+
+    // ---------- new styles ----------
+
+    [Fact]
+    public void Archipelago_RaisesIslandDomes_OverAFlatFloor()
+    {
+        var ocean = Content.Planets["ocean"];
+        var gen = Gen(2026, 1);
+        int raised = 0, total = 0;
+        for (int z = -1500; z < 1500; z += 17)
+            for (int x = 0; x < 3000; x += 19)
+            {
+                double o = gen.StyledOffsetForTest("archipelago", ocean, x, z);
+                total++;
+                if (o > ocean.Amplitude * 0.6)
+                {
+                    raised++;
+                }
+            }
+
+        double frac = raised / (double)total;
+        Assert.InRange(frac, 0.03, 0.40);
+    }
+
+    [Fact]
+    public void Downs_RollGently_NeverStep()
+    {
+        var savanna = Content.Planets["savanna"];
+        var gen = Gen(77, 1);
+        for (int x = 0; x < 3000; x++)
+        {
+            double a = gen.StyledOffsetForTest("downs", savanna, x, 40);
+            double b = gen.StyledOffsetForTest("downs", savanna, x + 1, 40);
+            Assert.True(Math.Abs(a - b) <= 1.5, $"downs slope {Math.Abs(a - b):F2} at x={x}");
+        }
+    }
+
+    [Fact]
+    public void Terraces_QuantiseIntoFlatDecks()
+    {
+        var tablelands = Content.Planets["tablelands"];
+        var gen = Gen(5, 1);
+        double step = Math.Max(2.0, tablelands.Amplitude * 0.12);
+        for (int x = 0; x < 2000; x += 3)
+        {
+            double o = gen.StyledOffsetForTest("terraces", tablelands, x, -300);
+            double r = o / step;
+            Assert.True(Math.Abs(r - Math.Round(r)) < 1e-6, $"terrace offset {o} is not a whole deck");
+        }
+    }
+
+    [Fact]
+    public void Shattered_CutsDeepRifts_SomewhereInEveryCell()
+    {
+        var corrupted = Content.Planets["corrupted"];
+        var gen = Gen(31337, 1);
+        double deepest = 0.0;
+        for (int z = -900; z < 900; z += 7)
+            for (int x = 0; x < 1800; x += 7)
+            {
+                deepest = Math.Min(deepest, gen.StyledOffsetForTest("shattered", corrupted, x, z));
+            }
+
+        Assert.True(deepest < -corrupted.Amplitude * 1.5, $"no rift found, deepest {deepest:F1}");
+    }
+
+    [Theory]
+    [InlineData("desert")]
+    [InlineData("highland")]
+    [InlineData("ocean")]
+    [InlineData("tundra")]
+    [InlineData("corrupted")]
+    public void GenerationOneWorlds_AreDeterministic_SeamFree_AndMemoConsistent(string key)
+    {
+        var planet = Content.Planets[key];
+        var a = Gen(8080, 1);
+        var b = Gen(8080, 1);
+        int circ = WorldConstants.Circumference;
+        int period = WorldConstants.LatitudePeriodFor(circ);
+        for (int z = -period / 2; z < period / 2; z += 131)
+            for (int x = 0; x < circ; x += 173)
+            {
+                int h = a.SurfaceHeight(planet, x, z);
+                Assert.Equal(h, b.SurfaceHeight(planet, x, z));
+                Assert.Equal(h, a.SurfaceHeightUncached(planet, x, z));
+                Assert.Equal(h, a.SurfaceHeight(planet, x + circ, z));
+                Assert.Equal(h, a.SurfaceHeight(planet, x, z + period));
+                // Negative world Y is legal (a gen-0 mega-rift floor already goes there); the ceiling is the
+                // MaxNaturalSurfaceY clamp under the atmosphere line.
+                Assert.InRange(h, -400, 288);
+            }
+    }
+
+    // ---------- archetype pool ----------
+
+    [Fact]
+    public void ArchetypePool_IsElevenOnGenerationOne()
+    {
+        var lava = Content.Planets["lava"]; // archetype-blend type (no style)
+        Assert.Equal(8, Gen(1, 0).ArchetypePoolForTest(lava));
+        Assert.Equal(11, Gen(1, 1).ArchetypePoolForTest(lava));
+        Assert.Empty(Gen(1, 1).StylesForTest(lava));
+    }
+
+    // ---------- baseline regimes ----------
+
+    [Fact]
+    public void Regimes_RollRarely_AndEachAppearsSomewhere()
+    {
+        var savanna = Content.Planets["savanna"];
+        int tilted = 0, stepped = 0, ridged = 0;
+        const int worlds = 400;
+        for (long s = 1; s <= worlds; s++)
+        {
+            var (t, st, r, esc) = Gen(s * 6151 + 1, 1).RegimesForTest(savanna);
+            tilted += t ? 1 : 0;
+            stepped += st ? 1 : 0;
+            ridged += r ? 1 : 0;
+            if (st)
+            {
+                Assert.True(esc, "a stepped world always carries the first escarpment too");
+            }
+        }
+
+        Assert.InRange(tilted, 10, 80);
+        Assert.InRange(stepped, 2, 40);
+        Assert.InRange(ridged, 2, 40);
+    }
+
+    [Fact]
+    public void Regimes_NeverRoll_OnSkyOrCrateredWorlds()
+    {
+        foreach (var key in new[] { "skylands", "asteroid", "orbital_station" })
+        {
+            var planet = Content.Planets[key];
+            for (long s = 1; s <= 150; s++)
+            {
+                var (t, st, r, _) = Gen(s * 6151 + 1, 1).RegimesForTest(planet);
+                Assert.False(t || st || r, key);
+            }
+        }
+    }
+
+    [Fact]
+    public void TiltedWorld_HasAHighAndALowHemisphere()
+    {
+        var savanna = Content.Planets["savanna"];
+        WorldGenerator? gen = null;
+        for (long s = 1; s <= 400 && gen is null; s++)
+        {
+            var g = Gen(s * 6151 + 1, 1);
+            if (g.RegimesForTest(savanna).Tilted)
+            {
+                gen = g;
+            }
+        }
+
+        Assert.NotNull(gen);
+        int period = WorldConstants.LatitudePeriodFor(WorldConstants.Circumference);
+        double lo = double.MaxValue, hi = double.MinValue;
+        for (int z = -period / 2; z < period / 2; z += 32)
+        {
+            double o = gen!.TiltOffsetForTest(savanna, z);
+            lo = Math.Min(lo, o);
+            hi = Math.Max(hi, o);
+        }
+
+        Assert.True(hi >= 19.0 && lo <= -19.0, $"tilt hi {hi:F1} lo {lo:F1}");
+        Assert.Equal(gen!.TiltOffsetForTest(savanna, 100), gen.TiltOffsetForTest(savanna, 100 + period), 6);
+    }
+
+    [Fact]
+    public void EquatorialRidge_GirdlesThePlanet()
+    {
+        var savanna = Content.Planets["savanna"];
+        WorldGenerator? gen = null;
+        for (long s = 1; s <= 600 && gen is null; s++)
+        {
+            var g = Gen(s * 6151 + 1, 1);
+            if (g.RegimesForTest(savanna).EquatorRidge)
+            {
+                gen = g;
+            }
+        }
+
+        Assert.NotNull(gen);
+        int circ = WorldConstants.Circumference;
+        int period = WorldConstants.LatitudePeriodFor(circ);
+        // At every longitude sampled the ridge exists at SOME latitude (a closed girdle), and it is tall.
+        for (int x = 0; x < circ; x += 397)
+        {
+            double best = 0.0;
+            for (int z = -period / 2; z < period / 2; z += 4)
+            {
+                best = Math.Max(best, gen!.EquatorialRidgeOffsetForTest(savanna, x, z));
+            }
+
+            Assert.True(best >= 25.0, $"ridge missing at x={x} (best {best:F1})");
+        }
+    }
+}

--- a/tests/BlocksBeyondTheStars.Tests/NpcRadioTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/NpcRadioTests.cs
@@ -51,6 +51,7 @@ public sealed class NpcRadioTests : IDisposable
             StartPlanet = "jungle",
             AutoSaveIntervalMinutes = 9999,
             PlaceStarterShip = false,
+            World = { TerrainGeneration = 0 }, // #1645: gameplay test on the classic relief — the player sits at a fixed (0, 64, 0), which generation-1 terrain may flood or bury
             PlaceSettlements = true,
             PlaceWrecks = false,
         };

--- a/tests/BlocksBeyondTheStars.Tests/TamingShapesStoryTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/TamingShapesStoryTests.cs
@@ -47,6 +47,7 @@ public sealed class TamingShapesStoryTests : IDisposable
             StartPlanet = "jungle", // "many" fauna — easy to find a wild creature to tame
             AutoSaveIntervalMinutes = 9999,
             PlaceStarterShip = false,
+            World = { TerrainGeneration = 0 }, // #1645: gameplay test on the classic relief — the player sits at a fixed (0, 64, 0), which generation-1 terrain may flood or bury
         };
         var server = new SvGameServer(config, _content, st, repo);
         server.Start();

--- a/tests/BlocksBeyondTheStars.Tests/TerrainTagsAndGenerationTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/TerrainTagsAndGenerationTests.cs
@@ -160,8 +160,16 @@ public sealed class TerrainTagsAndGenerationTests
         gen.SetTerrainGeneration(WorldDescription.CurrentTerrainGeneration);
         Assert.Equal(WorldDescription.CurrentTerrainGeneration, gen.TerrainGeneration);
         Assert.Equal(0, gen.CachedColumnProfiles);
-        // Generation 1 carries no visible feature yet in this PR — heights are identical, and stay so once
-        // the wave lands only where a feature explicitly gates on the generation.
+        // Since #1645 generation 1 reshapes the relief (scale jitter alone moves nearly every column), and
+        // switching back restores the classic height exactly — the generation is a pure input, never state.
+        bool anyDiffers = false;
+        for (int x = 0; x < 640 && !anyDiffers; x += 32)
+        {
+            anyDiffers = gen.SurfaceHeight(planet, x, 37) != new WorldGenerator(7, Content).SurfaceHeight(planet, x, 37);
+        }
+
+        Assert.True(anyDiffers, "generation 1 should change the relief somewhere");
+        gen.SetTerrainGeneration(0);
         Assert.Equal(h0, gen.SurfaceHeight(planet, 100, 37));
     }
 

--- a/tests/BlocksBeyondTheStars.Tests/WeaponTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/WeaponTests.cs
@@ -41,6 +41,7 @@ public sealed class WeaponTests : IDisposable
             StartPlanet = "jungle",
             AutoSaveIntervalMinutes = 9999,
             PlaceStarterShip = false,
+            World = { TerrainGeneration = 0 }, // #1645: gameplay test on the classic relief — the player sits at a fixed (0, 64, 0), which generation-1 terrain may flood or bury
         };
         var server = new SvGameServer(config, _content, st, repo);
         server.Start();

--- a/tests/BlocksBeyondTheStars.Tests/WorldGenerationGoldenTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/WorldGenerationGoldenTests.cs
@@ -35,7 +35,8 @@ public sealed class WorldGenerationGoldenTests
     /// <summary>One pinned group: a generator configuration whose chunks are hashed together in a fixed order.
     /// <see cref="Circumference"/> 0 = the generator's default mode (no <c>SetWorldMode</c> call, the legacy
     /// per-type seeding); otherwise the full per-world mode is applied like <c>ServerWorld.GetOrLoadChunk</c> does.</summary>
-    private sealed record Group(string Name, long Seed, string Planet, int Circumference, bool Cratered, string? LocationId);
+    private sealed record Group(string Name, long Seed, string Planet, int Circumference, bool Cratered, string? LocationId,
+        int Generation = 0);
 
     private static readonly Group[] Groups =
     {
@@ -47,6 +48,11 @@ public sealed class WorldGenerationGoldenTests
         new("jungle-default", 20260903, "jungle", 0, false, null),
         new("varied-world-5472", 424242, "varied", 5472, false, "golden:varied-body"),
         new("asteroid-cratered-800", 14, "asteroid", 800, true, "golden:asteroid"),
+        // Terrain generation 1 (#1645, landscape-variety part 2): the gen-0 groups above must never move; these
+        // pin the generation-1 relief (style regions, scale jitter, biome relief, new archetypes, regimes).
+        new("varied-gen1", 424242, "varied", 5472, false, "golden:varied-body", 1),
+        new("desert-gen1", 1, "desert", 0, false, null, 1),
+        new("highland-gen1", 20260903, "highland", 0, false, null, 1),
     };
 
     /// <summary>Sample columns: the spawn column (pad 0 sits at (0,0) on every world), one ordinary inland
@@ -67,6 +73,10 @@ public sealed class WorldGenerationGoldenTests
             ["jungle-default"] = 0xfafe0246f460230cUL,
             ["varied-world-5472"] = 0xd184d06aee4c17feUL,
             ["asteroid-cratered-800"] = 0xea45216efb76ba71UL,
+            // Pinned 2026-09-05 (#1645, Windows 11, .NET 10).
+            ["varied-gen1"] = 0x06b7238c0bfd64a9UL,
+            ["desert-gen1"] = 0x3a9c31b0e73aca33UL,
+            ["highland-gen1"] = 0x350b70a0088675a2UL,
         },
         // Linux (ubuntu CI runners): filled in from the first CI run of this test; a group absent here falls
         // back to the Windows value above and fails with the value to pin if the libm differs.
@@ -91,6 +101,11 @@ public sealed class WorldGenerationGoldenTests
             if (group.Circumference > 0)
             {
                 gen.SetWorldMode(group.Circumference, group.Cratered, null, group.LocationId);
+            }
+
+            if (group.Generation > 0)
+            {
+                gen.SetTerrainGeneration(group.Generation); // #1645
             }
 
             var perChunk = new List<string>();


### PR DESCRIPTION
Part 2 of 6 of the **landscape-variety package** (#1644–#1649). Everything here gates on `TerrainGeneration >= 1`, so it reaches **new worlds only**: the eight classic `WorldGenerationGoldenTests` groups are byte-identical, and three new `*-gen1` groups pin the generation-1 relief.

Closes #1645

## What changes (generation ≥ 1)

- **Style pools, regionally mixed.** `PlanetType.TerrainStyles` on 16 types (desert `[dunes, badlands, flats, downs]`, highland `[mountains, fjordlands, canyons]`, ocean `[flats, archipelago]`, tundra `[hills, downs, drumlins]`, …). Each world rolls 1–3 styles (25 % / 45 % / 30 %, seeded Fisher–Yates like the biome subset) and `StyleOffset` lays them out as **regions**: a broad field (`Scale × 8`) partitions the surface, 70 % of each region is one pure style, the 30 % boundary band smoothstep-blends the two neighbours' offsets. The #703 style×archetype hybrid fade stays on top and runs on every multi-style world; `flats` / `spires` stay pure only as the sole pick.
- **Per-world wavelength.** `WonderProfile.Scale = TerrainScale × 0.75–1.35`; every relief field (base swell, styles, archetypes, hybrid + region fields) reads it. Biome, forest and pond masks keep the type scale so flora patch sizes do not move.
- **Biome relief.** `Biome.ReliefMul` (mud 0.35, sand 0.8, stone/granite 1.3–1.5 in `planets.json`) multiplies the style/archetype relief — never the baseline or a landmark — through the biome **region** field alone (`ReliefMulAt`), so relief cannot feed back into its own multiplier; a ±10 % band around each region boundary lerps the two multipliers.
- **Seven new styles:** `archipelago` (one island dome per 120-block hotspot cell), `fjordlands` (mountains with deep broad troughs that flood), `downs` (chalk country at `Scale × 2.5`), `shattered` (2–3 straight rifts per 900-block cell), `terraces`, `drumlins`, `glacial` (U-troughs along the grain). `WorldGenerator.KnownTerrainStyles` lists every name; a test checks every pooled name against it.
- **Archetype pool 8 → 11:** moorland, knob-and-kettle, coastal cliffs. The subset roll depends on the pool size, so generation 0 keeps 8.
- **Baseline regimes** (`WorldGenerator.Regimes.cs`): tilted world (~8 %), stepped world = a second escarpment → three storeys (~3 %), equatorial ridge girdling the planet (~3 %). Never on sky, void or cratered worlds.

## Generation 0

Every classic path takes the classic value verbatim (single type style, `planet.TerrainScale`, no multipliers, no regimes, pool 8). Goldens: 8/8 unchanged on Windows; Linux values come from the first CI run as before.

## Tests

`LandscapeReliefTests` (18 tests): gen-0 invariance for every type, pool coverage + 1–3 picks, known-style check, identity purity, region coverage, scale range, relief-mul monotonicity (marsh vs stone) + continuity, archipelago dome fraction, downs slope bound, terrace quantisation, shattered depth, determinism / seam / memo consistency on gen-1 worlds, archetype pool, regime rates, no regimes on sky/cratered worlds, tilt hemispheres, ridge girdle. `TerrainTagsAndGenerationTests` updated: generation 1 now changes the relief, switching back restores the classic height exactly.

Six gameplay test classes (creatures, creature taming, taming story, weapons, NPC radio, atmosphere) pin their test world to `TerrainGeneration = 0`: they park the player at a fixed `(0, 64, 0)` and read the first creature / a settlement's neighbourhood, which the generation-1 relief of their seed floods or moves (jungle 4242 now has its sea at Y 74 around the origin). Their subject is the gameplay system, not the terrain.

Fast tier green locally, `dotnet format --verify-no-changes` clean. No `client/Assets` change (the WorldGeneration DLL is synced at build time).

## Playtest ask

One new desert + one new highland world: do the style regions read as one world? Steers the landmark tuning of part 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
