### PR TITLE
test(server): seam-streaming sweep test pins the classic terrain generation — main green again after #1645

### DIFF
--- a/tests/BlocksBeyondTheStars.Tests/ChunkStreamingTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/ChunkStreamingTests.cs
@@ -154,6 +154,10 @@ public sealed class ChunkStreamingTests : IDisposable
             AutoSaveIntervalMinutes = 9999,
             PlaceStarterShip = false,
             ViewDistanceChunks = 4,
+            // #1645: the seam precondition below relies on where seed 1's dry-pad search lands pad 0 on the
+            // CLASSIC relief; the generation-1 relief moves it off the seam (chunk x=740). Streaming, not
+            // terrain, is the subject — pin the classic generation.
+            World = { TerrainGeneration = 0 },
         };
         var server = new SvGameServer(config, _content, st, repo);
         server.Start();


### PR DESCRIPTION
The main run after #1651 (landscape variety 2/6) failed its Slow tier on one test: `ChunkStreamingTests.Sweep_KeepsTheWholeStreamedView_OfAPlayerStandingOnTheSeam` asserts as a **precondition** that seed 1's natural spawn (pad 0) sits on the longitude seam. Where the dry-pad search lands pad 0 depends on the relief, and the generation-1 relief moves it to chunk x=740, five columns off the seam.

Streaming across the seam, not terrain, is the subject — the test world now carries `World = { TerrainGeneration = 0 }`, the same pin the six gameplay test classes got in #1651. Test-only change; the test passes locally on the classic relief.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
