### PR TITLE
feat(worldgen): 12 landmark families, 4 overhang bands, geodes / aquifers / strata — new kinds of mountains, holes and hidden places on generation-1 worlds (#1646)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ the richer, screenshot-laden versions live there. `(#123)` references the pull r
 
 ## [Unreleased]
 
+### 🏔️ Landscape variety, part 3 of 6 — new kinds of mountains, holes and hidden places (#1646)
+
+- **New worlds only.** Twelve new landform kinds join the volcanoes, buttes and rifts: broad shield
+  volcanoes, round impact basins that fill with water, glacier-carved U-valleys, wind-carved yardang ridges,
+  drumlin fields, lone granite domes (inselbergs), star dunes, fields of little mud volcanoes, chains of
+  sinkholes, small crater bowls (maars), mushroom rocks, and glacier tongues running down cold mountains.
+- **Things that hang in the air:** natural rock bridges over gorges, wave-cut ledges at the foot of sea
+  cliffs, snow cornices on the ridges of the coldest worlds.
+- **Under the ground:** hollow crystal geodes to break into, caverns that hold whole underground lakes on
+  wet worlds, and layered rock strata in the upper crust.
+- Existing worlds are byte-identical.
+
 ### 🏔️ Landscape variety, part 2 of 6 — every new world rolls its own relief (#1645)
 
 - **New worlds only.** A planet type used to have one landscape: every desert a dune sea, every highland a

--- a/TODO.md
+++ b/TODO.md
@@ -24,6 +24,20 @@ envelope at the WebSocket edge; deterministic seed world-gen; SQLite default per
 
 ---
 
+### ★ Landscape variety 3/6: 12 landmark families, 4 overhang bands, geodes / aquifers / strata (#1646, 2026-09-05, branch landscape/1646-landmarks)
+
+Generation-1 worlds only; the eight classic goldens are byte-identical, `tundra-gen1` + `rocky-gen1` pinned
+(`highland-gen1` re-pinned — the gen-1 groups move with every part until release). `WorldGenerator.LandmarksGen1.cs`:
+rows `shield-volcano`, `impact-basin`, `glacial-trough`, `yardangs`, `drumlin-field`, `inselberg` (granite paint),
+`star-dunes`, `mud-volcanoes`, `sinkhole-chain`, `maar`, `mushroom-rock`, `glacier-tongue` (ice paint) appended to
+`LandmarkKinds` after the classic rows; bands natural bridge / coastal ledge / ice cornice / mushroom cap
+(`MaxColumnBands` 8); geodes (crystal shell, hollow), aquifer caverns, sediment strata (granite until sandstone lands
+in part 4). Tags `inselbergs` / `wind` / `glacial` in `planets.json`. `LandscapeLandmarksTests` (gen-0 invariance,
+table order, per-row shape ranges, granite/ice paints, clamp + determinism + seam, bridge/cap/cornice bands, geode
+hollow, strata count gen 0 vs 1, aquifer lake rate). Docs: WORLD_GENERATION.md §12.2.
+
+---
+
 ### ★ Landscape variety 2/6: regional style pools, per-world scale, biome relief, 7 new styles, 11 archetypes, planet regimes (#1645, 2026-09-05, branch landscape/1645-relief)
 
 Generation-1 worlds only (`w.Generation >= 1`; the eight classic goldens are byte-identical, three `*-gen1` groups

--- a/data/planets.json
+++ b/data/planets.json
@@ -1,7 +1,7 @@
 [
   {
     "key": "rocky", "baseTemperature": 12, "nameKey": "planet.rocky.name", "atmosphereHeight": 190, "cloudColor": 15593458, "cloudDensity": 0.35,
-    "terrainTags": ["buttes", "hoodoos"],
+    "terrainTags": ["buttes", "hoodoos", "inselbergs"],
     "baseHeight": 64, "amplitude": 14, "terrainScale": 48.0, "terrainStyle": "mesa",
     "terrainStyles": ["mesa", "hills", "canyons", "downs"],
     "surfaceBlock": "dirt", "subSurfaceBlock": "dirt", "deepBlock": "stone", "surfaceDepth": 4,
@@ -24,6 +24,7 @@
   },
   {
     "key": "ice", "floraTheme": "tundra", "baseTemperature": -38, "nameKey": "planet.ice.name", "atmosphereHeight": 200, "cloudColor": 14478069, "cloudDensity": 0.5,
+    "terrainTags": ["glacial"],
     "baseHeight": 60, "amplitude": 10, "terrainScale": 56.0,
     "terrainStyles": ["hills", "flats", "glacial"],
     "surfaceBlock": "ice", "subSurfaceBlock": "ice", "deepBlock": "stone", "surfaceDepth": 5,
@@ -70,7 +71,7 @@
   },
   {
     "key": "desert", "floraTheme": "desert", "baseTemperature": 44, "nameKey": "planet.desert.name", "atmosphereHeight": 190, "cloudColor": 15260080, "cloudDensity": 0.3,
-    "terrainTags": ["buttes"],
+    "terrainTags": ["buttes", "inselbergs", "wind"],
     "baseHeight": 62, "amplitude": 10, "terrainScale": 60.0, "terrainStyle": "dunes",
     "terrainStyles": ["dunes", "badlands", "flats", "downs"],
     "surfaceBlock": "sand", "subSurfaceBlock": "sand", "deepBlock": "stone", "surfaceDepth": 5,
@@ -204,7 +205,7 @@
   },
   {
     "key": "savanna", "floraTheme": "savanna", "baseTemperature": 32, "nameKey": "planet.savanna.name", "atmosphereHeight": 210, "cloudColor": 15261109, "cloudDensity": 0.3,
-    "terrainTags": ["buttes"],
+    "terrainTags": ["buttes", "inselbergs"],
     "baseHeight": 64, "amplitude": 10, "terrainScale": 58.0,
     "terrainStyles": ["hills", "downs", "flats"],
     "surfaceBlock": "grass", "subSurfaceBlock": "dirt", "deepBlock": "stone", "surfaceDepth": 4,
@@ -297,6 +298,7 @@
   },
   {
     "key": "tundra", "floraTheme": "tundra", "baseTemperature": -22, "nameKey": "planet.tundra.name", "atmosphereHeight": 220, "cloudColor": 14606326, "cloudDensity": 0.5,
+    "terrainTags": ["glacial"],
     "baseHeight": 62, "amplitude": 14, "terrainScale": 52.0, "terrainStyle": "hills",
     "terrainStyles": ["hills", "downs", "drumlins"],
     "surfaceBlock": "snow", "subSurfaceBlock": "dirt", "deepBlock": "stone", "surfaceDepth": 4,
@@ -369,7 +371,7 @@
   },
   {
     "key": "salt_flats", "floraTheme": "desert", "exotic": true, "baseTemperature": 40, "nameKey": "planet.salt_flats.name", "atmosphereHeight": 200, "cloudColor": 15263962, "cloudDensity": 0.2,
-    "terrainTags": ["salt"],
+    "terrainTags": ["salt", "wind"],
     "baseHeight": 60, "amplitude": 4, "terrainScale": 70.0, "terrainStyle": "flats",
     "surfaceBlock": "salt", "subSurfaceBlock": "sand", "deepBlock": "stone", "surfaceDepth": 4, "beachBlock": "salt",
     "caveThreshold": 0.82, "dataCacheRarity": 0.0012,
@@ -409,7 +411,7 @@
   },
   {
     "key": "tablelands", "floraTheme": "savanna", "baseTemperature": 24, "nameKey": "planet.tablelands.name", "atmosphereHeight": 200, "cloudColor": 15450749, "cloudDensity": 0.25,
-    "terrainTags": ["buttes", "hoodoos"],
+    "terrainTags": ["buttes", "hoodoos", "inselbergs", "wind"],
     "baseHeight": 62, "amplitude": 26, "terrainScale": 58.0, "terrainStyle": "tablelands",
     "terrainStyles": ["tablelands", "terraces", "mesa"],
     "surfaceBlock": "granite", "subSurfaceBlock": "granite", "deepBlock": "stone", "surfaceDepth": 4,
@@ -431,7 +433,7 @@
   },
   {
     "key": "badlands", "floraTheme": "desert", "baseTemperature": 38, "nameKey": "planet.badlands.name", "atmosphereHeight": 190, "cloudColor": 15593458, "cloudDensity": 0.2,
-    "terrainTags": ["buttes", "hoodoos"],
+    "terrainTags": ["buttes", "hoodoos", "wind"],
     "baseHeight": 60, "amplitude": 16, "terrainScale": 40.0, "terrainStyle": "badlands",
     "terrainStyles": ["badlands", "canyons", "terraces"],
     "surfaceBlock": "sand", "subSurfaceBlock": "granite", "deepBlock": "stone", "surfaceDepth": 3,

--- a/docs/developer/WORLD_GENERATION.md
+++ b/docs/developer/WORLD_GENERATION.md
@@ -658,5 +658,35 @@ escarpment at its own latitude → three storeys; the first escarpment is forced
 (~3 %, a 30–60-block wall 24–44 wide girdling the planet along X, meandering like the mega-rift).
 Never on sky, void or cratered worlds.
 
-Parts 3–6 (new landmarks, water bodies, paints, props, trees, data-only planet types, monument archetypes)
-are documented here as they land.
+### 12.2 Part 3 — landmark families, overhang bands, underground finds (#1646, generation ≥ 1)
+
+`WorldGenerator.LandmarksGen1.cs`. Every family is a hotspot-cell feature on the #477 recipe and gates on a
+profile flag that `WonderFor` only sets on generation-1 worlds, so the classic table order and every
+generation-0 world are untouched. The new rows are appended after `mega-rift` in footprint order (largest
+first): `shield-volcano` (r 200–400, h 20–40, a 6-deep summit bowl for part 4's lava lake; volcanic tag or a
+quarter of volcano worlds), `impact-basin` (r 120–250, 20–35 deep, raised rim; floods where it dips under the
+sea), `glacial-trough` (U-valley 25–45 deep whose floor slopes to one end; `glacial` tag or ≤ −5 °C),
+`yardangs` (grain-aligned rock ridges 6–12 tall inside a round field; `wind`), `drumlin-field` (rounded
+whalebacks; `glacial`, unless the world rolled the drumlins style), `inselberg` (granite dome r 60–150,
+h 40–90 with a granite paint delegate; `inselbergs`), `star-dunes` (pyramidal dune 15–30 tall with 3–5 arms;
+`wind` + sand), `mud-volcanoes` (fields of 3–6-tall cones on wet volcano worlds), `sinkhole-chain` (3–5
+sheer shafts along a line; cenote worlds), `maar` (bowl r 20–40, 8–14 deep with a low rim; the lake is part
+4), `mushroom-rock` (a 5–8 stem under a wide cap band; buttes worlds), `glacier-tongue` (paint only: ice on
+one flank sector of a cold massif). Tags in `planets.json`: `inselbergs` on rocky/savanna/desert/tablelands,
+`wind` on desert/tablelands/badlands/salt_flats, `glacial` on ice/tundra.
+
+**Bands** (`GetExtraBands`, `MaxColumnBands` 6 → 8): a natural bridge over a rift (1–2 rolled points per
+gorge, a 3-thick deck at the pre-rift rim ground, `TryGetRiftGeometry` repeats the rift's rolls so the classic
+`RiftOffset` stays byte-identical), a wave-cut coastal ledge (a 2-thick band just above the waterline on a
+shallow-water column next to ground 4+ above the sea, half of all such coasts by mask), ice cornices (a
+2-thick lip at crest level on a column 3 from a crest that stands 6+ higher, inside sparse regions of the
+coldest worlds), and the mushroom-rock cap.
+
+**Underground:** crystal geodes (hollow spheres r 6–14, 30–80 below base, crystal shell 1.6 thick, the
+interior air — `TryGetGeodeSpan` in the column profile, filled before caves and tunnels), aquifer caverns (on
+wet generation-1 worlds seven of eight mega-caverns hold a lake that fills most of the bowl), sediment strata
+(inside a 420-block region mask the upper crust between the topsoil and 48 deep carries tilted granite bands,
+2 of every 7 cells; ores keep their cells; sandstone replaces granite once part 4 ships the block).
+
+Parts 4–6 (water bodies, paints, props, trees, data-only planet types, monument archetypes) are documented
+here as they land.

--- a/src/BlocksBeyondTheStars.WorldGeneration/WorldGenerator.Columns.cs
+++ b/src/BlocksBeyondTheStars.WorldGeneration/WorldGenerator.Columns.cs
@@ -109,6 +109,13 @@ public sealed partial class WorldGenerator
         var saltBlockId = _content.GetBlock("salt")?.NumericId ?? BlockId.Air;
         var cavernCrystalId = _content.GetBlock("crystal")?.NumericId ?? BlockId.Air;
 
+        // Generation-1 underground finds (#1646): crystal geodes (hollow crystal-lined spheres) and sediment
+        // strata (tilted granite bands in the upper crust). Both gates are false on a generation-0 world.
+        var wonderGates = WonderFor(planet);
+        bool geodeWorld = wonderGates.Geodes && !cavernCrystalId.IsAir;
+        var strataId = _content.GetBlock("granite")?.NumericId ?? BlockId.Air;
+        bool strataWorld = wonderGates.Strata && !strataId.IsAir;
+
         // Geysers / vents (item 21 follow-up): sparse erupting spouts — water geysers on reasonably wet worlds,
         // steam/lava vents on volcanic/ashen worlds. A marker block at the surface; the client attaches the
         // eruption VFX + hiss when the player is near. Deterministic, very sparse (landmark-rare).
@@ -188,6 +195,8 @@ public sealed partial class WorldGenerator
             AnyBands = anyBands,
             CavernWorld = cavernWorld,
             TunnelWorld = tunnelWorld,
+            GeodeWorld = geodeWorld,
+            StrataWorld = strataWorld,
         };
 
         // #1527: per-chunk ore invariants + one lazily built noise lattice per (column, field): slot 0 caves,
@@ -222,6 +231,9 @@ public sealed partial class WorldGenerator
                 int tunnelCount = tunnelSpans.Length;
                 BlockId? craterMetal = col.CraterMetal;
                 int effSurfaceDepth = col.EffSurfaceDepth;
+                bool geodeHere = col.GeodeHere;
+                int geoLo = col.GeoLo, geoHi = col.GeoHi, geoInLo = col.GeoInLo, geoInHi = col.GeoInHi;
+                int strataShift = col.StrataShift;
 
                 for (int ly = 0; ly < WorldConstants.ChunkSize; ly++)
                 {
@@ -305,6 +317,19 @@ public sealed partial class WorldGenerator
                         continue; // void (or the lake fill above)
                     }
 
+                    // Crystal geode (#1646): a hollow sphere lined with crystal — the shell is solid crystal, the
+                    // interior air; nothing else (caves, tunnels, ores) touches the cells it claims.
+                    if (geodeHere && worldY >= geoLo && worldY <= geoHi)
+                    {
+                        if (worldY >= geoInLo && worldY <= geoInHi)
+                        {
+                            continue; // the hollow
+                        }
+
+                        chunk.Set(lx, ly, lz, cavernCrystalId);
+                        continue;
+                    }
+
                     // Cavern shell glints (#707): sparse crystal studs the cell just under the cavern floor.
                     if (cavernHere && worldY == cavLo - 1 && !cavernCrystalId.IsAir
                         && Noise.Value01(seed + 0x0CAFE1, WorldConstants.WrapX(worldX, _circumference), worldY, Wz(worldZ)) < 0.10)
@@ -377,6 +402,13 @@ public sealed partial class WorldGenerator
                         // interior isn't one uniform stone column on every world. Ores still vein through it.
                         var rock = depth >= mantleDepth ? mantleId : deepId;
                         block = SelectOre(calib, oreSlots, samplers, worldX, worldZ, worldY, depth, fallback: rock);
+
+                        // Sediment strata (#1646): inside a strata region the upper crust carries tilted granite
+                        // bands (2 of every 7 cells) between the topsoil and 48 deep; ores keep their cells.
+                        if (block == rock && strataShift != int.MinValue && depth < 48 && StrataBandAt(worldY, strataShift))
+                        {
+                            block = strataId;
+                        }
 
                         if (block == rock && planet.DataCacheRarity > 0 && !dataCacheId.IsAir)
                         {
@@ -482,7 +514,8 @@ public sealed partial class WorldGenerator
     private sealed class ColumnProfile
     {
         public int SurfaceY, SeabedY, WaterTop, IceTop, BiomeIndex, IslandTop, CavLo, CavHi, CavLakeY, EffSurfaceDepth;
-        public bool CavernHere, BeachHere;
+        public int GeoLo, GeoHi, GeoInLo, GeoInHi, StrataShift = int.MinValue; // #1646
+        public bool CavernHere, BeachHere, GeodeHere;
         public BlockId ColumnFluid, SurfaceId, SubSurfaceId;
         public BlockId? CraterMetal;
         public ColumnBand[] Bands = System.Array.Empty<ColumnBand>();
@@ -501,6 +534,7 @@ public sealed partial class WorldGenerator
         public BlockId FluidId, SeaWaterId, CraterLavaId, BeachId, SnowId, IceId, BasaltId, SaltBlockId, DeepId;
         public bool Ponds, VolcanoWorld, TravertineWorld, CenoteWorld, FreezeWater, BeachPossible, SnowPossible;
         public bool PenitenteWorld, BasaltFieldWorld, AnyBands, CavernWorld, TunnelWorld;
+        public bool GeodeWorld, StrataWorld; // #1646
         public double PondThreshold;
     }
 
@@ -776,6 +810,11 @@ public sealed partial class WorldGenerator
         // Tunnel carver (#708): this column's worm-carve y-spans (empty on most columns).
         int tunnelCount = tunnelWorld ? TunnelSpans(planet, worldX, worldZ, tunnelSpans) : 0;
 
+        // Generation-1 underground finds (#1646): the geode sphere covering this column, and the strata region.
+        int geoLo = 0, geoHi = -1, geoInLo = 1, geoInHi = 0;
+        bool geodeHere = c.GeodeWorld && TryGetGeodeSpan(planet, wonder, worldX, worldZ, out geoLo, out geoHi, out geoInLo, out geoInHi);
+        int strataShift = c.StrataWorld ? StrataShiftAt(seed, worldX, worldZ) : int.MinValue;
+
         // Crater-floor metal clumps (item 33): on a cratered world, the top cells of a metal-bearing deep
         // crater floor are exposed rare ore instead of regolith (only some craters, a few clumps each).
         BlockId? craterMetal = (planet.Cratered || _crateredWorld)
@@ -805,6 +844,12 @@ public sealed partial class WorldGenerator
             Tunnels = tunnelCount > 0 ? tunnelSpans.Slice(0, tunnelCount).ToArray() : System.Array.Empty<(int Lo, int Hi)>(),
             CraterMetal = craterMetal,
             EffSurfaceDepth = effSurfaceDepth,
+            GeodeHere = geodeHere,
+            GeoLo = geoLo,
+            GeoHi = geoHi,
+            GeoInLo = geoInLo,
+            GeoInHi = geoInHi,
+            StrataShift = strataShift,
         };
     }
 }

--- a/src/BlocksBeyondTheStars.WorldGeneration/WorldGenerator.LandmarksGen1.cs
+++ b/src/BlocksBeyondTheStars.WorldGeneration/WorldGenerator.LandmarksGen1.cs
@@ -1,0 +1,736 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using BlocksBeyondTheStars.Shared.Definitions;
+using BlocksBeyondTheStars.Shared.Primitives;
+using BlocksBeyondTheStars.Shared.World;
+
+namespace BlocksBeyondTheStars.WorldGeneration;
+
+/// <summary>Generation-1 landmark families, overhang bands and underground finds (#1646, landscape variety 3/6):
+/// shield volcanoes, impact basins, glacial troughs, yardang and drumlin fields, inselbergs, star dunes,
+/// mud-volcano fields, sinkhole chains, maars, mushroom rocks, glacier tongues; natural bridges, wave-cut
+/// coastal overhangs, ice cornices; crystal geodes and sediment strata (partial of <see cref="WorldGenerator"/>).
+/// Every family is one hotspot-cell feature on the #477 recipe (one deterministic candidate per cell, the
+/// centre kept a full extent inside its cell) and gates on the world's generation through its profile flag,
+/// so no generation-0 world ever sees one.</summary>
+public sealed partial class WorldGenerator
+{
+    private static double Smooth01(double t) => t <= 0.0 ? 0.0 : t >= 1.0 ? 1.0 : t * t * (3.0 - 2.0 * t);
+
+    private static bool HasAir(PlanetType planet)
+        => !string.Equals(planet.Atmosphere, "none", System.StringComparison.OrdinalIgnoreCase);
+
+    private static double WaterAbundanceOf(PlanetType planet) => planet.WaterAbundance ?? (HasAir(planet) ? 0.55 : 0.0);
+
+    private static bool SandSurface(PlanetType planet)
+    {
+        if (string.Equals(planet.SurfaceBlock, "sand", System.StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        foreach (var b in planet.Biomes)
+        {
+            if (string.Equals(b.SurfaceBlock, "sand", System.StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    // ---------------- gates (resolved once per world in WonderFor, generation ≥ 1 only) ----------------
+
+    /// <summary>Shield volcanoes: every volcanic-tagged world, plus a quarter of the other volcano worlds.</summary>
+    private bool HasShieldVolcanoes(PlanetType planet, long seed)
+        => HasVolcanoes(planet) && (planet.HasTag(TerrainTag.Volcanic) || (Noise.Hash(seed ^ 0x5A1E1D01, 1, 2, 3) & 0xFF) < 64);
+
+    private bool HasImpactBasins(PlanetType planet) => HasMassifs(planet);
+
+    private bool HasInselbergs(PlanetType planet) => HasMassifs(planet) && planet.HasTag(TerrainTag.Inselbergs);
+
+    private bool HasGlacialTroughs(PlanetType planet)
+        => HasMassifs(planet) && (planet.HasTag(TerrainTag.Glacial) || planet.BaseTemperature <= -5.0);
+
+    private bool HasGlacierTongues(PlanetType planet) => HasMassifs(planet) && planet.BaseTemperature <= -5.0;
+
+    private bool HasYardangs(PlanetType planet) => HasMassifs(planet) && planet.HasTag(TerrainTag.Wind);
+
+    /// <summary>Drumlin fields as a landmark region — unless the world already rolled the drumlins STYLE.</summary>
+    private bool HasDrumlinFields(PlanetType planet, string[] styles)
+        => HasMassifs(planet) && planet.HasTag(TerrainTag.Glacial) && System.Array.IndexOf(styles, "drumlins") < 0;
+
+    private bool HasStarDunes(PlanetType planet) => HasMassifs(planet) && planet.HasTag(TerrainTag.Wind) && SandSurface(planet);
+
+    private bool HasMudVolcanoes(PlanetType planet) => HasVolcanoes(planet) && HasAir(planet) && WaterAbundanceOf(planet) >= 0.4;
+
+    private bool HasSinkholeChains(PlanetType planet) => HasCenotes(planet);
+
+    private bool HasMaars(PlanetType planet) => HasMassifs(planet) && WaterAbundanceOf(planet) > 0.3;
+
+    private bool HasMushroomRocks(PlanetType planet) => HasTableMountains(planet);
+
+    private bool HasNaturalBridges(PlanetType planet) => HasRifts(planet);
+
+    private bool HasCoastalOverhangs(PlanetType planet) => HasSeaStacks(planet);
+
+    private bool HasIceCornices(PlanetType planet) => HasPenitentes(planet);
+
+    private bool HasGeodes(PlanetType planet) => HasCaverns(planet) && !planet.Cratered && !_crateredWorld;
+
+    private bool HasStrata(PlanetType planet) => HasMassifs(planet);
+
+    // ---------------- shield volcano ----------------
+    private const double ShieldCellSize = 3000.0;
+    private const double ShieldChance = 0.12;
+    private const double ShieldMaxRadius = 400.0;
+
+    /// <summary>A very broad, low dome (r 200–400, h 20–40) with a shallow summit bowl — the lava lake that
+    /// fills the bowl is part 4's fluid work; until then the summit is a wide crater.</summary>
+    private double ShieldVolcanoOffset(PlanetType planet, long seed, int worldX, int worldZ)
+    {
+        if (!TryGetHotspot(seed ^ 0x5A1E1D02, ShieldCellSize, ShieldChance, ShieldMaxRadius + 20.0,
+                worldX, worldZ, out ulong h, out double dx, out double dz))
+        {
+            return 0.0;
+        }
+
+        double radius = 200.0 + ((h >> 16) & 0x3FF) / 1023.0 * (ShieldMaxRadius - 200.0); // 200..400
+        double dist = System.Math.Sqrt(dx * dx + dz * dz);
+        if (dist >= radius)
+        {
+            return 0.0;
+        }
+
+        double height = 20.0 + ((h >> 26) & 0x3FF) / 1023.0 * 20.0; // 20..40
+        height = System.Math.Min(height, MaxNaturalSurfaceY - 16.0 - planet.BaseHeight);
+        double u = dist / radius;
+        double dome = height * System.Math.Pow(1.0 - u * u, 1.2);
+        double bowlR = radius * 0.22;
+        if (dist < bowlR)
+        {
+            dome -= 6.0 * Smooth01(1.0 - dist / bowlR);
+        }
+
+        return dome;
+    }
+
+    // ---------------- flooded impact basin ----------------
+    private const double BasinCellSize = 2600.0;
+    private const double BasinChance = 0.08;
+    private const double BasinMaxRadius = 250.0;
+
+    /// <summary>A rare broad bowl (r 120–250, 20–35 deep) with a raised rim; wherever the floor dips under
+    /// the sea percentile it floods into a round lake for free.</summary>
+    private double ImpactBasinOffset(long seed, int worldX, int worldZ)
+    {
+        if (!TryGetHotspot(seed ^ 0x1B0A51, BasinCellSize, BasinChance, BasinMaxRadius + 20.0,
+                worldX, worldZ, out ulong h, out double dx, out double dz))
+        {
+            return 0.0;
+        }
+
+        double radius = 120.0 + ((h >> 16) & 0x3FF) / 1023.0 * (BasinMaxRadius - 120.0); // 120..250
+        double dist = System.Math.Sqrt(dx * dx + dz * dz);
+        if (dist >= radius)
+        {
+            return 0.0;
+        }
+
+        double depth = 20.0 + ((h >> 26) & 0x3FF) / 1023.0 * 15.0; // 20..35
+        double u = dist / radius;
+        double bowl = u < 0.85 ? -depth * (1.0 - (u / 0.85) * (u / 0.85)) : 0.0;
+        double rim = 6.0 * System.Math.Exp(-((u - 0.92) / 0.05) * ((u - 0.92) / 0.05)) * Smooth01((1.0 - u) / 0.04);
+        return bowl + rim;
+    }
+
+    // ---------------- glacial trough ----------------
+    private const double TroughCellSize = 2200.0;
+    private const double TroughChance = 0.25;
+    private const double TroughMaxHalfLen = 400.0;
+    private const double TroughMaxHalfWidth = 45.0;
+
+    /// <summary>A U-shaped valley (25–45 deep) whose floor slopes toward one end — the deep end takes the
+    /// terminal tarn (part 4) or floods where it dips under the sea.</summary>
+    private double GlacialTroughOffset(long seed, int worldX, int worldZ)
+    {
+        if (!TryGetHotspot(seed ^ 0x61AC1A1, TroughCellSize, TroughChance, TroughMaxHalfLen + TroughMaxHalfWidth + 16.0,
+                worldX, worldZ, out ulong h, out double dx, out double dz))
+        {
+            return 0.0;
+        }
+
+        double angle = ((h >> 16) & 0x3FF) / 1023.0 * System.Math.PI;
+        double halfLen = 200.0 + ((h >> 26) & 0x3FF) / 1023.0 * (TroughMaxHalfLen - 200.0);   // 200..400
+        double halfWidth = 25.0 + ((h >> 56) & 0xFF) / 255.0 * (TroughMaxHalfWidth - 25.0);   // 25..45
+        double cos = System.Math.Cos(angle);
+        double sin = System.Math.Sin(angle);
+        double along = dx * cos + dz * sin;
+        double across = -dx * sin + dz * cos;
+        if (System.Math.Abs(along) > halfLen || System.Math.Abs(across) > halfWidth)
+        {
+            return 0.0;
+        }
+
+        ulong h2 = h * 0x9E3779B97F4A7C15UL;
+        double depth = 25.0 + ((h2 >> 20) & 0x3FF) / 1023.0 * 20.0; // 25..45
+        double u = across / halfWidth;
+        double wall = 1.0 - u * u;                                   // the U
+        double slope = 0.55 + 0.45 * (along / halfLen * 0.5 + 0.5);  // deeper toward the +along end
+        double endT = 1.0 - System.Math.Abs(along) / halfLen;
+        double taper = endT >= 0.15 ? 1.0 : Smooth01(endT / 0.15);
+        return -depth * wall * slope * taper;
+    }
+
+    // ---------------- yardang field ----------------
+    private const double YardangCellSize = 1400.0;
+    private const double YardangChance = 0.35;
+    private const double YardangMaxRadius = 260.0;
+
+    /// <summary>Parallel wind-carved rock ridges (6–12 tall, pitch 18–30) along the world's grain inside a
+    /// round field; the field edge fades over its outer quarter.</summary>
+    private double YardangOffset(WonderProfile w, int worldX, int worldZ)
+    {
+        if (!TryGetHotspot(w.Seed ^ 0x9A2DA46, YardangCellSize, YardangChance, YardangMaxRadius + 16.0,
+                worldX, worldZ, out ulong h, out double dx, out double dz))
+        {
+            return 0.0;
+        }
+
+        double radius = 120.0 + ((h >> 16) & 0x3FF) / 1023.0 * (YardangMaxRadius - 120.0); // 120..260
+        double dist = System.Math.Sqrt(dx * dx + dz * dz);
+        if (dist >= radius)
+        {
+            return 0.0;
+        }
+
+        double amp = 6.0 + ((h >> 26) & 0x3FF) / 1023.0 * 6.0;    // 6..12
+        double pitch = 18.0 + ((h >> 36) & 0x3FF) / 1023.0 * 12.0; // 18..30
+        double ridge = System.Math.Max(0.0, OrientedRidge(w.Seed + 0x9A2DA47, w.Grain, worldX, worldZ, pitch));
+        double fall = Smooth01((1.0 - dist / radius) / 0.25);
+        return amp * System.Math.Pow(ridge, 1.5) * fall;
+    }
+
+    // ---------------- drumlin field ----------------
+    private const double DrumlinCellSize = 1400.0;
+    private const double DrumlinChance = 0.35;
+    private const double DrumlinMaxRadius = 260.0;
+
+    /// <summary>Rounded whaleback ridges (6–10 tall) elongated along the grain inside a round field.</summary>
+    private double DrumlinFieldOffset(WonderProfile w, int worldX, int worldZ)
+    {
+        if (!TryGetHotspot(w.Seed ^ 0xD2A1B, DrumlinCellSize, DrumlinChance, DrumlinMaxRadius + 16.0,
+                worldX, worldZ, out ulong h, out double dx, out double dz))
+        {
+            return 0.0;
+        }
+
+        double radius = 120.0 + ((h >> 16) & 0x3FF) / 1023.0 * (DrumlinMaxRadius - 120.0);
+        double dist = System.Math.Sqrt(dx * dx + dz * dz);
+        if (dist >= radius)
+        {
+            return 0.0;
+        }
+
+        double amp = 6.0 + ((h >> 26) & 0x3FF) / 1023.0 * 4.0; // 6..10
+        double d = GrainFbm(w.Seed + 0xD2A1C, w.Grain, worldX, worldZ, 40.0, octaves: 2);
+        double ridged = Smooth01(1.0 - System.Math.Abs(d * 2.0 - 1.0));
+        return amp * ridged * Smooth01((1.0 - dist / radius) / 0.25);
+    }
+
+    // ---------------- inselberg ----------------
+    private const double InselbergCellSize = 1500.0;
+    private const double InselbergChance = 0.35;
+    private const double InselbergMaxRadius = 150.0;
+
+    private bool TryGetInselberg(PlanetType planet, long seed, int worldX, int worldZ, out double rise, out double radius, out double dist)
+    {
+        rise = radius = dist = 0.0;
+        if (!TryGetHotspot(seed ^ 0x1A5E1B, InselbergCellSize, InselbergChance, InselbergMaxRadius + 16.0,
+                worldX, worldZ, out ulong h, out double dx, out double dz))
+        {
+            return false;
+        }
+
+        radius = 60.0 + ((h >> 16) & 0x3FF) / 1023.0 * (InselbergMaxRadius - 60.0); // 60..150
+        dist = System.Math.Sqrt(dx * dx + dz * dz);
+        if (dist >= radius)
+        {
+            return false;
+        }
+
+        double height = 40.0 + ((h >> 26) & 0x3FF) / 1023.0 * 50.0; // 40..90
+        height = System.Math.Min(height, MaxNaturalSurfaceY - 16.0 - planet.BaseHeight);
+        double u = dist / radius;
+        rise = height * System.Math.Pow(1.0 - u * u, 0.8); // steep flanks, rounded crown
+        return true;
+    }
+
+    /// <summary>A lone smooth granite dome rising from flat ground (r 60–150, h 40–90).</summary>
+    private double InselbergOffset(PlanetType planet, long seed, int worldX, int worldZ)
+        => TryGetInselberg(planet, seed, worldX, worldZ, out double rise, out _, out _) ? rise : 0.0;
+
+    /// <summary>The dome's bare granite skin (the paint delegate of the inselberg row).</summary>
+    private BlockId? InselbergPaint(PlanetType planet, WonderProfile w, int worldX, int worldZ)
+    {
+        if (!TryGetInselberg(planet, w.Seed, worldX, worldZ, out double rise, out _, out _) || rise < 2.5)
+        {
+            return null;
+        }
+
+        var granite = _content.GetBlock("granite")?.NumericId ?? BlockId.Air;
+        return granite.IsAir ? null : granite;
+    }
+
+    // ---------------- star dunes ----------------
+    private const double StarDuneCellSize = 700.0;
+    private const double StarDuneChance = 0.30;
+    private const double StarDuneMaxRadius = 120.0;
+
+    /// <summary>A pyramidal sand mountain (15–30 tall) with 3–5 radial arms.</summary>
+    private double StarDuneOffset(long seed, int worldX, int worldZ)
+    {
+        if (!TryGetHotspot(seed ^ 0x57A2D0, StarDuneCellSize, StarDuneChance, StarDuneMaxRadius + 8.0,
+                worldX, worldZ, out ulong h, out double dx, out double dz))
+        {
+            return 0.0;
+        }
+
+        double radius = 60.0 + ((h >> 16) & 0x3FF) / 1023.0 * (StarDuneMaxRadius - 60.0);
+        double dist = System.Math.Sqrt(dx * dx + dz * dz);
+        if (dist >= radius)
+        {
+            return 0.0;
+        }
+
+        double height = 15.0 + ((h >> 26) & 0x3FF) / 1023.0 * 15.0; // 15..30
+        int arms = 3 + (int)((h >> 36) & 0x3) % 3;                    // 3..5
+        double phase = ((h >> 40) & 0x3FF) / 1023.0 * System.Math.PI * 2.0;
+        double theta = System.Math.Atan2(dz, dx);
+        double arm = System.Math.Max(0.0, System.Math.Cos(arms * (theta - phase)));
+        double core = System.Math.Pow(1.0 - dist / radius, 1.5);
+        return height * core * (0.35 + 0.65 * arm * arm);
+    }
+
+    // ---------------- mud-volcano / fumarole field ----------------
+    private const double MudFieldCellSize = 900.0;
+    private const double MudFieldChance = 0.12;
+    private const double MudFieldMaxRadius = 120.0;
+
+    /// <summary>A round field of small cones (3–6 tall) with a dip at each vent — wet volcano worlds.</summary>
+    private double MudVolcanoOffset(long seed, int worldX, int worldZ)
+    {
+        if (!TryGetHotspot(seed ^ 0x3DD0F1, MudFieldCellSize, MudFieldChance, MudFieldMaxRadius + 8.0,
+                worldX, worldZ, out ulong h, out double dx, out double dz))
+        {
+            return 0.0;
+        }
+
+        double radius = 60.0 + ((h >> 16) & 0x3FF) / 1023.0 * (MudFieldMaxRadius - 60.0);
+        double dist = System.Math.Sqrt(dx * dx + dz * dz);
+        if (dist >= radius)
+        {
+            return 0.0;
+        }
+
+        double c = FbmT(seed + 0x3DD0F2, worldX, worldZ, 9.0, octaves: 2);
+        if (c <= 0.72)
+        {
+            return 0.0;
+        }
+
+        double coneH = 3.0 + ((h >> 26) & 0x3FF) / 1023.0 * 3.0; // 3..6
+        double rise = System.Math.Pow((c - 0.72) / 0.28, 1.3) * coneH;
+        if (c > 0.95)
+        {
+            rise *= 0.4; // the vent dip
+        }
+
+        return rise * Smooth01((1.0 - dist / radius) / 0.3);
+    }
+
+    // ---------------- sinkhole chain ----------------
+    private const double SinkholeCellSize = 900.0;
+    private const double SinkholeChance = 0.25;
+    private const double SinkholeMaxHalfLen = 90.0;
+
+    /// <summary>3–5 sheer shafts (r 3–5, 12–20 deep) strung along a straight line.</summary>
+    private double SinkholeChainOffset(long seed, int worldX, int worldZ)
+    {
+        if (!TryGetHotspot(seed ^ 0x51AC40, SinkholeCellSize, SinkholeChance, SinkholeMaxHalfLen + 8.0,
+                worldX, worldZ, out ulong h, out double dx, out double dz))
+        {
+            return 0.0;
+        }
+
+        double angle = ((h >> 16) & 0x3FF) / 1023.0 * System.Math.PI;
+        double halfLen = 40.0 + ((h >> 26) & 0x3FF) / 1023.0 * (SinkholeMaxHalfLen - 40.0);
+        int count = 3 + (int)((h >> 36) & 0x3) % 3;                   // 3..5
+        double radius = 3.0 + ((h >> 40) & 0x3FF) / 1023.0 * 2.0;      // 3..5
+        double depth = 12.0 + ((h >> 50) & 0x3FF) / 1023.0 * 8.0;      // 12..20
+        double cos = System.Math.Cos(angle);
+        double sin = System.Math.Sin(angle);
+        double along = dx * cos + dz * sin;
+        double across = -dx * sin + dz * cos;
+        if (System.Math.Abs(across) > radius || System.Math.Abs(along) > halfLen + radius)
+        {
+            return 0.0;
+        }
+
+        for (int k = 0; k < count; k++)
+        {
+            double pos = -halfLen + 2.0 * halfLen * (k + 0.5) / count;
+            double dd = System.Math.Sqrt((along - pos) * (along - pos) + across * across);
+            if (dd < radius)
+            {
+                return -depth * Smooth01((1.0 - dd / radius) / 0.3);
+            }
+        }
+
+        return 0.0;
+    }
+
+    // ---------------- maar ----------------
+    private const double MaarCellSize = 1100.0;
+    private const double MaarChance = 0.25;
+    private const double MaarMaxRadius = 40.0;
+
+    /// <summary>A small round explosion bowl (r 20–40, 8–14 deep) with a low rim — the crater lake is part 4.</summary>
+    private double MaarOffset(long seed, int worldX, int worldZ)
+    {
+        if (!TryGetHotspot(seed ^ 0x3AA201, MaarCellSize, MaarChance, MaarMaxRadius * 1.15 + 6.0,
+                worldX, worldZ, out ulong h, out double dx, out double dz))
+        {
+            return 0.0;
+        }
+
+        double radius = 20.0 + ((h >> 16) & 0x3FF) / 1023.0 * (MaarMaxRadius - 20.0);
+        double dist = System.Math.Sqrt(dx * dx + dz * dz);
+        double u = dist / radius;
+        if (u >= 1.15)
+        {
+            return 0.0;
+        }
+
+        double depth = 8.0 + ((h >> 26) & 0x3FF) / 1023.0 * 6.0; // 8..14
+        double bowl = u < 1.0 ? -depth * (1.0 - u * u) : 0.0;
+        double rim = 2.0 * System.Math.Exp(-((u - 1.0) / 0.08) * ((u - 1.0) / 0.08));
+        if (u > 1.0)
+        {
+            rim *= Smooth01((1.15 - u) / 0.15);
+        }
+
+        return bowl + rim;
+    }
+
+    // ---------------- mushroom rock ----------------
+    private const double MushroomCellSize = 260.0;
+    private const double MushroomChance = 0.25;
+
+    private bool TryGetMushroomRock(PlanetType planet, WonderProfile w, int worldX, int worldZ,
+        out double dist, out double rise, out double capR, out int anchor)
+    {
+        dist = rise = capR = 0.0;
+        anchor = 0;
+        if (!TryGetHotspot(w.Seed ^ 0x3B5D00, MushroomCellSize, MushroomChance, 8.0,
+                worldX, worldZ, out ulong h, out double dx, out double dz))
+        {
+            return false;
+        }
+
+        dist = System.Math.Sqrt(dx * dx + dz * dz);
+        capR = 3.5 + ((h >> 16) & 0x3) * 0.6;   // 3.5..5.3
+        if (dist > capR || FbmT(w.Seed + 0x3B5D01, worldX, worldZ, w.Scale * 1.6, octaves: 2) <= 0.58)
+        {
+            return false; // outside the cap, or outside a mushroom-rock region
+        }
+
+        rise = 5.0 + ((h >> 20) & 0x3);         // 5..8
+        anchor = RawSurfaceHeight(planet, worldX - (int)System.Math.Round(dx), worldZ - (int)System.Math.Round(dz));
+        return true;
+    }
+
+    /// <summary>The mushroom rock's stem (the landmark row): a sheer pillar 5–8 tall under the cap.</summary>
+    private double MushroomStemOffset(PlanetType planet, WonderProfile w, int worldX, int worldZ)
+    {
+        if (!TryGetMushroomRock(planet, w, worldX, worldZ, out double dist, out double rise, out _, out _) || dist > 1.6)
+        {
+            return 0.0;
+        }
+
+        return rise * System.Math.Pow(1.0 - dist / 1.6, 0.2);
+    }
+
+    /// <summary>The mushroom rock's wide cap band: a 2-thick rock disc on the stem top.</summary>
+    private bool TryGetMushroomCap(PlanetType planet, WonderProfile w, int worldX, int worldZ, out int bottom, out int top)
+    {
+        bottom = 0;
+        top = -1;
+        if (!TryGetMushroomRock(planet, w, worldX, worldZ, out _, out double rise, out _, out int anchor))
+        {
+            return false;
+        }
+
+        top = anchor + (int)System.Math.Round(rise) + 1;
+        bottom = top - 1;
+        return true;
+    }
+
+    // ---------------- glacier tongue (paint only) ----------------
+
+    /// <summary>Ice paint on one flank sector of a massif on a cold world — a glacier tongue running down
+    /// from the summit region (the crevasse fields of #709 already slit the ice).</summary>
+    private BlockId? GlacierTonguePaint(WonderProfile w, int worldX, int worldZ)
+    {
+        if (!TryGetHotspot(w.Seed ^ 0x3A551F, MassifCellSize, MassifChance, MassifMaxRadius + 20.0,
+                worldX, worldZ, out ulong h, out double dx, out double dz))
+        {
+            return null;
+        }
+
+        double radius = 150.0 + ((h >> 16) & 0x3FF) / 1023.0 * (MassifMaxRadius - 150.0); // the massif's own roll
+        double dist = System.Math.Sqrt(dx * dx + dz * dz);
+        if (dist < radius * 0.12 || dist > radius * 0.85)
+        {
+            return null;
+        }
+
+        double phi = ((h >> 40) & 0x3FF) / 1023.0 * System.Math.PI * 2.0;
+        double half = 0.35 + ((h >> 50) & 0xFF) / 255.0 * 0.25;
+        double theta = System.Math.Atan2(dz, dx);
+        double diff = System.Math.Abs(System.Math.IEEERemainder(theta - phi, System.Math.PI * 2.0));
+        if (diff > half)
+        {
+            return null;
+        }
+
+        var ice = _content.GetBlock("ice")?.NumericId ?? BlockId.Air;
+        return ice.IsAir ? null : ice;
+    }
+
+    // ---------------- natural bridge over a rift ----------------
+
+    /// <summary>The rift's straight-gorge geometry, the same rolls <see cref="RiftOffset"/> makes (kept
+    /// separate so the classic offset stays byte-identical).</summary>
+    private bool TryGetRiftGeometry(long seed, int worldX, int worldZ,
+        out double along, out double across, out double halfLen, out double halfWidth, out ulong hash)
+    {
+        along = across = halfLen = halfWidth = 0.0;
+        if (!TryGetHotspot(seed ^ 0x21F7A9, RiftCellSize, RiftChance,
+                RiftMaxHalfLen + RiftMaxHalfWidth + 16.0, worldX, worldZ,
+                out hash, out double dx, out double dz))
+        {
+            return false;
+        }
+
+        double angle = ((hash >> 16) & 0x3FF) / 1023.0 * System.Math.PI;
+        halfLen = 260.0 + ((hash >> 26) & 0x3FF) / 1023.0 * (RiftMaxHalfLen - 260.0);
+        halfWidth = 14.0 + ((hash >> 56) & 0xFF) / 255.0 * (RiftMaxHalfWidth - 14.0);
+        double cos = System.Math.Cos(angle);
+        double sin = System.Math.Sin(angle);
+        along = dx * cos + dz * sin;
+        across = -dx * sin + dz * cos;
+        return true;
+    }
+
+    /// <summary>A rock bridge spanning the gorge at 1–2 rolled points: a 3-thick deck at the rim ground, 7 wide.</summary>
+    private bool TryGetNaturalBridge(PlanetType planet, long seed, int worldX, int worldZ, out int bottom, out int top)
+    {
+        bottom = 0;
+        top = -1;
+        if (!TryGetRiftGeometry(seed, worldX, worldZ, out double along, out double across, out double halfLen, out double halfWidth, out ulong h)
+            || System.Math.Abs(across) > halfWidth + 1.0 || System.Math.Abs(along) > halfLen * 0.8)
+        {
+            return false;
+        }
+
+        ulong h2 = h * 0xD1B54A32D192ED03UL;
+        int bridges = 1 + (int)((h2 >> 4) & 1UL);
+        for (int k = 0; k < bridges; k++)
+        {
+            double pos = (-0.55 + 1.1 * ((h2 >> (8 + 10 * k)) & 0x3FF) / 1023.0) * halfLen * 0.8;
+            if (System.Math.Abs(along - pos) <= 3.0)
+            {
+                int anchor = RawSurfaceHeight(planet, worldX, worldZ); // the pre-rift rim ground
+                top = anchor;
+                bottom = anchor - 2;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    // ---------------- wave-cut coastal overhang ----------------
+
+    /// <summary>A rock ledge hanging over the water at the foot of a sea cliff: on a shallow-water column next
+    /// to ground that stands 4+ above the sea, a 2-thick band just above the waterline (about half of all
+    /// such coasts, by a mask).</summary>
+    private bool TryGetCoastalOverhang(PlanetType planet, long seed, int worldX, int worldZ, int surfaceY, out int bottom, out int top)
+    {
+        bottom = 0;
+        top = -1;
+        int sea = SeaLevel(planet);
+        if (sea == int.MinValue || surfaceY >= sea - 1 || surfaceY < sea - 6)
+        {
+            return false;
+        }
+
+        if (FbmT(seed + 0xC0A57A1, worldX, worldZ, 60.0, octaves: 2) <= 0.5)
+        {
+            return false;
+        }
+
+        bool cliff = SurfaceHeight(planet, worldX + 2, worldZ) >= sea + 4
+            || SurfaceHeight(planet, worldX - 2, worldZ) >= sea + 4
+            || SurfaceHeight(planet, worldX, worldZ + 2) >= sea + 4
+            || SurfaceHeight(planet, worldX, worldZ - 2) >= sea + 4;
+        if (!cliff)
+        {
+            return false;
+        }
+
+        bottom = sea + 2;
+        top = sea + 3;
+        return true;
+    }
+
+    // ---------------- ice cornice ----------------
+    private const double CorniceCellSize = 700.0;
+    private const double CorniceChance = 0.30;
+    private const double CorniceMaxRadius = 200.0;
+
+    /// <summary>Snow lips jutting from ridge crests over a steep drop, inside sparse cornice regions of the
+    /// coldest worlds: a column 3 from a crest that stands 6+ higher carries a 2-thick band at crest level.</summary>
+    private bool TryGetIceCornice(PlanetType planet, long seed, int worldX, int worldZ, int surfaceY, out int bottom, out int top)
+    {
+        bottom = 0;
+        top = -1;
+        if (!TryGetHotspot(seed ^ 0x1CEC0A1, CorniceCellSize, CorniceChance, CorniceMaxRadius + 8.0,
+                worldX, worldZ, out ulong h, out double dx, out double dz))
+        {
+            return false;
+        }
+
+        double radius = 100.0 + ((h >> 16) & 0x3FF) / 1023.0 * (CorniceMaxRadius - 100.0);
+        if (dx * dx + dz * dz >= radius * radius)
+        {
+            return false;
+        }
+
+        int crest = System.Math.Max(
+            System.Math.Max(SurfaceHeight(planet, worldX + 3, worldZ), SurfaceHeight(planet, worldX - 3, worldZ)),
+            System.Math.Max(SurfaceHeight(planet, worldX, worldZ + 3), SurfaceHeight(planet, worldX, worldZ - 3)));
+        if (crest < surfaceY + 6)
+        {
+            return false;
+        }
+
+        top = crest;
+        bottom = crest - 1;
+        return true;
+    }
+
+    // ---------------- crystal geode ----------------
+    private const double GeodeCellSize = 500.0;
+    private const double GeodeChance = 0.30;
+    private const double GeodeMaxRadius = 14.0;
+
+    /// <summary>The geode covering this column (r 6–14, 30–80 below base): the full sphere span and the hollow
+    /// interior span (empty when the column only grazes the shell). Everything between is crystal shell.</summary>
+    private bool TryGetGeodeSpan(PlanetType planet, WonderProfile w, int worldX, int worldZ,
+        out int yLo, out int yHi, out int innerLo, out int innerHi)
+    {
+        yLo = yHi = 0;
+        innerLo = 1;
+        innerHi = 0;
+        if (!TryGetHotspot(w.Seed ^ 0x6E0DE01, GeodeCellSize, GeodeChance, GeodeMaxRadius + 4.0,
+                worldX, worldZ, out ulong h, out double dx, out double dz))
+        {
+            return false;
+        }
+
+        double r = 6.0 + ((h >> 16) & 0x3FF) / 1023.0 * (GeodeMaxRadius - 6.0);
+        double q = r * r - dx * dx - dz * dz;
+        if (q <= 0.0)
+        {
+            return false;
+        }
+
+        int cy = planet.BaseHeight - 30 - (int)((h >> 26) & 0x3F) % 51; // 30..80 below base
+        double half = System.Math.Sqrt(q);
+        yLo = cy - (int)half;
+        yHi = cy + (int)half;
+        double ri = r - 1.6;
+        double qi = ri * ri - dx * dx - dz * dz;
+        if (qi > 0.0)
+        {
+            double hi = System.Math.Sqrt(qi);
+            innerLo = cy - (int)hi;
+            innerHi = cy + (int)hi;
+        }
+
+        return true;
+    }
+
+    // ---------------- sediment strata ----------------
+
+    /// <summary>The strata region shift for a column (gently tilted bands 7 apart, 2 thick, granite), or
+    /// <see cref="int.MinValue"/> where the column lies outside a strata region.</summary>
+    private int StrataShiftAt(long seed, int worldX, int worldZ)
+    {
+        if (FbmT(seed + 0x57A7A01, worldX, worldZ, 420.0, octaves: 2) <= 0.58)
+        {
+            return int.MinValue;
+        }
+
+        return (int)System.Math.Round((FbmT(seed + 0x57A7A02, worldX, worldZ, 300.0, octaves: 2) - 0.5) * 24.0);
+    }
+
+    private static bool StrataBandAt(int worldY, int shift) => ((worldY + shift) % 7 + 7) % 7 < 2;
+
+    // ---------------- test hooks ----------------
+
+    /// <summary>A landmark row's offset at a column, 0 when the row is inactive on this world (tests).</summary>
+    internal double LandmarkOffsetForTest(string name, PlanetType planet, int worldX, int worldZ)
+    {
+        var w = WonderFor(planet);
+        foreach (var k in LandmarkKinds)
+        {
+            if (k.Name == name)
+            {
+                return k.Active(w) ? k.Offset(this, planet, w, worldX, worldZ) : 0.0;
+            }
+        }
+
+        throw new System.ArgumentException($"unknown landmark row '{name}'", nameof(name));
+    }
+
+    /// <summary>A landmark row's paint at a column (tests).</summary>
+    internal BlockId? LandmarkPaintForTest(string name, PlanetType planet, int worldX, int worldZ)
+    {
+        var w = WonderFor(planet);
+        foreach (var k in LandmarkKinds)
+        {
+            if (k.Name == name)
+            {
+                return k.Active(w) && k.Paint is { } paint ? paint(this, planet, w, worldX, worldZ, SurfaceHeight(planet, worldX, worldZ)) : null;
+            }
+        }
+
+        throw new System.ArgumentException($"unknown landmark row '{name}'", nameof(name));
+    }
+
+    /// <summary>The geode span at a column (tests).</summary>
+    internal bool TryGetGeodeSpanForTest(PlanetType planet, int worldX, int worldZ, out int yLo, out int yHi, out int innerLo, out int innerHi)
+    {
+        var w = WonderFor(planet);
+        yLo = yHi = innerLo = innerHi = 0;
+        return w.Geodes && TryGetGeodeSpan(planet, w, worldX, worldZ, out yLo, out yHi, out innerLo, out innerHi);
+    }
+
+    /// <summary>Whether the strata bands run on this world (tests).</summary>
+    internal bool StrataForTest(PlanetType planet) => WonderFor(planet).Strata;
+}

--- a/src/BlocksBeyondTheStars.WorldGeneration/WorldGenerator.Overhangs.cs
+++ b/src/BlocksBeyondTheStars.WorldGeneration/WorldGenerator.Overhangs.cs
@@ -36,8 +36,9 @@ public sealed partial class WorldGenerator
         public BandKind Kind;
     }
 
-    /// <summary>Max extra bands a column can carry (#705): 3 island tiers + a cap + a waterfall.</summary>
-    public const int MaxColumnBands = 6;
+    /// <summary>Max extra bands a column can carry (#705): 3 island tiers + a cap + a waterfall, plus room for
+    /// the generation-1 bands (#1646: bridge, coastal ledge, cornice, mushroom cap) stacking on one column.</summary>
+    public const int MaxColumnBands = 8;
 
     /// <summary>Collects every extra band covering this column (#705): sky-island tiers (with ponds,
     /// stalactites and edge waterfalls, #707), arch bars, sea-stack and hoodoo caps and cenote lips
@@ -96,6 +97,32 @@ public sealed partial class WorldGenerator
         if (n < bands.Length && w.Cenotes && TryGetCenoteLip(planet, seed, worldX, worldZ, out int clLo, out int clHi))
         {
             bands[n++] = new ColumnBand { Bottom = clLo, Top = clHi, Kind = BandKind.Cap };
+        }
+
+        // Generation-1 bands (#1646): natural bridges over rifts, wave-cut coastal ledges, ice cornices,
+        // mushroom-rock caps. Every gate is false on a generation-0 world.
+        if (n < bands.Length && w.NaturalBridges && TryGetNaturalBridge(planet, seed, worldX, worldZ, out int nbLo, out int nbHi))
+        {
+            bands[n++] = new ColumnBand { Bottom = nbLo, Top = nbHi, Kind = BandKind.Cap };
+        }
+
+        if (n < bands.Length && w.MushroomRocks && TryGetMushroomCap(planet, w, worldX, worldZ, out int mcLo, out int mcHi))
+        {
+            bands[n++] = new ColumnBand { Bottom = mcLo, Top = mcHi, Kind = BandKind.Cap };
+        }
+
+        if (n < bands.Length && (w.CoastalOverhangs || w.IceCornices))
+        {
+            int surfaceY = SurfaceHeight(planet, worldX, worldZ);
+            if (w.CoastalOverhangs && TryGetCoastalOverhang(planet, seed, worldX, worldZ, surfaceY, out int coLo, out int coHi))
+            {
+                bands[n++] = new ColumnBand { Bottom = coLo, Top = coHi, Kind = BandKind.Cap };
+            }
+
+            if (n < bands.Length && w.IceCornices && TryGetIceCornice(planet, seed, worldX, worldZ, surfaceY, out int icLo, out int icHi))
+            {
+                bands[n++] = new ColumnBand { Bottom = icLo, Top = icHi, Kind = BandKind.Cap };
+            }
         }
 
         return n;

--- a/src/BlocksBeyondTheStars.WorldGeneration/WorldGenerator.Underground.cs
+++ b/src/BlocksBeyondTheStars.WorldGeneration/WorldGenerator.Underground.cs
@@ -55,7 +55,16 @@ public sealed partial class WorldGenerator
         double half = ry * System.Math.Sqrt(q);
         yLo = cy - (int)half;
         yHi = cy + (int)half;
-        if (((h >> 50) & 0x1) != 0)
+        if (w.Generation >= 1 && WaterAbundanceOf(planet) >= 0.4)
+        {
+            // Aquifer caverns (#1646): on wet generation-1 worlds seven of eight caverns hold a lake that fills
+            // most of the bowl — a still underground sea, not a puddle.
+            if (((h >> 50) & 0x7) != 0)
+            {
+                lakeY = cy - (int)(ry * 0.15);
+            }
+        }
+        else if (((h >> 50) & 0x1) != 0)
         {
             lakeY = cy - (int)(ry * (0.35 + ((h >> 52) & 0x3) * 0.05)); // lake fills the lower bowl
         }

--- a/src/BlocksBeyondTheStars.WorldGeneration/WorldGenerator.cs
+++ b/src/BlocksBeyondTheStars.WorldGeneration/WorldGenerator.cs
@@ -393,6 +393,11 @@ public sealed partial class WorldGenerator
         public double[]? ReliefMuls;
         public bool Tilted, Stepped, EquatorRidge;
 
+        // #1646 (generation 1): landmark families, overhang bands and underground finds — all false on gen 0.
+        public bool ShieldVolcanoes, ImpactBasins, GlacialTroughs, Yardangs, DrumlinFields, Inselbergs;
+        public bool StarDunes, MudVolcanoes, SinkholeChains, Maars, MushroomRocks, GlacierTongues;
+        public bool NaturalBridges, CoastalOverhangs, IceCornices, Geodes, Strata;
+
         /// <summary>The landmark table rows active on this world, in precedence order (#1644) — what
         /// <see cref="SurfaceHeightUncached"/> loops instead of a hand-written if-chain.</summary>
         public LandmarkOffsetFn[] ActiveLandmarks = System.Array.Empty<LandmarkOffsetFn>();
@@ -444,6 +449,22 @@ public sealed partial class WorldGenerator
         new("crevasse", w => w.Crevasses, static (g, p, w, x, z) => g.CrevasseOffset(w.Seed, x, z)),
         new("rift", w => w.Rifts, static (g, p, w, x, z) => g.RiftOffset(w.Seed, x, z)),
         new("mega-rift", w => w.MegaRift, static (g, p, w, x, z) => g.MegaRiftOffset(w.Seed, x, z)),
+        // Generation-1 families (#1646), appended after the classic rows in footprint order (largest first);
+        // their gates are false on every generation-0 world, so the classic precedence is untouched.
+        new("shield-volcano", w => w.ShieldVolcanoes, static (g, p, w, x, z) => g.ShieldVolcanoOffset(p, w.Seed, x, z)),
+        new("impact-basin", w => w.ImpactBasins, static (g, p, w, x, z) => g.ImpactBasinOffset(w.Seed, x, z)),
+        new("glacial-trough", w => w.GlacialTroughs, static (g, p, w, x, z) => g.GlacialTroughOffset(w.Seed, x, z)),
+        new("yardangs", w => w.Yardangs, static (g, p, w, x, z) => g.YardangOffset(w, x, z)),
+        new("drumlin-field", w => w.DrumlinFields, static (g, p, w, x, z) => g.DrumlinFieldOffset(w, x, z)),
+        new("inselberg", w => w.Inselbergs, static (g, p, w, x, z) => g.InselbergOffset(p, w.Seed, x, z),
+            static (g, p, w, x, z, y) => g.InselbergPaint(p, w, x, z)),
+        new("star-dunes", w => w.StarDunes, static (g, p, w, x, z) => g.StarDuneOffset(w.Seed, x, z)),
+        new("mud-volcanoes", w => w.MudVolcanoes, static (g, p, w, x, z) => g.MudVolcanoOffset(w.Seed, x, z)),
+        new("sinkhole-chain", w => w.SinkholeChains, static (g, p, w, x, z) => g.SinkholeChainOffset(w.Seed, x, z)),
+        new("maar", w => w.Maars, static (g, p, w, x, z) => g.MaarOffset(w.Seed, x, z)),
+        new("mushroom-rock", w => w.MushroomRocks, static (g, p, w, x, z) => g.MushroomStemOffset(p, w, x, z)),
+        new("glacier-tongue", w => w.GlacierTongues, static (g, p, w, x, z) => 0.0,
+            static (g, p, w, x, z, y) => g.GlacierTonguePaint(w, x, z)),
     };
 
     /// <summary>The landmark families active on this world in precedence order (tests).</summary>
@@ -621,6 +642,25 @@ public sealed partial class WorldGenerator
                     {
                         w.Escarpment = true; // three storeys = the classic escarpment plus a second one
                     }
+
+                    // #1646 landmark families, bands and underground finds.
+                    w.ShieldVolcanoes = HasShieldVolcanoes(planet, seed);
+                    w.ImpactBasins = HasImpactBasins(planet);
+                    w.GlacialTroughs = HasGlacialTroughs(planet);
+                    w.Yardangs = HasYardangs(planet);
+                    w.DrumlinFields = HasDrumlinFields(planet, w.Styles);
+                    w.Inselbergs = HasInselbergs(planet);
+                    w.StarDunes = HasStarDunes(planet);
+                    w.MudVolcanoes = HasMudVolcanoes(planet);
+                    w.SinkholeChains = HasSinkholeChains(planet);
+                    w.Maars = HasMaars(planet);
+                    w.MushroomRocks = HasMushroomRocks(planet);
+                    w.GlacierTongues = HasGlacierTongues(planet);
+                    w.NaturalBridges = HasNaturalBridges(planet);
+                    w.CoastalOverhangs = HasCoastalOverhangs(planet);
+                    w.IceCornices = HasIceCornices(planet);
+                    w.Geodes = HasGeodes(planet);
+                    w.Strata = HasStrata(planet);
                 }
 
                 var offsets = new System.Collections.Generic.List<LandmarkOffsetFn>(LandmarkKinds.Length);
@@ -641,7 +681,8 @@ public sealed partial class WorldGenerator
 
                 w.ActiveLandmarks = offsets.ToArray();
                 w.ActivePaints = paints.ToArray();
-                w.AnyBands = planet.FloatingIslands || w.Arches || w.SeaStacks || w.Hoodoos || w.Cenotes;
+                w.AnyBands = planet.FloatingIslands || w.Arches || w.SeaStacks || w.Hoodoos || w.Cenotes
+                    || w.NaturalBridges || w.CoastalOverhangs || w.IceCornices || w.MushroomRocks; // #1646
                 // #703 hybrid fade; #1645: on a multi-style world the fade runs whenever more than one style was
                 // rolled — identity styles (flats, spires) stay pure only as the sole pick.
                 w.HybridEligible = _terrainGeneration >= 1 && w.Styles.Length != 0

--- a/tests/BlocksBeyondTheStars.Tests/LandscapeLandmarksTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/LandscapeLandmarksTests.cs
@@ -1,0 +1,454 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using BlocksBeyondTheStars.Shared.Content;
+using BlocksBeyondTheStars.Shared.Definitions;
+using BlocksBeyondTheStars.Shared.Primitives;
+using BlocksBeyondTheStars.Shared.World;
+using BlocksBeyondTheStars.WorldGeneration;
+using Xunit;
+
+namespace BlocksBeyondTheStars.Tests;
+
+/// <summary>
+/// #1646 (landscape variety 3/6): the generation-1 landmark families, overhang bands and underground finds.
+/// Each family is probed on a world where its gate is open — the feature exists somewhere on the scanned
+/// area and its offset lies in the designed range — and every gate is closed on generation 0.
+/// </summary>
+public sealed class LandscapeLandmarksTests
+{
+    private static readonly GameContent Content = ContentLoader.LoadFromDirectory(TestPaths.DataDir());
+
+    private static readonly string[] Gen1Rows =
+    {
+        "shield-volcano", "impact-basin", "glacial-trough", "yardangs", "drumlin-field", "inselberg",
+        "star-dunes", "mud-volcanoes", "sinkhole-chain", "maar", "mushroom-rock", "glacier-tongue",
+    };
+
+    private static WorldGenerator Gen(long seed, int generation)
+    {
+        var gen = new WorldGenerator(seed, Content);
+        gen.SetLavaCoreVolcanoes(true); // every new world since #1631 — the shield volcanoes ride on the volcano gate
+        if (generation > 0)
+        {
+            gen.SetTerrainGeneration(generation);
+        }
+
+        return gen;
+    }
+
+    /// <summary>Scans a grid for the row's offset extremes: (min, max, hit count).</summary>
+    private static (double Min, double Max, int Hits) Scan(WorldGenerator gen, string row, PlanetType planet, int step)
+    {
+        double min = 0.0, max = 0.0;
+        int hits = 0;
+        int circ = WorldConstants.Circumference;
+        int period = WorldConstants.LatitudePeriodFor(circ);
+        for (int z = -period / 2; z < period / 2; z += step)
+            for (int x = 0; x < circ; x += step)
+            {
+                double o = gen.LandmarkOffsetForTest(row, planet, x, z);
+                if (o != 0.0)
+                {
+                    hits++;
+                    min = Math.Min(min, o);
+                    max = Math.Max(max, o);
+                }
+            }
+
+        return (min, max, hits);
+    }
+
+    /// <summary>The first of up to <paramref name="tries"/> seeds whose world carries the row somewhere.</summary>
+    private static WorldGenerator? FindWorldWith(string row, PlanetType planet, int step, int tries, out (double Min, double Max, int Hits) scan)
+    {
+        scan = default;
+        for (long s = 1; s <= tries; s++)
+        {
+            var gen = Gen(s * 6151 + 3, 1);
+            scan = Scan(gen, row, planet, step);
+            if (scan.Hits > 0)
+            {
+                return gen;
+            }
+        }
+
+        return null;
+    }
+
+    // ---------- generation 0 stays classic ----------
+
+    [Fact]
+    public void GenerationZero_ActivatesNoneOfTheNewRows_Bands_OrFinds()
+    {
+        foreach (var planet in Content.Planets.Values)
+        {
+            var gen = Gen(4711, 0);
+            var order = gen.LandmarkOrderForTest(planet);
+            foreach (var row in Gen1Rows)
+            {
+                Assert.DoesNotContain(row, order);
+            }
+
+            Assert.False(gen.StrataForTest(planet), planet.Key);
+            Assert.False(gen.TryGetGeodeSpanForTest(planet, 10, 10, out _, out _, out _, out _), planet.Key);
+        }
+    }
+
+    [Fact]
+    public void LandmarkTable_AppendsTheNewRows_AfterTheClassicOnes()
+    {
+        var rocky = Content.Planets["rocky"];
+        var order = Gen(1, 1).LandmarkOrderForTest(rocky);
+        int lastClassic = Array.LastIndexOf(order, "mega-rift");
+        if (lastClassic < 0)
+        {
+            lastClassic = Array.LastIndexOf(order, "rift");
+        }
+
+        Assert.True(lastClassic >= 0);
+        foreach (var row in Gen1Rows)
+        {
+            int i = Array.IndexOf(order, row);
+            if (i >= 0)
+            {
+                Assert.True(i > lastClassic, $"{row} precedes a classic row");
+            }
+        }
+
+        Assert.Contains("inselberg", order);      // rocky carries the tag
+        Assert.Contains("mushroom-rock", order);  // buttes tag
+        Assert.DoesNotContain("yardangs", order); // no wind tag on rocky
+    }
+
+    // ---------- landmark shapes ----------
+
+    [Theory]
+    [InlineData("shield-volcano", "lava", 24, 15.0, 45.0, -8.0, 0.0)]
+    [InlineData("impact-basin", "savanna", 16, 0.0, 7.0, -36.0, -14.0)]
+    [InlineData("glacial-trough", "tundra", 16, 0.0, 0.0, -46.0, -18.0)]
+    [InlineData("yardangs", "desert", 12, 3.0, 13.0, 0.0, 0.0)]
+    [InlineData("drumlin-field", "tundra", 12, 3.0, 11.0, 0.0, 0.0)]
+    [InlineData("inselberg", "rocky", 16, 35.0, 95.0, 0.0, 0.0)]
+    [InlineData("star-dunes", "desert", 8, 10.0, 32.0, 0.0, 0.0)]
+    [InlineData("mud-volcanoes", "jungle", 6, 1.5, 7.0, 0.0, 0.0)]
+    [InlineData("sinkhole-chain", "jungle", 3, 0.0, 0.0, -21.0, -9.0)]
+    [InlineData("maar", "savanna", 6, 0.5, 2.5, -15.0, -6.0)]
+    [InlineData("mushroom-rock", "desert", 2, 4.0, 9.0, 0.0, 0.0)]
+    public void Row_AppearsOnAnEligibleWorld_WithinItsDesignedRange(string row, string key, int step, double maxLo, double maxHi, double minLo, double minHi)
+    {
+        var planet = Content.Planets[key];
+        var gen = FindWorldWith(row, planet, step, 40, out var scan);
+        Assert.NotNull(gen);
+        Assert.True(scan.Hits > 0, $"{row} never appears on {key}");
+        Assert.InRange(scan.Max, maxLo, maxHi);
+        Assert.InRange(scan.Min, minLo, minHi);
+    }
+
+    [Fact]
+    public void Inselberg_PaintsItsDomeGranite()
+    {
+        var rocky = Content.Planets["rocky"];
+        var granite = Content.GetBlock("granite")!.NumericId;
+        var gen = FindWorldWith("inselberg", rocky, 16, 40, out _);
+        Assert.NotNull(gen);
+        int circ = WorldConstants.Circumference;
+        int period = WorldConstants.LatitudePeriodFor(circ);
+        int painted = 0, domeCols = 0;
+        for (int z = -period / 2; z < period / 2; z += 16)
+            for (int x = 0; x < circ; x += 16)
+            {
+                double o = gen!.LandmarkOffsetForTest("inselberg", rocky, x, z);
+                if (o > 3.0)
+                {
+                    domeCols++;
+                    if (gen.LandmarkPaintForTest("inselberg", rocky, x, z) == granite)
+                    {
+                        painted++;
+                    }
+                }
+                else if (o == 0.0)
+                {
+                    Assert.Null(gen.LandmarkPaintForTest("inselberg", rocky, x, z));
+                }
+            }
+
+        Assert.True(domeCols > 0 && painted == domeCols, $"dome columns {domeCols}, granite {painted}");
+    }
+
+    [Fact]
+    public void GlacierTongue_PaintsIce_OnOneFlankSectorOfAColdMassif()
+    {
+        var ice = Content.Planets["ice"];
+        var iceBlock = Content.GetBlock("ice")!.NumericId;
+        int circ = WorldConstants.Circumference;
+        int period = WorldConstants.LatitudePeriodFor(circ);
+        for (long s = 1; s <= 120; s++)
+        {
+            var gen = Gen(s * 6151 + 3, 1);
+            if (!gen.LandmarkOrderForTest(ice).Contains("glacier-tongue"))
+            {
+                continue;
+            }
+
+            int painted = 0, massifCols = 0;
+            for (int z = -period / 2; z < period / 2; z += 12)
+                for (int x = 0; x < circ; x += 12)
+                {
+                    if (gen.LandmarkOffsetForTest("massif", ice, x, z) > 5.0)
+                    {
+                        massifCols++;
+                        if (gen.LandmarkPaintForTest("glacier-tongue", ice, x, z) == iceBlock)
+                        {
+                            painted++;
+                        }
+                    }
+                }
+
+            if (massifCols > 0)
+            {
+                Assert.True(painted > 0 && painted < massifCols, $"tongue covers {painted} of {massifCols} massif columns");
+                return;
+            }
+        }
+
+        Assert.Fail("no cold massif world found in 120 seeds");
+    }
+
+    // ---------- one overlay per column, clamp ----------
+
+    [Theory]
+    [InlineData("rocky")]
+    [InlineData("tundra")]
+    [InlineData("desert")]
+    [InlineData("jungle")]
+    [InlineData("ice")]
+    public void GenerationOneWorlds_StayClamped_Deterministic_AndSeamFree(string key)
+    {
+        var planet = Content.Planets[key];
+        var a = Gen(9090, 1);
+        var b = Gen(9090, 1);
+        int circ = WorldConstants.Circumference;
+        int period = WorldConstants.LatitudePeriodFor(circ);
+        for (int z = -period / 2; z < period / 2; z += 97)
+            for (int x = 0; x < circ; x += 131)
+            {
+                int h = a.SurfaceHeight(planet, x, z);
+                Assert.True(h <= 288, $"{key} ({x},{z}) = {h} pokes above the clamp");
+                Assert.Equal(h, b.SurfaceHeight(planet, x, z));
+                Assert.Equal(h, a.SurfaceHeightUncached(planet, x, z));
+                Assert.Equal(h, a.SurfaceHeight(planet, x + circ, z));
+                Assert.Equal(h, a.SurfaceHeight(planet, x, z + period));
+            }
+    }
+
+    // ---------- bands ----------
+
+    private static int CountBands(WorldGenerator gen, PlanetType planet, Func<int, int, bool> where, int step, out int sampled)
+    {
+        var bands = new WorldGenerator.ColumnBand[WorldGenerator.MaxColumnBands];
+        int circ = WorldConstants.Circumference;
+        int period = WorldConstants.LatitudePeriodFor(circ);
+        int count = 0;
+        sampled = 0;
+        for (int z = -period / 2; z < period / 2; z += step)
+            for (int x = 0; x < circ; x += step)
+            {
+                if (!where(x, z))
+                {
+                    continue;
+                }
+
+                sampled++;
+                int n = gen.GetExtraBands(planet, x, z, bands);
+                for (int i = 0; i < n; i++)
+                {
+                    if (bands[i].Kind == WorldGenerator.BandKind.Cap)
+                    {
+                        count++;
+                    }
+                }
+            }
+
+        return count;
+    }
+
+    [Fact]
+    public void NaturalBridge_SpansARift_AtRimLevel()
+    {
+        var savanna = Content.Planets["savanna"];
+        for (long s = 1; s <= 200; s++)
+        {
+            var gen = Gen(s * 6151 + 3, 1);
+            var rift = Scan(gen, "rift", savanna, 8);
+            if (rift.Hits == 0)
+            {
+                continue;
+            }
+
+            // Somewhere over the gorge (rift offset < 0) a Cap band hangs whose top is the pre-rift ground.
+            var bands = new WorldGenerator.ColumnBand[WorldGenerator.MaxColumnBands];
+            int circ = WorldConstants.Circumference;
+            int period = WorldConstants.LatitudePeriodFor(circ);
+            int found = 0;
+            for (int z = -period / 2; z < period / 2 && found == 0; z += 2)
+                for (int x = 0; x < circ; x += 2)
+                {
+                    if (gen.LandmarkOffsetForTest("rift", savanna, x, z) >= -5.0)
+                    {
+                        continue;
+                    }
+
+                    int n = gen.GetExtraBands(savanna, x, z, bands);
+                    for (int i = 0; i < n; i++)
+                    {
+                        if (bands[i].Kind == WorldGenerator.BandKind.Cap && bands[i].Top > gen.SurfaceHeight(savanna, x, z) + 5)
+                        {
+                            found++;
+                        }
+                    }
+                }
+
+            if (found > 0)
+            {
+                return;
+            }
+        }
+
+        Assert.Fail("no rift world with a natural bridge found in 200 seeds");
+    }
+
+    [Fact]
+    public void MushroomRocks_CapTheirStems()
+    {
+        var desert = Content.Planets["desert"];
+        var gen = FindWorldWith("mushroom-rock", desert, 2, 40, out _);
+        Assert.NotNull(gen);
+        int caps = CountBands(gen!, desert, (x, z) => gen.LandmarkOffsetForTest("mushroom-rock", desert, x, z) > 3.0, 2, out int stems);
+        Assert.True(stems > 0 && caps >= stems, $"stems {stems}, caps {caps}");
+    }
+
+    [Fact]
+    public void IceCornices_HangOffCrests_OnColdWorlds()
+    {
+        var ice = Content.Planets["ice"];
+        for (long s = 1; s <= 60; s++)
+        {
+            var gen = Gen(s * 6151 + 3, 1);
+            var bands = new WorldGenerator.ColumnBand[WorldGenerator.MaxColumnBands];
+            int circ = WorldConstants.Circumference;
+            int period = WorldConstants.LatitudePeriodFor(circ);
+            for (int z = -period / 2; z < period / 2; z += 5)
+                for (int x = 0; x < circ; x += 5)
+                {
+                    int n = gen.GetExtraBands(ice, x, z, bands);
+                    for (int i = 0; i < n; i++)
+                    {
+                        int h = gen.SurfaceHeight(ice, x, z);
+                        if (bands[i].Kind == WorldGenerator.BandKind.Cap && bands[i].Top >= h + 6 && bands[i].Top - bands[i].Bottom == 1)
+                        {
+                            return; // a cornice: a thin lip well above this column's ground
+                        }
+                    }
+                }
+        }
+
+        Assert.Fail("no ice cornice found in 60 ice worlds");
+    }
+
+    // ---------- underground ----------
+
+    [Fact]
+    public void Geodes_AreHollowCrystalSpheres_BelowTheSurface()
+    {
+        var crystal = Content.Planets["crystal"];
+        for (long s = 1; s <= 40; s++)
+        {
+            var gen = Gen(s * 6151 + 3, 1);
+            int circ = WorldConstants.Circumference;
+            int period = WorldConstants.LatitudePeriodFor(circ);
+            for (int z = -period / 2; z < period / 2; z += 3)
+                for (int x = 0; x < circ; x += 3)
+                {
+                    if (!gen.TryGetGeodeSpanForTest(crystal, x, z, out int lo, out int hi, out int inLo, out int inHi))
+                    {
+                        continue;
+                    }
+
+                    Assert.True(hi - lo <= 2 * 14 + 1);
+                    Assert.True(hi < gen.SurfaceHeight(crystal, x, z) - 10, "geode breaks the surface");
+                    if (inHi >= inLo)
+                    {
+                        Assert.True(inLo > lo && inHi < hi, "the hollow must sit inside the shell");
+                        return;
+                    }
+                }
+        }
+
+        Assert.Fail("no geode with a hollow found in 40 crystal worlds");
+    }
+
+    [Fact]
+    public void Strata_LayGraniteBands_InTheUpperCrust_OnGenerationOneOnly()
+    {
+        var rocky = Content.Planets["rocky"];
+        var granite = Content.GetBlock("granite")!.NumericId;
+        int CountGranite(WorldGenerator gen)
+        {
+            int count = 0;
+            int cs = WorldConstants.ChunkSize;
+            for (int cx = 0; cx < 12; cx++)
+                for (int cz = 0; cz < 12; cz++)
+                {
+                    int sx = cx * cs * 7, sz = cz * cs * 5 - 900;
+                    int surfaceCy = WorldConstants.WorldToChunk(gen.SurfaceHeight(rocky, sx, sz));
+                    var chunk = gen.Generate(rocky, new ChunkCoord(WorldConstants.WorldToChunk(sx), surfaceCy - 1, WorldConstants.WorldToChunk(sz)));
+                    for (int x = 0; x < cs; x++)
+                        for (int y = 0; y < cs; y++)
+                            for (int z = 0; z < cs; z++)
+                            {
+                                if (chunk.Get(x, y, z) == granite)
+                                {
+                                    count++;
+                                }
+                            }
+                }
+
+            return count;
+        }
+
+        Assert.Equal(0, CountGranite(Gen(77, 0)));
+        Assert.True(CountGranite(Gen(77, 1)) > 50, "generation 1 rocky world shows no strata");
+    }
+
+    [Fact]
+    public void AquiferCaverns_HoldLakes_OnWetGenerationOneWorlds()
+    {
+        var jungle = Content.Planets["jungle"];
+        int lakes = 0, caverns = 0;
+        for (long s = 1; s <= 30; s++)
+        {
+            var gen = Gen(s * 6151 + 3, 1);
+            int circ = WorldConstants.Circumference;
+            int period = WorldConstants.LatitudePeriodFor(circ);
+            for (int z = -period / 2; z < period / 2; z += 40)
+                for (int x = 0; x < circ; x += 40)
+                {
+                    if (gen.TryGetCavernSpan(jungle, x, z, out _, out _, out int lakeY))
+                    {
+                        caverns++;
+                        if (lakeY != int.MinValue)
+                        {
+                            lakes++;
+                        }
+                    }
+                }
+        }
+
+        Assert.True(caverns > 20, $"only {caverns} cavern columns sampled");
+        Assert.True(lakes * 10 >= caverns * 7, $"only {lakes} of {caverns} cavern columns hold a lake");
+    }
+}

--- a/tests/BlocksBeyondTheStars.Tests/WorldGenerationGoldenTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/WorldGenerationGoldenTests.cs
@@ -53,6 +53,9 @@ public sealed class WorldGenerationGoldenTests
         new("varied-gen1", 424242, "varied", 5472, false, "golden:varied-body", 1),
         new("desert-gen1", 1, "desert", 0, false, null, 1),
         new("highland-gen1", 20260903, "highland", 0, false, null, 1),
+        // #1646 (part 3): landmark families, bands and underground finds on generation-1 worlds.
+        new("tundra-gen1", 424242, "tundra", 0, false, null, 1),
+        new("rocky-gen1", 1, "rocky", 5472, false, "golden:rocky-body", 1),
     };
 
     /// <summary>Sample columns: the spawn column (pad 0 sits at (0,0) on every world), one ordinary inland
@@ -76,7 +79,10 @@ public sealed class WorldGenerationGoldenTests
             // Pinned 2026-09-05 (#1645, Windows 11, .NET 10).
             ["varied-gen1"] = 0x06b7238c0bfd64a9UL,
             ["desert-gen1"] = 0x3a9c31b0e73aca33UL,
-            ["highland-gen1"] = 0x350b70a0088675a2UL,
+            ["highland-gen1"] = 0x5ca22595bc582292UL, // re-pinned for #1646 (gen-1 landmarks; unreleased)
+            // Pinned 2026-09-05 (#1646, Windows 11, .NET 10).
+            ["tundra-gen1"] = 0x0fc36734f6fd655bUL,
+            ["rocky-gen1"] = 0xc8a627b43c22e758UL,
         },
         // Linux (ubuntu CI runners): filled in from the first CI run of this test; a group absent here falls
         // back to the Windows value above and fails with the value to pin if the libm differs.


### PR DESCRIPTION
Part 3 of 6 of the **landscape-variety package** (#1644–#1649). New landform *kinds* next to the existing ones, overhang bands and underground finds — all behind profile flags that `WonderFor` only sets on **generation-1 worlds**. The eight classic `WorldGenerationGoldenTests` groups are byte-identical; `tundra-gen1` and `rocky-gen1` are pinned, `highland-gen1` re-pinned (the gen-1 groups move with every part until release).

Closes #1646

## Landmarks (`WorldGenerator.LandmarksGen1.cs`, 12 rows appended after `mega-rift`, footprint order)

| row | shape | gate |
|---|---|---|
| `shield-volcano` | r 200–400, h 20–40 dome, 6-deep summit bowl (part 4 fills the lava lake) | volcano world + `volcanic` tag or 25 % roll |
| `impact-basin` | r 120–250 bowl 20–35 deep, raised rim; floods under the sea percentile | solid + air (8 % of cells) |
| `glacial-trough` | U-valley 25–45 deep, floor sloping to one end (tarn in part 4) | `glacial` or ≤ −5 °C |
| `yardangs` | grain-aligned rock ridges 6–12 tall in a round field | `wind` |
| `drumlin-field` | rounded whalebacks along the grain | `glacial`, unless the drumlins style rolled |
| `inselberg` | granite dome r 60–150, h 40–90, **granite paint** | `inselbergs` |
| `star-dunes` | pyramidal dune 15–30 tall, 3–5 arms | `wind` + sand |
| `mud-volcanoes` | field of 3–6-tall cones with vent dips | wet volcano worlds |
| `sinkhole-chain` | 3–5 sheer shafts along a line | cenote worlds |
| `maar` | bowl r 20–40, 8–14 deep, low rim (lake in part 4) | wet solid worlds |
| `mushroom-rock` | 5–8 stem under a wide cap band | `buttes` |
| `glacier-tongue` | **ice paint** on one flank sector of a cold massif | massif + ≤ −5 °C |

Tags in `planets.json`: `inselbergs` on rocky/savanna/desert/tablelands, `wind` on desert/tablelands/badlands/salt_flats, `glacial` on ice/tundra.

## Bands (`GetExtraBands`, `MaxColumnBands` 6 → 8)

Natural bridge over a rift (1–2 rolled points per gorge, 3-thick deck at the pre-rift rim; `TryGetRiftGeometry` repeats the rift's rolls so the classic `RiftOffset` stays byte-identical), wave-cut coastal ledge (2-thick band above the waterline on a shallow-water column beside a 4+ cliff, half of such coasts by mask), ice cornice (2-thick lip at crest level 3 columns off a 6+ crest, sparse regions on the coldest worlds), mushroom-rock cap.

## Underground

Crystal geodes (hollow spheres r 6–14, 30–80 below base, 1.6-thick crystal shell; `TryGetGeodeSpan` in the column profile, filled before caves and tunnels), aquifer caverns (7 of 8 mega-caverns on wet gen-1 worlds hold a lake filling most of the bowl), sediment strata (tilted granite bands, 2 of every 7 cells, topsoil to 48 deep, inside a 420-block region mask; ores keep their cells — sandstone replaces granite when part 4 ships the block).

## Tests

`LandscapeLandmarksTests` (21 tests): every new row/band/find absent on generation 0 for all types; new rows appended after the classic ones; each row appears on an eligible world within its designed offset range; inselberg granite and glacier-tongue ice paints; clamp ≤ 288 + determinism + seam on five gen-1 worlds; natural bridge, mushroom caps, ice cornices found; geode hollow inside its shell below the surface; strata granite count 0 on gen 0 and > 50 on gen 1; aquifer lake rate ≥ 70 %. Goldens as above. Fast tier green locally, `dotnet format` clean. No `client/Assets` change.

## Not measured

The plan asked for a chunk-gen cost check (≤ +3 % per column) on a quiet machine; not done in this PR — the new families add one hotspot-cell hash per active row per column (≈ 0.3 µs each) plus two FBM samples on strata worlds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
