### PR TITLE
feat(worldgen): 16 prop rows with micro-ruins, 7 tree kinds, giant-flora table — the things you meet every hundred blocks on generation-1 worlds (#1648)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,19 @@ the richer, screenshot-laden versions live there. `(#123)` references the pull r
 
 ## [Unreleased]
 
+### 🏔️ Landscape variety, part 5 of 6 — the things you meet every hundred blocks (#1648)
+
+- **New worlds only — set dressing:** fallen logs in the woods, termite mounds on the savanna, cairns in the
+  cold, bone piles and whole rib cages in the dry lands, ice boulders, lava spatter, coral on the shore,
+  crystal clusters, meteorites on airless rock, tar pools — and small ruins to stumble over: a wall
+  fragment, a buried pillar, a crashed probe, an abandoned mining rig, a lone rune stone, some with a data
+  cache hidden in them.
+- **Seven new tree kinds:** baobabs on the savanna, mangroves on stilts beside the water, bamboo groves,
+  saguaro cacti in the desert, weeping willows, alien mushroom trees and crystal trees.
+- **Giant flora beyond mushrooms:** giant ferns in the jungle mud, giant crystals on crystal ground, giant
+  cacti on the sand.
+- Existing worlds are unchanged.
+
 ### 🏔️ Landscape variety, part 4 of 6 — water in the desert, moss on the rock, five new blocks (#1647)
 
 - **Five new blocks:** moss stone, tar, bone, sandstone and scree — each a material you can mine, carry and

--- a/TODO.md
+++ b/TODO.md
@@ -24,6 +24,19 @@ envelope at the WebSocket edge; deterministic seed world-gen; SQLite default per
 
 ---
 
+### ★ Landscape variety 5/6: 16 prop rows with micro-ruins, 7 tree kinds, giant-flora table (#1648, 2026-09-06, branch landscape/1648-props-trees)
+
+Generation-1 worlds only; classic goldens unchanged, `savanna-gen1` + `swamp-gen1` pinned. `WorldGenerator.StampsGen1.cs`:
+`PropKind` + `Gate` / `MaterialKey` / `SecondaryKey`, 16 rows appended (fallen log, termite mound, cairn, bone pile, rib
+cage, ice boulder, lava spatter, coral outcrop, crystal cluster, meteorite, tar pool, wall fragment, buried pillar, crashed
+probe, mining rig, rune stone — the ruins roll a data cache), scan margin 6 → 8. `TreeKind` + Baobab / Mangrove / Bamboo /
+Saguaro / Willow / MushroomTree / CrystalTree, `Theme.TreesGen1` + `PaletteFor(generation)` (gen-0 palettes untouched),
+mangroves need water within 4. `GiantFloraKinds` (fern on mud, crystal on crystal, cactus on sand) via
+`StampGiantFloraGen1`. `LandscapeStampsTests` (table order, gen-0 invariance, per-row rate within ×2 + never on an
+ineligible world, rib-cage chunk seam, palette gating, tree envelope, baobab presence, giant-flora rows + cactus probe).
+
+---
+
 ### ★ Landscape variety 4/6: five new blocks, water / lava bodies, surface paints (#1647, 2026-09-06, branch landscape/1647-blocks-fluids)
 
 New blocks `moss_stone`, `tar`, `bone`, `sandstone`, `scree` (block + material item + locales in 14 languages + AI tiles

--- a/docs/developer/WORLD_GENERATION.md
+++ b/docs/developer/WORLD_GENERATION.md
@@ -721,5 +721,32 @@ foot to 1.5 radii (dithered), dry riverbeds on dry worlds (a ridged channel mask
 sand elsewhere), deck banding on mesa / tablelands / terraces worlds (every third 6-block deck sandstone,
 every other third granite), soil patches in grass biomes, moss stone on the rock of temperate wet worlds.
 
-Parts 5–6 (props, trees, giant flora, data-only planet types, monument archetypes) are documented here as
-they land.
+### 12.4 Part 5 — props, micro-ruins, tree kinds, giant flora (#1648, generation ≥ 1)
+
+`WorldGenerator.StampsGen1.cs`. **Prop rows.** `PropKind` gained an optional per-world `Gate`, a fixed
+`MaterialKey` and a `SecondaryKey`; the classic five rows keep their salts, order and material rule, the 16
+generation-1 rows are appended (table order = precedence) and gate on the generation plus a theme / tag /
+climate rule: fallen logs (wooded worlds), termite mounds (savanna theme), cairns (≤ 5 °C), bone piles and
+**rib cages** (dry worlds; the rib cage is 7 across and raises the set-dressing scan margin 6 → 8 — a column
+7–8 away never wrote into the chunk before, so classic output is unchanged), ice boulders (≤ −5 °C), lava
+spatter (`volcanic`), coral outcrops (wet worlds, on the dry strip within 2 above the waterline), crystal
+clusters (`crystal`), meteorites (airless bodies, iron ore), tar pools (dry `buttes` / `wind` flats), and the
+micro-ruins — wall fragment, buried pillar (ancient brick), crashed probe (iron wall + glass), abandoned
+mining rig (machine block + pipe), lone rune stone — each rolling a data cache 30–50 % of the time.
+Rows fill air only, never carve. `PropActiveForTest` / `PropRollForTest` expose gate + roll.
+
+**Trees.** `TreeKind` gained Baobab (2×2 trunk, flat crown), Mangrove (stilt roots; falls back to a
+broadleaf where no water lies within 4 — `NearWater`), Bamboo (a grove of 3–6 stems 8–12 tall), Saguaro (a
+green column with arms, built from the leaf block; allowed on sand like palms), Willow (a broad crown
+dripping strands), MushroomTree (mushroom stem + cap), CrystalTree (crystal shaft + cross). A theme lists
+them in `TreesGen1`; `Theme.PaletteFor(generation)` hands generation-0 worlds the classic `Trees`, so their
+woods never change. Palettes: temperate + willow; tropical + mangrove, bamboo; savanna + baobab; desert +
+saguaro; swamp + willow, mangrove; alien + mushroom tree, crystal tree. Every kind stays inside the stamp
+envelope (|dx|, |dz| ≤ 4, height ≤ 18 — `BuildTreeForTest`).
+
+**Giant flora.** `GiantFloraKinds` is the host-block table the giant-mushroom recipe generalises to:
+giant fern on mud (log stem, a fan of leaf fronds), giant crystal on crystal ground, giant cactus on sand
+(leaf block, two arms) — each with its own salt and density; `StampGiantFloraGen1` runs after the classic
+mushroom stamp, which is untouched.
+
+Part 6 (data-only planet types, monument archetypes, cliff-hugging settlements) is documented here when it lands.

--- a/src/BlocksBeyondTheStars.Shared/Definitions/FloraThemes.cs
+++ b/src/BlocksBeyondTheStars.Shared/Definitions/FloraThemes.cs
@@ -17,6 +17,15 @@ public enum TreeKind
     Palm,      // bare trunk + a frond burst at the very top (tropical/oasis)
     Jungle,    // very tall, broad heavy canopy (rainforest)
     Dead,      // bare trunk + stub branches, no leaves (arid / scorched / blighted)
+
+    // Generation-1 kinds (#1648): themes list them in TreesGen1 only, so classic worlds never roll them.
+    Baobab,       // thick 2×2 trunk under a flat wide crown (savanna)
+    Mangrove,     // stilt roots beside water (tropical / swamp coasts)
+    Bamboo,       // a grove of thin 8–12 stems (tropical)
+    Saguaro,      // a green column with up-turned arms (desert)
+    Willow,       // a broad crown dripping leaf strands (temperate / swamp)
+    MushroomTree, // a mushroom-stem trunk under a flat cap (alien)
+    CrystalTree,  // a crystal shaft with a cross of arms (alien / crystal)
 }
 
 /// <summary>
@@ -33,23 +42,34 @@ public static class FloraThemes
         FloraTag Preferred,
         double DensityMul,
         double TreeMul,
-        TreeKind[] Trees);
+        TreeKind[] Trees,
+        TreeKind[]? TreesGen1 = null)
+    {
+        /// <summary>The palette a generation-1 world draws from (#1648): the classic kinds plus the new ones;
+        /// generation-0 worlds keep <see cref="Trees"/> so their woods never change.</summary>
+        public TreeKind[] PaletteFor(int generation) => generation >= 1 && TreesGen1 is { } g1 ? g1 : Trees;
+    }
 
     private static readonly Theme Temperate = new("temperate", FloraTag.Lush, 1.0, 1.0,
-        new[] { TreeKind.Broadleaf });
+        new[] { TreeKind.Broadleaf },
+        new[] { TreeKind.Broadleaf, TreeKind.Willow });
 
     /// <summary>The themes, keyed by name. Unknown / empty names fall back to <see cref="Temperate"/>.</summary>
     private static readonly Theme[] AllThemes =
     {
         Temperate,
         new("tropical", FloraTag.Tropical | FloraTag.Lush, 1.3, 1.3,
-            new[] { TreeKind.Jungle, TreeKind.Palm, TreeKind.Broadleaf }),
+            new[] { TreeKind.Jungle, TreeKind.Palm, TreeKind.Broadleaf },
+            new[] { TreeKind.Jungle, TreeKind.Palm, TreeKind.Broadleaf, TreeKind.Mangrove, TreeKind.Bamboo }),
         new("savanna", FloraTag.Dry | FloraTag.Lush, 0.9, 0.7,
-            new[] { TreeKind.Broadleaf }),
+            new[] { TreeKind.Broadleaf },
+            new[] { TreeKind.Broadleaf, TreeKind.Baobab }),
         new("desert", FloraTag.Dry, 0.6, 0.5,
-            new[] { TreeKind.Palm, TreeKind.Dead }),
+            new[] { TreeKind.Palm, TreeKind.Dead },
+            new[] { TreeKind.Palm, TreeKind.Dead, TreeKind.Saguaro }),
         new("swamp", FloraTag.Wetland | FloraTag.Fungal, 1.2, 0.9,
-            new[] { TreeKind.Broadleaf, TreeKind.Dead }),
+            new[] { TreeKind.Broadleaf, TreeKind.Dead },
+            new[] { TreeKind.Broadleaf, TreeKind.Dead, TreeKind.Willow, TreeKind.Mangrove }),
         new("tundra", FloraTag.Cold, 0.85, 0.8,
             new[] { TreeKind.Conifer }),
         new("alpine", FloraTag.Cold | FloraTag.Rocky, 0.75, 0.9,
@@ -57,7 +77,8 @@ public static class FloraThemes
         new("fungal", FloraTag.Fungal | FloraTag.Alien, 1.2, 0.0,
             new[] { TreeKind.None }),
         new("alien", FloraTag.Alien, 1.15, 0.8,
-            new[] { TreeKind.Broadleaf, TreeKind.Dead }),
+            new[] { TreeKind.Broadleaf, TreeKind.Dead },
+            new[] { TreeKind.Broadleaf, TreeKind.Dead, TreeKind.MushroomTree, TreeKind.CrystalTree }),
         new("crystal", FloraTag.Rocky | FloraTag.Alien | FloraTag.Glow, 1.0, 0.0,
             new[] { TreeKind.None }),
         new("ashen", FloraTag.Dry | FloraTag.Glow, 0.8, 0.4,

--- a/src/BlocksBeyondTheStars.WorldGeneration/WorldGenerator.Columns.cs
+++ b/src/BlocksBeyondTheStars.WorldGeneration/WorldGenerator.Columns.cs
@@ -508,6 +508,13 @@ public sealed partial class WorldGenerator
             StampGiantMushrooms(planet, seed, chunk, coord, biomes, stemId, capId, myceliumId, fluidLevel);
         }
 
+        // Generation-1 giant flora (#1648): giant ferns on jungle mud, giant crystals on crystal ground, giant
+        // cacti on sand — the same recipe as the mushrooms with their own salts; classic worlds never roll them.
+        if (wonderGates.Generation >= 1)
+        {
+            StampGiantFloraGen1(planet, seed, chunk, coord, biomes, fluidLevel);
+        }
+
         if (geysers)
         {
             StampGeysers(planet, seed, chunk, coord, geyserVentId, fluidLevel);

--- a/src/BlocksBeyondTheStars.WorldGeneration/WorldGenerator.Stamps.cs
+++ b/src/BlocksBeyondTheStars.WorldGeneration/WorldGenerator.Stamps.cs
@@ -26,7 +26,7 @@ public sealed partial class WorldGenerator
     private readonly struct PropStamp
     {
         public PropStamp(WorldGenerator generator, PlanetType planet, int wx, int sy, int wz, int shapeHash,
-            BlockId material, BlockId cache, System.Action<int, int, int, BlockId> set)
+            BlockId material, BlockId cache, System.Action<int, int, int, BlockId> set, BlockId secondary = default)
         {
             Generator = generator;
             Planet = planet;
@@ -37,7 +37,10 @@ public sealed partial class WorldGenerator
             Material = material;
             Cache = cache;
             Set = set;
+            Secondary = secondary;
         }
+
+        public readonly BlockId Secondary;                      // #1648: a row's second block (glass, pipe), Air if none
 
         public readonly WorldGenerator Generator;
         public readonly PlanetType Planet;
@@ -55,7 +58,8 @@ public sealed partial class WorldGenerator
     /// Adding a prop = one row + one shape method.</summary>
     private readonly struct PropKind
     {
-        public PropKind(string name, long salt, int row, double chance, PropMaterial material, System.Action<PropStamp> shape)
+        public PropKind(string name, long salt, int row, double chance, PropMaterial material, System.Action<PropStamp> shape,
+            System.Func<WonderProfile, PlanetType, bool>? gate = null, string? materialKey = null, string? secondaryKey = null)
         {
             Name = name;
             Salt = salt;
@@ -63,6 +67,9 @@ public sealed partial class WorldGenerator
             Chance = chance;
             Material = material;
             Shape = shape;
+            Gate = gate;
+            MaterialKey = materialKey;
+            SecondaryKey = secondaryKey;
         }
 
         public readonly string Name;
@@ -71,6 +78,9 @@ public sealed partial class WorldGenerator
         public readonly double Chance;  // per-column probability
         public readonly PropMaterial Material;
         public readonly System.Action<PropStamp> Shape;
+        public readonly System.Func<WonderProfile, PlanetType, bool>? Gate; // #1648: per-world gate (null = the classic material rule)
+        public readonly string? MaterialKey;   // #1648: a fixed block key instead of the classic material enum
+        public readonly string? SecondaryKey;  // #1648: the row's second block
     }
 
     private static readonly PropKind[] PropKinds =
@@ -83,7 +93,67 @@ public sealed partial class WorldGenerator
         new("boulder", 0xB01D, 29, 0.0012, PropMaterial.Boulder, StampBoulder),
         new("crystal-shard", 0xC57A, 31, 0.0008, PropMaterial.Crystal, StampCrystalShard),
         new("dead-tree", 0xDEAD, 37, 0.0009, PropMaterial.DeadLog, StampDeadTree),
+        // Generation-1 rows (#1648): each gates on the world (generation ≥ 1 + a theme / tag / climate rule) and
+        // names its block; appended after the classic rows so their precedence is untouched.
+        new("fallen-log", 0xFA11, 53, 0.0015, PropMaterial.Boulder, StampFallenLog, PropWooded, "wood_log"),
+        new("termite-mound", 0x7E21, 59, 0.0020, PropMaterial.Boulder, StampTermiteMound, PropSavanna, "dirt"),
+        new("cairn", 0xCA12, 61, 0.0012, PropMaterial.Boulder, StampCairn, PropCold, "stone"),
+        new("bone-pile", 0xB0E1, 67, 0.0008, PropMaterial.Boulder, StampBonePile, PropDry, "bone"),
+        new("rib-cage", 0x21BC, 71, 0.00015, PropMaterial.Boulder, StampRibCage, PropDry, "bone"),
+        new("ice-boulder", 0x1CEB, 73, 0.0012, PropMaterial.Boulder, StampBoulder, PropFrozen, "ice"),
+        new("lava-spatter", 0x5A77, 79, 0.0015, PropMaterial.Boulder, StampMeteorite, PropVolcanic, "basalt"),
+        new("coral-outcrop", 0xC02A, 83, 0.0030, PropMaterial.Boulder, StampCoralOutcrop, PropCoast, "flora_coral"),
+        new("crystal-cluster", 0xC1C5, 89, 0.0004, PropMaterial.Boulder, StampCrystalCluster, PropCrystal, "crystal"),
+        new("meteorite", 0x3E7E, 97, 0.0006, PropMaterial.Boulder, StampMeteorite, PropAirless, "iron_ore"),
+        new("tar-pit", 0x7A21, 101, 0.0006, PropMaterial.Boulder, StampTarPit, PropTarFlats, "tar"),
+        new("wall-fragment", 0x2A11, 103, 0.00012, PropMaterial.Boulder, StampWallFragment, PropRuins, "ancient_brick"),
+        new("buried-pillar", 0x9111, 107, 0.00012, PropMaterial.Boulder, StampBuriedPillar, PropRuins, "ancient_brick"),
+        new("crashed-probe", 0xC2A5, 109, 0.00008, PropMaterial.Boulder, StampCrashedProbe, PropRuins, "iron_wall", "glass"),
+        new("mining-rig", 0x3116, 113, 0.00008, PropMaterial.Boulder, StampMiningRig, PropRuins, "machine_block", "factory_pipe"),
+        new("rune-stone", 0x2E5E, 127, 0.00012, PropMaterial.Boulder, StampRuneStone, PropRuins, "rune_stone"),
     };
+
+    /// <summary>The prop rows active on this world (tests): the classic rows whose material exists here, plus
+    /// the generation-1 rows whose gate opens.</summary>
+    internal string[] PropActiveForTest(PlanetType planet, bool crystalWorld, bool dryWorld)
+    {
+        var w = WonderFor(planet);
+        var names = new System.Collections.Generic.List<string>();
+        foreach (var k in PropKinds)
+        {
+            bool active = k.Gate is { } gate
+                ? gate(w, planet) && !(_content.GetBlock(k.MaterialKey!)?.NumericId ?? BlockId.Air).IsAir
+                : k.Material switch { PropMaterial.Crystal => crystalWorld, PropMaterial.DeadLog => dryWorld, _ => true };
+            if (active)
+            {
+                names.Add(k.Name);
+            }
+        }
+
+        return names.ToArray();
+    }
+
+    /// <summary>Whether the named row rolls a prop at this column on this world (tests; gate + material + roll).</summary>
+    internal bool PropRollForTest(string name, PlanetType planet, int worldX, int worldZ)
+    {
+        var w = WonderFor(planet);
+        foreach (var k in PropKinds)
+        {
+            if (k.Name != name)
+            {
+                continue;
+            }
+
+            if (k.Gate is { } gate && !gate(w, planet))
+            {
+                return false;
+            }
+
+            return Noise.Value01(PlanetSeed(planet) + k.Salt, WorldConstants.WrapX(worldX, _circumference), k.Row, Wz(worldZ)) < k.Chance;
+        }
+
+        throw new System.ArgumentException($"unknown prop row '{name}'", nameof(name));
+    }
 
     /// <summary>The prop table's row names in precedence order (tests).</summary>
     internal static string[] PropOrderForTest()
@@ -131,10 +201,30 @@ public sealed partial class WorldGenerator
             _ => boulderId,
         };
 
-        // Margin 6 so the widest feature (a stone circle, radius ~4) generates identically from either side
-        // of a chunk edge.
-        for (int wx = origin.X - 6; wx < origin.X + cs + 6; wx++)
-            for (int wz = origin.Z - 6; wz < origin.Z + cs + 6; wz++)
+        // #1648: per-chunk row resolution — the classic rows by material rule, the generation-1 rows by their
+        // world gate + block key. A row that is off here never rolls (same as a missing material before).
+        var wonderProps = WonderFor(planet);
+        var rowMaterial = new BlockId[PropKinds.Length];
+        var rowSecondary = new BlockId[PropKinds.Length];
+        for (int k = 0; k < PropKinds.Length; k++)
+        {
+            ref readonly var kind = ref PropKinds[k];
+            if (kind.Gate is { } gate)
+            {
+                rowMaterial[k] = gate(wonderProps, planet) ? _content.GetBlock(kind.MaterialKey!)?.NumericId ?? BlockId.Air : BlockId.Air;
+                rowSecondary[k] = kind.SecondaryKey is { } sk ? _content.GetBlock(sk)?.NumericId ?? BlockId.Air : BlockId.Air;
+            }
+            else
+            {
+                rowMaterial[k] = MaterialOf(kind.Material);
+            }
+        }
+
+        // Margin 8 so the widest feature (a rib cage, 7 across — #1648; before that a stone circle, radius ~4)
+        // generates identically from either side of a chunk edge. The wider scan changes nothing for the
+        // classic rows: a column 7–8 away cannot write into this chunk.
+        for (int wx = origin.X - 8; wx < origin.X + cs + 8; wx++)
+            for (int wz = origin.Z - 8; wz < origin.Z + cs + 8; wz++)
             {
                 int cx = WorldConstants.WrapX(wx, _circumference);
                 int cz = Wz(wz);
@@ -144,7 +234,7 @@ public sealed partial class WorldGenerator
                 for (int k = 0; k < PropKinds.Length; k++)
                 {
                     ref readonly var kind = ref PropKinds[k];
-                    if (MaterialOf(kind.Material).IsAir)
+                    if (rowMaterial[k].IsAir)
                     {
                         continue;
                     }
@@ -175,7 +265,12 @@ public sealed partial class WorldGenerator
 
                 int h1 = (int)(Noise.Value01(seed + 0x5E7D, cx, 41, cz) * 997); // per-column shape hash
                 ref readonly var row = ref PropKinds[hit];
-                row.Shape(new PropStamp(this, planet, wx, sy, wz, h1, MaterialOf(row.Material), cacheId, set));
+                if (row.Name == "coral-outcrop" && (sy > SeaLevel(planet) + 2 || sy <= SeaLevel(planet)))
+                {
+                    continue; // #1648: coral outcrops sit on the dry strip right above the waterline only
+                }
+
+                row.Shape(new PropStamp(this, planet, wx, sy, wz, h1, rowMaterial[hit], cacheId, set, rowSecondary[hit]));
             }
     }
 
@@ -436,6 +531,11 @@ public sealed partial class WorldGenerator
         var calib = CalibFor(planet);
         var waterId = _content.GetBlock("water")?.NumericId ?? BlockId.Air;
         var riverField = RiverFieldFor(planet); // cached — needed for the beach ground check (#679)
+        var wonderTrees = WonderFor(planet);    // #1648: the generation decides the theme palette
+        int seaLevelTrees = SeaLevel(planet);
+        var stemId = _content.GetBlock("mushroom_stem")?.NumericId ?? logId;
+        var capId = _content.GetBlock("mushroom_cap")?.NumericId ?? leafId;
+        var crystalTreeId = _content.GetBlock("crystal")?.NumericId ?? leafId;
 
         // #1527: the density roll is tested against a conservative UPPER BOUND of every biome's multiplier first,
         // so the ~99 % of margin columns the exact test rejects never pay SurfaceHeight / BiomeIndex. The exact
@@ -490,10 +590,15 @@ public sealed partial class WorldGenerator
                 }
 
                 // Pick a grove kind from the biome theme's tree palette (one kind per low-frequency patch).
-                var kind = PickTreeKind(biome.Theme.Trees, seed, wx, wz, planet.TerrainScale);
+                var kind = PickTreeKind(biome.Theme.PaletteFor(wonderTrees.Generation), seed, wx, wz, planet.TerrainScale);
                 if (kind == TreeKind.None)
                 {
                     continue; // this theme grows no trees here (e.g. fungal → giant mushrooms instead)
+                }
+
+                if (kind == TreeKind.Mangrove && !NearWater(planet, wx, wz, seaLevelTrees))
+                {
+                    kind = TreeKind.Broadleaf; // #1648: mangroves stand beside water only
                 }
 
                 if (oasisFringe && System.Array.IndexOf(biome.Theme.Trees, TreeKind.Palm) >= 0)
@@ -535,7 +640,7 @@ public sealed partial class WorldGenerator
                 {
                     var surf = biome.Surface;
                     bool earthy = surf == grassId || surf == dirtId || surf == mudId;
-                    bool sandyOk = surf == sandId && (kind == TreeKind.Palm || kind == TreeKind.Dead); // palms/dead snags on sand
+                    bool sandyOk = surf == sandId && (kind == TreeKind.Palm || kind == TreeKind.Dead || kind == TreeKind.Saguaro); // palms/dead snags/saguaros on sand
                     if (!earthy && !sandyOk)
                     {
                         continue;
@@ -554,6 +659,14 @@ public sealed partial class WorldGenerator
                     case TreeKind.Palm: BuildPalm(wx, sy, wz, sizeF, hJit, cJit, logId, palmId, SetCell); break;
                     case TreeKind.Jungle: BuildJungle(wx, sy, wz, sizeF, hJit, cJit, logId, leafId, SetCell); break;
                     case TreeKind.Dead: BuildDead(wx, sy, wz, sizeF, hJit, logId, SetCell); break;
+                    // #1648 generation-1 kinds (the palette only offers them from generation 1)
+                    case TreeKind.Baobab: BuildBaobab(wx, sy, wz, sizeF, hJit, cJit, logId, leafId, SetCell); break;
+                    case TreeKind.Mangrove: BuildMangrove(wx, sy, wz, sizeF, hJit, cJit, logId, leafId, SetCell); break;
+                    case TreeKind.Bamboo: BuildBamboo(wx, sy, wz, sizeF, hJit, (int)(Noise.Value01(seed + 0xBA3B0, WorldConstants.WrapX(wx, _circumference), 41, Wz(wz)) * 997), logId, leafId, SetCell); break;
+                    case TreeKind.Saguaro: BuildSaguaro(wx, sy, wz, sizeF, hJit, (int)(Noise.Value01(seed + 0x5A6A0, WorldConstants.WrapX(wx, _circumference), 41, Wz(wz)) * 997), leafId, SetCell); break;
+                    case TreeKind.Willow: BuildWillow(wx, sy, wz, sizeF, hJit, cJit, logId, leafId, SetCell); break;
+                    case TreeKind.MushroomTree: BuildMushroomTree(wx, sy, wz, sizeF, hJit, stemId, capId, SetCell); break;
+                    case TreeKind.CrystalTree: BuildCrystalTree(wx, sy, wz, sizeF, hJit, crystalTreeId, SetCell); break;
                     default: BuildBroadleaf(wx, sy, wz, sizeF, hJit, cJit, logId, leafId, SetCell); break;
                 }
             }

--- a/src/BlocksBeyondTheStars.WorldGeneration/WorldGenerator.StampsGen1.cs
+++ b/src/BlocksBeyondTheStars.WorldGeneration/WorldGenerator.StampsGen1.cs
@@ -298,9 +298,9 @@ public sealed partial class WorldGenerator
         for (int ty = sy + 1; ty <= topY; ty++)
         {
             set(wx, ty, wz, logId, true);
-            set(wx + 1, ty, wz, logId, true);
-            set(wx, ty, wz + 1, logId, true);
-            set(wx + 1, ty, wz + 1, logId, true);
+            set(wx + 1, ty, wz, logId, false); // the three offset trunk columns fill air only — their ground was not checked
+            set(wx, ty, wz + 1, logId, false);
+            set(wx + 1, ty, wz + 1, logId, false);
         }
 
         for (int dy = 0; dy <= 1; dy++)
@@ -359,7 +359,7 @@ public sealed partial class WorldGenerator
             int px = wx + spots[i].X, pz = wz + spots[i].Z;
             for (int ty = sy + 1; ty <= sy + height; ty++)
             {
-                set(px, ty, pz, logId, true);
+                set(px, ty, pz, logId, i == 0); // only the centre stem may overwrite; the others fill air
             }
 
             set(px, sy + height + 1, pz, leafId, false);

--- a/src/BlocksBeyondTheStars.WorldGeneration/WorldGenerator.StampsGen1.cs
+++ b/src/BlocksBeyondTheStars.WorldGeneration/WorldGenerator.StampsGen1.cs
@@ -1,0 +1,697 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using System.Collections.Generic;
+using BlocksBeyondTheStars.Shared.Definitions;
+using BlocksBeyondTheStars.Shared.Primitives;
+using BlocksBeyondTheStars.Shared.World;
+
+namespace BlocksBeyondTheStars.WorldGeneration;
+
+/// <summary>Generation-1 set dressing (#1648, landscape variety 5/6): the new prop rows and micro-ruins, the
+/// seven new tree kinds and the giant-flora table (partial of <see cref="WorldGenerator"/>). Prop rows gate
+/// on the world's generation plus a per-row world gate; the classic five rows keep their salts, order and
+/// materials so every generation-0 world is byte-identical.</summary>
+public sealed partial class WorldGenerator
+{
+    // ---------------- prop gates (generation ≥ 1; each also needs the row's material to exist) ----------------
+
+    private static bool PropSolidGround(WonderProfile w, PlanetType p) => w.Generation >= 1 && !p.Void && !p.FloatingIslands;
+
+    private static bool PropWooded(WonderProfile w, PlanetType p)
+        => PropSolidGround(w, p) && !p.Cratered && HasAir(p) && p.FloraDensity > 0 && (p.TreeDensity ?? 0.012) > 0.0;
+
+    private static bool PropSavanna(WonderProfile w, PlanetType p)
+        => PropSolidGround(w, p) && string.Equals(p.FloraTheme, "savanna", System.StringComparison.OrdinalIgnoreCase);
+
+    private static bool PropCold(WonderProfile w, PlanetType p) => PropSolidGround(w, p) && HasAir(p) && p.BaseTemperature <= 5.0;
+
+    private static bool PropFrozen(WonderProfile w, PlanetType p) => PropSolidGround(w, p) && HasAir(p) && p.BaseTemperature <= -5.0;
+
+    private static bool PropDry(WonderProfile w, PlanetType p) => PropSolidGround(w, p) && HasAir(p) && WaterAbundanceOf(p) <= 0.3;
+
+    private static bool PropVolcanic(WonderProfile w, PlanetType p) => PropSolidGround(w, p) && p.HasTag(TerrainTag.Volcanic);
+
+    private static bool PropCoast(WonderProfile w, PlanetType p) => PropSolidGround(w, p) && HasAir(p) && WaterAbundanceOf(p) >= 0.5;
+
+    private static bool PropCrystal(WonderProfile w, PlanetType p) => PropSolidGround(w, p) && p.HasTag(TerrainTag.Crystal);
+
+    private static bool PropAirless(WonderProfile w, PlanetType p) => w.Generation >= 1 && !p.Void && p.IsAirless;
+
+    private static bool PropTarFlats(WonderProfile w, PlanetType p)
+        => PropDry(w, p) && (p.HasTag(TerrainTag.Buttes) || p.HasTag(TerrainTag.Wind));
+
+    private static bool PropRuins(WonderProfile w, PlanetType p) => PropSolidGround(w, p) && !p.Cratered && HasAir(p);
+
+    // ---------------- prop shapes (fill air only, never carve) ----------------
+
+    /// <summary>Two logs are stamped: a horizontal 3–5-long trunk along X or Z one cell above the ground of each column.</summary>
+    private static void StampFallenLog(PropStamp s)
+    {
+        int len = 3 + s.ShapeHash % 3;
+        bool alongX = (s.ShapeHash & 8) == 0;
+        for (int i = 0; i < len; i++)
+        {
+            int px = s.Wx + (alongX ? i : 0), pz = s.Wz + (alongX ? 0 : i);
+            int py = s.Generator.SurfaceHeight(s.Planet, px, pz);
+            s.Set(px, py + 1, pz, s.Material);
+        }
+    }
+
+    /// <summary>A termite mound: a 2–3-tall spire on a 3-cell base.</summary>
+    private static void StampTermiteMound(PropStamp s)
+    {
+        int h = 2 + s.ShapeHash % 2;
+        for (int dy = 1; dy <= h; dy++)
+        {
+            s.Set(s.Wx, s.Sy + dy, s.Wz, s.Material);
+        }
+
+        s.Set(s.Wx + 1, s.Sy + 1, s.Wz, s.Material);
+        s.Set(s.Wx, s.Sy + 1, s.Wz + ((s.ShapeHash & 4) == 0 ? 1 : -1), s.Material);
+    }
+
+    /// <summary>A cairn: a 3–4 stone stack with two side stones at the foot.</summary>
+    private static void StampCairn(PropStamp s)
+    {
+        int h = 3 + s.ShapeHash % 2;
+        for (int dy = 1; dy <= h; dy++)
+        {
+            s.Set(s.Wx, s.Sy + dy, s.Wz, s.Material);
+        }
+
+        s.Set(s.Wx - 1, s.Sy + 1, s.Wz, s.Material);
+        s.Set(s.Wx, s.Sy + 1, s.Wz + 1, s.Material);
+    }
+
+    /// <summary>A bone pile: a 2×2 scatter with one two-tall heap.</summary>
+    private static void StampBonePile(PropStamp s)
+    {
+        s.Set(s.Wx, s.Sy + 1, s.Wz, s.Material);
+        s.Set(s.Wx + 1, s.Sy + 1, s.Wz, s.Material);
+        if ((s.ShapeHash & 1) == 0) s.Set(s.Wx, s.Sy + 1, s.Wz + 1, s.Material);
+        if ((s.ShapeHash & 2) == 0) s.Set(s.Wx + 1, s.Sy + 1, s.Wz + 1, s.Material);
+        s.Set(s.Wx, s.Sy + 2, s.Wz, s.Material);
+    }
+
+    /// <summary>A rib cage: seven arches of bone along one axis — the widest prop (7 across), which sets the
+    /// set-dressing scan margin of 8.</summary>
+    private static void StampRibCage(PropStamp s)
+    {
+        bool alongX = (s.ShapeHash & 8) == 0;
+        for (int k = -3; k <= 3; k++)
+        {
+            int ax = s.Wx + (alongX ? k : 0), az = s.Wz + (alongX ? 0 : k);
+            int height = System.Math.Abs(k) >= 3 ? 1 : System.Math.Abs(k) == 2 ? 2 : 3;
+            for (int side = -1; side <= 1; side += 2)
+            {
+                int px = ax + (alongX ? 0 : side * 2), pz = az + (alongX ? side * 2 : 0);
+                int py = s.Generator.SurfaceHeight(s.Planet, px, pz);
+                for (int dy = 1; dy <= height; dy++)
+                {
+                    s.Set(px, py + dy, pz, s.Material);
+                }
+            }
+
+            if (height == 3)
+            {
+                // the arch top joins the two ribs
+                for (int t = -1; t <= 1; t++)
+                {
+                    s.Set(ax + (alongX ? 0 : t), s.Sy + 4, az + (alongX ? t : 0), s.Material);
+                }
+            }
+        }
+
+        // the spine
+        for (int k = -3; k <= 3; k++)
+        {
+            s.Set(s.Wx + (alongX ? k : 0), s.Sy + 1, s.Wz + (alongX ? 0 : k), s.Material);
+        }
+    }
+
+    /// <summary>A 3×3 crystal cluster with 1–4-tall spikes.</summary>
+    private static void StampCrystalCluster(PropStamp s)
+    {
+        int h = s.ShapeHash;
+        for (int dx = -1; dx <= 1; dx++)
+            for (int dz = -1; dz <= 1; dz++)
+            {
+                int bit = (dx + 1) * 3 + (dz + 1);
+                int height = dx == 0 && dz == 0 ? 4 : 1 + ((h >> bit) & 0x3);
+                if (dx != 0 && dz != 0 && ((h >> (bit + 2)) & 1) == 0)
+                {
+                    continue; // the odd empty corner
+                }
+
+                int px = s.Wx + dx, pz = s.Wz + dz;
+                int py = s.Generator.SurfaceHeight(s.Planet, px, pz);
+                for (int dy = 1; dy <= height; dy++)
+                {
+                    s.Set(px, py + dy, pz, s.Material);
+                }
+            }
+    }
+
+    /// <summary>A coral outcrop on the dry strip above the waterline: one or two coral cells.</summary>
+    private static void StampCoralOutcrop(PropStamp s)
+    {
+        s.Set(s.Wx, s.Sy + 1, s.Wz, s.Material);
+        if ((s.ShapeHash & 1) == 0)
+        {
+            s.Set(s.Wx + ((s.ShapeHash & 2) == 0 ? 1 : -1), s.Sy + 1, s.Wz, s.Material);
+        }
+    }
+
+    /// <summary>A meteorite: a 2–3-cell lump of iron ore resting on the regolith.</summary>
+    private static void StampMeteorite(PropStamp s)
+    {
+        s.Set(s.Wx, s.Sy + 1, s.Wz, s.Material);
+        s.Set(s.Wx + ((s.ShapeHash & 1) == 0 ? 1 : -1), s.Sy + 1, s.Wz, s.Material);
+        if ((s.ShapeHash & 6) == 0)
+        {
+            s.Set(s.Wx, s.Sy + 2, s.Wz, s.Material);
+        }
+    }
+
+    /// <summary>A tar pool: a 3×3 (corners rolled) tar pad flush on the flat ground.</summary>
+    private static void StampTarPit(PropStamp s)
+    {
+        for (int dx = -1; dx <= 1; dx++)
+            for (int dz = -1; dz <= 1; dz++)
+            {
+                if (dx != 0 && dz != 0 && ((s.ShapeHash >> ((dx + 1) + (dz + 1) * 3)) & 1) == 0)
+                {
+                    continue;
+                }
+
+                int px = s.Wx + dx, pz = s.Wz + dz;
+                int py = s.Generator.SurfaceHeight(s.Planet, px, pz);
+                s.Set(px, py + 1, pz, s.Material);
+            }
+    }
+
+    // --- micro-ruins: a data cache rolls in with some of them ---
+
+    /// <summary>An L-shaped wall fragment, 3 + 2 long, 2 tall (one course crumbled), a cache in the corner 30 % of the time.</summary>
+    private static void StampWallFragment(PropStamp s)
+    {
+        for (int i = 0; i < 3; i++)
+        {
+            int px = s.Wx + i;
+            int py = s.Generator.SurfaceHeight(s.Planet, px, s.Wz);
+            int h = i == 2 && (s.ShapeHash & 1) == 0 ? 1 : 2;
+            for (int dy = 1; dy <= h; dy++)
+            {
+                s.Set(px, py + dy, s.Wz, s.Material);
+            }
+        }
+
+        for (int j = 1; j <= 2; j++)
+        {
+            int pz = s.Wz + j;
+            int py = s.Generator.SurfaceHeight(s.Planet, s.Wx, pz);
+            int h = j == 2 && (s.ShapeHash & 2) == 0 ? 1 : 2;
+            for (int dy = 1; dy <= h; dy++)
+            {
+                s.Set(s.Wx, py + dy, pz, s.Material);
+            }
+        }
+
+        if (!s.Cache.IsAir && s.ShapeHash % 10 < 3)
+        {
+            s.Set(s.Wx + 1, s.Sy + 1, s.Wz + 1, s.Cache);
+        }
+    }
+
+    /// <summary>A buried pillar: 2–4 courses of ancient brick with rubble at the foot.</summary>
+    private static void StampBuriedPillar(PropStamp s)
+    {
+        int h = 2 + s.ShapeHash % 3;
+        for (int dy = 1; dy <= h; dy++)
+        {
+            s.Set(s.Wx, s.Sy + dy, s.Wz, s.Material);
+        }
+
+        s.Set(s.Wx + 1, s.Sy + 1, s.Wz, s.Material);
+        s.Set(s.Wx - 1, s.Sy + 1, s.Wz + 1, s.Material);
+    }
+
+    /// <summary>A crashed probe: a 2×2 hull with a glass eye, debris around it, a cache under the hull half the time.</summary>
+    private static void StampCrashedProbe(PropStamp s)
+    {
+        s.Set(s.Wx, s.Sy + 1, s.Wz, s.Material);
+        s.Set(s.Wx + 1, s.Sy + 1, s.Wz, s.Material);
+        s.Set(s.Wx, s.Sy + 1, s.Wz + 1, s.Material);
+        s.Set(s.Wx + 1, s.Sy + 1, s.Wz + 1, s.Secondary.IsAir ? s.Material : s.Secondary);
+        s.Set(s.Wx, s.Sy + 2, s.Wz, s.Material);
+        s.Set(s.Wx + ((s.ShapeHash & 1) == 0 ? 3 : -2), s.Sy + 1, s.Wz, s.Material);
+        s.Set(s.Wx, s.Sy + 1, s.Wz + ((s.ShapeHash & 2) == 0 ? 3 : -2), s.Material);
+        if (!s.Cache.IsAir && (s.ShapeHash & 4) == 0)
+        {
+            s.Set(s.Wx + 1, s.Sy + 2, s.Wz + 1, s.Cache);
+        }
+    }
+
+    /// <summary>An abandoned mining rig: a 2×2 machine housing with a 3-tall pipe stack.</summary>
+    private static void StampMiningRig(PropStamp s)
+    {
+        for (int dx = 0; dx <= 1; dx++)
+            for (int dz = 0; dz <= 1; dz++)
+            {
+                s.Set(s.Wx + dx, s.Sy + 1, s.Wz + dz, s.Material);
+            }
+
+        var pipe = s.Secondary.IsAir ? s.Material : s.Secondary;
+        for (int dy = 2; dy <= 4; dy++)
+        {
+            s.Set(s.Wx, s.Sy + dy, s.Wz, pipe);
+        }
+
+        s.Set(s.Wx + 1, s.Sy + 2, s.Wz + 1, pipe);
+        if (!s.Cache.IsAir && s.ShapeHash % 10 < 4)
+        {
+            s.Set(s.Wx + 2, s.Sy + 1, s.Wz, s.Cache);
+        }
+    }
+
+    /// <summary>A lone rune stone, 2 tall, a cache at its foot 40 % of the time.</summary>
+    private static void StampRuneStone(PropStamp s)
+    {
+        s.Set(s.Wx, s.Sy + 1, s.Wz, s.Material);
+        s.Set(s.Wx, s.Sy + 2, s.Wz, s.Material);
+        if (!s.Cache.IsAir && s.ShapeHash % 10 < 4)
+        {
+            s.Set(s.Wx + 1, s.Sy + 1, s.Wz, s.Cache);
+        }
+    }
+
+    // ---------------- trees (generation-1 kinds) ----------------
+
+    /// <summary>A baobab: a thick 2×2 trunk 5–8 tall under a flat, wide crown.</summary>
+    private static void BuildBaobab(int wx, int sy, int wz, double sizeF, double hJit, double cJit,
+        BlockId logId, BlockId leafId, System.Action<int, int, int, BlockId, bool> set)
+    {
+        int height = System.Math.Clamp((int)System.Math.Round(6.0 * sizeF * hJit), 5, 8);
+        int crownR = System.Math.Clamp((int)System.Math.Round(3.0 * sizeF * cJit), 2, 3);
+        int topY = sy + height;
+        for (int ty = sy + 1; ty <= topY; ty++)
+        {
+            set(wx, ty, wz, logId, true);
+            set(wx + 1, ty, wz, logId, true);
+            set(wx, ty, wz + 1, logId, true);
+            set(wx + 1, ty, wz + 1, logId, true);
+        }
+
+        for (int dy = 0; dy <= 1; dy++)
+        {
+            int r = crownR - dy;
+            for (int dx = -r; dx <= r + 1; dx++)
+                for (int dz = -r; dz <= r + 1; dz++)
+                {
+                    if ((dx - 0.5) * (dx - 0.5) + (dz - 0.5) * (dz - 0.5) <= r * r + 1.5)
+                    {
+                        set(wx + dx, topY + dy, wz + dz, leafId, false);
+                    }
+                }
+        }
+    }
+
+    /// <summary>A mangrove: four stilt roots rising diagonally to a trunk that starts three cells up, a rounded crown.</summary>
+    private static void BuildMangrove(int wx, int sy, int wz, double sizeF, double hJit, double cJit,
+        BlockId logId, BlockId leafId, System.Action<int, int, int, BlockId, bool> set)
+    {
+        int height = System.Math.Clamp((int)System.Math.Round(6.0 * sizeF * hJit), 5, 9);
+        int crownR = System.Math.Clamp((int)System.Math.Round(2.0 * sizeF * cJit), 1, 2);
+        int[,] roots = { { 2, 0 }, { -2, 0 }, { 0, 2 }, { 0, -2 } };
+        for (int r = 0; r < 4; r++)
+        {
+            set(wx + roots[r, 0], sy + 1, wz + roots[r, 1], logId, true);
+            set(wx + roots[r, 0] / 2, sy + 2, wz + roots[r, 1] / 2, logId, true);
+        }
+
+        int topY = sy + height;
+        for (int ty = sy + 3; ty <= topY; ty++)
+        {
+            set(wx, ty, wz, logId, true);
+        }
+
+        for (int dy = -1; dy <= crownR; dy++)
+            for (int dx = -crownR; dx <= crownR; dx++)
+                for (int dz = -crownR; dz <= crownR; dz++)
+                {
+                    if (dx * dx + dz * dz + dy * dy <= crownR * crownR + 1)
+                    {
+                        set(wx + dx, topY + dy, wz + dz, leafId, false);
+                    }
+                }
+    }
+
+    /// <summary>A bamboo grove: 3–6 one-wide stems 8–12 tall within radius 2, two leaf cells at each top.</summary>
+    private static void BuildBamboo(int wx, int sy, int wz, double sizeF, double hJit, int shapeHash,
+        BlockId logId, BlockId leafId, System.Action<int, int, int, BlockId, bool> set)
+    {
+        int stems = 3 + shapeHash % 4;
+        (int X, int Z)[] spots = { (0, 0), (1, 1), (-1, 1), (2, -1), (-2, 0), (0, -2), (1, -1), (-1, -2) };
+        for (int i = 0; i < stems && i < spots.Length; i++)
+        {
+            int height = System.Math.Clamp((int)System.Math.Round(10.0 * sizeF * hJit) + (shapeHash >> i) % 3 - 1, 8, 12);
+            int px = wx + spots[i].X, pz = wz + spots[i].Z;
+            for (int ty = sy + 1; ty <= sy + height; ty++)
+            {
+                set(px, ty, pz, logId, true);
+            }
+
+            set(px, sy + height + 1, pz, leafId, false);
+            set(px + ((shapeHash >> i) & 1) * 2 - 1, sy + height, pz, leafId, false);
+        }
+    }
+
+    /// <summary>A saguaro: a 4–7 column with two up-turned arms — the cactus is built from the leaf block (green).</summary>
+    private static void BuildSaguaro(int wx, int sy, int wz, double sizeF, double hJit, int shapeHash,
+        BlockId leafId, System.Action<int, int, int, BlockId, bool> set)
+    {
+        int height = System.Math.Clamp((int)System.Math.Round(5.5 * sizeF * hJit), 4, 7);
+        for (int ty = sy + 1; ty <= sy + height; ty++)
+        {
+            set(wx, ty, wz, leafId, true);
+        }
+
+        int armY = sy + System.Math.Max(2, height / 2);
+        int ax = (shapeHash & 1) == 0 ? 1 : -1;
+        set(wx + ax, armY, wz, leafId, true);
+        set(wx + ax, armY + 1, wz, leafId, true);
+        set(wx + ax, armY + 2, wz, leafId, true);
+        if ((shapeHash & 2) == 0)
+        {
+            int az = (shapeHash & 4) == 0 ? 1 : -1;
+            set(wx, armY + 1, wz + az, leafId, true);
+            set(wx, armY + 2, wz + az, leafId, true);
+        }
+    }
+
+    /// <summary>A willow: a 4–6 trunk under a broad crown whose rim drips 3–4-cell leaf strands.</summary>
+    private static void BuildWillow(int wx, int sy, int wz, double sizeF, double hJit, double cJit,
+        BlockId logId, BlockId leafId, System.Action<int, int, int, BlockId, bool> set)
+    {
+        int height = System.Math.Clamp((int)System.Math.Round(5.0 * sizeF * hJit), 4, 6);
+        int crownR = System.Math.Clamp((int)System.Math.Round(2.5 * sizeF * cJit), 2, 3);
+        int topY = sy + height;
+        for (int ty = sy + 1; ty <= topY; ty++)
+        {
+            set(wx, ty, wz, logId, true);
+        }
+
+        for (int dy = 0; dy <= 1; dy++)
+            for (int dx = -crownR; dx <= crownR; dx++)
+                for (int dz = -crownR; dz <= crownR; dz++)
+                {
+                    int d2 = dx * dx + dz * dz;
+                    if (d2 <= crownR * crownR + 1)
+                    {
+                        set(wx + dx, topY + dy, wz + dz, leafId, false);
+                        if (dy == 0 && d2 >= (crownR - 1) * (crownR - 1) + 1 && ((dx + dz) & 1) == 0)
+                        {
+                            for (int s = 1; s <= 3; s++)
+                            {
+                                set(wx + dx, topY - s, wz + dz, leafId, false); // the drooping strands
+                            }
+                        }
+                    }
+                }
+    }
+
+    /// <summary>An alien mushroom tree: a 4–6 stem under a flat cap disc of radius 2.</summary>
+    private static void BuildMushroomTree(int wx, int sy, int wz, double sizeF, double hJit,
+        BlockId stemId, BlockId capId, System.Action<int, int, int, BlockId, bool> set)
+    {
+        int height = System.Math.Clamp((int)System.Math.Round(5.0 * sizeF * hJit), 4, 6);
+        int topY = sy + height;
+        for (int ty = sy + 1; ty <= topY; ty++)
+        {
+            set(wx, ty, wz, stemId, true);
+        }
+
+        for (int dx = -2; dx <= 2; dx++)
+            for (int dz = -2; dz <= 2; dz++)
+            {
+                if (dx * dx + dz * dz <= 5)
+                {
+                    set(wx + dx, topY + 1, wz + dz, capId, false);
+                }
+            }
+
+        set(wx, topY + 2, wz, capId, false);
+    }
+
+    /// <summary>A crystal tree: a 3–5 crystal shaft crowned by a cross of crystal arms.</summary>
+    private static void BuildCrystalTree(int wx, int sy, int wz, double sizeF, double hJit,
+        BlockId crystalId, System.Action<int, int, int, BlockId, bool> set)
+    {
+        int height = System.Math.Clamp((int)System.Math.Round(4.0 * sizeF * hJit), 3, 5);
+        int topY = sy + height;
+        for (int ty = sy + 1; ty <= topY; ty++)
+        {
+            set(wx, ty, wz, crystalId, true);
+        }
+
+        int[,] dirs = { { 1, 0 }, { -1, 0 }, { 0, 1 }, { 0, -1 } };
+        for (int i = 0; i < 4; i++)
+        {
+            set(wx + dirs[i, 0], topY, wz + dirs[i, 1], crystalId, false);
+            set(wx + dirs[i, 0] * 2, topY + 1, wz + dirs[i, 1] * 2, crystalId, false);
+        }
+
+        set(wx, topY + 1, wz, crystalId, false);
+        set(wx, topY + 2, wz, crystalId, false);
+    }
+
+    /// <summary>Builds one generation-1 tree kind into a cell list relative to its column (tests): (dx, dy, dz).</summary>
+    internal static List<(int Dx, int Dy, int Dz)> BuildTreeForTest(TreeKind kind, double sizeF, double hJit, double cJit, int shapeHash)
+    {
+        var cells = new List<(int, int, int)>();
+        var a = new BlockId(1);
+        var b = new BlockId(2);
+        void Set(int x, int y, int z, BlockId _, bool __) => cells.Add((x, y, z));
+        switch (kind)
+        {
+            case TreeKind.Baobab: BuildBaobab(0, 0, 0, sizeF, hJit, cJit, a, b, Set); break;
+            case TreeKind.Mangrove: BuildMangrove(0, 0, 0, sizeF, hJit, cJit, a, b, Set); break;
+            case TreeKind.Bamboo: BuildBamboo(0, 0, 0, sizeF, hJit, shapeHash, a, b, Set); break;
+            case TreeKind.Saguaro: BuildSaguaro(0, 0, 0, sizeF, hJit, shapeHash, b, Set); break;
+            case TreeKind.Willow: BuildWillow(0, 0, 0, sizeF, hJit, cJit, a, b, Set); break;
+            case TreeKind.MushroomTree: BuildMushroomTree(0, 0, 0, sizeF, hJit, a, b, Set); break;
+            case TreeKind.CrystalTree: BuildCrystalTree(0, 0, 0, sizeF, hJit, b, Set); break;
+            default: BuildBroadleaf(0, 0, 0, sizeF, hJit, cJit, a, b, Set); break;
+        }
+
+        return cells;
+    }
+
+    /// <summary>True when water lies within four cells of the column (a mangrove's place). Four memoised lookups.</summary>
+    private bool NearWater(PlanetType planet, int wx, int wz, int seaLevel)
+    {
+        for (int d = 0; d < 4; d++)
+        {
+            int px = wx + (d == 0 ? 4 : d == 1 ? -4 : 0), pz = wz + (d == 2 ? 4 : d == 3 ? -4 : 0);
+            if (SurfaceHeight(planet, px, pz) < seaLevel || SurfacePondDepth(planet, px, pz) > 0 || SurfaceGen1WaterDepth(planet, px, pz) > 0)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    // ---------------- giant flora table ----------------
+
+    /// <summary>What grows huge on which ground (#1648): the classic giant mushroom on mycelium (its roll and
+    /// sizes untouched), and from generation 1 the giant fern on jungle mud, the giant crystal on crystal
+    /// ground and the giant cactus on sand.</summary>
+    private readonly struct GiantFloraKind
+    {
+        public GiantFloraKind(string name, string host, string stem, string cap, long salt, double density, int gen)
+        {
+            Name = name;
+            Host = host;
+            Stem = stem;
+            Cap = cap;
+            Salt = salt;
+            Density = density;
+            Generation = gen;
+        }
+
+        public readonly string Name, Host, Stem, Cap;
+        public readonly long Salt;
+        public readonly double Density;
+        public readonly int Generation; // the first generation the row grows on
+    }
+
+    private static readonly GiantFloraKind[] GiantFloraKinds =
+    {
+        new("giant-fern", "mud", "wood_log", "tree_leaves", 0x6F3A0, 0.006, 1),
+        new("giant-crystal", "crystal", "crystal", "crystal", 0x6C570, 0.004, 1),
+        new("giant-cactus", "sand", "tree_leaves", "tree_leaves", 0x6CAC0, 0.0025, 1),
+    };
+
+    /// <summary>Stamps the generation-1 giant flora (#1648): the giant-mushroom recipe (per-column roll on the host
+    /// ground, tree line, dry ground, a bell-sized stem) with each row's own salt and shape — a fan-crowned fern
+    /// on mud, a spiked crystal on crystal ground, an armed cactus on sand. Never touches the mycelium path.</summary>
+    private void StampGiantFloraGen1(PlanetType planet, long seed, ChunkData chunk, ChunkCoord coord,
+        List<BiomeResolved> biomes, int fluidLevel)
+    {
+        var origin = WorldConstants.ChunkOrigin(coord);
+        int cs = WorldConstants.ChunkSize;
+        const int maxR = 3;
+
+        void SetCell(int wx, int wy, int wz, BlockId block, bool overwrite)
+        {
+            int lx = wx - origin.X, ly = wy - origin.Y, lz = wz - origin.Z;
+            if (lx < 0 || lx >= cs || ly < 0 || ly >= cs || lz < 0 || lz >= cs)
+            {
+                return;
+            }
+
+            if (!overwrite && !chunk.Get(lx, ly, lz).IsAir)
+            {
+                return;
+            }
+
+            chunk.Set(lx, ly, lz, block);
+        }
+
+        var calib = CalibFor(planet);
+        var waterId = _content.GetBlock("water")?.NumericId ?? BlockId.Air;
+        foreach (var row in GiantFloraKinds)
+        {
+            var hostId = _content.GetBlock(row.Host)?.NumericId ?? BlockId.Air;
+            var stemId = _content.GetBlock(row.Stem)?.NumericId ?? BlockId.Air;
+            var capId = _content.GetBlock(row.Cap)?.NumericId ?? BlockId.Air;
+            if (hostId.IsAir || stemId.IsAir || capId.IsAir || !biomes.Exists(b => b.Surface == hostId))
+            {
+                continue; // this world has no such ground
+            }
+
+            for (int wx = origin.X - maxR; wx < origin.X + cs + maxR; wx++)
+                for (int wz = origin.Z - maxR; wz < origin.Z + cs + maxR; wz++)
+                {
+                    int cx = WorldConstants.WrapX(wx, _circumference);
+                    if (Noise.Value01(seed + row.Salt, cx, 17, Wz(wz)) >= row.Density)
+                    {
+                        continue;
+                    }
+
+                    int sy = SurfaceHeight(planet, wx, wz);
+                    if (sy + 1 > origin.Y + cs - 1 || sy + MaxStampRise < origin.Y)
+                    {
+                        continue;
+                    }
+
+                    var surf = biomes[biomes.Count <= 1 ? 0 : BiomeIndex(calib, seed, wx, wz, biomes.Count, sy)].Surface;
+                    if (surf != hostId || TempAt(calib, sy) < TreeLineC)
+                    {
+                        continue;
+                    }
+
+                    if (sy + 1 <= fluidLevel || SurfacePondDepth(planet, wx, wz) > 0 || SurfaceRiverDepth(planet, wx, wz) > 0
+                        || SurfaceGen1WaterDepth(planet, wx, wz) > 0
+                        || DryBeachAt(planet, calib, seed, RiverFieldFor(planet), waterId, wx, wz, sy))
+                    {
+                        continue;
+                    }
+
+                    double sizeF = SizeFactor(seed + row.Salt + 1, wx, wz, 0.30);
+                    double hJit = SizeFactor(seed + row.Salt + 2, wx, wz, 0.12);
+                    int shapeHash = (int)(Noise.Value01(seed + row.Salt + 3, cx, 41, Wz(wz)) * 997);
+                    switch (row.Name)
+                    {
+                        case "giant-fern":
+                            {
+                                int height = System.Math.Clamp((int)System.Math.Round(5.0 * sizeF * hJit), 4, 7);
+                                int topY = sy + height;
+                                for (int ty = sy + 1; ty <= topY; ty++)
+                                {
+                                    SetCell(wx, ty, wz, stemId, true);
+                                }
+
+                                // a flat fan of fronds, the tips drooping one cell
+                                int[,] dirs = { { 1, 0 }, { -1, 0 }, { 0, 1 }, { 0, -1 }, { 1, 1 }, { 1, -1 }, { -1, 1 }, { -1, -1 } };
+                                for (int i = 0; i < 8; i++)
+                                {
+                                    SetCell(wx + dirs[i, 0], topY, wz + dirs[i, 1], capId, false);
+                                    SetCell(wx + dirs[i, 0] * 2, topY, wz + dirs[i, 1] * 2, capId, false);
+                                    SetCell(wx + dirs[i, 0] * 3, topY - 1, wz + dirs[i, 1] * 3, capId, false);
+                                }
+
+                                SetCell(wx, topY + 1, wz, capId, false);
+                                break;
+                            }
+
+                        case "giant-crystal":
+                            {
+                                int height = System.Math.Clamp((int)System.Math.Round(6.0 * sizeF * hJit), 4, 9);
+                                for (int ty = sy + 1; ty <= sy + height; ty++)
+                                {
+                                    SetCell(wx, ty, wz, stemId, true);
+                                    if (ty <= sy + 2)
+                                    {
+                                        SetCell(wx + 1, ty, wz, stemId, true);
+                                        SetCell(wx, ty, wz + 1, stemId, true);
+                                    }
+                                }
+
+                                // satellite spikes
+                                SetCell(wx + 2, sy + 1, wz, capId, false);
+                                SetCell(wx + 2, sy + 2, wz, capId, false);
+                                SetCell(wx - 1, sy + 1, wz - 1, capId, false);
+                                if ((shapeHash & 1) == 0)
+                                {
+                                    SetCell(wx - 1, sy + 2, wz - 1, capId, false);
+                                }
+
+                                break;
+                            }
+
+                        default: // giant-cactus
+                            {
+                                int height = System.Math.Clamp((int)System.Math.Round(6.0 * sizeF * hJit), 4, 9);
+                                for (int ty = sy + 1; ty <= sy + height; ty++)
+                                {
+                                    SetCell(wx, ty, wz, stemId, true);
+                                }
+
+                                int armY = sy + System.Math.Max(2, height / 2);
+                                for (int i = 0; i < 2; i++)
+                                {
+                                    int ax = i == 0 ? 1 : -1;
+                                    int len = 2 + ((shapeHash >> i) & 1);
+                                    SetCell(wx + ax, armY + i, wz, stemId, true);
+                                    for (int k = 1; k <= len; k++)
+                                    {
+                                        SetCell(wx + ax, armY + i + k, wz, stemId, true);
+                                    }
+                                }
+
+                                break;
+                            }
+                    }
+                }
+        }
+    }
+
+    /// <summary>The giant-flora rows active on this world (tests).</summary>
+    internal string[] GiantFloraForTest(PlanetType planet)
+    {
+        var w = WonderFor(planet);
+        var names = new List<string>();
+        foreach (var k in GiantFloraKinds)
+        {
+            if (w.Generation >= k.Generation && !(_content.GetBlock(k.Host)?.NumericId ?? BlockId.Air).IsAir)
+            {
+                names.Add(k.Name);
+            }
+        }
+
+        return names.ToArray();
+    }
+}

--- a/tests/BlocksBeyondTheStars.Tests/LandscapeFluidsPaintsTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/LandscapeFluidsPaintsTests.cs
@@ -105,12 +105,16 @@ public sealed class LandscapeFluidsPaintsTests
 
     // ---------- helper agreement ----------
 
-    /// <summary>For every sampled column: the helper's water column == the generated column's water cells.</summary>
-    private static void AssertHelpersAgree(WorldGenerator gen, PlanetType planet, int step, out int waterColumns)
+    /// <summary>Helper agreement over whole CHUNKS: a coarse scan (no chunk generation) finds columns the helper
+    /// calls water, the chunks containing them plus a fixed spread of chunks are generated once, and every column
+    /// in them is compared cell by cell — thousands of columns for a few dozen chunk generations, inside the
+    /// fast-tier budget (the old one-chunk-per-sampled-column version took 153 s on the CI runner, #1648).</summary>
+    private static void AssertHelpersAgree(WorldGenerator gen, PlanetType planet, int scanStep, out int waterColumns)
     {
         var water = Content.GetBlock("water")!.NumericId;
         int circ = WorldConstants.Circumference;
         int period = WorldConstants.LatitudePeriodFor(circ);
+        int cs = WorldConstants.ChunkSize;
         waterColumns = 0;
         var chunks = new Dictionary<(int, int, int), ChunkData>();
         ChunkData ChunkAt(int x, int y, int z)
@@ -124,46 +128,61 @@ public sealed class LandscapeFluidsPaintsTests
             return chunk;
         }
 
-        int cs = WorldConstants.ChunkSize;
-        for (int z = -period / 2; z < period / 2; z += step)
-            for (int x = 0; x < circ; x += step)
+        BlockId Cell(int x, int y, int z)
+            => ChunkAt(x, y, z).Get(((x % cs) + cs) % cs, ((y % cs) + cs) % cs, ((z % cs) + cs) % cs);
+
+        // Target chunks: up to eight around helper-water columns found by the coarse scan, plus six spread out.
+        var targets = new HashSet<(int Cx, int Cz)>();
+        for (int z = -period / 2; z < period / 2 && targets.Count < 8; z += scanStep)
+            for (int x = 0; x < circ && targets.Count < 8; x += scanStep)
             {
-                int surface = gen.SurfaceHeight(planet, x, z);
-                bool helperWater = gen.TryGetWaterSurface(planet, x, z, out int top, out int bed);
-                // The generated cell just above the reported bed must be water, and the cell above the reported
-                // top must not be; a column the helper calls dry has no water right above its surface.
-                if (helperWater)
+                if (gen.TryGetWaterSurface(planet, x, z, out _, out _) && gen.SurfaceHeight(planet, x, z) > gen.SeaLevel(planet))
                 {
-                    waterColumns++;
-                    var probe = ChunkAt(x, bed + 1, z);
-                    var cell = probe.Get(((x % cs) + cs) % cs, ((bed + 1) % cs + cs) % cs, ((z % cs) + cs) % cs);
-                    // The fill may put aquatic flora (kelp, coral, seagrass, lily) or an ice sheet into that water cell.
-                    var def = Content.Blocks.Values.FirstOrDefault(b => b.NumericId == cell);
-                    bool wet = cell == water || def?.Key == "ice" || (def?.Category == "flora");
-                    Assert.True(wet, $"{planet.Key} ({x},{z}): helper reports water over bed {bed}, generated cell is {def?.Key ?? cell.ToString()}");
-                    var above = ChunkAt(x, top + 1, z);
-                    Assert.True(above.Get(((x % cs) + cs) % cs, ((top + 1) % cs + cs) % cs, ((z % cs) + cs) % cs) != water,
-                        $"{planet.Key} ({x},{z}): water generated above the helper's top {top}");
-                }
-                else
-                {
-                    var probe = ChunkAt(x, surface + 1, z);
-                    var cell = probe.Get(((x % cs) + cs) % cs, ((surface + 1) % cs + cs) % cs, ((z % cs) + cs) % cs);
-                    Assert.True(cell != water, $"{planet.Key} ({x},{z}): generated water at {surface + 1} but the helper says dry");
+                    targets.Add((WorldConstants.WorldToChunk(x), WorldConstants.WorldToChunk(z)));
                 }
             }
+
+        for (int i = 0; i < 6; i++)
+        {
+            targets.Add((WorldConstants.WorldToChunk(i * circ / 6 + 7), WorldConstants.WorldToChunk(-period / 2 + (i * 2 + 1) * period / 12)));
+        }
+
+        foreach (var (cx, cz) in targets)
+        {
+            for (int lx = 0; lx < cs; lx++)
+                for (int lz = 0; lz < cs; lz++)
+                {
+                    int x = cx * cs + lx, z = cz * cs + lz;
+                    int surface = gen.SurfaceHeight(planet, x, z);
+                    if (gen.TryGetWaterSurface(planet, x, z, out int top, out int bed))
+                    {
+                        waterColumns++;
+                        var cell = Cell(x, bed + 1, z);
+                        // The fill may put aquatic flora (kelp, coral, seagrass, lily), an ice sheet or a mangrove's stilt
+                        // root (#1648) into that water cell — all of them stand IN the water the helper reports.
+                        var def = Content.Blocks.Values.FirstOrDefault(b => b.NumericId == cell);
+                        bool wet = cell == water || def?.Key == "ice" || def?.Key == "wood_log" || (def?.Category == "flora");
+                        Assert.True(wet, $"{planet.Key} ({x},{z}): helper reports water over bed {bed}, generated cell is {def?.Key ?? cell.ToString()}");
+                        Assert.True(Cell(x, top + 1, z) != water, $"{planet.Key} ({x},{z}): water generated above the helper's top {top}");
+                    }
+                    else
+                    {
+                        Assert.True(Cell(x, surface + 1, z) != water, $"{planet.Key} ({x},{z}): generated water at {surface + 1} but the helper says dry");
+                    }
+                }
+        }
     }
 
     [Theory]
-    [InlineData("swamp", 101)]   // marsh sheets
-    [InlineData("desert", 53)]   // oases + playas
-    [InlineData("jungle", 127)]  // hot springs, marshes, maars
-    [InlineData("tundra", 131)]  // tarns
+    [InlineData("swamp", 61)]   // marsh sheets
+    [InlineData("desert", 23)]  // oases + playas (sparse — the scan step is fine, it generates no chunks)
+    [InlineData("jungle", 61)]  // hot springs, marshes, maars
+    [InlineData("tundra", 61)]  // tarns
     public void SurfaceWaterHelpers_AgreeWithTheGeneratedColumns_OnGenerationOneWorlds(string key, int step)
     {
         var planet = Content.Planets[key];
         int totalWater = 0;
-        for (long s = 1; s <= 3; s++)
+        for (long s = 1; s <= 2; s++)
         {
             AssertHelpersAgree(Gen(s * 6151 + 3, 1), planet, step, out int n);
             totalWater += n;

--- a/tests/BlocksBeyondTheStars.Tests/LandscapeStampsTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/LandscapeStampsTests.cs
@@ -1,0 +1,298 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using BlocksBeyondTheStars.Shared.Content;
+using BlocksBeyondTheStars.Shared.Definitions;
+using BlocksBeyondTheStars.Shared.Primitives;
+using BlocksBeyondTheStars.Shared.World;
+using BlocksBeyondTheStars.WorldGeneration;
+using Xunit;
+
+namespace BlocksBeyondTheStars.Tests;
+
+/// <summary>
+/// #1648 (landscape variety 5/6): the generation-1 prop rows and micro-ruins, the seven new tree kinds and the
+/// giant-flora table. Generation 0 keeps the classic five rows, palettes and the mycelium mushrooms only.
+/// </summary>
+public sealed class LandscapeStampsTests
+{
+    private static readonly GameContent Content = ContentLoader.LoadFromDirectory(TestPaths.DataDir());
+
+    private static readonly string[] ClassicRows = { "monolith", "stone-circle", "boulder", "crystal-shard", "dead-tree" };
+
+    private static readonly (string Row, string Planet, double Chance)[] Gen1Rows =
+    {
+        ("fallen-log", "jungle", 0.0015), ("termite-mound", "savanna", 0.0020), ("cairn", "tundra", 0.0012),
+        ("bone-pile", "desert", 0.0008), ("rib-cage", "desert", 0.00015), ("ice-boulder", "ice", 0.0012),
+        ("lava-spatter", "lava", 0.0015), ("coral-outcrop", "ocean", 0.0030), ("crystal-cluster", "crystal", 0.0004),
+        ("meteorite", "asteroid", 0.0006), ("tar-pit", "desert", 0.0006), ("wall-fragment", "savanna", 0.00012),
+        ("buried-pillar", "savanna", 0.00012), ("crashed-probe", "savanna", 0.00008), ("mining-rig", "savanna", 0.00008),
+        ("rune-stone", "savanna", 0.00012),
+    };
+
+    private static WorldGenerator Gen(long seed, int generation)
+    {
+        var gen = new WorldGenerator(seed, Content);
+        gen.SetLavaCoreVolcanoes(true);
+        if (generation > 0)
+        {
+            gen.SetTerrainGeneration(generation);
+        }
+
+        return gen;
+    }
+
+    [Fact]
+    public void PropTable_KeepsTheClassicRowsFirst_AndAppendsTheNewOnes()
+    {
+        var order = WorldGenerator.PropOrderForTest();
+        Assert.Equal(ClassicRows, order.Take(5).ToArray());
+        foreach (var (row, _, _) in Gen1Rows)
+        {
+            Assert.Contains(row, order.Skip(5));
+        }
+    }
+
+    [Fact]
+    public void GenerationZero_ActivatesNoNewRow_OnAnyWorld()
+    {
+        foreach (var planet in Content.Planets.Values)
+        {
+            var active = Gen(4711, 0).PropActiveForTest(planet, crystalWorld: true, dryWorld: true);
+            foreach (var (row, _, _) in Gen1Rows)
+            {
+                Assert.DoesNotContain(row, active);
+            }
+
+            Assert.Empty(Gen(4711, 0).GiantFloraForTest(planet));
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(RowCases))]
+    public void Row_RollsAtItsDesignedRate_OnAnEligibleWorld_AndNeverElsewhere(string row, string key, double chance)
+    {
+        var planet = Content.Planets[key];
+        var gen = Gen(31, 1);
+        Assert.Contains(row, gen.PropActiveForTest(planet, crystalWorld: true, dryWorld: true));
+
+        int hits = 0, n = 0;
+        int circ = WorldConstants.Circumference;
+        int period = WorldConstants.LatitudePeriodFor(circ);
+        int step = chance < 0.0005 ? 1 : 3;
+        for (int z = -period / 2; z < period / 2; z += step)
+            for (int x = 0; x < circ; x += step)
+            {
+                n++;
+                if (gen.PropRollForTest(row, planet, x, z))
+                {
+                    hits++;
+                }
+            }
+
+        double rate = hits / (double)n;
+        Assert.InRange(rate, chance / 2.0, chance * 2.0);
+
+        // A world the gate rejects never rolls the row.
+        var ineligible = Content.Planets[key == "asteroid" ? "jungle" : "orbital_station"];
+        for (int x = 0; x < 3000; x += 7)
+        {
+            Assert.False(gen.PropRollForTest(row, ineligible, x, 11));
+        }
+    }
+
+    public static IEnumerable<object[]> RowCases() => Gen1Rows.Select(r => new object[] { r.Row, r.Planet, r.Chance });
+
+    [Fact]
+    public void RibCage_StraddlingAChunkEdge_GeneratesOnBothSides()
+    {
+        // The widest prop (7 across) drives the scan margin: a rib cage rolled 2 columns inside one chunk must write
+        // bone cells into the neighbouring chunk too — i.e. the neighbour's margin scan reaches the roll column.
+        var desert = Content.Planets["desert"];
+        var bone = Content.GetBlock("bone")!.NumericId;
+        int cs = WorldConstants.ChunkSize;
+        for (long s = 1; s <= 60; s++)
+        {
+            var gen = Gen(s * 6151 + 3, 1);
+            int circ = WorldConstants.Circumference;
+            int period = WorldConstants.LatitudePeriodFor(circ);
+            for (int z = -period / 2; z < period / 2; z++)
+                for (int cx = 1; cx < circ / cs - 1; cx++)
+                {
+                    int x = cx * cs + 1; // one column inside chunk cx: both orientations reach the chunk to the west
+                    if (!gen.PropRollForTest("rib-cage", desert, x, z))
+                    {
+                        continue;
+                    }
+
+                    int sy = gen.SurfaceHeight(desert, x, z);
+                    if (gen.SurfaceGen1WaterDepth(desert, x, z) > 0 || sy <= gen.SeaLevel(desert))
+                    {
+                        continue;
+                    }
+
+                    // An earlier row may win the column (table precedence), and the west chunk's ground may sit a
+                    // little lower — probe two stacked chunks and move on if this candidate stamped nothing.
+                    int count = 0;
+                    foreach (int cy in new[] { WorldConstants.WorldToChunk(sy + 1), WorldConstants.WorldToChunk(sy + 4) }.Distinct())
+                    {
+                        var left = gen.Generate(desert, new ChunkCoord(cx - 1, cy, WorldConstants.WorldToChunk(z)));
+                        for (int lx = 0; lx < cs; lx++)
+                            for (int ly = 0; ly < cs; ly++)
+                                for (int lz = 0; lz < cs; lz++)
+                                {
+                                    if (left.Get(lx, ly, lz) == bone)
+                                    {
+                                        count++;
+                                    }
+                                }
+                    }
+
+                    if (count > 0)
+                    {
+                        return; // the west chunk carries the ribs that straddle the edge
+                    }
+                }
+        }
+
+        Assert.Fail("no rib cage straddling a chunk edge left bone in the neighbouring chunk (60 desert worlds)");
+    }
+
+    // ---------- trees ----------
+
+    [Fact]
+    public void Palettes_OfferTheNewKinds_OnGenerationOneOnly()
+    {
+        foreach (var name in new[] { "temperate", "tropical", "savanna", "desert", "swamp", "alien" })
+        {
+            var theme = FloraThemes.Resolve(name);
+            var classic = theme.PaletteFor(0);
+            var gen1 = theme.PaletteFor(1);
+            Assert.Equal(theme.Trees, classic);
+            Assert.True(gen1.Length > classic.Length, $"{name}: no new kind on generation 1");
+            foreach (var k in classic)
+            {
+                Assert.Contains(k, gen1);
+            }
+
+            foreach (var k in classic)
+            {
+                Assert.True(k <= TreeKind.Dead, $"{name}: classic palette carries the generation-1 kind {k}");
+            }
+        }
+
+        Assert.Equal(FloraThemes.Resolve("tundra").Trees, FloraThemes.Resolve("tundra").PaletteFor(1));
+    }
+
+    [Fact]
+    public void NewTrees_StayInsideTheStampEnvelope()
+    {
+        // Every tree kind's cells must lie within the scan margin (|dx|,|dz| ≤ 4) and under MaxStampRise (18).
+        foreach (var kind in new[] { TreeKind.Baobab, TreeKind.Mangrove, TreeKind.Bamboo, TreeKind.Saguaro, TreeKind.Willow, TreeKind.MushroomTree, TreeKind.CrystalTree })
+        {
+            for (int variant = 0; variant < 12; variant++)
+            {
+                var cells = WorldGenerator.BuildTreeForTest(kind, 0.7 + variant * 0.05, 1.0 + (variant % 3) * 0.06, 1.0 + (variant % 4) * 0.05, variant * 83);
+                Assert.NotEmpty(cells);
+                foreach (var (dx, dy, dz) in cells)
+                {
+                    Assert.InRange(dx, -4, 4);
+                    Assert.InRange(dz, -4, 4);
+                    Assert.InRange(dy, 1, 18);
+                }
+            }
+        }
+    }
+
+    [Fact]
+    public void Trees_OnGenerationOneWorlds_IncludeANewKind_Somewhere()
+    {
+        // A savanna gen-1 world grows baobabs (2×2 trunks) — count columns with a 2×2 log square above the ground.
+        var savanna = Content.Planets["savanna"];
+        var log = Content.GetBlock("wood_log")!.NumericId;
+        int cs = WorldConstants.ChunkSize;
+        for (long s = 1; s <= 8; s++)
+        {
+            var gen = Gen(s * 977 + 5, 1);
+            for (int cx = 0; cx < 14; cx++)
+                for (int cz = 0; cz < 10; cz++)
+                {
+                    int sx = cx * cs * 5, sz = cz * cs * 5 - 700;
+                    int sy = gen.SurfaceHeight(savanna, sx, sz);
+                    var chunk = gen.Generate(savanna, new ChunkCoord(WorldConstants.WorldToChunk(sx), WorldConstants.WorldToChunk(sy + 3), WorldConstants.WorldToChunk(sz)));
+                    for (int x = 0; x < cs - 1; x++)
+                        for (int y = 0; y < cs; y++)
+                            for (int z = 0; z < cs - 1; z++)
+                            {
+                                if (chunk.Get(x, y, z) == log && chunk.Get(x + 1, y, z) == log && chunk.Get(x, y, z + 1) == log && chunk.Get(x + 1, y, z + 1) == log)
+                                {
+                                    return; // a baobab trunk
+                                }
+                            }
+                }
+        }
+
+        Assert.Fail("no baobab trunk found on eight generation-1 savanna worlds");
+    }
+
+    // ---------- giant flora ----------
+
+    [Fact]
+    public void GiantFlora_RowsFollowTheHostGround()
+    {
+        var gen = Gen(9, 1);
+        Assert.Contains("giant-fern", gen.GiantFloraForTest(Content.Planets["jungle"]));
+        Assert.Contains("giant-crystal", gen.GiantFloraForTest(Content.Planets["crystal_living"]));
+        Assert.Contains("giant-cactus", gen.GiantFloraForTest(Content.Planets["desert"]));
+        Assert.Empty(Gen(9, 0).GiantFloraForTest(Content.Planets["jungle"]));
+    }
+
+    [Fact]
+    public void GiantCactus_StandsOnGenerationOneDesert()
+    {
+        // A giant cactus is a 4+ tall column of the leaf block with an arm; the desert theme's saguaro also uses the
+        // leaf block, so this probe only asserts that leaf-block columns ≥ 4 exist at all on gen 1 and not on gen 0.
+        var desert = Content.Planets["desert"];
+        var leaf = Content.GetBlock("tree_leaves")!.NumericId;
+        int cs = WorldConstants.ChunkSize;
+        int Columns(WorldGenerator gen)
+        {
+            int found = 0;
+            for (int cx = 0; cx < 14; cx++)
+                for (int cz = 0; cz < 10; cz++)
+                {
+                    int sx = cx * cs * 5, sz = cz * cs * 5 - 700;
+                    int sy = gen.SurfaceHeight(desert, sx, sz);
+                    var chunk = gen.Generate(desert, new ChunkCoord(WorldConstants.WorldToChunk(sx), WorldConstants.WorldToChunk(sy + 3), WorldConstants.WorldToChunk(sz)));
+                    for (int x = 0; x < cs; x++)
+                        for (int z = 0; z < cs; z++)
+                        {
+                            int run = 0;
+                            for (int y = 0; y < cs; y++)
+                            {
+                                run = chunk.Get(x, y, z) == leaf ? run + 1 : 0;
+                                if (run >= 4)
+                                {
+                                    found++;
+                                    break;
+                                }
+                            }
+                        }
+                }
+
+            return found;
+        }
+
+        Assert.Equal(0, Columns(Gen(77, 0)));
+        int gen1 = 0;
+        for (long s = 1; s <= 6 && gen1 == 0; s++)
+        {
+            gen1 = Columns(Gen(s * 977 + 5, 1));
+        }
+
+        Assert.True(gen1 > 0, "no cactus column on six generation-1 desert worlds");
+    }
+}

--- a/tests/BlocksBeyondTheStars.Tests/TerrainTagsAndGenerationTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/TerrainTagsAndGenerationTests.cs
@@ -148,7 +148,9 @@ public sealed class TerrainTagsAndGenerationTests
     [Fact]
     public void PropTable_KeepsTheFormerPrecedence()
     {
-        Assert.Equal(new[] { "monolith", "stone-circle", "boulder", "crystal-shard", "dead-tree" }, WorldGenerator.PropOrderForTest());
+        // #1648 appends the generation-1 rows after the classic five — the classic precedence is the prefix.
+        Assert.Equal(new[] { "monolith", "stone-circle", "boulder", "crystal-shard", "dead-tree" },
+            WorldGenerator.PropOrderForTest().Take(5).ToArray());
     }
 
     [Fact]

--- a/tests/BlocksBeyondTheStars.Tests/WorldGenerationGoldenTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/WorldGenerationGoldenTests.cs
@@ -59,6 +59,9 @@ public sealed class WorldGenerationGoldenTests
         // #1647 (part 4): water / lava bodies and paints on generation-1 worlds.
         new("ocean-gen1", 424242, "ocean", 0, false, null, 1),
         new("jungle-gen1", 20260903, "jungle", 0, false, null, 1),
+        // #1648 (part 5): props, micro-ruins, new tree kinds and giant flora on generation-1 worlds.
+        new("savanna-gen1", 424242, "savanna", 0, false, null, 1),
+        new("swamp-gen1", 20260903, "swamp", 0, false, null, 1),
     };
 
     /// <summary>Sample columns: the spawn column (pad 0 sits at (0,0) on every world), one ordinary inland
@@ -80,15 +83,18 @@ public sealed class WorldGenerationGoldenTests
             ["varied-world-5472"] = 0x2dcf8cfc85d02359UL,
             ["asteroid-cratered-800"] = 0x0ccae399034733eeUL,
             // Pinned 2026-09-05 (#1645, Windows 11, .NET 10).
-            ["varied-gen1"] = 0x39e14dd48827b658UL, // re-pinned for #1647 (gen-1 bodies + paints; unreleased)
-            ["desert-gen1"] = 0x0e94fb4685e1fb71UL, // re-pinned for #1647
-            ["highland-gen1"] = 0xd587b8e9a3784938UL, // re-pinned for #1646 + #1647
+            ["varied-gen1"] = 0xaba279484571bcb4UL, // re-pinned for #1647 (gen-1 bodies + paints; unreleased)
+            ["desert-gen1"] = 0x5e5d6d6f809bb612UL, // re-pinned for #1647
+            ["highland-gen1"] = 0x49f4107c54801291UL, // re-pinned for #1646 + #1647
             // Pinned 2026-09-05 (#1646, Windows 11, .NET 10).
-            ["tundra-gen1"] = 0x75a685d971bd98a4UL, // re-pinned for #1647
-            ["rocky-gen1"] = 0xde6420a248761193UL, // re-pinned for #1647
+            ["tundra-gen1"] = 0x6e7d5380a92cd7f3UL, // re-pinned for #1647
+            ["rocky-gen1"] = 0x9981bc39fdae70e5UL, // re-pinned for #1647
             // Pinned 2026-09-05 (#1647, Windows 11, .NET 10).
             ["ocean-gen1"] = 0xcd2223af53fc3766UL,
-            ["jungle-gen1"] = 0xbf0fe45f613e46e8UL,
+            ["jungle-gen1"] = 0xc9e7499dcae9f034UL,
+            // Pinned 2026-09-06 (#1648, Windows 11, .NET 10).
+            ["savanna-gen1"] = 0x1f2b23eba6c17a34UL,
+            ["swamp-gen1"] = 0x5c5a1959a7982a19UL,
         },
         // Linux (ubuntu CI runners): filled in from the first CI run of this test; a group absent here falls
         // back to the Windows value above and fails with the value to pin if the libm differs.


### PR DESCRIPTION
Part 5 of 6 of the **landscape-variety package** (#1644–#1649): the things you meet every hundred blocks — set-dressing props and micro-ruins, seven new tree kinds, and giant flora beyond mushrooms. **Generation-1 worlds only**: the classic goldens are unchanged, `savanna-gen1` and `swamp-gen1` are pinned (the other gen-1 groups move with every part until release).

Closes #1648

## Props (`WorldGenerator.StampsGen1.cs`)

`PropKind` gained an optional per-world `Gate`, a fixed `MaterialKey` and a `SecondaryKey`. The classic five rows keep their salts, order and material rule; 16 rows are appended (table order = precedence) and gate on the generation plus a theme / tag / climate rule:

| row | gate | shape |
|---|---|---|
| fallen-log | wooded worlds | 3–5 logs along X or Z, each on its own ground |
| termite-mound | savanna theme | 2–3-tall spire on a 3-cell base |
| cairn | ≤ 5 °C | 3–4 stone stack + side stones |
| bone-pile / **rib-cage** | dry worlds | 2×2 scatter / seven bone arches, 7 across |
| ice-boulder | ≤ −5 °C | boulder of ice |
| lava-spatter | `volcanic` | basalt lump |
| coral-outcrop | wet worlds, the dry strip ≤ 2 above the waterline | 1–2 coral cells |
| crystal-cluster | `crystal` | 3×3 cluster, spikes 1–4 |
| meteorite | airless bodies | iron-ore lump on the regolith |
| tar-pit | dry `buttes` / `wind` flats | 3×3 tar pad |
| wall-fragment, buried-pillar | solid air worlds | ancient brick, cache 30 % |
| crashed-probe | solid air worlds | iron wall + glass eye + debris, cache 50 % |
| mining-rig | solid air worlds | machine block + 3-tall pipe, cache 40 % |
| rune-stone | solid air worlds | 2-tall rune stone, cache 40 % |

Rows fill air only, never carve. The rib cage is the widest prop and raises the set-dressing scan margin 6 → 8 — a column 7–8 away never wrote into the chunk before, so classic output is unchanged (goldens prove it).

## Trees

`TreeKind` + Baobab (2×2 trunk, flat crown), Mangrove (stilt roots; `NearWater` falls back to a broadleaf without water within 4), Bamboo (grove of 3–6 stems 8–12 tall), Saguaro (green column with arms, built from the leaf block; allowed on sand like palms), Willow (broad crown dripping strands), MushroomTree (mushroom stem + cap), CrystalTree (crystal shaft + cross). Themes list them in `TreesGen1`; `Theme.PaletteFor(generation)` hands generation-0 worlds the classic `Trees`. Palettes: temperate + willow; tropical + mangrove, bamboo; savanna + baobab; desert + saguaro; swamp + willow, mangrove; alien + mushroom tree, crystal tree. Every kind stays inside the stamp envelope (|dx|, |dz| ≤ 4, height ≤ 18).

## Giant flora

`GiantFloraKinds` — the host-block table the giant-mushroom recipe generalises to: giant fern on mud (log stem, fan of fronds), giant crystal on crystal ground, giant cactus on sand (leaf block, two arms), each with its own salt and density. `StampGiantFloraGen1` runs after the untouched mushroom stamp.

## Tests

`LandscapeStampsTests` (10 tests): table order, gen-0 invariance for every type (no new row, no giant-flora row), per-row roll rate within ×2 of design on an eligible world and never on an ineligible one (16 rows), rib cage straddling a chunk edge writes bone into the neighbour, palettes offer new kinds on generation 1 only, tree envelope for all seven kinds × 12 sizes, baobab trunks on a gen-1 savanna, giant-flora rows per host, cactus columns on gen-1 desert only. Fast tier green locally, `dotnet format` clean. No `client/Assets` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
