### PR TITLE
fix(client): world-options planet-type page fits all 29 types above the footer — row pitch follows the type count

### DIFF
--- a/client/Assets/BlocksBeyondTheStars/Scripts/UiWorldOptions.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/UiWorldOptions.cs
@@ -201,8 +201,14 @@ namespace BlocksBeyondTheStars.Client
                 _ => 4,     // Frequent
             };
 
-            float x = 30f, y = 86f;
-            int column = 0;
+            // Two columns whose row pitch follows the type count (#1649 added eight types — 29 selectable): the
+            // longer column must end above the footer, so the pitch shrinks from the comfortable 56 px down to
+            // 40 px (a slider row is 40 px tall) before the list would ever run under the Back button.
+            const float FirstRowY = 86f;
+            int perColumn = Mathf.Max(1, Mathf.CeilToInt(types.Count / 2f));
+            float pitch = Mathf.Clamp((FooterY - 16f - FirstRowY) / perColumn, 40f, 56f);
+            float x = 30f, y = FirstRowY;
+            int row = 0;
             foreach (var p in types)
             {
                 string key = p.Key;
@@ -212,12 +218,11 @@ namespace BlocksBeyondTheStars.Client
                     v => opt.PlanetTypes[key] = v,
                     rebuilders: null);
 
-                y += 56f;
-                if (y > 640f && column == 0)
+                y += pitch;
+                if (++row == perColumn)
                 {
-                    column = 1;
                     x = 820f;
-                    y = 86f;
+                    y = FirstRowY;
                 }
             }
 


### PR DESCRIPTION
Marcel's screenshot after #1649: the **World Options → Planet-Type Frequencies** page overflows — with eight new planet types (29 selectable) the right column runs under the Reset / Back footer and off the panel.

Cause: the advanced page laid its sliders out in two columns at a fixed 56 px pitch and switched columns at a hard-coded y 640, sized for the old 21 types.

Fix: the rows per column come from the type count, and the pitch shrinks from the comfortable 56 px down to the 40 px a slider row is tall (`clamp((FooterY − 16 − firstRow) / rowsPerColumn, 40, 56)`), so the longer column always ends above the footer line. With 29 types that is 15 rows per column at ~45 px. Client-only change; local Unity player build succeeded on this tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
