### PR TITLE
docs: landscape package follow-up — monument pool per generation, style pools cross-reference, README counts 29 planet types

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Design your ship block by block, fly real system-scale routes, dock at space sta
 
 **Explore**
 
-*   **System-scale flight:** procedurally generated star systems — each with its own sun, planets, moons and mineable asteroid belts — and **21 planet types** (airless rocks, lava fields, jungles, oceans, skylands, fungal and crystal worlds, …) with their own terrain, flora, fauna and sky. Worlds wrap east–west, so you can walk around a planet. Jump between systems; the far **frontier** is richer, and a *Growing* galaxy grows a new system every time you push past its edge.
+*   **System-scale flight:** procedurally generated star systems — each with its own sun, planets, moons and mineable asteroid belts — and **29 planet types** (airless rocks, lava fields, jungles, oceans, skylands, fungal and crystal worlds, red deserts, archipelagos, glaciers, …) with their own terrain, flora, fauna and sky. Worlds wrap east–west, so you can walk around a planet. Jump between systems; the far **frontier** is richer, and a *Growing* galaxy grows a new system every time you push past its edge.
 *   **Living worlds:** per-position **weather and seasons** (storms that drift across the land, fog, blizzards, acid rain, ember fall, ion storms, meteor showers — with real consequences and opportunities), a true day/night terminator, creatures you can scan, hunt or **tame as companions**, binoculars with thermal vision and an in-game camera with a photo album.
 *   **Places to find:** settlements and space stations with NPCs, rare **factories**, fallen ruins, treasure chests, **monuments with glowing runes**, bandit camps and pirate space — and a handful of **one-of-a-kind mysteries** per galaxy.
 
@@ -485,7 +485,7 @@ changes are needed to add content. Player-facing names use localization keys res
 A fully playable client + server game: **multiple star systems** (each with its own sun, planets,
 moons and **asteroid belts** you can mine from the ship or on an EVA), procedurally generated
 worlds that wrap east–west (walk around the planet, seam-free) with a real day/night terminator,
-21 planet types including exotic ones (skylands, fungal, corrupted, ocean, salt flats, …) with their
+29 planet types including exotic ones (skylands, fungal, corrupted, ocean, salt flats, ash seas, …) with their
 own flora and fauna, **per-position weather and seasons** (episodic fronts that drift across the
 world — rain, fog, blizzards, acid rain, ember fall, spore blooms, ion storms, meteor showers — with
 gameplay consequences and a weather scanner), swimming/diving, a survival **temperature/climate

--- a/docs/developer/FACTORIES_RUINS_AND_CLAIMING.md
+++ b/docs/developer/FACTORIES_RUINS_AND_CLAIMING.md
@@ -113,6 +113,9 @@ reload never resurrects blocks the player cleared.
 Ruins are *statistically* eroded architecture, so they can never produce a deliberate silhouette.
 `StampMonuments` (`GameServer/GameServerMonuments.cs`) adds the authored counterpart: 0–3 relics per body,
 one per archetype (`arcade`, `gate`, `circle`, `obelisk`, `altar`) from `WorldGeneration/MonumentGenerator.cs`.
+Generation-1 worlds (#1649, terrain generation ≥ 1) draw from `MonumentGenerator.ArchetypesGen1` — the same
+five plus `bridge`, `watchtower`, `tomb`, `ziggurat`, `colossus`, `aqueduct`; classic worlds keep the five in
+the same order, so a loaded save meets the same relics (see [WORLD_GENERATION.md §12.5](WORLD_GENERATION.md)).
 Each is built intact, then run through an erosion pass plus a **settle** pass (a stone with nothing under
 it, nothing corbelled under its shoulder and nothing beside it falls) so what survives still reads as the
 thing it was. It is the first procedural generator to emit per-cell **shapes and glow** — arches are

--- a/docs/developer/WORLD_GENERATION.md
+++ b/docs/developer/WORLD_GENERATION.md
@@ -199,7 +199,9 @@ chasms** (50–130 deep, fjord-flooded below sea level). `SurfaceHeight` clamps 
 safely under the ~Y 320 atmosphere line.
 
 **e) Overriding shapes** — `TerrainStyle` (mesa, **tablelands**, dunes, **badlands**, spires,
-**karst**, flats… — the bold three are #579), `Cratered` (flat regolith + impact craters for airless
+**karst**, flats… — the bold three are #579; generation-1 worlds roll 1–3 styles from a per-type
+`terrainStyles` pool and lay them out as regions, with seven more styles — §12.1), `Cratered` (flat
+regolith + impact craters for airless
 bodies), and `FloatingIslands`. A cratered body skips (c) and (d) entirely and instead rolls a
 **`CraterProfile`** from its own body seed (#518): crater density, basin width, depth (5–12 blocks),
 rim height and how rolling the regolith between craters is — so one rock is a pounded ruin and the


### PR DESCRIPTION
Docs-only follow-up to #1644–#1649: FACTORIES_RUINS_AND_CLAIMING.md §3.1 names the generation-1 monument pool, WORLD_GENERATION.md §e cross-references the style pools of §12.1, README says 29 planet types (was 21) in both feature lists. No code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)