### PR TITLE
fix(server,worldhost,client): nobody stays stuck, and a hosted world stays up (#1704–#1712)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,11 +56,20 @@ RUN chmod +x /usr/local/bin/entrypoint.sh
 # Default the admin UI/portal bind to all interfaces (the app's own default is loopback, which would be
 # unreachable from outside the container). ALWAYS pair a public admin port with BBS_ADMIN_PASSWORD.
 ENV BBS_ADMIN_BIND=0.0.0.0
-# #1536: give memory back readily on the many-worlds VPS (the cgroup limit already bounds each heap;
-# GCConserveMemory=5 measured −1.3 MB private at idle and trims harder under load). NOT gcConcurrent=0 (+7.5 MB
-# per process on the dev box) and NOT invariant globalization (the name screening normalises diacritics with
-# ICU — a "hïtler" evasion stopped matching without it).
+# #1536: give memory back readily on the many-worlds VPS. GCConserveMemory=5 measured −1.3 MB private at idle
+# and trims harder under load. NOT gcConcurrent=0 (+7.5 MB per process on the dev box) and NOT invariant
+# globalization (the name screening normalises diacritics with ICU — a "hïtler" evasion stopped matching).
 ENV DOTNET_GCConserveMemory=5
+# #1704: cap the GC heap BELOW the container's memory limit. The note above used to claim "the cgroup limit
+# already bounds each heap" — it bounds the PROCESS, which is the heap plus everything the GC does not count:
+# ICU, SQLite, the JIT, thread stacks; ~150 MB on a world instance. The runtime's own default hard limit is
+# 75 % of the cgroup limit, so on a 768 MiB world container the GC grows to 576 MiB, resident memory reaches
+# ~730 MB, and the kernel kills the process while the GC still believes it is inside its budget. That is what
+# took a hosted world down for a day: loading its save churned garbage (123 MB → 805 MB in under a second) and
+# was killed mid-spike, although the very same save settles at 85 MB once the GC is made to collect instead of
+# grow. Measured: with a 384 MB hard limit that save loads and runs; with none it peaks at 958 MB.
+# The value is HEX and a percentage — 0x37 = 55 %, i.e. ~422 MB of a 768 MiB cap, leaving the native side room.
+ENV DOTNET_GCHeapHardLimitPercent=0x37
 
 # 31415/udp native client · 31415/tcp browser WebSocket (when BBS_ENABLE_WEBSOCKET=true) · 31416/tcp admin+portal+download+/play
 EXPOSE 31415/udp 31415/tcp 31416/tcp

--- a/TODO.md
+++ b/TODO.md
@@ -24,6 +24,54 @@ envelope at the WebSocket edge; deterministic seed world-gen; SQLite default per
 
 ---
 
+### 🛟 Nobody stays stuck, and a hosted world stays up (#1704–#1712, 2026-09-09, branch fix/reports-0909)
+
+Nine reports in one day, all on 2026.9.4: two children from the school club, three from a builder on her own
+server, and five identical server crashes from one hosted world. Two threads ran through them.
+
+**A hosted world was down all day, and nothing said so.** "Glitch Arcade 3" was OOM-killed within seconds of
+every start — over 2000 starts in eighteen hours. Measuring the cgroup showed 123 MB → 805 MB in under a
+second and then death, but the same save loaded locally peaks at 958 MB and settles at **85 MB**: the spike is
+garbage the GC never had to keep. The runtime caps its heap at 75 % of the container limit and native memory
+(ICU, SQLite, JIT, stacks — ~150 MB) sits outside that budget, so resident memory reached 730 MB against a
+768 MiB cap while the GC believed it was fine. Reseeding the world would not have helped: the seed is a
+function of the world id, and a fresh world on that exact seed runs clean.
+
+- **#1704 — cap the GC heap below the container limit.** `DOTNET_GCHeapHardLimitPercent=0x37` (55 %) leaves
+  the native side room; verified by loading the failing save under a 384 MB hard limit, where it settles at
+  85 MB instead of dying.
+- **#1705 — workstation GC is actually pinned now.** The csproj said `ServerGarbageCollector`; the property is
+  `ServerGarbageCollection`, so it was silently ignored and `runtimeconfig.json` carried no `System.GC.Server`
+  key at all. The comment claiming the VPS "can never flip to server GC by accident" is now true.
+- **#1706 — the keep-awake pass gives up.** It restarted every dead arcade world every 30 s forever. Failures
+  now back off (30 s doubling to 30 min) and stop after five, logging the world as needing a person.
+- **#1707 — a listener race no longer kills the container.** The managed `HttpListener` calls Accept from its
+  own constructor and can throw `ArgumentNullException` out of `Start()`. It ran unguarded straight out of
+  `Main`; it is retried now, and a genuinely occupied port still fails loudly.
+
+**Three ways to be somewhere a body cannot be.** A child fell, respawned inside his own hull, and could not
+get out — the hull is indestructible, so he could not even dig. Another was dug out of terrain and then held
+frozen. And a builder was told her wooden door was a ship hull.
+
+- **#1709 — a player sealed in their own hull is freed.** The block rescue cannot see hulls (they are placed
+  objects, not world blocks) and the hull rescue asked for *two* overlapping ones. A single hull with no body
+  space in the cell is now the trigger. Standing in your own cabin stays ordinary.
+- **#1708 — the rescue stops fighting the client.** Every `RespawnNotice` re-arms an 8 s settle freeze; at 1 Hz
+  the grace never elapsed and the player sat motionless with the mouse still working. No second rescue goes
+  out while the first is unacknowledged.
+- **#1710 — the pad guard protects ground, not your buildings.** It covered the whole footprint nine blocks
+  deep regardless of what the cell was, so anything built there was permanently unmineable — and answered
+  "ship hull" about a door on a planet. Player-placed blocks come out again; the foundation stays; the
+  rejection names the pad.
+- **#1711 — creatures stop resting inside cave ceilings.** The rest-height probe fell back to the generator's
+  noise surface, which for an animal under a roof is on the far side of solid rock.
+- **#1712 — the scan panel grows with its text.** Fixed 78 px for three lines meant the tool-tier line added
+  in #1686 clipped the fourth: "braucht einen Grundstein in" with the rest gone.
+
+Still open from the same batch: **#1713** (WebGL renders no terrain after landing — needs a browser console
+capture on the school hardware) and **#1714** (a sentry must sit within 8 blocks of a base core, too tight for
+large builds — a design decision, not a defect).
+
 ### 🌊 Built water is real water — a player-report package (#1697–#1701, 2026-09-08, branch feat/water-defence-lava)
 
 Seven reports from one session of a player fortifying her spaceport: a moat, a wall, a lava trench, sentry

--- a/client/Assets/BlocksBeyondTheStars/Scripts/HudUi.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/HudUi.cs
@@ -2152,6 +2152,49 @@ namespace BlocksBeyondTheStars.Client
                 _scanKnow.color = UiKit.TextCol;
                 _scanKnow.text = $"{loc.Get("ui.scan.knowledge")}: {scan.KnowledgeTotal}";
             }
+
+            ReflowScanPanel();
+        }
+
+        /// <summary>
+        /// Sizes the scan panel to the text it is actually showing (#1712).
+        /// <para>
+        /// Every row used to be a constant: the info block was 78 px — three lines at size 17 — with the threat
+        /// and knowledge rows nailed to y=122 and y=148 inside a panel of fixed height. The tool-tier line added
+        /// in #1686 makes the sentry's block four lines, so the fourth was simply clipped and a player read
+        /// "Schießt 14 Blöcke weit · braucht einen Grundstein in" with the rest of the sentence gone.
+        /// </para>
+        /// The panel grows UPWARD — its bottom edge is what must stay put, because it sits just above the
+        /// screen edge and beside the hotbar backplate. A hidden threat row now closes its gap too, which is
+        /// the dead space visible in that same report.
+        /// </summary>
+        private void ReflowScanPanel()
+        {
+            const float infoTop = 40f, infoMinH = 78f, rowGap = 4f, threatH = 22f, knowH = 26f, padBottom = 8f;
+            const float textW = ScanPanelW - 24f;
+            // Ceiling, so the panel grows for a wrapped sentence but never for a runaway list: an asteroid
+            // reports every distinct resource it holds, and #482 already had that text running over the rows
+            // below. Past this the truncation set up in Build takes over again, as it did before.
+            const float infoMaxH = 160f;
+
+            // TMP measures the wrapped text itself; a height of 0 asks for "as tall as it needs".
+            float infoH = Mathf.Clamp(
+                _scanInfo.GetPreferredValues(_scanInfo.text, textW, 0f).y, infoMinH, infoMaxH);
+            UiKit.Place(_scanInfo.gameObject, 12f, infoTop, textW, infoH);
+
+            float y = infoTop + infoH + rowGap;
+            if (_scanThreat.gameObject.activeSelf)
+            {
+                UiKit.Place(_scanThreat.gameObject, 12f, y, textW, threatH);
+                y += threatH + rowGap;
+            }
+
+            UiKit.Place(_scanKnow.gameObject, 12f, y, textW, knowH);
+            y += knowH + padBottom;
+
+            // Keep the bottom edge where the design put it: grow up, never down into the hotbar.
+            float panelH = Mathf.Max(ScanPanelH, y);
+            UiKit.Place(_scanPanel, 10f, ScanPanelY + ScanPanelH - panelH, ScanPanelW, panelH);
         }
 
         /// <summary>Builds the scan panel's description line from the STRUCTURED payload (#484): a creature's

--- a/data/locales/de.json
+++ b/data/locales/de.json
@@ -3640,6 +3640,7 @@
   "srv.loot.filter_blocked": "Diese Kiste nimmt diese Gegenstände nicht an.",
   "srv.mine.not_mineable": "Dieser Block lässt sich nicht abbauen.",
   "srv.mine.ship_hull": "Die Schiffshülle kann nicht abgebaut werden.",
+  "srv.mine.ship_pad": "Der Boden unter dem Schiff muss liegen bleiben — er trägt es.",
   "srv.mine.wrong_tool": "Dein aktuelles Werkzeug kann diesen Block nicht abbauen.",
   "srv.mine.wrong_tool_named": "Dein Werkzeug ist für diesen Block nicht stark genug. Nötig: {name}.",
   "srv.misc.aboard_for_cargo": "Geh an Bord des Schiffs, um den Frachtraum zu benutzen.",

--- a/data/locales/en.json
+++ b/data/locales/en.json
@@ -3640,6 +3640,7 @@
   "srv.loot.filter_blocked": "This crate doesn't take those items.",
   "srv.mine.not_mineable": "Block cannot be mined.",
   "srv.mine.ship_hull": "The ship hull cannot be mined.",
+  "srv.mine.ship_pad": "The ground under the ship has to stay — it is what the hull rests on.",
   "srv.mine.wrong_tool": "Your current tool cannot mine this block.",
   "srv.mine.wrong_tool_named": "Your tool is not strong enough for this block. Needs: {name}.",
   "srv.misc.aboard_for_cargo": "Step aboard the ship to use the cargo hold.",

--- a/src/BlocksBeyondTheStars.GameServer/BlocksBeyondTheStars.GameServer.csproj
+++ b/src/BlocksBeyondTheStars.GameServer/BlocksBeyondTheStars.GameServer.csproj
@@ -36,9 +36,15 @@
          · InvariantGlobalization: NameScreenTests' "hïtler" evasion stopped matching — the name screening
            normalises diacritics with string.Normalize, which needs ICU. ICU stays; its RSS is the price of that filter.
        The Windows run loop's timer resolution (HighResolutionTimerScope) is the knob that paid off: 68–70 → 76 ticks
-       per 5 s window, i.e. the configured 15 Hz instead of ~13.8. -->
+       per 5 s window, i.e. the configured 15 Hz instead of ~13.8.
+       #1705: the pin below was spelled ServerGarbageCollector for its whole life. No such MSBuild property
+       exists, unrecognised properties are ignored without a warning, and the generated runtimeconfig.json
+       carried no System.GC.Server key at all — so the "pinned explicitly" above was never true. Workstation
+       happens to be the runtime default for a console app, which is why nothing looked wrong; but a default is
+       not a pin, and a stray DOTNET_gcServer=1 or a base-image change would have flipped every world container
+       to per-core server heaps on a box that already runs several under a memory cap (see #1704). -->
   <PropertyGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <ServerGarbageCollector>false</ServerGarbageCollector>
+    <ServerGarbageCollection>false</ServerGarbageCollection>
   </PropertyGroup>
 
 </Project>

--- a/src/BlocksBeyondTheStars.GameServer/GameServer.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServer.cs
@@ -3952,7 +3952,10 @@ public sealed partial class GameServer
 
         if (IsShipBlock(pos))
         {
-            Reject(session, "mine", "@srv.mine.ship_hull");
+            // #1710: this guard is about the pad ground the hull stands on, never about the hull — which has
+            // not been world blocks since ship-as-object. Saying "ship hull" here sent a builder off writing a
+            // feature request for removable doors, because the door she was aiming at answered as a hull.
+            Reject(session, "mine", "@srv.mine.ship_pad");
             return;
         }
 

--- a/src/BlocksBeyondTheStars.GameServer/GameServerCreatures.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerCreatures.cs
@@ -1330,6 +1330,10 @@ public sealed partial class GameServer
     private bool LavaUnderFeet(int x, int feetY, int z)
         => _creatureLavaId != 0 && _world.GetBlockIfLoaded(new Vector3i(x, feetY - 1, z)).Value == _creatureLavaId;
 
+    /// <summary>Test seam (#1711): the Y an airborne creature at <paramref name="refY"/> measures its band
+    /// from in this column.</summary>
+    public int RestSurfaceYForTest(int x, int z, int refY) => RestSurfaceYAt(x, z, refY);
+
     /// <summary>Test seam (#1367): the terrain gate's verdict for a creature stepping to <paramref name="next"/>
     /// from where it stands, in its current motion class.</summary>
     public bool TerrainStepBlockedForTest(string creatureId, Vector3f next)
@@ -1469,7 +1473,43 @@ public sealed partial class GameServer
 
         int bed = SubmergedFeetYAt(x, z, refY, CreatureWideGroundScan);
         int top = bed != int.MinValue ? FluidTopAt(x, z, bed) : int.MinValue;
-        return top != int.MinValue ? top + 1 : _generator.SurfaceHeight(_world.Planet, x, z) + 1;
+        if (top != int.MinValue)
+        {
+            return top + 1;
+        }
+
+        // #1711: the last resort is the generator's noise surface — the height this column has where nothing
+        // has been dug. For a creature under a ROOF that Y is on the far side of solid rock, and handing it
+        // back parks the animal inside the ceiling: a player photographed one asleep halfway into the stone
+        // above her cave, with water above that. Its sibling GroundFeetFor already refuses to answer the noise
+        // surface for a cave dweller; this probe never got the same guard. Keyed on the rock rather than on
+        // Habitat, because Habitat is a single value — the creature stuck in her ceiling was a hoverer, not a
+        // cave species, and any animal below a ceiling has the same problem.
+        int surface = _generator.SurfaceHeight(_world.Planet, x, z) + 1;
+        return RoofBetween(x, z, refY, surface) ? refY : surface;
+    }
+
+    /// <summary>True when the column between a creature and a candidate rest Y above it is not open (#1711):
+    /// solid ground in the way, or the candidate further off than the probe is willing to vouch for. Either
+    /// way the noise surface is not a place this animal could come to rest, and the caller holds its depth
+    /// instead. Cheap no-load reads, bounded by <see cref="FluidColumnScan"/>.</summary>
+    private bool RoofBetween(int x, int z, int fromY, int toY)
+    {
+        if (toY <= fromY)
+        {
+            return false; // the candidate is at or below us — nothing to pass through
+        }
+
+        int scanTo = System.Math.Min(toY, fromY + FluidColumnScan);
+        for (int y = fromY + 1; y <= scanTo; y++)
+        {
+            if (IsSupportCell(x, y, z))
+            {
+                return true;
+            }
+        }
+
+        return toY > scanTo; // surface further up than we looked — do not teleport blind
     }
 
     /// <summary>The feet cell a ground mover of this species stands on in a column, nearest to

--- a/src/BlocksBeyondTheStars.GameServer/GameServerShipStructure.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerShipStructure.cs
@@ -467,7 +467,8 @@ public sealed partial class GameServer
 
     /// <summary>True if the world cell is protected because a parked ship rests on it: the pad ground
     /// directly under any ship's footprint cannot be mined out (the object must keep its foundation).
-    /// The hull itself is no longer world blocks, so this guards only the ground.</summary>
+    /// The hull itself is no longer world blocks, so this guards only the ground — and, since #1710, only
+    /// the ground the world put there. See <see cref="IsShipBlock"/>'s body for why.</summary>
     private bool IsShipBlock(Vector3i p)
     {
         foreach (var rec in _worlds.Active.LandedShips.Values)
@@ -483,7 +484,14 @@ public sealed partial class GameServer
                 && p.Z >= rec.Origin.Z - 1 && p.Z <= rec.Origin.Z + s.Length
                 && p.Y < rec.Origin.Y && p.Y >= rec.Origin.Y - PadGroundProtectDepth)
             {
-                return true;
+                // #1710: this box is the whole footprint, one cell wider on each side, nine blocks deep — and
+                // it used to protect everything inside it regardless of what the cell was. A builder on her own
+                // server could not remove two wooden doors she had placed beside her ship, and was told "Die
+                // Schiffshülle kann nicht abgebaut werden" about a door on a planet. The foundation this guard
+                // exists to keep is the ground the WORLD put there; a block the player carried in and placed is
+                // hers to take out again. An owned edit on a cell that still holds a block is exactly that
+                // (a mined cell would be air and would never reach here).
+                return !_repo.HasPlayerBlockEdits(_world.LocationId, p, p);
             }
         }
 

--- a/src/BlocksBeyondTheStars.GameServer/GameServerSpawnSafety.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerSpawnSafety.cs
@@ -213,6 +213,68 @@ public sealed partial class GameServer
             && InsideForeignHull(s.State.PlayerId, s.State.Position);
     }
 
+    /// <summary>
+    /// True when a position has no body space inside a parked hull — feet cell and head cell both filled by
+    /// ship blocks (#1709).
+    /// <para>
+    /// The block rescue above cannot see this at all: a hull is a placed OBJECT, so <see cref="IsEntombed"/>
+    /// reads air from the world grid and reports a perfectly safe spot. <see cref="WedgedInOverlappingHulls"/>
+    /// cannot see it either — it asks for TWO hulls, because visiting someone else's ship is normal and only
+    /// the overlap of two is unambiguous. Between them they missed the simplest trap of all: a player sealed
+    /// inside a SINGLE hull, their own. A child in the school club fell, respawned at his heal tank inside the
+    /// hull, and could not get out — the hull is indestructible, so he could not even dig. He had to abandon
+    /// the session.
+    /// </para>
+    /// Being inside your own ship stays normal: the test is "no body space in this cell", not "inside a hull".
+    /// </summary>
+    private bool SealedInHull(Vector3f p)
+    {
+        if (!float.IsFinite(p.X) || !float.IsFinite(p.Y) || !float.IsFinite(p.Z))
+        {
+            return false; // non-finite is the void guard's business
+        }
+
+        var cell = new Vector3i(
+            (int)System.Math.Floor(p.X), (int)System.Math.Floor(p.Y), (int)System.Math.Floor(p.Z));
+
+        foreach (var (key, rec) in _worlds.Active.LandedShips)
+        {
+            // A construction site is an open keel frame — meant to be walked into, and its cells are not a trap.
+            if (!rec.Placed || IsConstructionKey(key) || !LandedBoundsContain(rec, p))
+            {
+                continue;
+            }
+
+            var feet = rec.ToLocal(cell, _world.Circumference);
+            var head = new Vector3i(feet.X, feet.Y + 1, feet.Z);
+            if (HullCellBlocksBody(rec, feet) && HullCellBlocksBody(rec, head))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>Whether one structure-local cell of a parked hull is a cell a player's body cannot occupy
+    /// (#1709). Mirrors <see cref="IsBodyBlockingCell"/>, but reads the ship's sparse cell grid instead of the
+    /// world: a missing key is the hull's own air (corridors, cabins), which is where players belong.</summary>
+    private bool HullCellBlocksBody(LandedShip rec, Vector3i local)
+    {
+        if (!rec.Structure.Cells.TryGetValue(local, out var id) || id.IsAir)
+        {
+            return false;
+        }
+
+        var def = _content.BlockById(id);
+        if (def == null)
+        {
+            return true; // unknown id → treat as blocking, same safe default as the world-side predicate
+        }
+
+        return def.Solid && def.Category != "flora";
+    }
+
     /// <summary>Open ground beside the player's pad, outside every parked hull (#1681), or null when the whole
     /// band around the pad is blocked — then the rescue leaves them be rather than teleporting them somewhere
     /// worse.</summary>
@@ -308,6 +370,23 @@ public sealed partial class GameServer
             // because a full teleport across the map for what may be a moment of clipping would be worse.
             if (IsEntombed(p.Position))
             {
+                // #1708: never send a second rescue while OUR OWN last one is still in flight. A RespawnNotice
+                // is a hard snap on the client: it re-arms the settle freeze (_settling, _settleTimer = 0),
+                // which holds the body with no gravity and no WASD and only releases after an 8 s grace. At
+                // 1 Hz the grace never elapsed, so the freeze was re-armed a second before it could lift and
+                // the player sat there permanently — "kann mich nicht bewegen, nur drehen", with "Stabilisiere
+                // Position …" on screen and the rescue toast above it.
+                // Both halves of the condition matter. AwaitingSpawnAdopt alone is NOT enough: a join sets it
+                // too, so gating on it would have silenced the FIRST rescue of anyone who logs in sealed in —
+                // and someone entombed may never send the movement report that clears it, which would leave
+                // them stuck forever by the guard meant to protect them. EntombedRescueSpot is set only by the
+                // rescue below, so together they mean exactly "we placed them and the client has not arrived
+                // yet". A player still sealed in after adoption is rescued again on the next tick.
+                if (s.AwaitingSpawnAdopt && s.EntombedRescueSpot is not null)
+                {
+                    continue;
+                }
+
                 var freed = DigOutUpwards(p.Position) ?? SafeSpawnPoint(p.PlayerId);
                 // #1367: when the pad fallback is walled in as well (a build higher than the touchdown scan over
                 // the pad), the rescue used to fire every second — teleport, toast and chat line — into the same
@@ -333,15 +412,18 @@ public sealed partial class GameServer
 
             // #1681: hulls are placed OBJECTS, not world blocks, so IsEntombed above cannot see them at all.
             // A player standing where two hulls overlap is walled in by geometry the block rescue is blind to.
-            if (WedgedInOverlappingHulls(s))
+            // #1709: so is a player sealed inside a SINGLE hull — feet and head cell both ship blocks. That is
+            // the trap a fallen player lands in when the heal tank sits behind hull geometry, and because the
+            // hull is indestructible it is the one trap the player cannot dig out of.
+            if (WedgedInOverlappingHulls(s) || SealedInHull(p.Position))
             {
                 if (FreeSpotOutsideHulls(s) is { } outside)
                 {
                     s.EntombedRescueSpot = null;
                     p.Position = outside;
-                    p.AboardShip = false; // stepped out from between the hulls, onto open ground
+                    p.AboardShip = false; // stepped out of the hull, onto open ground
                     s.AwaitingSpawnAdopt = true;
-                    _log.Warn($"Player '{p.Name}' was wedged between two parked hulls; moved to {outside}.");
+                    _log.Warn($"Player '{p.Name}' had no body space inside a parked hull; moved to {outside}.");
                     Send(s, new RespawnNotice { X = outside.X, Y = outside.Y, Z = outside.Z, Reason = "@srv.misc.freed_from_hull" });
                     Send(s, new ServerMessage { Text = Localize(s.Locale, "srv.misc.freed_from_hull") });
                     SendPlayerState(s);
@@ -379,6 +461,38 @@ public sealed partial class GameServer
 
     /// <summary>Test entrypoint: whether a position is sealed inside solid blocks.</summary>
     public bool IsEntombedForTest(Vector3f pos) => IsEntombed(pos);
+
+    /// <summary>Test entrypoint (#1709): whether a position has no body space inside a parked hull.</summary>
+    public bool SealedInHullForTest(Vector3f pos) => SealedInHull(pos);
+
+    /// <summary>Test/diagnostic (#1709): a world cell inside this player's parked hull where a body has no
+    /// room — feet and head cell both ship blocks — or null when the design has no such spot.</summary>
+    public Vector3f? SealedHullSpotForTest(string playerId)
+    {
+        var rec = _worlds.Active.LandedFor(playerId);
+        if (!rec.Placed)
+        {
+            return null;
+        }
+
+        foreach (var local in rec.Structure.Cells.Keys)
+        {
+            var head = new Vector3i(local.X, local.Y + 1, local.Z);
+            if (!HullCellBlocksBody(rec, local) || !HullCellBlocksBody(rec, head))
+            {
+                continue;
+            }
+
+            var spot = new Vector3f(
+                rec.Origin.X + local.X + 0.5f, rec.Origin.Y + local.Y, rec.Origin.Z + local.Z + 0.5f);
+            if (SealedInHull(spot))
+            {
+                return spot;
+            }
+        }
+
+        return null;
+    }
 
     /// <summary>Test entrypoint: run the join-time spawn-safety guard for a player session.</summary>
     public void EnsureSafeSpawnForTest(PlayerSession session) => EnsureSafeSpawn(session);

--- a/src/BlocksBeyondTheStars.Networking/Transport/WebSocketServerTransport.cs
+++ b/src/BlocksBeyondTheStars.Networking/Transport/WebSocketServerTransport.cs
@@ -88,10 +88,47 @@ public sealed class WebSocketServerTransport : IServerTransport
         _handshakeTimeout = handshakeTimeout ?? DefaultHandshakeTimeout;
     }
 
+    /// <summary>How many times <see cref="HttpListener.Start"/> may be retried before the failure is real
+    /// (#1707), and how long to wait between attempts.</summary>
+    private const int StartAttempts = 4;
+    private const int StartRetryDelayMs = 250;
+
+    /// <summary>Test seam (#1707): replaces the listener start so a test can make the first attempt throw.
+    /// Null in production, where the real <see cref="HttpListener"/> is started.</summary>
+    internal Action? StartListenerForTest { get; set; }
+
     public void Start(int port)
     {
         _listener.Prefixes.Add($"http://{_bindHost}:{port}/");
-        _listener.Start();
+
+        // #1707: the managed HttpListener used off Windows races itself at bind time — HttpEndPointListener
+        // calls Accept from its own constructor and reaches Monitor.Enter before the lock object is assigned,
+        // which surfaces here as an ArgumentNullException out of Start(). Nothing about the port is wrong; the
+        // next attempt a moment later succeeds. This ran unguarded, so a lost coin flip threw straight out of
+        // GameServer.Start() into Main and killed the container — five crash reports from one hosted world in
+        // a single night, all of them this. A transient race must cost a quarter second, not the process.
+        // A port that is genuinely taken still fails: the last attempt's exception is the one that propagates.
+        for (int attempt = 1; ; attempt++)
+        {
+            try
+            {
+                if (StartListenerForTest is { } startForTest)
+                {
+                    startForTest();
+                }
+                else
+                {
+                    _listener.Start();
+                }
+
+                break;
+            }
+            catch (Exception) when (attempt < StartAttempts)
+            {
+                System.Threading.Thread.Sleep(StartRetryDelayMs);
+            }
+        }
+
         _running = true;
         _ = Task.Run(AcceptLoopAsync);
     }

--- a/src/BlocksBeyondTheStars.WorldHost/GlitchGateway.cs
+++ b/src/BlocksBeyondTheStars.WorldHost/GlitchGateway.cs
@@ -69,6 +69,35 @@ public sealed class GlitchGateway
     private readonly Func<WorldRecord, Task<string?>> _statusReader;
     private readonly Lock _poolGate = new();
     private readonly ConcurrentDictionary<string, (long ExpiresUnix, string UserName)> _validateCache = new();
+    private readonly Func<DateTimeOffset> _utcNow;
+
+    /// <summary>Keep-awake backoff state per world (#1706): how many wakes in a row did not stick, and the
+    /// earliest time the next one may be attempted.</summary>
+    private readonly Dictionary<string, (int Failures, DateTimeOffset NextAttemptUtc)> _wakeBackoff = new(StringComparer.Ordinal);
+
+    /// <summary>Worlds this gateway woke on the previous keep-awake pass (#1706). One that is down again on
+    /// the next pass did not survive its wake — that, not the start call's return value, is the failure signal:
+    /// the container starts fine and dies seconds later.</summary>
+    private readonly HashSet<string> _wokeLastPass = new(StringComparer.Ordinal);
+
+    /// <summary>After this many consecutive wakes that did not stick, stop waking the world at all (#1706).
+    /// It needs a person, not another restart.</summary>
+    public const int MaxConsecutiveWakeFailures = 5;
+
+    /// <summary>Worlds that crossed <see cref="MaxConsecutiveWakeFailures"/> and have not been reported yet.</summary>
+    private readonly List<string> _givenUp = new();
+
+    /// <summary>Guards the keep-awake pass against overlapping itself. The startup pass is fire-and-forget and
+    /// a fresh pool can take a minute per world, so the 30 s reaper tick runs into it — and the backoff
+    /// bookkeeping above is plain (non-concurrent) state. An overlapping tick SKIPS rather than queues: it
+    /// would only re-ask a question the pass in flight is already answering, and queueing would also let its
+    /// failure accounting double-count the same dead world.</summary>
+    private readonly Lock _wakeGate = new();
+    private bool _wakePassRunning;
+
+    /// <summary>Backoff after n failed wakes: 30 s doubling to a 30 min ceiling (#1706).</summary>
+    public static TimeSpan WakeBackoffFor(int failures)
+        => TimeSpan.FromSeconds(Math.Min(30d * Math.Pow(2, Math.Max(0, failures - 1)), 1800d));
 
     public GlitchGateway(
         WorldHostConfig config,
@@ -77,11 +106,13 @@ public sealed class GlitchGateway
         HttpMessageHandler? glitchHttpHandler = null,
         RateLimiter? heartbeatLimit = null,
         Func<WorldRecord, Task<string?>>? statusReader = null,
-        RateLimiter? saveLimit = null)
+        RateLimiter? saveLimit = null,
+        Func<DateTimeOffset>? utcNow = null)
     {
         _config = config;
         _registry = registry;
         _orchestrator = orchestrator;
+        _utcNow = utcNow ?? (() => DateTimeOffset.UtcNow); // injectable so the wake backoff (#1706) is testable
         _glitchApi = glitchHttpHandler is null
             ? new HttpClient { Timeout = TimeSpan.FromSeconds(15) } // save payloads are MBs, not the 5s probe class
             : new HttpClient(glitchHttpHandler) { Timeout = TimeSpan.FromSeconds(15) };
@@ -547,22 +578,100 @@ public sealed class GlitchGateway
             return 0;
         }
 
+        lock (_wakeGate)
+        {
+            if (_wakePassRunning)
+            {
+                return 0; // a pass is already in flight — this tick has nothing to add
+            }
+
+            _wakePassRunning = true;
+        }
+
+        try
+        {
+            return await WakePoolCoreAsync().ConfigureAwait(false);
+        }
+        finally
+        {
+            lock (_wakeGate)
+            {
+                _wakePassRunning = false;
+            }
+        }
+    }
+
+    private async Task<int> WakePoolCoreAsync()
+    {
         EnsurePool();
         int woken = 0;
+        var now = _utcNow();
+        var wokeThisPass = new HashSet<string>(StringComparer.Ordinal);
+
         foreach (var world in _registry.ListWorldsByChannel(WorldChannel.Glitch))
         {
-            if (world.Status != WorldStatus.Running)
+            if (world.Status == WorldStatus.Running)
             {
-                var (running, _) = await _orchestrator.EnsureRunningAsync(world.Id).ConfigureAwait(false);
-                if (running is not null)
+                _wakeBackoff.Remove(world.Id); // up again — forget the history, a later wobble starts over
+                continue;
+            }
+
+            // #1706: this pass used to restart every dead arcade world every 30 s, for as long as it stayed
+            // dead. One world spent roughly eighteen hours in that loop — 2000+ starts, each generating the
+            // galaxy and being killed seconds later, burning CPU on a shared box, filling the feedback inbox
+            // with the same crash and growing its SQLite write-ahead log to eight times the database because
+            // the process never lived long enough to checkpoint. Nothing anywhere said the world was broken.
+            // A world that was woken last pass and is down again did not survive its wake.
+            if (_wokeLastPass.Contains(world.Id))
+            {
+                int failures = (_wakeBackoff.TryGetValue(world.Id, out var prev) ? prev.Failures : 0) + 1;
+                _wakeBackoff[world.Id] = (failures, now + WakeBackoffFor(failures));
+                if (failures == MaxConsecutiveWakeFailures)
                 {
-                    woken++;
+                    _givenUp.Add(world.Id); // crossed the threshold on THIS pass — the reaper logs it once
                 }
+            }
+
+            if (_wakeBackoff.TryGetValue(world.Id, out var state)
+                && (state.Failures >= MaxConsecutiveWakeFailures || now < state.NextAttemptUtc))
+            {
+                continue; // given up on, or still backing off
+            }
+
+            var (running, _) = await _orchestrator.EnsureRunningAsync(world.Id).ConfigureAwait(false);
+            if (running is not null)
+            {
+                woken++;
+                wokeThisPass.Add(world.Id);
             }
         }
 
+        _wokeLastPass.Clear();
+        _wokeLastPass.UnionWith(wokeThisPass);
         return woken;
     }
+
+    /// <summary>Worlds the keep-awake pass gave up on since this was last called, emptied by the read (#1706).
+    /// The reaper logs them — a world that will not stay up needs a person to look at it, and until it is
+    /// mentioned somewhere nobody knows to.</summary>
+    public IReadOnlyList<string> DrainGivenUpWorlds()
+    {
+        if (_givenUp.Count == 0)
+        {
+            return System.Array.Empty<string>();
+        }
+
+        var ids = _givenUp.ToArray();
+        _givenUp.Clear();
+        return ids;
+    }
+
+    /// <summary>Test seam (#1706): how many consecutive failed wakes this gateway has recorded for a world,
+    /// and whether it has given up on it.</summary>
+    public (int Failures, bool GivenUp) WakeStateFor(string worldId)
+        => _wakeBackoff.TryGetValue(worldId, out var s)
+            ? (s.Failures, s.Failures >= MaxConsecutiveWakeFailures)
+            : (0, false);
 
     /// <summary>Picks the arcade world for the next guest: a running world with player headroom first
     /// (probed live), then a sleeping one to wake on demand. Racy by design — the instance's own

--- a/src/BlocksBeyondTheStars.WorldHost/Program.cs
+++ b/src/BlocksBeyondTheStars.WorldHost/Program.cs
@@ -1784,6 +1784,16 @@ var reaper = Task.Run(async () =>
                 log.LogInformation("glitch.fun keep-awake: {Count} arcade world(s) re-woken.", rewoken);
             }
 
+            // #1706: a world that will not survive its wake is no longer restarted forever — say so, loudly
+            // and once, because until it is mentioned somewhere nobody knows to go and look at it.
+            foreach (var deadWorld in glitch.DrainGivenUpWorlds())
+            {
+                log.LogError(
+                    "glitch.fun keep-awake: giving up on world {WorldId} — {Count} restarts in a row did not survive. " +
+                    "It stays down until someone looks at it.",
+                    deadWorld, GlitchGateway.MaxConsecutiveWakeFailures);
+            }
+
             // Archive sweep once an hour (120 × 30 s): long-inactive stopped worlds move to the archive.
             if (++ticks % 120 == 0)
             {

--- a/tests/BlocksBeyondTheStars.Tests/GlitchGatewayTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/GlitchGatewayTests.cs
@@ -610,6 +610,94 @@ public sealed class GlitchGatewayTests : IDisposable
         Assert.Equal(0, await gateway.WakePoolAsync());
     }
 
+    /// <summary>#1706: a world that dies straight after every wake must be backed off and eventually given up
+    /// on. Before this, the 30 s pass restarted one such world for eighteen hours — 2000+ starts, each killed
+    /// seconds later — and nothing anywhere said the world was broken.</summary>
+    [Fact]
+    public async Task WakePool_BacksOffAndGivesUp_OnAWorldThatNeverSurvivesItsWakeAsync()
+    {
+        var config = NewConfig();
+        config.GlitchWorldCount = 1;
+        var registry = NewRegistry(config);
+        var launcher = new FakeLauncher();
+        var orchestrator = new WorldOrchestrator(config, registry, launcher,
+            w => Task.FromResult(launcher.IsRunning(w.ContainerId)));
+
+        var now = new DateTimeOffset(2026, 9, 9, 12, 0, 0, TimeSpan.Zero);
+        var gateway = new GlitchGateway(config, registry, orchestrator, new FakeGlitchApi(),
+            statusReader: _ => Task.FromResult<string?>(null), utcNow: () => now);
+
+        // Every wake "succeeds" (the container starts) and the world is dead again by the next pass — exactly
+        // what an instance killed a second after startup looks like to the control plane.
+        async Task<int> PassAsync()
+        {
+            int woken = await gateway.WakePoolAsync();
+            launcher.Running.Clear();
+            orchestrator.Reap();
+            return woken;
+        }
+
+        Assert.Equal(1, await PassAsync()); // first wake — nothing known yet, so it is tried
+        string worldId = registry.ListWorldsByChannel(WorldChannel.Glitch).Single().Id;
+        Assert.Equal(0, gateway.WakeStateFor(worldId).Failures);
+
+        // Second pass: the world is down again, so the first wake did not stick. That is failure #1, and the
+        // backoff now holds the retry back — at the same instant, no wake goes out.
+        int startsBefore = launcher.StartCount;
+        Assert.Equal(0, await PassAsync());
+        Assert.Equal(1, gateway.WakeStateFor(worldId).Failures);
+        Assert.Equal(startsBefore, launcher.StartCount);
+
+        // Walk the clock past each backoff window: every retry fails, the count climbs, the delay grows.
+        for (int expected = 2; expected <= GlitchGateway.MaxConsecutiveWakeFailures; expected++)
+        {
+            now += GlitchGateway.WakeBackoffFor(expected) + TimeSpan.FromSeconds(1);
+            await PassAsync(); // the retry goes out
+            await PassAsync(); // and is found dead, recording the failure
+            Assert.Equal(expected, gateway.WakeStateFor(worldId).Failures);
+        }
+
+        Assert.True(gateway.WakeStateFor(worldId).GivenUp);
+        Assert.Equal(new[] { worldId }, gateway.DrainGivenUpWorlds()); // reported once …
+        Assert.Empty(gateway.DrainGivenUpWorlds());                    // … and only once
+
+        // Given up: no amount of waiting starts it again.
+        int startsAtGiveUp = launcher.StartCount;
+        now += TimeSpan.FromHours(6);
+        Assert.Equal(0, await PassAsync());
+        Assert.Equal(startsAtGiveUp, launcher.StartCount);
+    }
+
+    /// <summary>#1706: the backoff must forget a world that comes back up, so one bad night does not leave it
+    /// throttled forever.</summary>
+    [Fact]
+    public async Task WakePool_ForgetsTheFailureHistory_OnceAWorldStaysUpAsync()
+    {
+        var config = NewConfig();
+        config.GlitchWorldCount = 1;
+        var registry = NewRegistry(config);
+        var launcher = new FakeLauncher();
+        var orchestrator = new WorldOrchestrator(config, registry, launcher,
+            w => Task.FromResult(launcher.IsRunning(w.ContainerId)));
+        var now = new DateTimeOffset(2026, 9, 9, 12, 0, 0, TimeSpan.Zero);
+        var gateway = new GlitchGateway(config, registry, orchestrator, new FakeGlitchApi(),
+            statusReader: _ => Task.FromResult<string?>(null), utcNow: () => now);
+
+        await gateway.WakePoolAsync();
+        string worldId = registry.ListWorldsByChannel(WorldChannel.Glitch).Single().Id;
+        launcher.Running.Clear();
+        orchestrator.Reap();
+        await gateway.WakePoolAsync(); // records failure #1
+        Assert.Equal(1, gateway.WakeStateFor(worldId).Failures);
+
+        // It survives this time: the next pass sees it running and the history is dropped.
+        now += GlitchGateway.WakeBackoffFor(1) + TimeSpan.FromSeconds(1);
+        await gateway.WakePoolAsync();
+        await gateway.WakePoolAsync();
+        Assert.Equal(0, gateway.WakeStateFor(worldId).Failures);
+        Assert.False(gateway.WakeStateFor(worldId).GivenUp);
+    }
+
     public void Dispose()
     {
         foreach (var registry in _registries)

--- a/tests/BlocksBeyondTheStars.Tests/PlayerReports20260909Tests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/PlayerReports20260909Tests.cs
@@ -1,0 +1,249 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using System;
+using BlocksBeyondTheStars.Networking.Transport;
+using BlocksBeyondTheStars.Persistence;
+using BlocksBeyondTheStars.Shared.Configuration;
+using BlocksBeyondTheStars.Shared.Content;
+using BlocksBeyondTheStars.Shared.Geometry;
+using BlocksBeyondTheStars.Shared.Primitives;
+using Xunit;
+using SvGameServer = BlocksBeyondTheStars.GameServer.GameServer;
+
+namespace BlocksBeyondTheStars.Tests;
+
+/// <summary>
+/// The player reports of 2026-09-09, on 2026.9.4 — two from the school club, three from a builder on her own
+/// server. Three of them are the same shape: the world decided a player or a creature belonged somewhere a
+/// body cannot be, and the code that was supposed to notice could not see it.
+///   · #1709 a player sealed inside their OWN hull had no rescue — the block rescue cannot see hulls at all,
+///     and the hull rescue asked for two of them. The hull is indestructible, so he could not dig out either.
+///   · #1708 the entombed rescue re-fired at 1 Hz, re-arming the client's settle freeze faster than its 8 s
+///     grace could lift it: frozen in place, only the mouse working.
+///   · #1710 the pad-ground guard protected every cell under a parked ship, player-placed blocks included,
+///     and called a wooden door a ship hull.
+/// </summary>
+public sealed class PlayerReports20260909Tests : IDisposable
+{
+    private readonly string _root;
+    private readonly GameContent _content;
+
+    public PlayerReports20260909Tests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "bbts_reports0909_" + Guid.NewGuid().ToString("N"));
+        _content = ContentLoader.LoadFromDirectory(TestPaths.DataDir());
+    }
+
+    private SvGameServer Start(out SqliteWorldRepository repo, bool withShip)
+    {
+        repo = new SqliteWorldRepository(new SaveGamePaths(_root, "reports0909"));
+        var st = new LoopbackServerTransport(new LoopbackLink());
+        var config = new ServerConfig
+        {
+            WorldName = "reports0909",
+            Seed = 4242,
+            StartPlanet = "jungle",
+            AutoSaveIntervalMinutes = 9999,
+            PlaceStarterShip = withShip,
+            PlaceSettlements = false,
+            PlaceWrecks = false,
+        };
+        var server = new SvGameServer(config, _content, st, repo);
+        server.Start();
+        return server;
+    }
+
+    // ---------------- #1709: sealed inside your own hull ----------------
+
+    /// <summary>The trap itself: a cell whose feet AND head are hull blocks has no body space, while the
+    /// cabins and corridors of the same ship — where players are meant to be — do not read as sealed.</summary>
+    [Fact]
+    public void SealedInHull_IsTrueInsideHullGeometry_AndFalseInTheCabin()
+    {
+        var server = Start(out var repo, withShip: true);
+        using (repo)
+        {
+            var p = server.AddLocalPlayer("Paul");
+            var sealedSpot = server.SealedHullSpotForTest(p.State.PlayerId);
+            Assert.NotNull(sealedSpot); // the starter hull has walls; if it ever stops having any, say so loudly
+            Assert.True(server.SealedInHullForTest(sealedSpot!.Value));
+
+            // Standing aboard normally is not a trap — that distinction is the whole point of the guard.
+            Assert.False(server.SealedInHullForTest(p.State.Position));
+        }
+    }
+
+    /// <summary>The rescue: a player who ends up inside hull geometry — the shape of "fell, respawned at the
+    /// heal tank, woke up inside the wall" — is moved somewhere a body fits, within one rescue tick.</summary>
+    [Fact]
+    public void RuntimeRescue_FreesAPlayerSealedInsideTheirOwnHull()
+    {
+        var server = Start(out var repo, withShip: true);
+        using (repo)
+        {
+            var p = server.AddLocalPlayer("Paul");
+            var sealedSpot = server.SealedHullSpotForTest(p.State.PlayerId);
+            Assert.NotNull(sealedSpot);
+
+            p.State.Position = sealedSpot!.Value;
+            p.State.AboardShip = true;
+            Assert.True(server.SealedInHullForTest(p.State.Position));
+
+            server.RunVoidRescueForTest();
+
+            Assert.False(server.SealedInHullForTest(p.State.Position));
+            Assert.NotEqual(sealedSpot.Value, p.State.Position);
+        }
+    }
+
+    /// <summary>Being inside your own ship must stay ordinary: the rescue does not fire on a player standing
+    /// in the cabin. A guard that evicted people from their own ship would be worse than the bug.</summary>
+    [Fact]
+    public void RuntimeRescue_LeavesAPlayerStandingInTheirCabinAlone()
+    {
+        var server = Start(out var repo, withShip: true);
+        using (repo)
+        {
+            var p = server.AddLocalPlayer("Lyxette");
+            var before = p.State.Position;
+            Assert.False(server.SealedInHullForTest(before));
+
+            server.RunVoidRescueForTest();
+
+            Assert.Equal(before, p.State.Position);
+        }
+    }
+
+    // ---------------- #1708: the rescue must not re-fire while it is still landing ----------------
+
+    /// <summary>A RespawnNotice is a hard snap on the client: it re-arms the settle freeze, which only lifts
+    /// after an 8 s grace. Sending another every second meant the grace never elapsed and the player sat
+    /// frozen — "kann mich nicht bewegen, nur drehen". While the last placement is unacknowledged, no second
+    /// rescue goes out; once the client has adopted it, a player who really is still stuck is rescued again.
+    /// </summary>
+    [Fact]
+    public void EntombedRescue_DoesNotFireAgain_WhileTheLastPlacementIsUnacknowledged()
+    {
+        var server = Start(out var repo, withShip: false);
+        using (repo)
+        {
+            var p = server.AddLocalPlayer("Justus");
+            var buried = Entomb(server, p.State.Position);
+            p.State.Position = buried;
+            p.AwaitingSpawnAdopt = false;
+
+            server.RunVoidRescueForTest();
+            var afterFirst = p.State.Position;
+            Assert.NotEqual(buried, afterFirst);
+            Assert.True(p.AwaitingSpawnAdopt, "a rescue placement must wait to be adopted");
+
+            // Still sealed in (the client has not moved yet) — the old code fired again here, every second.
+            p.State.Position = buried;
+            server.RunVoidRescueForTest();
+            Assert.Equal(buried, p.State.Position); // suppressed: no second snap while the first is in flight
+
+            // The client catches up and adopts the placement; now the rescue may act again.
+            p.AwaitingSpawnAdopt = false;
+            server.RunVoidRescueForTest();
+            Assert.NotEqual(buried, p.State.Position);
+        }
+    }
+
+    /// <summary>Buries a position in solid stone so the entombment guard sees it, and returns it.</summary>
+    private Vector3f Entomb(SvGameServer server, Vector3f near)
+    {
+        int bx = (int)Math.Floor(near.X), bz = (int)Math.Floor(near.Z);
+        int by = (int)Math.Floor(near.Y) - 6;
+        var stone = _content.GetBlock("stone")!.NumericId;
+        for (int y = by - 1; y <= by + 3; y++)
+        {
+            server.World.SetBlock(new Vector3i(bx, y, bz), stone);
+        }
+
+        var pos = new Vector3f(bx + 0.5f, by, bz + 0.5f);
+        Assert.True(server.IsEntombedForTest(pos), "the carved block should read as entombed");
+        return pos;
+    }
+
+    // ---------------- #1710: the pad guard must not swallow player blocks ----------------
+
+    /// <summary>The ground a hull rests on stays protected; a block the player placed inside the same slab
+    /// comes out again. She could not remove two wooden doors she had built, and the game told her they were
+    /// ship hull.</summary>
+    [Fact]
+    public void PadGuard_ProtectsNaturalGround_ButNotABlockThePlayerPlaced()
+    {
+        var server = Start(out var repo, withShip: true);
+        using (repo)
+        {
+            var p = server.AddLocalPlayer("Lyxette");
+            var (origin, size) = server.LandedShipBoundsForTest(p.State.PlayerId);
+
+            // A cell in the protected slab under the hull footprint.
+            var cell = new Vector3i(origin.X + size.X / 2, origin.Y - 2, origin.Z + size.Z / 2);
+            Assert.True(server.IsProtectedShipBlock(cell.X, cell.Y, cell.Z),
+                "the ground under a parked hull is the foundation and stays put");
+
+            // The same cell, but this time the player built there: it is hers to take out again.
+            repo.SetBlock(server.World.LocationId, cell,
+                _content.GetBlock("door_wood")!.NumericId.Value, owner: p.State.PlayerId);
+            Assert.False(server.IsProtectedShipBlock(cell.X, cell.Y, cell.Z));
+        }
+    }
+
+    // ---------------- #1711: a creature under a roof must not be handed the surface above it ----------------
+
+    /// <summary>A player photographed a sleeping creature clipped halfway into her cave ceiling. The band an
+    /// airborne creature rests at falls back to the generator's noise surface when the column offers nothing
+    /// else — and for an animal under a roof that Y is on the far side of solid rock. Hollow out a cave, seal
+    /// it with a thick ceiling, and the probe must keep the creature in the cave.</summary>
+    [Fact]
+    public void RestSurface_KeepsACreatureUnderItsCeiling_InsteadOfTheSurfaceAbove()
+    {
+        var server = Start(out var repo, withShip: false);
+        using (repo)
+        {
+            var p = server.AddLocalPlayer("Lyxette");
+            int x = (int)Math.Floor(p.State.Position.X) + 24;
+            int z = (int)Math.Floor(p.State.Position.Z) + 24;
+            int surface = (int)Math.Floor(p.State.Position.Y);
+
+            var stone = _content.GetBlock("stone")!.NumericId;
+            int caveFloor = surface - 20;
+            int caveTop = caveFloor + 4; // a 4-cell hollow …
+
+            // Fill the column solid, then hollow the cave out of it: floor below, thick roof above.
+            for (int y = caveFloor - 2; y <= surface; y++)
+            {
+                server.World.SetBlock(new Vector3i(x, y, z), stone);
+            }
+
+            for (int y = caveFloor; y < caveTop; y++)
+            {
+                server.World.SetBlock(new Vector3i(x, y, z), BlockId.Air);
+            }
+
+            int rest = server.RestSurfaceYForTest(x, z, caveFloor + 1);
+
+            Assert.True(rest < caveTop,
+                $"a creature in the cave must rest inside it, not at Y {rest} with the ceiling at {caveTop}");
+            Assert.True(rest < surface, "the noise surface above the roof is not a place it can come to rest");
+        }
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_root))
+            {
+                Directory.Delete(_root, recursive: true);
+            }
+        }
+        catch (IOException)
+        {
+            // A leftover temp dir is not worth failing a test run over.
+        }
+    }
+}

--- a/tests/BlocksBeyondTheStars.Tests/WebSocketTransportTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/WebSocketTransportTests.cs
@@ -245,6 +245,50 @@ public sealed class WebSocketTransportTests : IDisposable
         }
     }
 
+    /// <summary>#1707: the managed HttpListener used off Windows races itself at bind time and throws an
+    /// ArgumentNullException out of Start(). It ran unguarded straight out of Main, so a lost coin flip killed
+    /// the container — five crash reports from one hosted world in a single night. A transient failure is
+    /// retried instead.</summary>
+    [Fact]
+    public void Start_RetriesATransientListenerFailure()
+    {
+        using var transport = new WebSocketServerTransport("127.0.0.1");
+        int attempts = 0;
+        transport.StartListenerForTest = () =>
+        {
+            if (++attempts == 1)
+            {
+                SimulateMonitorEnterRace(null);
+            }
+        };
+
+        transport.Start(FreeTcpPort());
+
+        Assert.Equal(2, attempts); // failed once, came up on the retry
+    }
+
+    /// <summary>What the listener's own bind race surfaces as: Monitor.Enter on a lock object the
+    /// HttpEndPointListener constructor has not assigned yet.</summary>
+    private static void SimulateMonitorEnterRace(object? lockObject)
+        => throw new ArgumentNullException(nameof(lockObject));
+
+    /// <summary>…but a port that is genuinely unusable must still fail loudly rather than be swallowed: the
+    /// retry budget is for a race, not for a real bind error.</summary>
+    [Fact]
+    public void Start_StillThrows_WhenEveryAttemptFails()
+    {
+        using var transport = new WebSocketServerTransport("127.0.0.1");
+        int attempts = 0;
+        transport.StartListenerForTest = () =>
+        {
+            attempts++;
+            throw new HttpListenerException(48, "address already in use");
+        };
+
+        Assert.Throws<HttpListenerException>(() => transport.Start(FreeTcpPort()));
+        Assert.True(attempts > 1, "the retry budget should have been spent before giving up");
+    }
+
     private static int FreeTcpPort()
     {
         var listener = new TcpListener(IPAddress.Loopback, 0);


### PR DESCRIPTION
Nine player reports arrived on 2026-09-09, all on 2026.9.4: two children from the school club, three from a
builder on her own server, and five identical server crashes from one hosted world. Two threads ran through
them, and both ended somewhere other than where the reports pointed.

closes #1704
closes #1705
closes #1706
closes #1707
closes #1708
closes #1709
closes #1710
closes #1711
closes #1712

---

## A hosted world was down all day, and nothing said so

"Glitch Arcade 3" was OOM-killed within seconds of every start — **over 2000 starts in eighteen hours**, each
one generating the galaxy and dying. Its SQLite write-ahead log had grown to eight times the size of the
database because the process never lived long enough to checkpoint.

The obvious move was to reseed the world. **The measurement says that would not have helped.** The seed is a
pure function of the world id, and a fresh world on that exact seed (`-3337868914532719042`) runs clean
locally at 82 MB. The failure needs the existing save:

| run | peak | settles at |
|---|---|---|
| fresh world, same seed | 82 MB | 82 MB |
| the real save, no limit | **958 MB** | **85 MB** |
| the real save, 384 MB GC hard limit | — | **85 MB** |

Sampling the container's cgroup every 200 ms caught the event: `123 MB → 188 → 528 → 805 MB` in under a
second, then `oom 1`. But the same load settles at 85 MB once the GC is *made* to collect — so the spike is
garbage, not a memory requirement. The world itself is tiny: 8323 block edits across 34 chunks, 13 containers,
0 players, a 704 KB database.

**#1704** is the cause: the runtime caps its heap at 75 % of the cgroup limit (576 MiB of 768), but native
memory — ICU, SQLite, the JIT, thread stacks, ~150 MB — is not in that budget. Resident memory reaches 730 MB
(exactly the kernel log's `anon-rss:730716kB`) and the container dies while the GC believes it is fine. The
Dockerfile's note said "the cgroup limit already bounds each heap"; it bounds the *process*, and the process is
bigger than the heap. `DOTNET_GCHeapHardLimitPercent=0x37` (55 %) leaves the native side room.

**#1705** — while reading that: the csproj pins workstation GC with `<ServerGarbageCollector>`. The property is
`ServerGarbageCollection`. Unrecognised properties are ignored silently, and the built `runtimeconfig.json`
carried no `System.GC.Server` key at all, so the comment promising the VPS "can never flip to server GC by
accident" described something that never happened. It does now.

**#1706** — the keep-awake pass restarted every dead arcade world every 30 s with no backoff and no give-up.
Failures now back off (30 s doubling to a 30 min ceiling) and stop after five, with the reaper logging the
world as needing a person. A world that cannot stay up needs attention, not another restart.

**#1707** — the five crash reports were a race in the managed `HttpListener`: it calls `Accept` from its own
constructor and reaches `Monitor.Enter` before the lock object is assigned. Our `Start` gave it exactly one
chance, straight out of `Main`, so a lost coin flip killed the container. Retried now; a genuinely occupied
port still fails loudly.

## Three ways to be somewhere a body cannot be

**#1709 (critical)** — a child fell, respawned at his heal tank *inside his own hull*, and could not get out:
the hull is indestructible, so he could not even dig. Neither rescue could see him. The block rescue reads
world blocks and a hull is a placed object; the hull rescue asks for **two** overlapping hulls, deliberately,
because visiting someone else's ship is normal. A single hull — your own — fell between them. The machinery to
fix it already existed and was wired only to NPCs: `TryPushOutsideShip` frees bandits, enemies and creatures
from hulls, and never a player. The trigger is now "no body space in this cell", so standing in your own cabin
stays ordinary.

**#1708** — the other child was dug out of terrain and then *held*: hovering, unable to move, only the mouse
working. His screenshot has both strings on it at once — the rescue toast and "Stabilisiere Position …". Every
`RespawnNotice` is a hard snap that re-arms an 8 s settle freeze; at 1 Hz the grace never elapsed, so the
rescue meant to free him was what pinned him. No second rescue goes out while the first is unacknowledged.

**#1710** — the builder could not remove two wooden doors and was told they were ship hull, so she filed a
feature request for removable doors. Doors are removable (`door_wood`, hardness 1.0, tier 0). `IsShipBlock` is
not a hull test: it is a bounding box over the whole ship footprint, nine blocks deep, and it protected
everything inside regardless of what the cell was. Anything a player built there was permanently unmineable.
The foundation stays protected; player-placed blocks come out again; the rejection names the pad instead of a
hull that has not been world blocks since ship-as-object.

**#1711** — she also photographed a creature asleep halfway inside her cave ceiling. `RestSurfaceYAt` (added
last release in #1697) falls back to the generator's noise surface, which for an animal under a roof is on the
far side of solid rock. Its sibling `GroundFeetFor` guards that case; this probe never got the guard. Keyed on
the rock rather than on habitat, because the creature she photographed was a hoverer, not a cave species.

**#1712** — and the scan panel cut its own sentence off: "Schießt 14 Blöcke weit · braucht einen Grundstein
in", with the rest gone. `_scanInfo` is 78 px — three lines — with the rows below nailed to fixed offsets; the
tool-tier line added in #1686 makes four. The panel now measures its text and grows **upward**, so the bottom
edge stays clear of the hotbar, with a ceiling so a runaway yield list still truncates as before.

## Tests

New coverage in `PlayerReports20260909Tests` (sealed-in-hull detection, the rescue, the cabin non-case, the
re-fire guard, the pad guard, the cave ceiling), plus the keep-awake backoff in `GlitchGatewayTests` and the
listener retry in `WebSocketTransportTests`.

`client/Assets` is touched (#1712), so this was built locally with Unity before merge — PR CI never compiles
the Unity client.

## Deliberately not in this PR

- **#1713** — WebGL renders no terrain after landing (only sky; HUD and creature billboards draw fine). A
  WebGL report carries no snapshot and no console, so there is no way to tell from here whether chunks stop
  arriving or stop meshing. Needs a console capture on the school hardware.
- **#1714** — a sentry must sit within 8 blocks of a base core while shooting 14. A real design limit and a
  reasonable request, but the fix is a decision (widen the radius, split it from base protection, or her
  suggestion of a power block beside the sentry), not a patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
