### PR TITLE
fix(worldgen,flora,fauna,client): generation 4 biome-theme rosters and nine audit hygiene fixes (#1715–#1724)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -103,6 +103,42 @@ Still open from the same batch: **#1713** (WebGL renders no terrain after landin
 capture on the school hardware) and **#1714** (a sentry must sit within 8 blocks of a base core, too tight for
 large builds — a design decision, not a defect).
 
+---
+
+### 🌱 Worldgen audit — generation 4 (biome-theme rosters) and nine hygiene fixes (#1715–#1724, 2026-09-09, branch fix/worldgen-audit-0909)
+
+A read-through of the terrain, flora and fauna generators against the July 2026 audit: seven of its nine
+findings were already fixed by the August fauna waves; the two that remained and eight new small ones make
+this package. Nothing here moves a classic golden — the one behaviour change is gated on a new generation.
+
+- **#1715 — flora roster reads the biome themes (generation 4).** `CurrentTerrainGeneration` 3 → 4. The
+  activation roll's "on theme" is the union of the planet theme and every biome theme in the type's pool, so a
+  `varied` world's swamp and desert biomes grow what their own themes prefer instead of a pool the temperate
+  theme thinned to 40 %. Older worlds keep the planet-only roll — and every species they ever grew.
+- **#1716 — farmed crops kept taking the world hue.** The mesher put every `flora_*` block into tint mode 1;
+  a crop carries no species tint, so the shader fell back to the world's base hue — violet berries on a violet
+  world. Crops are `TraitCultivated` now (mode 0, the authored tile). The base hue itself moved next to the
+  per-species colours as `FloraTints.ForWorld` (same value; the server ships it from there).
+- **#1717 — the spawn tick gated on the unclamped cap.** A world modelling above the hard cap of 64 sat in
+  the 1.5 s fast-fill cadence forever, walking ring + roster with terrain probes for nothing.
+- **#1718 — spawn probes read real blocks first.** `TryGetFluidColumn`: a pool the player built hosts a
+  school, a drained pond does not; every herd member runs the leader's probe from its own spot (a school
+  beside a small pond used to be the leader alone).
+- **#1719 — the cave-floor and shoreline probes no longer load chunks** on the tick thread.
+- **#1720 — the spawn-target round robin counts the wild population**, not companions.
+- **#1721 — one flora-form truth.** `FloraCatalog.Species.Solid`; the mesher derives its tall and solid
+  sets from the catalog, a test holds `bake_leaf_alpha.py`'s FOLIAGE list to it.
+- **#1722 — one roster-seed formula.** `WorldGenerator.RosterSeedFor`, used by worldgen and both server
+  sites, with a test that the server's rosters equal the generators' output.
+- **#1723 — `WonderFor`'s lock-free fast path** holds key + profile in one immutable slot.
+- **#1724 — column memos key on the wrapped column**, guarded by a seam-identity test over generation 0,
+  1 and 3 worlds.
+
+Docs: WORLD_GENERATION.md §6, §7, §14. Tests: 9 new across the existing flora / creature / column-cache
+classes (no new test class — the shard-weight guard).
+
+---
+
 ### 🌊 Built water is real water — a player-report package (#1697–#1701, 2026-09-08, branch feat/water-defence-lava)
 
 Seven reports from one session of a player fortifying her spaceport: a moat, a wall, a lava trench, sentry

--- a/client/Assets/BlocksBeyondTheStars/Scripts/ChunkMesher.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/ChunkMesher.cs
@@ -624,6 +624,11 @@ namespace BlocksBeyondTheStars.Client
                 // resolver, so wood_log stays a normal paintable hull block there.
                 bool isWood = floraTint != null && (tf & TraitWood) != 0;
                 Color speciesTint = (isFlora || isWood) && floraTint != null ? floraTint(id) : Color.black;
+                // #1716: a farmed crop is flora for everything BUT the tint. It carries no species colour (the
+                // tint map skips crops so a berry reads as ripe fruit on every world), and a black species tint
+                // in tint mode 1 made the shader fall back to the WORLD hue — violet berries on a violet world,
+                // the very confusion the exclusion was written to prevent. Mode 0 = the authored tile as is.
+                bool floraTinted = isFlora && (tf & TraitCultivated) == 0;
                 // Hull paint (item 32): ship meshes pass a per-block paint resolver — a painted face raises
                 // the tint-mode flag (TEXCOORD1.y) to 2 and carries the ship's hull colour in TEXCOORD2.yzw
                 // (the atlas shader multiplies it into the albedo; black = unpainted).
@@ -635,7 +640,7 @@ namespace BlocksBeyondTheStars.Client
                 var (modTint, _) = chunk.GetModifierLocal(WorldConstants.LocalIndex(x, y, z));
                 bool dyed = modTint != 0;
                 Color dye = dyed ? RgbToColor(modTint) : Color.black;
-                float floraFlag = dyed ? 3f : isWood ? 4f : isFlora ? 1f : painted ? 2f : 0f;
+                float floraFlag = dyed ? 3f : isWood ? 4f : floraTinted ? 1f : painted ? 2f : 0f;
                 // Foliage flag (TEXCOORD2.x): tree crowns + leafy plants whose tile carries a baked alpha
                 // mask — the shader clips it so the leaves are see-through (holes), not a solid cube.
                 bool foliage = (tf & TraitFoliage) != 0;
@@ -833,8 +838,8 @@ namespace BlocksBeyondTheStars.Client
                     float flSky = Skylight(wx, wy + 1, wz);
                     Vector3 flBl = BlockLightAt(wx, wy + 1, wz);
                     Vector3 flBlDir = BlockLightDirAt(wx, wy + 1, wz);
-                    Color flTint = dyed ? dye : isFlora ? speciesTint : Color.black;
-                    float flMode = dyed ? 3f : isFlora ? 1f : 0f;
+                    Color flTint = dyed ? dye : floraTinted ? speciesTint : Color.black;
+                    float flMode = dyed ? 3f : floraTinted ? 1f : 0f;
                     // Per-plant scale + squash (#675): solid flora used to stamp the identical full-cell shape
                     // for every individual — the single strongest "all flora is the same size" tell. A patchy
                     // bell (FloraScale) × rare runt/giant outliers gives ~0.45..1.0 overall size, and an
@@ -878,8 +883,8 @@ namespace BlocksBeyondTheStars.Client
                     float shSky = Skylight(wx, wy + 1, wz);          // open sky above the shaped block
                     Vector3 shBl = BlockLightAt(wx, wy + 1, wz);     // coloured block-light reaching it
                     Vector3 shBlDir = BlockLightDirAt(wx, wy + 1, wz);
-                    Color shTint = designId != 0 ? Color.black : dyed ? dye : (isWood || isFlora) ? speciesTint : Color.black;
-                    float shTintMode = designId != 0 ? 0f : dyed ? 3f : isWood ? 4f : isFlora ? 1f : 0f; // 3 dye, 4 bark, 1 flora (matches cubes)
+                    Color shTint = designId != 0 ? Color.black : dyed ? dye : (isWood || floraTinted) ? speciesTint : Color.black;
+                    float shTintMode = designId != 0 ? 0f : dyed ? 3f : isWood ? 4f : floraTinted ? 1f : 0f; // 3 dye, 4 bark, 1 flora (matches cubes)
                     AddShapedBlock(verts, designId != 0 ? trisP : tris, colliderTris, colliderVerts, colors, uvs, tangents, skyUv, leafUv, blockLight, blockLightDir,
                         ShapeCode.ShapeOf(shapeDesc), ShapeCode.OrientationOf(shapeDesc), ShapeCode.UpFaceOf(shapeDesc), new Vector3(x, y, z),
                         designId != 0 ? designRect : uv,
@@ -1580,10 +1585,12 @@ namespace BlocksBeyondTheStars.Client
         /// y=metal (0 dielectric .. 1 metal — metals tint their highlight + reflection by the albedo).
         /// Ice/glass/crystal are glossy, hull/ore metals reflective, soils matte.
         /// </summary>
-        /// <summary>True for plant foliage that takes the planet's uniform flora hue (B38): the small flora
-        /// plants (block key "flora_*") and tree crowns ("tree_leaves"). The server's flora colour is "one hue
-        /// for all of a planet's plant life", so leaves recolour per planet too; the wood_log trunk keeps its
-        /// natural bark colour.</summary>
+        /// <summary>True for plant foliage the block shader re-tints: the small flora plants (block key
+        /// "flora_*") and tree crowns ("tree_leaves" …). Each species carries its own per-world colour
+        /// (FloraTints.For, mesh tint mode 1); a face without one falls back to the world's base hue
+        /// (FloraTints.ForWorld, shipped by the server). Farmed crops are flora here (collision, exposure, the
+        /// upper vegetation layer) but are NOT tinted — see TraitCultivated (#1716). The wood_log trunk takes
+        /// its own dark bark hue (mode 4).</summary>
         private static bool IsFloraBlock(GameContent content, BlockId id) => TraitsFor(content).Has(id, TraitFlora);
 
         private static bool IsFloraBlockSlow(GameContent content, BlockId id)
@@ -1602,24 +1609,17 @@ namespace BlocksBeyondTheStars.Client
         private static bool IsWoodBlockSlow(GameContent content, BlockId id)
             => content.BlockById(id)?.Key == "wood_log";
 
-        // Tall cross-billboard flora (an upper vegetation layer above the low ground cover). MUST mirror the
-        // FloraHeight.Tall, non-solid entries in FloraCatalog. Solid/cube flora ignore height, so they're absent.
-        private static readonly HashSet<string> TallFlora = new HashSet<string>
-        {
-            "flora_fern", "flora_vine", "flora_reed", "flora_thornbush", "flora_kelp", "flora_seagrass",
-            "flora_tendril", "flora_alienfern", "flora_palm", "flora_grasstuft", "flora_icereed", "flora_saltgrass",
-            "flora_cropgrain", // farmed cereal (#1204) — stands as tall as the wild grass tuft
-        };
+        // Tall cross-billboard flora (an upper vegetation layer above the low ground cover) and the structural /
+        // solid / glowing-cap flora that read better as solid cubes (everything else leafy, plus tree crowns,
+        // gets the alpha-cutout leaf look). #1721: both sets come from the ONE catalog (FloraCatalog.Species
+        // .Height / .Solid) — they used to be hand-mirrored here, and a species added to Shared without a
+        // client edit rendered at the wrong height or as a cutout with no baked mask. A server test holds
+        // bake_leaf_alpha.py's FOLIAGE list to the same catalog.
+        private static readonly HashSet<string> TallFlora =
+            new HashSet<string>(BlocksBeyondTheStars.Shared.Definitions.FloraCatalog.TallKeys());
 
-        // The structural / solid / glowing-cap flora that read better as solid cubes — everything else
-        // leafy (plus tree crowns) gets the alpha-cutout leaf look. MUST match bake_leaf_alpha.py's FOLIAGE.
-        private static readonly HashSet<string> SolidFlora = new HashSet<string>
-        {
-            "flora_cactus", "flora_crystal", "flora_succulent", "flora_mushroom", "flora_puffball",
-            "flora_pitcher", "flora_glowcap", "flora_emberbloom", "flora_sporepod", "flora_glowvine",
-            "flora_bulb", "flora_gasbloom", "flora_shardbloom", // item 21 V3 alien flora (bulbous/crystalline)
-            "flora_cropshroom", // farmed mushroom bed (#1204) — a cap dome like the wild mushroom
-        };
+        private static readonly HashSet<string> SolidFlora =
+            new HashSet<string>(BlocksBeyondTheStars.Shared.Definitions.FloraCatalog.SolidKeys());
 
         /// <summary>True for foliage that renders with alpha-cutout leaves (holes punched into the tile):
         /// tree crowns + leafy/flowering plants. The leaf tiles carry a baked alpha mask; the block shader
@@ -2063,6 +2063,7 @@ namespace BlocksBeyondTheStars.Client
         private const uint TraitFlowerPot = 1u << 17;
         private const uint TraitFire = 1u << 18;
         private const uint TraitExposesOpaqueFace = 1u << 19; // transparent | flora | foliage | slim prop (air handled by the caller)
+        private const uint TraitCultivated = 1u << 20;        // #1716: a farmed crop — flora that keeps its authored colour (no tint mode)
 
         private sealed class BlockTraits
         {
@@ -2103,6 +2104,7 @@ namespace BlocksBeyondTheStars.Client
                     if (key != null && key.StartsWith("flora_", System.StringComparison.Ordinal)) f |= TraitFloraPrefix;
                     if (key != null && TallFlora.Contains(key)) f |= TraitTallFlora;
                     if (key != null && SolidFlora.Contains(key)) f |= TraitSolidFlora;
+                    if (key != null && BlocksBeyondTheStars.Shared.Definitions.FloraCatalog.IsCultivated(key)) f |= TraitCultivated;
                     if (key == "water") f |= TraitWater;
                     if (key == "lava") f |= TraitLava;
                     if (key == "fire") f |= TraitFire;

--- a/docs/developer/WORLD_GENERATION.md
+++ b/docs/developer/WORLD_GENERATION.md
@@ -260,10 +260,16 @@ worlds of the same planet type grow different species) by
 [`TreeGenerator.cs`](../../src/BlocksBeyondTheStars.WorldGeneration/TreeGenerator.cs):
 
 - **Catalogue:** 33 fixed flora archetypes (`FloraCatalog.All`).
-- **World roster:** each archetype is activated with `ActivationChance(theme, tags)` — **85 %** when
-  its climate tags match the world's theme, **40 %** otherwise. Each active species gets a
-  procedurally coined **name** and is **toxic with 30 % probability**. `EnsureCoverage` then
-  force-activates a minimum so no used surface and no sea ever goes bare.
+- **World roster:** each archetype is activated with `ActivationChance(preferred, tags)` — **85 %** when
+  its climate tags match the world's preferred tags, **40 %** otherwise. Up to generation 3 the preferred
+  tags are the planet theme's alone; from **generation 4** (#1715, `BiomeThemeRosterGeneration`) they are
+  the union of the planet theme and every biome theme in the type's pool, so a `varied` world's swamp and
+  desert biomes draw from a pool their own themes shaped (the planet-only roll thinned it to 40 % and
+  `PickWeight` could not add back what was never activated). Each active species gets a procedurally
+  coined **name** and is **toxic with 30 % probability**. `EnsureCoverage` then force-activates a
+  minimum so no used surface and no sea ever goes bare. The roster seed is
+  `WorldGenerator.RosterSeedFor(seed, locationId)` — one function shared by worldgen and the server's
+  scan lookups (#1722).
 - **Per biome:** `FloraForSurface` only draws from active species whose host surface matches the
   biome's surface block, weighted by theme (preferred species count 4:1). In practice **a handful of
   species per biome** (typically ~3–7 land plants on that biome's ground block) plus aquatic species
@@ -326,9 +332,14 @@ live by `GameServerCreatures.cs`.
   region B's violet-ish on the same world.
 
 **Live spawning:** a dynamic world cap (scaled by circumference × abundance × √players; a lush big
-world reaches ~25–45, backstopped by a safety ceiling of 64 — #470), ring placement 18–45 blocks out
-(two rotors: the ring slot advances on every attempt, the species on success), habitat gates (water animals only in
-water columns, cave animals only in caves; titans additionally need a 3×3 level-ground clearance),
+world reaches ~25–45, backstopped by a safety ceiling of 64 — #470; the tick's fill gate and cadence read
+the clamped value too, #1717, or a world modelling above 64 spun in the fast fill forever), ring placement 18–45 blocks out
+(two rotors: the ring slot advances on every attempt, the species on success; the player who gets the next
+spawn rotates on the wild count, #1720), habitat gates (water animals only in
+water columns — the water and lava probes read **real blocks first** and the generator only for unloaded
+columns, so a pool the player built hosts a school and a drained pond does not, and every herd member
+runs the same probe from its own spot, #1718; cave animals only in caves — the cave-floor and shoreline
+probes never load a chunk, #1719; titans additionally need a 3×3 level-ground clearance),
 despawn beyond 70 blocks (titans 110 — a landmark animal must not evaporate mid-approach). **No
 monoculture (#1325):** each species may hold at most a **share** of the live cap — 40 %, never below 3,
 never below cap ÷ roster size — a herd counts its members against it and spawns partially (as against
@@ -1142,3 +1153,36 @@ glacier gate (the gate is dry), the `VoidBelow` probe for structures (pads alrea
 and the `packed_ice` block (the glacier reads fine with the existing ice). The slot canyon, the arête,
 the tooth row and the glacial trough still use the libm angle (`Math.Cos/Sin`, like the classic rift):
 their goldens are Windows-pinned, as every trig-derived golden has been since #1503.
+
+---
+
+## 14. Generation 4 — the flora-roster wave, and the audit hygiene (#1715–#1724, 2026-09-09)
+
+A read-through of the three generators (terrain, flora, fauna) against the July audit found seven of its
+nine findings already fixed and left two, plus eight small ones of its own. All ten are in one package.
+
+**Generation 4 (#1715).** `WorldDescription.CurrentTerrainGeneration` is **4**; the terrain of a
+generation-4 world equals generation 3 — what changes is the flora roster's activation roll (§6): from
+`BiomeThemeRosterGeneration` the preferred tags are the union of the planet theme and its biome themes.
+`FloraGenerator.GenerateRoster` takes the generation; worldgen's `ResolveFlora` and the server's
+`InitFlora` pass theirs. An older world keeps the planet-only roll and every species it ever grew; the
+classic goldens do not move (they pin blocks, and a generation-0/1/3 roster is unchanged).
+
+**One flora colour file (#1716).** The world's base hue — the block shader's fallback for a flora face
+without a species tint, and the micro-fauna's tint — is `FloraTints.ForWorld(seed, locationId)` next to the
+per-species `FloraTints.For`; the server fills the environment message from it (same value as before, the
+hash is the historical one). The client mesher no longer puts a **farmed crop** into tint mode 1
+(`TraitCultivated`): a crop carries no species tint, and the black tint fell through to the world hue —
+violet berries on a violet world, the opposite of what the crop exclusion promised.
+
+**Fauna spawner hygiene.** #1717 the fill gate and cadence read the clamped cap; #1718 the water/lava
+probes read real blocks first (`TryGetFluidColumn`) and every herd member probes from its own spot;
+#1719 the cave-floor and shoreline probes use no-load reads; #1720 the spawn-target round robin counts
+the wild population.
+
+**One truth each.** #1721 `FloraCatalog.Species.Solid` — the mesher derives its tall and solid sets from
+the catalog (`TallKeys` / `SolidKeys`), and `FloraVarietyTests` holds `bake_leaf_alpha.py`'s `FOLIAGE`
+list to it; #1722 `WorldGenerator.RosterSeedFor` — the one roster-seed formula, with a test that the
+server's rosters equal the generators' output for it; #1723 `WonderFor`'s lock-free fast path holds key +
+profile in one immutable slot; #1724 the column memos key on the **wrapped** column, guarded by a test that
+every generation's landforms are identical across both seams (`SurfaceHeightAndChunks_AreTheSame_AcrossBothSeams`).

--- a/src/BlocksBeyondTheStars.GameServer/GameServerCreatures.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerCreatures.cs
@@ -83,10 +83,10 @@ public sealed partial class GameServer
 
     private void InitCreatures()
     {
-        // Per-BODY roster (#478): the seed is salted with the location id (same formula as
-        // WorldGenerator.RosterSeed) so two worlds of the same planet type host different species.
+        // Per-BODY roster (#478): the seed is salted with the location id — THE formula (#1722: one shared
+        // function, not a hand copy) — so two worlds of the same planet type host different species.
         var planet = _content.GetPlanet(_worlds.Active.PlanetType);
-        long rosterSeed = _meta.Seed ^ BlocksBeyondTheStars.WorldGeneration.WorldGenerator.StableHash(_world.LocationId);
+        long rosterSeed = BlocksBeyondTheStars.WorldGeneration.WorldGenerator.RosterSeedFor(_meta.Seed, _world.LocationId);
         _speciesRoster = planet is null
             ? System.Array.Empty<CreatureSpecies>()
             : CreatureGenerator.GenerateRoster(planet, rosterSeed).ToArray();
@@ -198,15 +198,23 @@ public sealed partial class GameServer
             return;
         }
 
-        int cap = WorldCreatureCap(targets.Count);
+        // #1717: the cadence and the fill gate read the SAME ceiling the spawner enforces. The model alone can
+        // reach ~200 on a huge lush world with the Extreme rule and four players; TrySpawnCreatureNear clamps
+        // to the hard cap and refuses, so an unclamped gate here kept the 1.5 s fast fill (a full ring + roster
+        // walk with terrain probes) running forever against a world that was already full — the very shape of
+        // the old cap-of-12 bug, moved to a rarer threshold.
+        int cap = System.Math.Min(WorldCreatureCap(targets.Count), CreatureHardCap);
+        int wild = WildCreatureCount;
         _creatureSpawnTimer += dt;
         // Fill faster while the world is far below its cap (a freshly visited world comes alive quickly),
         // then ease to the slow trickle near the cap.
-        double interval = WildCreatureCount < cap / 2 ? 1.5 : CreatureSpawnInterval;
-        if (_creatureSpawnTimer >= interval && WildCreatureCount < cap)
+        double interval = wild < cap / 2 ? 1.5 : CreatureSpawnInterval;
+        if (_creatureSpawnTimer >= interval && wild < cap)
         {
             _creatureSpawnTimer = 0;
-            if (TrySpawnCreatureNear(targets[_creatures.Count % targets.Count].State, cap))
+            // #1720: the player who gets the next spawn rotates on the WILD population — companions used to
+            // skew the round robin, so a pet owner's surroundings filled faster than everyone else's.
+            if (TrySpawnCreatureNear(targets[wild % targets.Count].State, cap))
             {
                 BroadcastCreatures();
             }
@@ -336,13 +344,14 @@ public sealed partial class GameServer
         (8, 0), (-8, 0), (0, 8), (0, -8),
     };
 
-    /// <summary>Finds the nearest water column (global sea or upland pond) to a spot, returning its
-    /// coordinates and the water-surface / seabed Y. False if no water is within the probe radius.</summary>
+    /// <summary>Finds the nearest water column (global sea, upland pond — or a pool the player built) to a
+    /// spot, returning its coordinates and the water-surface / seabed Y. False if no water is within the
+    /// probe radius.</summary>
     private bool TryFindWaterColumnNear(int x, int z, out int wx, out int wz, out int waterTopY, out int seabedY)
     {
         foreach (var (dx, dz) in WaterProbe)
         {
-            if (_generator.TryGetWaterSurface(_world.Planet, x + dx, z + dz, out waterTopY, out seabedY))
+            if (TryGetFluidColumn(x + dx, z + dz, _creatureWaterId, out waterTopY, out seabedY))
             {
                 wx = x + dx;
                 wz = z + dz;
@@ -363,7 +372,7 @@ public sealed partial class GameServer
     {
         foreach (var (dx, dz) in WaterProbe)
         {
-            if (_generator.TryGetLavaSurface(_world.Planet, x + dx, z + dz, out lavaTopY, out _))
+            if (TryGetFluidColumn(x + dx, z + dz, _creatureLavaId, out lavaTopY, out _))
             {
                 wx = x + dx;
                 wz = z + dz;
@@ -387,6 +396,7 @@ public sealed partial class GameServer
     /// </summary>
     private bool TrySpawnCreatureNear(Shared.State.PlayerState player, int cap)
     {
+        _spawnAttemptsForTest++;
         cap = System.Math.Min(cap, CreatureHardCap);
         if (WildCreatureCount >= cap)
         {
@@ -614,20 +624,25 @@ public sealed partial class GameServer
             float y;
             if (sp.Habitat == CreatureHabitat.Water || sp.Habitat == CreatureHabitat.Amphibian)
             {
-                if (!_generator.TryGetWaterSurface(_world.Planet, mx, mz, out int waterTopY, out int seabedY))
+                // #1718: a member runs the leader's probe from its own spot. It used to ask only its own column,
+                // so beside a small pond the golden-angle spots landed on the bank and the school was the leader
+                // alone — the water four blocks away was never looked at.
+                if (!TryFindWaterColumnNear(mx, mz, out mx, out mz, out int waterTopY, out int seabedY))
                 {
-                    continue; // this member's spot is dry — the school stays smaller
+                    continue; // no water near this member's spot — the school stays smaller
                 }
 
+                surface = _generator.SurfaceHeight(_world.Planet, mx, mz);
                 y = sp.Habitat == CreatureHabitat.Water ? (seabedY + 1 + waterTopY) * 0.5f : waterTopY;
             }
             else if (sp.Habitat == CreatureHabitat.Lava)
             {
-                if (!_generator.TryGetLavaSurface(_world.Planet, mx, mz, out int lavaTop, out _))
+                if (!TryFindLavaColumnNear(mx, mz, out mx, out mz, out int lavaTop))
                 {
                     continue;
                 }
 
+                surface = _generator.SurfaceHeight(_world.Planet, mx, mz);
                 y = lavaTop;
             }
             else if (sp.Habitat == CreatureHabitat.Cave)
@@ -725,9 +740,10 @@ public sealed partial class GameServer
             case CreatureHabitat.Lava:
                 return BlockValueAt(at) == _creatureLavaId && _creatureLavaId != 0;
             case CreatureHabitat.Cave:
-                // a standable air pocket on solid ground (the spawn probe places it in a real cave)
-                return _world.GetBlock(new Vector3i((int)System.Math.Floor(at.X), (int)System.Math.Floor(at.Y), (int)System.Math.Floor(at.Z))).IsAir
-                    && !_world.GetBlock(new Vector3i((int)System.Math.Floor(at.X), (int)System.Math.Floor(at.Y) - 1, (int)System.Math.Floor(at.Z))).IsAir;
+                // a standable air pocket on solid ground (the spawn probe places it in a real cave); #1719: no-load
+                // reads — an unloaded column has no solid floor, so it is not a cave
+                return _world.GetBlockIfLoaded(new Vector3i((int)System.Math.Floor(at.X), (int)System.Math.Floor(at.Y), (int)System.Math.Floor(at.Z))).IsAir
+                    && !_world.GetBlockIfLoaded(new Vector3i((int)System.Math.Floor(at.X), (int)System.Math.Floor(at.Y) - 1, (int)System.Math.Floor(at.Z))).IsAir;
             case CreatureHabitat.Amphibian:
                 return BlockValueAt(at) == _creatureWaterId || WaterWithin(at, 2); // in or beside water
             default:
@@ -1385,6 +1401,56 @@ public sealed partial class GameServer
         return top >= feetY - 1 ? top - bed : 0;
     }
 
+    /// <summary>The fluid body of one kind (water or lava) in a column, for the SPAWN probes (#1718): real
+    /// blocks first, the generator only where nothing is streamed in — the #1697 rule applied to placement.
+    /// A loaded column is scanned around its generator surface for the topmost cell of that fluid; the bed
+    /// is the first non-fluid cell under it. A body the player drained reads dry, a pool the player built
+    /// reads wet. Where the column's chunk is not loaded (or the fluid lies outside the scanned band) the
+    /// generator answers as it always did.</summary>
+    private bool TryGetFluidColumn(int x, int z, ushort fluidId, out int topY, out int bedY)
+    {
+        topY = 0;
+        bedY = 0;
+        if (fluidId == 0)
+        {
+            return false;
+        }
+
+        int surface = _generator.SurfaceHeight(_world.Planet, x, z);
+        if (_world.IsChunkLoaded(WorldConstants.WorldToChunk(new Vector3i(x, surface, z))))
+        {
+            for (int y = surface + FluidColumnScan; y >= surface - FluidColumnScan; y--)
+            {
+                if (_world.GetBlockIfLoaded(new Vector3i(x, y, z)).Value != fluidId)
+                {
+                    continue;
+                }
+
+                topY = y;
+                bedY = y - 1;
+                while (y - bedY < FluidColumnScan && _world.GetBlockIfLoaded(new Vector3i(x, bedY, z)).Value == fluidId)
+                {
+                    bedY--;
+                }
+
+                return true;
+            }
+        }
+
+        bool generated = fluidId == _creatureWaterId
+            ? _generator.TryGetWaterSurface(_world.Planet, x, z, out topY, out bedY)
+            : _generator.TryGetLavaSurface(_world.Planet, x, z, out topY, out bedY);
+        if (!generated)
+        {
+            return false;
+        }
+
+        // The generator's body, where its top cell is streamed in and is NOT that fluid any more, was drained
+        // or built over — offering it would only be rejected by HabitatSuitable one step later.
+        var top = new Vector3i(x, topY, z);
+        return !_world.IsChunkLoaded(WorldConstants.WorldToChunk(top)) || _world.GetBlockIfLoaded(top).Value == fluidId;
+    }
+
     /// <summary>The top cell of the fluid body filling this column at <paramref name="fromY"/>, or
     /// <see cref="int.MinValue"/> when that cell holds no fluid. Real blocks, no-load reads.</summary>
     private int FluidTopAt(int x, int z, int fromY)
@@ -1867,6 +1933,27 @@ public sealed partial class GameServer
         c.Loco.Speed = 0f;
     }
 
+    private int _spawnAttemptsForTest;
+
+    /// <summary>Test-only: how many times the spawner has been asked to place something since start — the
+    /// #1717 gate must stop asking once the world holds the hard cap.</summary>
+    public int SpawnAttemptsForTest => _spawnAttemptsForTest;
+
+    /// <summary>Test-only: the UNCLAMPED population model for this many surface players (#1717).</summary>
+    public int WorldCreatureCapForTest(int players) => WorldCreatureCap(players);
+
+    /// <summary>Test-only: the water probe (#1718) — the column it would seat an aquatic spawn in, or null.</summary>
+    public (int X, int Z, int Top, int Bed)? WaterColumnNearForTest(int x, int z)
+        => TryFindWaterColumnNear(x, z, out int wx, out int wz, out int top, out int bed) ? (wx, wz, top, bed) : null;
+
+    /// <summary>Test-only: places the herd of a species around a spot exactly as the spawner does after the
+    /// leader stands (#1718), against a cap of the hard cap.</summary>
+    public void SpawnGroupAroundForTest(string speciesId, int x, int z)
+        => SpawnGroupAround(_speciesById[speciesId], x, z, CreatureHardCap);
+
+    /// <summary>Test-only: the cave-floor probe (#1719) at a column, −1 when it finds no open cave.</summary>
+    public int CaveFloorForTest(int x, int z) => FindCaveFloorY(x, z, _generator.SurfaceHeight(_world.Planet, x, z));
+
     /// <summary>The spawner's full reject list for the first roster species at a spot (#1314 seam).</summary>
     public bool SpawnSpotClearForTest(Vector3f at)
     {
@@ -2156,11 +2243,14 @@ public sealed partial class GameServer
     /// from just below the surface downward. Returns the floor's air-cell Y, or -1 if the column has no open cave.</summary>
     private int FindCaveFloorY(int x, int z, int surface)
     {
+        // #1719: no-load reads. An unloaded column reads as air all the way down, so it has no solid floor and
+        // yields no cave spawn — the safe answer, and no chunk is generated on the tick thread for an animal
+        // that may not even spawn.
         for (int y = surface - 3; y > surface - 50; y--)
         {
-            if (!_world.GetBlock(new Vector3i(x, y - 1, z)).IsAir   // solid floor
-                && _world.GetBlock(new Vector3i(x, y, z)).IsAir      // feet in air
-                && _world.GetBlock(new Vector3i(x, y + 1, z)).IsAir) // headroom
+            if (!_world.GetBlockIfLoaded(new Vector3i(x, y - 1, z)).IsAir   // solid floor
+                && _world.GetBlockIfLoaded(new Vector3i(x, y, z)).IsAir      // feet in air
+                && _world.GetBlockIfLoaded(new Vector3i(x, y + 1, z)).IsAir) // headroom
             {
                 return y;
             }
@@ -2183,7 +2273,7 @@ public sealed partial class GameServer
             for (int dz = -r; dz <= r; dz++)
                 for (int dy = -1; dy <= 1; dy++)
                 {
-                    if (_world.GetBlock(new Vector3i(x + dx, y + dy, z + dz)).Value == _creatureWaterId)
+                    if (_world.GetBlockIfLoaded(new Vector3i(x + dx, y + dy, z + dz)).Value == _creatureWaterId) // #1719: no-load read
                     {
                         return true;
                     }

--- a/src/BlocksBeyondTheStars.GameServer/GameServerFlora.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerFlora.cs
@@ -56,10 +56,12 @@ public sealed partial class GameServer
         // worldgen actually planted. (Previously every world of the same planet type shared one roster.)
         _floraSpeciesByBlock.Clear();
         var planet = _content.GetPlanet(_worlds.Active.PlanetType);
-        long rosterSeed = _meta.Seed ^ BlocksBeyondTheStars.WorldGeneration.WorldGenerator.StableHash(_world.LocationId);
+        long rosterSeed = BlocksBeyondTheStars.WorldGeneration.WorldGenerator.RosterSeedFor(_meta.Seed, _world.LocationId); // #1722: THE formula
         if (planet != null)
         {
-            foreach (var fs in BlocksBeyondTheStars.WorldGeneration.FloraGenerator.GenerateRoster(planet, rosterSeed))
+            // #1715: the roster reads the world's generation — from generation 4 the biome themes take part in
+            // the activation roll, exactly as worldgen's ResolveFlora rolls it.
+            foreach (var fs in BlocksBeyondTheStars.WorldGeneration.FloraGenerator.GenerateRoster(planet, rosterSeed, _meta.Description.TerrainGeneration))
             {
                 if (_content.GetBlock(fs.BlockKey) is { } b && b.NumericId.Value != 0)
                 {

--- a/src/BlocksBeyondTheStars.GameServer/GameServerWeather.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerWeather.cs
@@ -182,8 +182,9 @@ public sealed partial class GameServer
         _sunColor = StarColor(system);
         // One uniform flora base hue per WORLD (green / brown / pink / purple …). Seeded from
         // LocationId ^ Seed like sky/cloud/gravity (#478) — it was the last per-TYPE hue, contradicting
-        // WORLD_GENERATION.md §3. Airless/floraless worlds still carry a value; it just goes unused.
-        _floraTint = FloraColor(unchecked((uint)(StableStringHash(_world.LocationId) ^ (int)_meta.Seed ^ 0x2F0A17)));
+        // WORLD_GENERATION.md §3. Airless/floraless worlds still carry a value; it just goes unused. The
+        // formula lives with the per-species colours (#1716) — one file for every flora colour.
+        _floraTint = Shared.World.FloraTints.ForWorld(_meta.Seed, _world.LocationId);
         // One seeded daytime sky hue per WORLD (blue → green → yellow → red, blue-dominant), so worlds with an
         // atmosphere don't all share the same blue sky. Seeded from LocationId ^ Seed (like AtmosphereDensity) so
         // two same-type worlds differ. Airless bodies (space sky) carry a value but the client ignores it.
@@ -566,51 +567,7 @@ public sealed partial class GameServer
         return (r << 16) | (g << 8) | bl;
     }
 
-    // Per-planet flora base hue: green-dominant, with rarer brown / pink / purple / amber exotics.
-    private static readonly (int Rgb, int Weight)[] FloraPalette =
-    {
-        (0x4FA63C, 30), // leaf green
-        (0x6FBF4A, 20), // bright green
-        (0x3E7D4F, 12), // deep teal-green
-        (0x8A7B3A, 12), // olive
-        (0x9C6B3A, 10), // brown
-        (0xB85C9E, 7),  // pink / magenta (exotic)
-        (0x7E4FB0, 6),  // violet / purple (exotic)
-        (0xC9A23A, 3),  // amber / yellow (rare)
-    };
-
-    /// <summary>A deterministic per-planet flora base hue: a weighted pick from a green-dominant palette (with
-    /// rarer brown / pink / purple / amber exotics) plus a small per-channel jitter, so most worlds are leafy
-    /// green but some are strikingly alien. One hue for all of a planet's plant life.</summary>
-    private static int FloraColor(uint h)
-    {
-        int total = 0;
-        foreach (var (_, w) in FloraPalette)
-        {
-            total += w;
-        }
-
-        int roll = (int)(h % (uint)total);
-        int i = 0;
-        for (; i < FloraPalette.Length; i++)
-        {
-            roll -= FloraPalette[i].Weight;
-            if (roll < 0)
-            {
-                break;
-            }
-        }
-
-        if (i >= FloraPalette.Length)
-        {
-            i = FloraPalette.Length - 1;
-        }
-
-        int anchor = FloraPalette[i].Rgb;
-        int r = (anchor >> 16) & 0xFF, g = (anchor >> 8) & 0xFF, b = anchor & 0xFF;
-        int Jit(int shift) => (int)((h >> shift) & 0x1F) - 16; // -16..+15
-        return (Clamp8b(r + Jit(3)) << 16) | (Clamp8b(g + Jit(8)) << 8) | Clamp8b(b + Jit(13));
-    }
+    // The world's flora base hue moved to Shared.World.FloraTints.ForWorld (#1716).
 
     private static int Clamp8b(int v) => v < 0 ? 0 : (v > 255 ? 255 : v);
 

--- a/src/BlocksBeyondTheStars.Shared/Definitions/FloraCatalog.cs
+++ b/src/BlocksBeyondTheStars.Shared/Definitions/FloraCatalog.cs
@@ -55,6 +55,9 @@ public static class FloraCatalog
     /// the same colour and — crucially — the same EDIBLE drop on every world. A wild species rolls
     /// <see cref="FloraSpecies.Toxic"/> at p = 0.3, and a toxic plant's <c>berries</c> drop is swapped for
     /// <c>toxic_berries</c> when it is broken; a crop grown in a village greenhouse must never do that.</param>
+    /// <param name="Solid">True for the structural / bulbous / glowing-cap forms that render as a solid cube
+    /// (cactus, crystal, caps …) instead of the alpha-cutout leaf look. #1721: THE list — the client mesher
+    /// derives its cube set and its tall set from the catalog, and a test holds the leaf-alpha bake to it.</param>
     public sealed record Species(
         string Key,
         string[] Hosts,
@@ -62,7 +65,8 @@ public static class FloraCatalog
         FloraTag Tags = FloraTag.None,
         FloraHeight Height = FloraHeight.Short,
         bool Cultivated = false,
-        string[]? LateHosts = null)
+        string[]? LateHosts = null,
+        bool Solid = false)
     {
         /// <summary>Hosts a later terrain generation added (the peat of generation 3). They are NOT part of
         /// <see cref="Hosts"/> on purpose: the roster's host-coverage rule reads <see cref="Hosts"/>, and a host
@@ -81,38 +85,38 @@ public static class FloraCatalog
         new Species("flora_flower",      new[] { "grass", "alien_grass" }, Tags: FloraTag.Lush),
         new Species("flora_bush",        new[] { "grass" }, Tags: FloraTag.Lush),
         new Species("flora_vine",        new[] { "grass" }, Tags: FloraTag.Lush | FloraTag.Tropical, Height: FloraHeight.Tall),
-        new Species("flora_mushroom",    new[] { "grass", "mud", "mycelium" }, Tags: FloraTag.Fungal),
+        new Species("flora_mushroom",    new[] { "grass", "mud", "mycelium" }, Tags: FloraTag.Fungal, Solid: true),
         // Desert (sand) + dry salt flats.
-        new Species("flora_cactus",      new[] { "sand" }, Tags: FloraTag.Dry),
+        new Species("flora_cactus",      new[] { "sand" }, Tags: FloraTag.Dry, Solid: true),
         new Species("flora_dryshrub",    new[] { "sand", "dirt", "salt" }, Tags: FloraTag.Dry),
         // Swamp / wetland (mud) + fungal mycelium.
         new Species("flora_reed",        new[] { "mud" }, Tags: FloraTag.Wetland, Height: FloraHeight.Tall, LateHosts: new[] { "peat" }), // peat: the cotton-grass stand of a bog
-        new Species("flora_glowcap",     new[] { "mud", "mycelium" }, Tags: FloraTag.Fungal | FloraTag.Glow),
+        new Species("flora_glowcap",     new[] { "mud", "mycelium" }, Tags: FloraTag.Fungal | FloraTag.Glow, Solid: true),
         // Aquatic — kelp roots on the seabed, lily pads float on the water surface (world gen places these
         // under/at the sea; the host lets harvested plants regrow on the same spot, like land flora).
         new Species("flora_kelp",        new[] { "sand", "dirt", "mud", "stone" }, Aquatic: true, Tags: FloraTag.Wetland, Height: FloraHeight.Tall),
         new Species("flora_lily",        new[] { "water" }, Aquatic: true, Tags: FloraTag.Wetland),
         // Harsh worlds — icy tundra + volcanic ash.
         new Species("flora_frostflower", new[] { "ice", "snow" }, Tags: FloraTag.Cold),
-        new Species("flora_emberbloom",  new[] { "basalt", "ash" }, Tags: FloraTag.Dry | FloraTag.Glow),
+        new Species("flora_emberbloom",  new[] { "basalt", "ash" }, Tags: FloraTag.Dry | FloraTag.Glow, Solid: true),
         // Crystalline (crystal/stone/basalt).
-        new Species("flora_crystal",     new[] { "crystal", "stone", "basalt" }, Tags: FloraTag.Rocky | FloraTag.Glow),
+        new Species("flora_crystal",     new[] { "crystal", "stone", "basalt" }, Tags: FloraTag.Rocky | FloraTag.Glow, Solid: true),
 
         // --- Task 6: more variety ---
         // Temperate / jungle greenery.
         new Species("flora_palm",        new[] { "grass", "sand" }, Tags: FloraTag.Tropical, Height: FloraHeight.Tall),
         new Species("flora_orchid",      new[] { "grass", "mud", "alien_grass" }, Tags: FloraTag.Tropical | FloraTag.Lush),
         new Species("flora_bellflower",  new[] { "grass", "alien_grass" }, Tags: FloraTag.Lush),
-        new Species("flora_glowvine",    new[] { "grass", "mud", "mycelium", "alien_grass" }, Tags: FloraTag.Lush | FloraTag.Glow), // bioluminescent (ChunkMesher.GlowFor)
+        new Species("flora_glowvine",    new[] { "grass", "mud", "mycelium", "alien_grass" }, Tags: FloraTag.Lush | FloraTag.Glow, Solid: true), // bioluminescent (ChunkMesher.GlowFor)
         // Stony / rocky.
         new Species("flora_moss",        new[] { "stone", "dirt" }, Tags: FloraTag.Rocky | FloraTag.Lush),
-        new Species("flora_sporepod",    new[] { "crystal", "stone", "mycelium" }, Tags: FloraTag.Fungal | FloraTag.Glow), // faintly glowing
+        new Species("flora_sporepod",    new[] { "crystal", "stone", "mycelium" }, Tags: FloraTag.Fungal | FloraTag.Glow, Solid: true), // faintly glowing
         // Desert + dry salt flats.
-        new Species("flora_succulent",   new[] { "sand", "salt" }, Tags: FloraTag.Dry),
+        new Species("flora_succulent",   new[] { "sand", "salt" }, Tags: FloraTag.Dry, Solid: true),
         new Species("flora_thornbush",   new[] { "sand", "dirt", "alien_grass" }, Tags: FloraTag.Dry, Height: FloraHeight.Tall),
         // Swamp / wetland + fungal mycelium.
-        new Species("flora_pitcher",     new[] { "mud", "grass" }, Tags: FloraTag.Wetland),
-        new Species("flora_puffball",    new[] { "mud", "dirt", "mycelium" }, Tags: FloraTag.Fungal),
+        new Species("flora_pitcher",     new[] { "mud", "grass" }, Tags: FloraTag.Wetland, Solid: true),
+        new Species("flora_puffball",    new[] { "mud", "dirt", "mycelium" }, Tags: FloraTag.Fungal, Solid: true),
         // Harsh worlds — icy tundra.
         new Species("flora_lichen",      new[] { "ice", "stone", "snow" }, Tags: FloraTag.Cold | FloraTag.Rocky, LateHosts: new[] { "peat" }),
         new Species("flora_ashweed",     new[] { "basalt", "ash" }, Tags: FloraTag.Dry),
@@ -122,10 +126,10 @@ public static class FloraCatalog
 
         // --- Item 21 V3: alien flora (corrupted / fungal / crystal worlds) ---
         new Species("flora_tendril",     new[] { "alien_grass", "mycelium" }, Tags: FloraTag.Alien, Height: FloraHeight.Tall),
-        new Species("flora_bulb",        new[] { "alien_grass", "mycelium" }, Tags: FloraTag.Alien | FloraTag.Glow),        // bioluminescent (ChunkMesher.GlowFor)
-        new Species("flora_gasbloom",    new[] { "alien_grass", "mud" }, Tags: FloraTag.Alien),
+        new Species("flora_bulb",        new[] { "alien_grass", "mycelium" }, Tags: FloraTag.Alien | FloraTag.Glow, Solid: true),        // bioluminescent (ChunkMesher.GlowFor)
+        new Species("flora_gasbloom",    new[] { "alien_grass", "mud" }, Tags: FloraTag.Alien, Solid: true),
         new Species("flora_alienfern",   new[] { "alien_grass", "grass" }, Tags: FloraTag.Alien, Height: FloraHeight.Tall),
-        new Species("flora_shardbloom",  new[] { "crystal", "stone" }, Tags: FloraTag.Alien | FloraTag.Rocky | FloraTag.Glow), // crystal flower (faint glow)
+        new Species("flora_shardbloom",  new[] { "crystal", "stone" }, Tags: FloraTag.Alien | FloraTag.Rocky | FloraTag.Glow, Solid: true), // crystal flower (faint glow)
 
         // --- Flora variety V2: fill the thin biomes (rock / ice / snow / salt / ash) + signature tall grass ---
         new Species("flora_grasstuft",   new[] { "grass", "dirt" }, Tags: FloraTag.Lush, Height: FloraHeight.Tall),  // waving tall grass — forest-floor / meadow staple
@@ -143,7 +147,7 @@ public static class FloraCatalog
         // list: a wild species' roster id is its catalog index, so inserting above them would rename every
         // world's plants. Grain is a tall cereal; the mushroom bed also takes to the fungal soils.
         new Species("flora_cropgrain",   new[] { "dirt", "grass", "mud", "hydro_tray" }, Tags: FloraTag.Lush, Height: FloraHeight.Tall, Cultivated: true),
-        new Species("flora_cropshroom",  new[] { "dirt", "mud", "mycelium", "hydro_tray" }, Tags: FloraTag.Fungal, Cultivated: true),
+        new Species("flora_cropshroom",  new[] { "dirt", "mud", "mycelium", "hydro_tray" }, Tags: FloraTag.Fungal, Cultivated: true, Solid: true),
     };
 
     /// <summary>True for a farmed crop rather than wild flora — world generation skips these entirely
@@ -178,7 +182,7 @@ public static class FloraCatalog
     }
 
     /// <summary>The set of species block keys that render as a TALL cross-billboard (an upper vegetation
-    /// layer). Mirrored by the client mesher (ChunkMesher.TallFlora) for the actual geometry.</summary>
+    /// layer). The client mesher reads the same catalog for the actual geometry (#1721).</summary>
     public static bool IsTall(string key)
     {
         foreach (var sp in All)
@@ -190,5 +194,51 @@ public static class FloraCatalog
         }
 
         return false;
+    }
+
+    /// <summary>True for a species that renders as a solid cube (see <see cref="Species.Solid"/>).</summary>
+    public static bool IsSolid(string key)
+    {
+        foreach (var sp in All)
+        {
+            if (sp.Key == key)
+            {
+                return sp.Solid;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>The block keys of every species that renders tall AND leafy — the client's upper vegetation
+    /// layer (a solid form ignores its height, so it is absent even when marked tall).</summary>
+    public static IReadOnlyList<string> TallKeys()
+    {
+        var keys = new List<string>();
+        foreach (var sp in All)
+        {
+            if (sp.Height == FloraHeight.Tall && !sp.Solid)
+            {
+                keys.Add(sp.Key);
+            }
+        }
+
+        return keys;
+    }
+
+    /// <summary>The block keys of every species that renders as a solid cube — the client's cube set, and
+    /// the complement of what the leaf-alpha bake (<c>tools/ai-assets/bake_leaf_alpha.py</c>) may list.</summary>
+    public static IReadOnlyList<string> SolidKeys()
+    {
+        var keys = new List<string>();
+        foreach (var sp in All)
+        {
+            if (sp.Solid)
+            {
+                keys.Add(sp.Key);
+            }
+        }
+
+        return keys;
     }
 }

--- a/src/BlocksBeyondTheStars.Shared/Definitions/FloraThemes.cs
+++ b/src/BlocksBeyondTheStars.Shared/Definitions/FloraThemes.cs
@@ -106,7 +106,13 @@ public static class FloraThemes
     /// matching a preferred tag are common; off-theme species stay an occasional find (coverage is enforced
     /// separately so no surface ever goes bare).</summary>
     public static double ActivationChance(Theme theme, FloraTag speciesTags)
-        => (theme.Preferred & speciesTags) != 0 ? 0.85 : 0.40;
+        => ActivationChance(theme.Preferred, speciesTags);
+
+    /// <summary>The same roll against a SET of preferred tags — the union of the planet theme and its biome
+    /// themes from <see cref="BlocksBeyondTheStars.Shared.World.WorldDescription.BiomeThemeRosterGeneration"/>
+    /// (#1715).</summary>
+    public static double ActivationChance(FloraTag preferred, FloraTag speciesTags)
+        => (preferred & speciesTags) != 0 ? 0.85 : 0.40;
 
     /// <summary>Relative pick weight (≥1) for a species with these tags under this theme — themed species
     /// dominate a patch, off-theme ones still appear for variety.</summary>

--- a/src/BlocksBeyondTheStars.Shared/World/FloraTints.cs
+++ b/src/BlocksBeyondTheStars.Shared/World/FloraTints.cs
@@ -37,6 +37,65 @@ public static class FloraTints
         return HsvToRgb(hue, sat, val);
     }
 
+    // The world's base flora hue: green-dominant, with rarer brown / pink / purple / amber exotics.
+    private static readonly (int Rgb, int Weight)[] WorldPalette =
+    {
+        (0x4FA63C, 30), // leaf green
+        (0x6FBF4A, 20), // bright green
+        (0x3E7D4F, 12), // deep teal-green
+        (0x8A7B3A, 12), // olive
+        (0x9C6B3A, 10), // brown
+        (0xB85C9E, 7),  // pink / magenta (exotic)
+        (0x7E4FB0, 6),  // violet / purple (exotic)
+        (0xC9A23A, 3),  // amber / yellow (rare)
+    };
+
+    /// <summary>The world's ONE base flora hue as 0xRRGGBB — a weighted pick from a green-dominant palette
+    /// (with rarer brown / pink / purple / amber exotics) plus a small per-channel jitter, so most worlds are
+    /// leafy green but some are strikingly alien. The server ships it in the environment message (the block
+    /// shader's fallback for a flora face without a species tint; the micro-fauna borrow it), and it used to
+    /// live there alone — #1716 moved the formula next to the per-species colours so the two flora colour
+    /// sources are one file with one seed convention. The hash is the server's historical one
+    /// (<c>h*31+c</c> over the location id, XOR the low seed word), so every existing world keeps its hue.</summary>
+    public static int ForWorld(long worldSeed, string? locationKey)
+    {
+        int h = 17;
+        foreach (char c in locationKey ?? string.Empty)
+        {
+            h = unchecked(h * 31 + c);
+        }
+
+        uint mix = unchecked((uint)(h ^ (int)worldSeed ^ 0x2F0A17));
+        int total = 0;
+        foreach (var (_, w) in WorldPalette)
+        {
+            total += w;
+        }
+
+        int roll = (int)(mix % (uint)total);
+        int i = 0;
+        for (; i < WorldPalette.Length; i++)
+        {
+            roll -= WorldPalette[i].Weight;
+            if (roll < 0)
+            {
+                break;
+            }
+        }
+
+        if (i >= WorldPalette.Length)
+        {
+            i = WorldPalette.Length - 1;
+        }
+
+        int anchor = WorldPalette[i].Rgb;
+        int r = (anchor >> 16) & 0xFF, g = (anchor >> 8) & 0xFF, b = anchor & 0xFF;
+        int Jit(int shift) => (int)((mix >> shift) & 0x1F) - 16; // -16..+15
+        return (Clamp8b(r + Jit(3)) << 16) | (Clamp8b(g + Jit(8)) << 8) | Clamp8b(b + Jit(13));
+    }
+
+    private static int Clamp8b(int v) => v < 0 ? 0 : (v > 255 ? 255 : v);
+
     /// <summary>FNV-1a (stable across platforms/runs — string.GetHashCode is randomized per process).</summary>
     private static ulong Hash(string s)
     {

--- a/src/BlocksBeyondTheStars.Shared/World/WorldDescription.cs
+++ b/src/BlocksBeyondTheStars.Shared/World/WorldDescription.cs
@@ -168,7 +168,9 @@ public sealed class WorldDescription
     /// nudge, deep-water islets on every world with a water sea, the plateau-and-beach islet shape);
     /// 3 = the landform completion package (2026-09): landmark paints that fill a whole column, sea-relative
     /// landmark rows (sea-floor landforms), ice/fluid overhang bands, sub-surface fluid spans, river
-    /// morphology, and the landform families built on them. MUST
+    /// morphology, and the landform families built on them; 4 = the flora-roster wave (#1715): the biome
+    /// themes take part in the species activation roll (the terrain of a generation-4 world equals
+    /// generation 3 — the roster is what changes, and a roster is as much "the world" as a mountain). MUST
     /// default to 0 like <see cref="TerrainContinents"/>: terrain is re-derived from the seed, so a loaded
     /// save keeps the generation it was created with and its terrain never moves — and neither do its
     /// landing pads, which are re-derived the same way. New worlds get the current generation from
@@ -176,8 +178,14 @@ public sealed class WorldDescription
     /// of one bool per wave — every later wave is a single compare.</summary>
     public int TerrainGeneration { get; set; }
 
-    /// <summary>The terrain generation new worlds are created with today (#1644, #1665, landform package).</summary>
-    public const int CurrentTerrainGeneration = 3;
+    /// <summary>The terrain generation new worlds are created with today (#1644, #1665, landform package,
+    /// #1715 flora roster).</summary>
+    public const int CurrentTerrainGeneration = 4;
+
+    /// <summary>The generation from which the flora roster's activation roll reads the biome themes as well as
+    /// the planet theme (#1715). Older worlds keep the planet-only roll — a changed roll would rename and
+    /// re-pick every species they ever grew.</summary>
+    public const int BiomeThemeRosterGeneration = 4;
 
     /// <summary>The generation from which landing pads use the ocean-pad rules (#1665): the 2-D nudge with the
     /// ocean search budget, islets under every deep all-water pad, the plateau islet shape. Older saves keep the

--- a/src/BlocksBeyondTheStars.WorldGeneration/FloraGenerator.cs
+++ b/src/BlocksBeyondTheStars.WorldGeneration/FloraGenerator.cs
@@ -8,16 +8,23 @@ using BlocksBeyondTheStars.Shared.Definitions;
 namespace BlocksBeyondTheStars.WorldGeneration;
 
 /// <summary>
-/// Deterministically derives a planet's roster of <see cref="FloraSpecies"/> from the world seed + planet —
-/// the flora counterpart to <see cref="CreatureGenerator"/>. Each entry in the fixed archetype catalogue
+/// Deterministically derives a body's roster of <see cref="FloraSpecies"/> from the roster seed (the world
+/// seed salted with the body, <see cref="WorldGenerator.RosterSeedFor"/>) + planet type — the flora
+/// counterpart to <see cref="CreatureGenerator"/>. Each entry in the fixed archetype catalogue
 /// (<see cref="FloraCatalog"/>) becomes a named, edible-or-toxic species for this world, so two worlds that
-/// both grow the "bush" archetype name and classify it differently. Combined with the planet's uniform flora
-/// hue (server-side <c>FloraColor</c>) and the coined names, each world's plant life reads as its own flora.
-/// Same seed + planet → the same roster, so nothing needs storing.
+/// both grow the "bush" archetype name and classify it differently. Combined with the per-species colours
+/// (<see cref="BlocksBeyondTheStars.Shared.World.FloraTints"/>, client-side from the same seed + body) and the
+/// coined names, each world's plant life reads as its own flora. Same seed + body + planet → the same
+/// roster, so nothing needs storing.
 /// </summary>
 public static class FloraGenerator
 {
-    public static IReadOnlyList<FloraSpecies> GenerateRoster(PlanetType planet, long worldSeed)
+    /// <summary>This world's roster. <paramref name="terrainGeneration"/> is the world's
+    /// <see cref="BlocksBeyondTheStars.Shared.World.WorldDescription.TerrainGeneration"/>: from
+    /// <see cref="BlocksBeyondTheStars.Shared.World.WorldDescription.BiomeThemeRosterGeneration"/> the biome
+    /// themes take part in the activation roll (#1715); older worlds keep the planet-theme-only roll — and
+    /// with it every species they ever grew.</summary>
+    public static IReadOnlyList<FloraSpecies> GenerateRoster(PlanetType planet, long worldSeed, int terrainGeneration = 0)
     {
         var list = new List<FloraSpecies>();
         if (planet.IsAirless || planet.FloraDensity <= 0)
@@ -31,7 +38,23 @@ public static class FloraGenerator
         // The world's flora theme biases WHICH forms grow: species whose climate tags match the theme are
         // common, off-theme species an occasional find — so a tropical world and a savanna world (both grass)
         // grow visibly different plant life. Coverage is enforced afterwards so no surface ever goes bare.
-        var theme = FloraThemes.Resolve(planet.FloraTheme);
+        //
+        // #1715 (generation ≥ 4): the biome themes count too. A `varied` world is temperate with desert, swamp
+        // and alpine biomes; under the planet-only roll its swamp drew from a pool thinned by the temperate
+        // theme's 40 % — a wetland species that rolled inactive could never grow there, and PickWeight (which
+        // does read the biome theme) cannot add back what was never activated. The union of preferred tags is
+        // data-only, so the roster stays a pure function of (type, seed, generation).
+        FloraTag preferred = FloraThemes.Resolve(planet.FloraTheme).Preferred;
+        if (terrainGeneration >= BlocksBeyondTheStars.Shared.World.WorldDescription.BiomeThemeRosterGeneration)
+        {
+            foreach (var biome in planet.Biomes)
+            {
+                if (!string.IsNullOrWhiteSpace(biome.FloraTheme))
+                {
+                    preferred |= FloraThemes.Resolve(biome.FloraTheme).Preferred;
+                }
+            }
+        }
 
         int i = 0;
         foreach (var archetype in FloraCatalog.All)
@@ -55,7 +78,7 @@ public static class FloraGenerator
                 BlockKey = archetype.Key,
                 Toxic = rng.NextDouble() < 0.3,  // most flora is benign; a notable minority is toxic
                 Aquatic = archetype.Aquatic,
-                Active = rng.NextDouble() < FloraThemes.ActivationChance(theme, archetype.Tags),
+                Active = rng.NextDouble() < FloraThemes.ActivationChance(preferred, archetype.Tags),
             });
             i++;
         }

--- a/src/BlocksBeyondTheStars.WorldGeneration/WorldGenerator.Flora.cs
+++ b/src/BlocksBeyondTheStars.WorldGeneration/WorldGenerator.Flora.cs
@@ -108,7 +108,7 @@ public sealed partial class WorldGenerator
         _floraTagByBlock.Clear();
 
         var active = new System.Collections.Generic.HashSet<string>();
-        foreach (var fs in FloraGenerator.GenerateRoster(planet, RosterSeed))
+        foreach (var fs in FloraGenerator.GenerateRoster(planet, RosterSeed, _terrainGeneration)) // #1715: the generation gates the biome-theme roll
         {
             if (fs.Active)
             {

--- a/src/BlocksBeyondTheStars.WorldGeneration/WorldGenerator.cs
+++ b/src/BlocksBeyondTheStars.WorldGeneration/WorldGenerator.cs
@@ -349,9 +349,15 @@ public sealed partial class WorldGenerator
     private long PlanetSeed(PlanetType planet) => _worldSeed ^ StableHash(planet.Key) ^ _locationSalt;
 
     /// <summary>The roster seed for this body — the world seed salted with the body identity (#478). The
-    /// server-side roster consumers (flora/tree/creature name + species lookups) MUST use the same formula,
-    /// or scanned names would disagree with what worldgen actually planted.</summary>
-    public long RosterSeed => _worldSeed ^ _locationSalt;
+    /// server-side roster consumers (flora/tree/creature name + species lookups) call
+    /// <see cref="RosterSeedFor"/> with the same inputs (#1722: one function, not three hand copies), or
+    /// scanned names would disagree with what worldgen actually planted.</summary>
+    public long RosterSeed => RosterSeedFor(_worldSeed, _locationId);
+
+    /// <summary>THE roster-seed formula: the world seed salted with the body's location id (an empty or
+    /// null id is the legacy unsalted seed, like <see cref="SetWorldMode"/>'s default).</summary>
+    public static long RosterSeedFor(long worldSeed, string? locationId)
+        => worldSeed ^ (string.IsNullOrEmpty(locationId) ? 0 : StableHash(locationId));
 
     // --- Round-world (torus) noise wrappers: X periodic at the circumference, Z at the latitude period
     // (≈ circumference/2), so terrain/caves/ores are seamless when circumnavigating in ANY direction. ---
@@ -690,8 +696,21 @@ public sealed partial class WorldGenerator
     private static readonly System.Collections.Generic.Dictionary<(long, string, int, bool, long, bool, bool, int), WonderProfile> _wonders = new();
     private static readonly object _wonderLock = new object();
     private static readonly System.Collections.Generic.Queue<(long, string, int, bool, long, bool, bool, int)> _wonderOrder = new();
-    private WonderProfile? _wonderCached;
-    private (long, string, int, bool, long, bool, bool, int) _wonderCachedKey;
+    // #1723: key + profile travel in ONE immutable object, so the lock-free read below sees a matching pair or
+    // nothing — two separately written fields let another thread observe a new key over the old profile.
+    private sealed class WonderSlot
+    {
+        public readonly (long, string, int, bool, long, bool, bool, int) Key;
+        public readonly WonderProfile Profile;
+
+        public WonderSlot((long, string, int, bool, long, bool, bool, int) key, WonderProfile profile)
+        {
+            Key = key;
+            Profile = profile;
+        }
+    }
+
+    private WonderSlot? _wonderSlot;
 
     /// <summary>#1527: the bounded static caches evict their OLDEST entry instead of clearing wholesale, so a
     /// world past the cap only re-derives one entry, not every resident body's.</summary>
@@ -722,7 +741,12 @@ public sealed partial class WorldGenerator
     private const int SurfaceCacheCap = 262_144;   // ~6 MB of entries at most
     private const int ColumnProfileCap = 100_000;  // ~12 MB: a VD-8 view is ~74k columns
 
-    private static long ColumnKey(int worldX, int worldZ) => ((long)(uint)worldX << 32) | (uint)worldZ;
+    // #1724: keyed on the WRAPPED column — the noise underneath wraps on the torus, so a column and its seam
+    // twin (x ± circumference, z ± latitude period) are one column and share one entry; the minimap bake, the
+    // pad planner's longitude march and the far-column band all cross the seam. The seam-identity test in
+    // WorldGenColumnCacheTests is what makes this correct: every landform family wraps.
+    private long ColumnKey(int worldX, int worldZ)
+        => ((long)(uint)WorldConstants.WrapX(worldX, _circumference) << 32) | (uint)Wz(worldZ);
 
     /// <summary>Drops every per-column memo — the world-mode setters call this because the memos are keyed
     /// on the planet + column only and rely on the mode (circumference, cratered, body salt, continents,
@@ -762,9 +786,9 @@ public sealed partial class WorldGenerator
     private WonderProfile WonderFor(PlanetType planet)
     {
         var key = (_worldSeed, planet.Key, _circumference, _crateredWorld, _locationSalt, _continentsEnabled, _lavaCoreVolcanoes, _terrainGeneration);
-        if (_wonderCached is { } fast && _wonderCachedKey == key)
+        if (_wonderSlot is { } fast && fast.Key == key)
         {
-            return fast;
+            return fast.Profile;
         }
 
         lock (_wonderLock)
@@ -939,8 +963,7 @@ public sealed partial class WorldGenerator
                 _wonderOrder.Enqueue(key);
             }
 
-            _wonderCached = w;
-            _wonderCachedKey = key;
+            _wonderSlot = new WonderSlot(key, w);
             return w;
         }
     }

--- a/tests/BlocksBeyondTheStars.Tests/CreatureTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/CreatureTests.cs
@@ -30,7 +30,7 @@ public sealed class CreatureTests : IDisposable
         _content = ContentLoader.LoadFromDirectory(TestPaths.DataDir());
     }
 
-    private SvGameServer Started(string planet, out SqliteWorldRepository repo)
+    private SvGameServer Started(string planet, out SqliteWorldRepository repo, Action<ServerConfig>? configure = null)
     {
         repo = new SqliteWorldRepository(new SaveGamePaths(_root, "creature"));
         var st = new LoopbackServerTransport(new LoopbackLink());
@@ -43,6 +43,7 @@ public sealed class CreatureTests : IDisposable
             PlaceStarterShip = false,
             World = { TerrainGeneration = 0 }, // #1645: gameplay test on the classic relief — the player sits at a fixed (0, 64, 0), which generation-1 terrain may flood or bury
         };
+        configure?.Invoke(config);
         var server = new SvGameServer(config, _content, st, repo);
         server.Start();
         return server;
@@ -1218,6 +1219,126 @@ public sealed class CreatureTests : IDisposable
                 server.Tick(0.2);
             }
             Assert.Equal(0.0, creature.GiveUpTimer);
+        }
+    }
+
+    // ---------------- Spawner hygiene (#1717, #1718, #1719) ----------------
+
+    /// <summary>The air cell standing on real ground at a column (the first air-over-solid from above).</summary>
+    private static int GroundCellY(SvGameServer server, int x, int z)
+    {
+        for (int y = 140; y > 10; y--)
+        {
+            if (server.World.GetBlock(new Vector3i(x, y, z)).IsAir && !server.World.GetBlock(new Vector3i(x, y - 1, z)).IsAir)
+            {
+                return y;
+            }
+        }
+
+        throw new InvalidOperationException($"no ground under ({x}, {z})");
+    }
+
+    [Fact]
+    public void SpawnGate_StopsAskingAtTheHardCap_EvenWhenThePopulationModelRunsHigher()
+    {
+        // #1717: TickCreatures gated the fill on the UNCLAMPED population model while TrySpawnCreatureNear
+        // clamped to the hard cap and refused — a world modelling above 64 sat in the 1.5 s fast-fill cadence
+        // forever, walking the ring and the roster with terrain probes for nothing (the shape of the old
+        // cap-of-12 bug at a rarer threshold).
+        var server = Started("jungle", out var repo, c => c.Rules.CreatureAbundance = AlienActivity.Extreme);
+        using (repo)
+        {
+            const int players = 25; // √25 = 5: 20 × 2.2 × 5 = 220 × size (≥ 0.5) × jitter (≥ 0.7) > 64 on any body
+            for (int i = 0; i < players; i++)
+            {
+                var p = server.AddLocalPlayer("Ranger" + i);
+                p.State.AboardShip = false;
+                p.State.Position = new Vector3f(0, 64, 0);
+            }
+
+            Assert.True(server.WorldCreatureCapForTest(players) > 64,
+                $"precondition: the model must exceed the hard cap (got {server.WorldCreatureCapForTest(players)})");
+
+            int ground = GroundCellY(server, 0, 0);
+            while (server.Creatures.Count(c => !c.IsCompanion) < 64)
+            {
+                server.SpawnCreatureAtForTest(new Vector3f(0.5f, ground, 0.5f));
+            }
+
+            server.Tick(0.1); // settle the tick's own bookkeeping before counting
+            int attempts = server.SpawnAttemptsForTest;
+            for (int i = 0; i < 40; i++)
+            {
+                server.Tick(0.5); // 20 s — a dozen fast-fill cadences' worth
+            }
+
+            Assert.True(server.Creatures.Count(c => !c.IsCompanion) >= 64, "the world stays at the hard cap");
+            Assert.Equal(attempts, server.SpawnAttemptsForTest);
+        }
+    }
+
+    [Fact]
+    public void WaterProbe_ReadsRealBlocks_SoASchoolFillsAPlayerBuiltPool()
+    {
+        // #1718: the spawn probes asked the GENERATOR alone, and a herd member asked only its own column — a
+        // pool the player dug and filled never hosted a spawn, and beside a small pond the golden-angle spots
+        // (4–8 blocks out) landed on the bank, so the school was the leader alone.
+        var server = Started("desert", out var repo); // a dry world: the generator has no water near the pool
+        using (repo)
+        {
+            var p = server.AddLocalPlayer("Ranger");
+            p.State.AboardShip = false;
+            p.State.Position = new Vector3f(0, 64, 0);
+
+            // A spot the generator calls dry (no water within the probe's 8 blocks) …
+            (int X, int Z)[] candidates = { (40, 40), (-50, 40), (60, -30), (-70, -60), (90, 20), (20, 90), (120, 120), (-130, 50) };
+            var (cx, cz) = candidates.First(c => server.WaterColumnNearForTest(c.X, c.Z) is null);
+
+            // … gets a 7 × 7 pool two cells deep, dug into the real ground.
+            var water = _content.GetBlock("water")!.NumericId;
+            int floor = GroundCellY(server, cx, cz);
+            for (int x = cx - 3; x <= cx + 3; x++)
+            {
+                for (int z = cz - 3; z <= cz + 3; z++)
+                {
+                    server.World.SetBlock(new Vector3i(x, floor - 1, z), water);
+                    server.World.SetBlock(new Vector3i(x, floor, z), water);
+                }
+            }
+
+            var found = server.WaterColumnNearForTest(cx, cz);
+            Assert.NotNull(found);
+            Assert.Equal(floor, found!.Value.Top);
+            Assert.Equal(floor - 2, found.Value.Bed);
+
+            // A social water species: the leader stands in the pool's centre; the members must find the pool
+            // from their own spots 4–8 blocks out, where the ground is dry.
+            var sp = server.SpeciesRoster.OrderBy(s => s.Size).First(); // the smallest body fits a two-deep pool
+            sp.Habitat = CreatureHabitat.Water;
+            sp.SocialGroupSize = 5;
+            server.SpawnGroupAroundForTest(sp.Id, cx, cz);
+
+            var school = server.Creatures.Where(c => c.SpeciesId == sp.Id).ToList();
+            Assert.True(school.Count >= 2, $"the members must find the pool beside their spots (got {school.Count})");
+            foreach (var fish in school)
+            {
+                var cell = new Vector3i((int)MathF.Floor(fish.Position.X), (int)MathF.Floor(fish.Position.Y), (int)MathF.Floor(fish.Position.Z));
+                Assert.Equal(water.Value, server.World.GetBlock(cell).Value);
+            }
+        }
+    }
+
+    [Fact]
+    public void CaveProbe_NeverLoadsAChunk()
+    {
+        // #1719: the cave-floor probe read through the LOADING block accessor, so a cave spawn attempt at a ring
+        // offset beyond the streamed chunks generated a chunk on the tick thread.
+        var server = Started("jungle", out var repo);
+        using (repo)
+        {
+            int before = server.World.LoadedChunkCount;
+            server.CaveFloorForTest(4000, 4000); // far outside anything streamed in
+            Assert.Equal(before, server.World.LoadedChunkCount);
         }
     }
 

--- a/tests/BlocksBeyondTheStars.Tests/FloraTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/FloraTests.cs
@@ -419,6 +419,78 @@ public sealed class FloraTests : IDisposable
         }
     }
 
+    [Fact]
+    public void FloraRoster_ReadsTheBiomeThemes_FromGeneration4_AndLeavesOlderWorldsAlone()
+    {
+        // #1715: a `varied` world is temperate with desert, swamp and alpine biomes. Under the planet-only roll
+        // its off-theme species came through at 40 % — a wetland species that rolled inactive could never grow
+        // in the swamp. From generation 4 the union of the planet AND biome themes decides "on theme".
+        var planet = _content.GetPlanet("varied")!;
+        var classic = FloraGenerator.GenerateRoster(planet, 4242);
+        var gen3 = FloraGenerator.GenerateRoster(planet, 4242, 3);
+        var gen4 = FloraGenerator.GenerateRoster(planet, 4242, BlocksBeyondTheStars.Shared.World.WorldDescription.BiomeThemeRosterGeneration);
+        var planetTheme = FloraThemes.Resolve(planet.FloraTheme);
+
+        int offThemeBefore = 0, offThemeAfter = 0;
+        for (int i = 0; i < classic.Count; i++)
+        {
+            Assert.Equal(classic[i].Active, gen3[i].Active); // below the wave: the planet-only roll, unchanged
+            Assert.Equal(classic[i].Id, gen4[i].Id);         // the wave changes WHICH species grow, never their identity
+            Assert.Equal(classic[i].Name, gen4[i].Name);
+            Assert.Equal(classic[i].Toxic, gen4[i].Toxic);
+
+            var tags = FloraCatalog.All.First(s => s.Key == classic[i].BlockKey).Tags;
+            if ((planetTheme.Preferred & tags) == 0)
+            {
+                if (gen3[i].Active) offThemeBefore++;
+                if (gen4[i].Active) offThemeAfter++;
+            }
+        }
+
+        Assert.True(offThemeAfter > offThemeBefore,
+            $"the biome themes must let more off-planet-theme species through ({offThemeBefore} → {offThemeAfter})");
+
+        // A single-theme world (no biome carries another theme) rolls exactly as before on every generation.
+        var single = _content.Planets.Values.First(p => p.FloraDensity > 0 && !p.IsAirless
+            && p.Biomes.All(b => string.IsNullOrWhiteSpace(b.FloraTheme) || FloraThemes.Resolve(b.FloraTheme).Name == FloraThemes.Resolve(p.FloraTheme).Name));
+        var s3 = FloraGenerator.GenerateRoster(single, 4242, 3);
+        var s4 = FloraGenerator.GenerateRoster(single, 4242, 4);
+        for (int i = 0; i < s3.Count; i++)
+        {
+            Assert.Equal(s3[i].Active, s4[i].Active);
+        }
+    }
+
+    [Fact]
+    public void ServerRosters_UseTheOneRosterSeedFormula_AndTheWorldHueIsTheSharedOne()
+    {
+        // #1722: the roster seed used to be re-typed by hand in three places; #1716: the world's base flora hue
+        // used to be a server-only formula. Both are one shared function now — and this proves the server's
+        // scan names + hue are exactly what worldgen and the client derive from the same inputs.
+        var server = Started(out var repo);
+        using (repo)
+        {
+            var planet = server.World.Planet;
+            long rosterSeed = WorldGenerator.RosterSeedFor(7, server.World.LocationId);
+            int generation = BlocksBeyondTheStars.Shared.World.WorldDescription.CurrentTerrainGeneration; // a fresh save
+            var flora = FloraGenerator.GenerateRoster(planet, rosterSeed, generation);
+            Assert.NotEmpty(flora);
+            foreach (var fs in flora)
+            {
+                var onServer = server.FloraSpeciesForBlock(fs.BlockKey);
+                Assert.NotNull(onServer);
+                Assert.Equal(fs.Name, onServer!.Name);
+                Assert.Equal(fs.Toxic, onServer.Toxic);
+                Assert.Equal(fs.Active, onServer.Active);
+            }
+
+            var creatures = CreatureGenerator.GenerateRoster(planet, rosterSeed);
+            Assert.Equal(creatures.Select(c => c.Id + ":" + c.Name), server.SpeciesRoster.Select(c => c.Id + ":" + c.Name));
+
+            Assert.Equal(BlocksBeyondTheStars.Shared.World.FloraTints.ForWorld(7, server.World.LocationId), server.FloraTint);
+        }
+    }
+
     public void Dispose()
     {
         try

--- a/tests/BlocksBeyondTheStars.Tests/FloraTintTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/FloraTintTests.cs
@@ -74,4 +74,26 @@ public sealed class FloraTintTests
             Assert.True(max - min >= 0.3f, $"tint too grey: {r},{g},{b}");
         }
     }
+
+    [Fact]
+    public void WorldHue_IsDeterministic_VariesPerBody_AndStaysOnThePalette()
+    {
+        // #1716: the world's base hue (the shader fallback + the micro-fauna's tint) lives here now, next to
+        // the per-species colours — the server ships exactly this value.
+        Assert.Equal(FloraTints.ForWorld(4242, "sys0-p1"), FloraTints.ForWorld(4242, "sys0-p1"));
+        Assert.Equal(FloraTints.ForWorld(4242, null), FloraTints.ForWorld(4242, string.Empty));
+
+        var seen = new HashSet<int>();
+        for (int i = 0; i < 64; i++)
+        {
+            int rgb = FloraTints.ForWorld(4242, "sys0-p" + i);
+            seen.Add(rgb);
+            // A palette anchor ± the 16-step jitter: never black, never white, never grey.
+            int r = (rgb >> 16) & 0xFF, g = (rgb >> 8) & 0xFF, b = rgb & 0xFF;
+            Assert.InRange(r + g + b, 100, 650);
+            Assert.True(System.Math.Max(r, System.Math.Max(g, b)) - System.Math.Min(r, System.Math.Min(g, b)) >= 20, $"grey hue {rgb:X6}");
+        }
+
+        Assert.True(seen.Count > 8, "bodies roll different base hues");
+    }
 }

--- a/tests/BlocksBeyondTheStars.Tests/FloraVarietyTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/FloraVarietyTests.cs
@@ -203,4 +203,45 @@ public sealed class FloraVarietyTests
         Assert.True(counts.GetValueOrDefault(pine) > 0, "an alpine world's trees are conifers (pine_needles).");
         Assert.Equal(0, counts.GetValueOrDefault(leaves)); // alpine grows no broadleaf crowns
     }
+
+    [Fact]
+    public void LeafAlphaBake_ListsExactlyTheLeafyFlora_AndTheCatalogFormsAreConsistent()
+    {
+        // #1721: which flora is tall and which is a solid cube used to be written three times by hand (the
+        // catalog, the client mesher, the leaf-alpha bake script). The mesher derives its sets from the catalog
+        // now; the bake script is Python, so this holds its FOLIAGE list to the catalog instead.
+        var tall = FloraCatalog.TallKeys().ToHashSet();
+        var solid = FloraCatalog.SolidKeys().ToHashSet();
+        Assert.NotEmpty(tall);
+        Assert.NotEmpty(solid);
+        Assert.Empty(tall.Intersect(solid)); // a solid form ignores its height, so it is never "tall"
+        foreach (var key in tall.Concat(solid))
+        {
+            Assert.NotNull(_content.GetBlock(key));
+        }
+
+        string script = File.ReadAllText(Path.Combine(TestPaths.RepoRoot(), "tools", "ai-assets", "bake_leaf_alpha.py"));
+        int open = script.IndexOf("FOLIAGE = [", StringComparison.Ordinal);
+        Assert.True(open >= 0, "bake_leaf_alpha.py must declare FOLIAGE = [...]");
+        int close = script.IndexOf(']', open);
+        Assert.True(close > open, "the FOLIAGE list must be closed");
+        var listed = script.Substring(open, close - open).Split('"')
+            .Where((part, index) => index % 2 == 1) // every odd piece sits between two quotes
+            .ToHashSet();
+
+        // Two leafy alien species never had a mask baked (their tiles are opaque by design) — the accepted
+        // exceptions. Every other leafy species and every tree crown must be listed, and no solid form may be.
+        var accepted = new HashSet<string> { "flora_tendril", "flora_alienfern" };
+        var expected = new HashSet<string> { "tree_leaves", "pine_needles", "palm_frond" };
+        foreach (var sp in FloraCatalog.All)
+        {
+            if (!sp.Solid && !accepted.Contains(sp.Key))
+            {
+                expected.Add(sp.Key);
+            }
+        }
+
+        Assert.Empty(expected.Except(listed));                  // every leafy species is baked
+        Assert.Empty(listed.Except(expected).Except(accepted)); // nothing solid or unknown is baked
+    }
 }

--- a/tests/BlocksBeyondTheStars.Tests/ShipAiTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/ShipAiTests.cs
@@ -698,7 +698,13 @@ public sealed class ShipAiTests : IDisposable
         using var serverTransport = new LoopbackServerTransport(NewLink(out var link));
         using var client = new LoopbackClientTransport(link);
         var lines = CaptureVega(client);
-        var server = new SvGameServer(Config(), _content, serverTransport, repo);
+        // No Guardian machines on this world: a scan-drone that spawns 35–50 blocks out reaches the player within
+        // the 75 s quiet window and shoots them dead (2/s), and the respawn puts them aboard — where the ore tip
+        // can never fire. It only ever passed because the fauna spawner's cave probe happened to LOAD the drone's
+        // path columns (#1719 stopped that), and a loaded rocky column reads as a wall to a machine (#1482).
+        var config = Config();
+        config.Rules.PlanetEnemies = AlienActivity.Off;
+        var server = new SvGameServer(config, _content, serverTransport, repo);
         server.Start();
         JoinAndDrain(server, client, "Prospector");
         var session = server.Sessions[1];

--- a/tests/BlocksBeyondTheStars.Tests/WorldGenColumnCacheTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/WorldGenColumnCacheTests.cs
@@ -154,4 +154,43 @@ public class WorldGenColumnCacheTests
         Assert.Equal(WorldGenerationGoldenTests.HashChunk(cold.Generate(planet, coord)),
             WorldGenerationGoldenTests.HashChunk(gen.Generate(planet, coord)));
     }
+
+    [Theory]
+    [InlineData("varied", 424242L, 0)]
+    [InlineData("desert", 20260905L, 1)]
+    [InlineData("ocean", 20260907L, 3)]
+    [InlineData("karst", 20260907L, 3)]
+    [InlineData("frozen_ocean", 20260907L, 3)]
+    public void SurfaceHeightAndChunks_AreTheSame_AcrossBothSeams(string planetKey, long seed, int generation)
+    {
+        // #1724: the column memos key on the WRAPPED column, so a column and its seam twin share one entry. That
+        // is only correct if every landform family wraps — this pins it for the classic, generation-1 and
+        // generation-3 families (a family that did not wrap would be a seam bug, not a cache bug).
+        var planet = Content.GetPlanet(planetKey)!;
+        var gen = new WorldGenerator(seed, Content);
+        gen.SetWorldMode(5472, cratered: false, landingPads: null, locationId: "seam-test:body");
+        gen.SetTerrainGeneration(generation);
+        int circ = gen.Circumference;
+        int lat = WorldConstants.LatitudePeriodFor(circ);
+
+        var rng = new Random(20260909);
+        for (int i = 0; i < 200; i++)
+        {
+            int x = rng.Next(-circ, 2 * circ);
+            int z = rng.Next(-lat, 2 * lat);
+            int h = gen.SurfaceHeight(planet, x, z);
+            Assert.Equal(h, gen.SurfaceHeight(planet, x + circ, z));
+            Assert.Equal(h, gen.SurfaceHeight(planet, x - circ, z));
+            Assert.Equal(h, gen.SurfaceHeight(planet, x, z + lat));
+            Assert.Equal(h, gen.SurfaceHeight(planet, x, z - lat));
+        }
+
+        // Whole chunks across the X seam and the Z seam equal the home chunk, blocks and all.
+        int cs = WorldConstants.ChunkSize;
+        var home = new ChunkCoord(3, 3, 2);
+        ulong expected = WorldGenerationGoldenTests.HashChunk(gen.Generate(planet, home));
+        Assert.Equal(expected, WorldGenerationGoldenTests.HashChunk(gen.Generate(planet, new ChunkCoord(3 + circ / cs, 3, 2))));
+        Assert.Equal(expected, WorldGenerationGoldenTests.HashChunk(gen.Generate(planet, new ChunkCoord(3 - circ / cs, 3, 2))));
+        Assert.Equal(expected, WorldGenerationGoldenTests.HashChunk(gen.Generate(planet, new ChunkCoord(3, 3, 2 + lat / cs))));
+    }
 }


### PR DESCRIPTION
## Summary

A read-through of the terrain, flora and fauna generators against the July 2026 audit: seven of its nine findings were already fixed by the August fauna waves; the two that remained and eight new small ones make this package. Nothing here moves a classic golden — the one behaviour change is gated on a new generation.

- **#1715 — flora roster reads the biome themes (generation 4).** `CurrentTerrainGeneration` 3 → 4. The activation roll's "on theme" is the union of the planet theme and every biome theme in the type's pool, so a `varied` world's swamp and desert biomes grow what their own themes prefer instead of a pool the temperate theme thinned to 40 %. `GenerateRoster` takes the generation; worldgen and the server pass theirs. Older worlds keep the planet-only roll and every species they ever grew.
- **#1716 — farmed crops kept taking the world hue.** The mesher put every `flora_*` block into tint mode 1; a crop carries no species tint, so the shader fell back to the world's base hue — violet berries on a violet world. Crops are `TraitCultivated` now (mode 0, the authored tile). The base hue moved next to the per-species colours as `FloraTints.ForWorld` (same value, same wire; the server ships it from there).
- **#1717 — the spawn tick gated on the unclamped cap.** A world modelling above the hard cap of 64 sat in the 1.5 s fast-fill cadence forever.
- **#1718 — spawn probes read real blocks first** (`TryGetFluidColumn`): a pool the player built hosts a school, a drained pond does not; every herd member runs the leader's probe from its own spot.
- **#1719 — the cave-floor and shoreline probes no longer load chunks** on the tick thread.
- **#1720 — the spawn-target round robin counts the wild population**, not companions.
- **#1721 — one flora-form truth.** `FloraCatalog.Species.Solid`; the mesher derives its tall and solid sets from the catalog; a test holds `bake_leaf_alpha.py`'s FOLIAGE list to it.
- **#1722 — one roster-seed formula.** `WorldGenerator.RosterSeedFor`, used by worldgen and both server sites, with a test that the server's rosters equal the generators' output.
- **#1723 — `WonderFor`'s lock-free fast path** holds key + profile in one immutable slot.
- **#1724 — column memos key on the wrapped column**, guarded by a seam-identity test over generation 0, 1 and 3 worlds.

Docs: WORLD_GENERATION.md §6, §7, new §14; TODO.md. Tests: 9 new, all in existing classes (no new test class, so the shard-weight guard stays put).

## Verification

- `dotnet format --verify-no-changes` clean.
- Fast-tier server suite green locally (2932 tests; see the checks below for CI).
- Every classic / gen-1 / gen-3 golden unchanged.
- `client/Assets` touched (ChunkMesher): local Unity batch compile of the worktree client clean; the `ChunkMesherFloraFloor` EditMode tests pass.
- One pre-existing test coupling surfaced: `ShipAiTests.ContextTips_ProbeFindsRareOre…` only passed because the fauna cave probe happened to load the path columns of a scan-drone, which then read as walls to the machine; with #1719 the drone glides in over the noise surface and kills the player before the tip fires. That test now runs with `PlanetEnemies = Off` (it is about the ore tip, not about machines).
- Known, NOT from this branch: `ChunkMesherGoldenEditModeTests` is stale on main (the gen-3 blocks shifted the numeric ids the synthetic world hashes; identical checksums with main's mesher). Left for a conscious re-pin.

closes #1715
closes #1716
closes #1717
closes #1718
closes #1719
closes #1720
closes #1721
closes #1722
closes #1723
closes #1724

🤖 Generated with [Claude Code](https://claude.com/claude-code)
