### PR TITLE
test(worldgen): the gen-3 cost guard measures the code, not the scheduler (#1735)

### DIFF
--- a/tests/BlocksBeyondTheStars.Tests/LandformGen3Tests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/LandformGen3Tests.cs
@@ -21,6 +21,7 @@ namespace BlocksBeyondTheStars.Tests;
 /// river reaches. Plus the two invariants the package rests on: the sea percentile never sees a sea-relative
 /// row, and a generation-3 world without any active family is the generation-1 world, cell for cell.
 /// </summary>
+[Collection(RealTimeSensitiveCollection.Name)] // the cost guard below is a wall-clock ratio (#1735)
 public sealed class LandformGen3Tests
 {
     private static readonly GameContent Content = ContentLoader.LoadFromDirectory(TestPaths.DataDir());
@@ -359,7 +360,18 @@ public sealed class LandformGen3Tests
     // ---------- the cost guard ----------
 
     /// <summary>No generation-time budget existed before this package; the client bakes up to 32 768 columns
-    /// synchronously on its main thread, so a chunk must not get meaningfully dearer. Slow tier: main only.</summary>
+    /// synchronously on its main thread, so a chunk must not get meaningfully dearer. Slow tier: main only.
+    ///
+    /// <para>A wall-clock ratio measures the scheduler as much as the code, and this one measured the
+    /// scheduler on the v2026.9.5 release gate: it read "generation 3 took 2688 ms against 144 ms" and took
+    /// the release run down, while the SAME commit passed on main with the whole test billed at 0.96 s. CPU
+    /// contention from the parallel suite, not a regression — the guard is tight in absolute terms because
+    /// generation 1 is only ~100 ms, so the 250 ms constant is the entire cushion and one preemption spends
+    /// it. Two defences, both needed: the class runs in <see cref="RealTimeSensitiveCollection"/> so no other
+    /// collection competes for the cores, and each generation is measured three times with the FASTEST run
+    /// kept. A minimum is the sample least contaminated by preemption — a stall can only inflate a run,
+    /// never shorten one — whereas a single measurement is poisoned by the first stall that lands on it.
+    /// Keep both: the sequential island alone still leaves the runner's own noise inside a 250 ms budget.</para></summary>
     [Fact]
     [Trait("Category", "Slow")]
     public void GenerationThree_ChunkCost_StaysNearGenerationOne()
@@ -381,8 +393,16 @@ public sealed class LandformGen3Tests
             return sw.ElapsedMilliseconds;
         }
 
-        long t1 = Measure(1);
-        long t3 = Measure(3);
-        Assert.True(t3 <= 1.3 * t1 + 250, $"generation 3 took {t3} ms against {t1} ms for generation 1");
+        // Interleaved so a slow patch of the runner cannot land on one generation alone, and each round
+        // builds a fresh generator, so no round is cheapened by the previous one's memos.
+        long t1 = long.MaxValue, t3 = long.MaxValue;
+        for (int round = 0; round < 3; round++)
+        {
+            t1 = Math.Min(t1, Measure(1));
+            t3 = Math.Min(t3, Measure(3));
+        }
+
+        Assert.True(t3 <= 1.3 * t1 + 250,
+            $"generation 3 took {t3} ms against {t1} ms for generation 1 (fastest of 3 rounds each)");
     }
 }


### PR DESCRIPTION
Fixes the flake that took the **v2026.9.5 release run** down on its first attempt.

## What happened

`LandformGen3Tests.GenerationThree_ChunkCost_StaysNearGenerationOne` failed the release gate with `generation 3 took 2688 ms against 144 ms for generation 1`. It was not a regression — the **same commit** passed on main minutes later:

| Run | Result | This test's duration |
|---|---|---|
| Release gate 34465901434 (1st attempt) | ❌ 2688 ms vs 144 ms | 7 s |
| main 34465875057, same commit `febcfd22` | ✅ 386/386 | **0.96 s** |

The assertion is `t3 <= 1.3 * t1 + 250`. Generation 1 measures ~100 ms, so the factor contributes ~30 ms and **the 250 ms constant is the whole cushion** — one preemption of the stopwatch thread spends it. Inside the parallel suite (4 threads on a 4-core runner) that is a coin flip.

## The fix — two defences, both needed

1. **`[Collection(RealTimeSensitiveCollection.Name)]` on the class.** No other collection runs beside it, so nothing competes for the cores while the stopwatch runs.
2. **Best of three, interleaved.** Each generation is measured three times and the **fastest** run is kept. Noise can only inflate a sample, never shorten one, so the minimum is the reading least contaminated by preemption — where a single measurement is decided by the first stall that lands on it.

The sequential island alone still leaves the runner's own noise inside a 250 ms budget, so the best-of-3 is not redundant.

## Cost, measured rather than guessed

From the trx of the green main run, the whole class is **13.6 s** across its 8 results — so moving it into the serial window costs seconds, which is exactly the case `RealTimeSensitiveCollection` documents ("These tests are fast in isolation, so the serial window costs only seconds").

**No new test class**, so `scripts/test-shard-weights*.json` and the weight-drift guard are untouched. The `Slow` tier placement stays as authored (main + release gate only) — this is about trusting the measurement, not moving coverage.

## Verification

- `dotnet build -c Release` — 0 warnings, 0 errors
- `dotnet test --filter FullyQualifiedName~.LandformGen3Tests.` — **8/8 passed in 7 s**, run on a machine sitting at >90 % CPU load, i.e. under exactly the contention that broke the old version
- `dotnet format --verify-no-changes` — clean

closes #1735

🤖 Generated with [Claude Code](https://claude.com/claude-code)