### PR TITLE
fix(worldgen,worldhost): one compile was bigger than a whole world's memory (#1740, #1741)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -72,6 +72,28 @@ here; the two that are client work (#1726 waterfall block, #1729 double doors) f
   Admins still see whichever core is nearest. The 48-block reach itself is unchanged; raising it needs a
   measurement of the flood fill first.
 
+### 🧱 One compile was bigger than a whole world's memory (#1740, #1741, 2026-09-10, branch fix/arcade-world-oom-jit)
+
+An arcade world was offline on the portal. It had in fact been dying on every start for two days — the kernel
+killed it 4–7 seconds in, `OOMKilled`, ~731 MB against the 768 MiB per-world fence, and the keep-awake pass
+restarted it every 30 s, 120 times an hour, without anything saying it was broken. The give-up guard from
+#1706 shipped that morning and finally latched it, which is how it became visible at all.
+
+- **#1740 — the JIT, not the game.** During the spike the managed heap sits at 42 MB and not one byte is
+  allocated: the memory is native, committed and released inside ~1.3 s, and `DOTNET_JITMinOpts=1` makes it
+  vanish. It is the optimizer compiling *one* method — `WorldGenerator.GetExtraBands` — and that single compile
+  costs **1.6 s and ~1.05 GB**. Measured on the same save: v2026.9.3 needed 31 ms and 14 MB; v2026.9.4, which
+  appended the three generation-3 band blocks (#1688–#1695), needed 1673 ms and 1055 MB. The blocks now live in
+  their own non-inlined `AppendGen3Bands` — 24 ms, 14 MB, and the failing world peaks at 86 MB instead of 1059.
+  A world is only exposed if its active planet carries extra bands at all, which is why the pool's other world
+  never flinched; on desktop the same compile is a 1.6 s hitch rather than a kill. Things that did not help:
+  `NoInlining` on the three helpers, on `SurfaceHeight`, on every callee, `TieredPGO=0`, `TieredCompilation=0`.
+- **#1741 — giving up must reach the picker too.** The reaper stopped restarting the dead world, but the join
+  path still offered exactly that world to the next guest as its wake-on-demand candidate. So as long as the
+  healthy world had headroom nobody noticed, and the moment it filled up, guests were sent into an instance the
+  gateway knew was dead. `PickWorldAsync` now skips given-up worlds and answers the friendly arcade-full notice
+  (#936/#941) instead; a world that comes back up is a candidate again. Two tests, both red before the fix.
+
 ### 🤔 Second batch of 2026-09-09 (#1726–#1729): seven reports, no defects — five decisions
 
 A second wave arrived the same evening, while the batch below was being fixed. Analysed against the code:

--- a/src/BlocksBeyondTheStars.WorldGeneration/WorldGenerator.Overhangs.cs
+++ b/src/BlocksBeyondTheStars.WorldGeneration/WorldGenerator.Overhangs.cs
@@ -133,6 +133,23 @@ public sealed partial class WorldGenerator
             }
         }
 
+        return AppendGen3Bands(planet, w, worldX, worldZ, bands, n);
+    }
+
+    /// <summary>The generation-3 material bands, split out of <see cref="GetExtraBands"/> and deliberately NOT
+    /// inlined back into it (#1740). Appending these three blocks to the method body pushed the JIT optimizer off
+    /// a cliff: compiling <see cref="GetExtraBands"/> went from 31 ms and 14 MB (v2026.9.3) to 1.6 s and ~1.05 GB
+    /// of transient native JIT memory (v2026.9.4, the generation-3 package #1688-#1695). That one compile is more
+    /// than a hosted world's whole 768 MiB container fence, so the kernel killed the instance seconds after start,
+    /// before anyone could join — and the keep-awake reaper restarted it every 30 s for two days. Keeping the
+    /// blocks behind their own call brings the compile back to 24 ms and 14 MB. Measured alternatives that did
+    /// NOT help: NoInlining on the three helpers themselves, on SurfaceHeight, or on every direct callee, and
+    /// DOTNET_TieredPGO=0 / DOTNET_TieredCompilation=0. The cost is in compiling the call sites inside the grown
+    /// method, so the method itself has to stay small — do not fold this back in, and add further band kinds
+    /// here rather than above.</summary>
+    [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+    private int AppendGen3Bands(PlanetType planet, WonderProfile w, int worldX, int worldZ, System.Span<ColumnBand> bands, int n)
+    {
         // Generation-3 material bands: icebergs standing in cold open water (false below generation 3).
         if (n < bands.Length && w.Icebergs && TryGetIcebergBand(planet, w, worldX, worldZ, out int ibLo, out int ibHi))
         {

--- a/src/BlocksBeyondTheStars.WorldHost/GlitchGateway.cs
+++ b/src/BlocksBeyondTheStars.WorldHost/GlitchGateway.cs
@@ -87,6 +87,12 @@ public sealed class GlitchGateway
     /// <summary>Worlds that crossed <see cref="MaxConsecutiveWakeFailures"/> and have not been reported yet.</summary>
     private readonly List<string> _givenUp = new();
 
+    /// <summary>Worlds this gateway has given up on, in a form a request thread may read (#1741). The backoff
+    /// dictionary above is plain state owned by the keep-awake pass, and a guest's join arrives on any thread —
+    /// so the give-up verdict is mirrored here rather than read from under the pass's feet. Entries leave again
+    /// when the world comes back up.</summary>
+    private readonly ConcurrentDictionary<string, byte> _givenUpOn = new(StringComparer.Ordinal);
+
     /// <summary>Guards the keep-awake pass against overlapping itself. The startup pass is fire-and-forget and
     /// a fresh pool can take a minute per world, so the 30 s reaper tick runs into it — and the backoff
     /// bookkeeping above is plain (non-concurrent) state. An overlapping tick SKIPS rather than queues: it
@@ -613,6 +619,7 @@ public sealed class GlitchGateway
             if (world.Status == WorldStatus.Running)
             {
                 _wakeBackoff.Remove(world.Id); // up again — forget the history, a later wobble starts over
+                _givenUpOn.TryRemove(world.Id, out _); // …and it may carry guests again (#1741)
                 continue;
             }
 
@@ -626,9 +633,13 @@ public sealed class GlitchGateway
             {
                 int failures = (_wakeBackoff.TryGetValue(world.Id, out var prev) ? prev.Failures : 0) + 1;
                 _wakeBackoff[world.Id] = (failures, now + WakeBackoffFor(failures));
-                if (failures == MaxConsecutiveWakeFailures)
+                if (failures >= MaxConsecutiveWakeFailures)
                 {
-                    _givenUp.Add(world.Id); // crossed the threshold on THIS pass — the reaper logs it once
+                    _givenUpOn[world.Id] = 0; // guests must not be sent there either (#1741)
+                    if (failures == MaxConsecutiveWakeFailures)
+                    {
+                        _givenUp.Add(world.Id); // crossed the threshold on THIS pass — the reaper logs it once
+                    }
                 }
             }
 
@@ -669,9 +680,7 @@ public sealed class GlitchGateway
     /// <summary>Test seam (#1706): how many consecutive failed wakes this gateway has recorded for a world,
     /// and whether it has given up on it.</summary>
     public (int Failures, bool GivenUp) WakeStateFor(string worldId)
-        => _wakeBackoff.TryGetValue(worldId, out var s)
-            ? (s.Failures, s.Failures >= MaxConsecutiveWakeFailures)
-            : (0, false);
+        => (_wakeBackoff.TryGetValue(worldId, out var s) ? s.Failures : 0, _givenUpOn.ContainsKey(worldId));
 
     /// <summary>Picks the arcade world for the next guest: a running world with player headroom first
     /// (probed live), then a sleeping one to wake on demand. Racy by design — the instance's own
@@ -695,7 +704,11 @@ public sealed class GlitchGateway
             }
         }
 
-        if (pool.FirstOrDefault(w => w.Status != WorldStatus.Running) is { } sleeping)
+        // …but never a world the keep-awake pass has given up on (#1741). The reaper stops RESTARTING such a
+        // world; before this, the picker still handed it to the next guest as its wake-on-demand candidate, so
+        // as soon as the healthy world filled up, guests were routed into an instance the gateway already knew
+        // was dead. They get the friendly full notice instead, which at least tells them something true.
+        if (pool.FirstOrDefault(w => w.Status != WorldStatus.Running && !_givenUpOn.ContainsKey(w.Id)) is { } sleeping)
         {
             return (sleeping, string.Empty);
         }

--- a/tests/BlocksBeyondTheStars.Tests/GlitchGatewayTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/GlitchGatewayTests.cs
@@ -698,6 +698,106 @@ public sealed class GlitchGatewayTests : IDisposable
         Assert.False(gateway.WakeStateFor(worldId).GivenUp);
     }
 
+    /// <summary>#1741: giving up must reach the picker too. The reaper stopped restarting a world that never
+    /// survives its wake, but the join path still offered exactly that world to the next guest — so the moment
+    /// the healthy world filled up, guests were sent into an instance the gateway knew was dead.</summary>
+    [Fact]
+    public async Task Session_SkipsAGivenUpWorld_AndTakesTheHealthySleepingOneAsync()
+    {
+        var (gateway, registry, orchestrator, launcher, tick) = NewFlappingPool(worldCount: 2);
+
+        await tick(); // both arcade worlds created and woken
+        var pool = registry.ListWorldsByChannel(WorldChannel.Glitch);
+        string sick = pool[0].Id, healthy = pool[1].Id;
+        await GiveUpOnAsync(gateway, sick, tick);
+        Assert.True(gateway.WakeStateFor(sick).GivenUp);
+        Assert.False(gateway.WakeStateFor(healthy).GivenUp);
+
+        // Send the healthy world to sleep as well, so both are candidates for a wake-on-demand pick.
+        launcher.Running.Remove(registry.GetWorld(healthy)!.ContainerId!);
+        orchestrator.Reap();
+
+        var result = await gateway.SessionAsync(Install);
+
+        Assert.True(result.Ok, result.Error);
+        Assert.Equal(healthy, result.WorldId);
+    }
+
+    /// <summary>#1741: with nothing left to offer, the guest gets the friendly full answer the client already
+    /// renders (#936/#941) — not a token for a world that dies under them.</summary>
+    [Fact]
+    public async Task Session_ReportsFull_WhenEveryPoolWorldIsGivenUpOnAsync()
+    {
+        var (gateway, registry, _, _, tick) = NewFlappingPool(worldCount: 1);
+
+        await tick();
+        string worldId = registry.ListWorldsByChannel(WorldChannel.Glitch).Single().Id;
+        await GiveUpOnAsync(gateway, worldId, tick);
+
+        var result = await gateway.SessionAsync(Install);
+
+        Assert.False(result.Ok);
+        Assert.Equal("All arcade worlds are full right now — please try again in a few minutes.", result.Error);
+    }
+
+    /// <summary>A pool whose worlds start fine and are dead again by the next pass — the shape of an instance
+    /// killed seconds after startup. <c>tick</c> runs one keep-awake pass and then lets the reaper see the
+    /// corpses; the world named in <c>dead</c> never comes up, whatever the launcher says.</summary>
+    private (GlitchGateway Gateway, HostRegistry Registry, WorldOrchestrator Orchestrator, FakeLauncher Launcher, Func<Task> Tick)
+        NewFlappingPool(int worldCount)
+    {
+        var config = NewConfig();
+        config.GlitchWorldCount = worldCount;
+        var registry = NewRegistry(config);
+        var launcher = new FakeLauncher();
+        var orchestrator = new WorldOrchestrator(config, registry, launcher,
+            w => Task.FromResult(launcher.IsRunning(w.ContainerId)));
+        var gateway = new GlitchGateway(config, registry, orchestrator, new FakeGlitchApi(),
+            statusReader: _ => Task.FromResult<string?>(null), utcNow: () => _clock);
+        _dead = new HashSet<string>(StringComparer.Ordinal);
+
+        // The wake itself always succeeds — the container starts and reports healthy — and the world named dead
+        // is a corpse by the time the next pass looks. That is what an instance killed seconds after startup
+        // looks like to the control plane, and the only thing the failure accounting can key on.
+        async Task TickAsync()
+        {
+            await gateway.WakePoolAsync();
+            foreach (string id in _dead!)
+            {
+                if (registry.GetWorld(id)?.ContainerId is { } container)
+                {
+                    launcher.Running.Remove(container);
+                }
+            }
+
+            orchestrator.Reap();
+        }
+
+        return (gateway, registry, orchestrator, launcher, TickAsync);
+    }
+
+    /// <summary>Walks a world through <see cref="GlitchGateway.MaxConsecutiveWakeFailures"/> wakes that do not
+    /// stick, stepping the clock past each backoff window, until the gateway gives up on it.</summary>
+    private async Task GiveUpOnAsync(GlitchGateway gateway, string worldId, Func<Task> tick)
+    {
+        _dead!.Add(worldId);
+        for (int pass = 0; pass < GlitchGateway.MaxConsecutiveWakeFailures * 3; pass++)
+        {
+            if (gateway.WakeStateFor(worldId).GivenUp)
+            {
+                return;
+            }
+
+            _clock += TimeSpan.FromMinutes(31); // past the 30 min backoff ceiling
+            await tick();
+        }
+
+        Assert.Fail($"world {worldId} was never given up on");
+    }
+
+    private DateTimeOffset _clock = new(2026, 9, 10, 12, 0, 0, TimeSpan.Zero);
+    private HashSet<string>? _dead;
+
     public void Dispose()
     {
         foreach (var registry in _registries)


### PR DESCRIPTION
An arcade world sat offline on the portal. It had in fact been dying on every start for two days: the kernel killed it 4-7 seconds in (`OOMKilled`, ~731 MB against the 768 MiB per-world fence) while the keep-awake pass restarted it every 30 s — 120 times an hour, ~4 600 kills in total — with nothing anywhere saying it was broken. The give-up guard from #1706 shipped that morning, latched it, and that is the only reason it became visible.

## #1740 — it is the JIT, not the game

During the spike the managed heap sits at 42 MB and not one byte is allocated; the memory is native, committed and released inside ~1.3 s, and `DOTNET_JITMinOpts=1` makes it vanish. The optimizer is compiling **one** method — `WorldGenerator.GetExtraBands` — and that single compile costs **1.6 s and ~1.05 GB**, more than the whole container is allowed.

Same save, same `PrepareMethod` probe:

| build | GetExtraBands JIT | peak private bytes during compile |
|---|---|---|
| v2026.9.3 | 31 ms | 14 MB |
| v2026.9.4 | 1673 ms | 1055 MB |
| v2026.9.5 | 1648 ms | 1065 MB |

v2026.9.4 is where the generation-3 package (#1688-#1695) appended three band blocks to the method. They now live in their own non-inlined `AppendGen3Bands`: **24 ms, 14 MB**, no method in the WorldGeneration assembly above 150 ms or 200 MB, and the failing world peaks at **86 MB instead of 1059** when run against its real save.

Only a world whose active planet carries extra bands ever pays this, which is why the pool's other world never flinched (82 MB) even though it is the bigger save. On desktop the same compile is a ~1.6 s hitch rather than a kill; WebGL is AOT and unaffected.

Measured and rejected: `NoInlining` on the three generation-3 helpers, on `SurfaceHeight`, on every direct callee, `DOTNET_TieredPGO=0`, `DOTNET_TieredCompilation=0`. The cost is in compiling the call sites inside the grown method, so the method has to stay small — hence the comment telling the next person not to fold it back in.

## #1741 — giving up has to reach the picker too

The reaper stopped restarting the dead world, but `PickWorldAsync` still offered exactly that world to the next guest as its wake-on-demand candidate. While the healthy world had headroom nobody noticed; the moment it filled up, guests were routed into an instance the gateway knew was dead. The picker now skips given-up worlds and answers the arcade-full notice the client already renders (#936/#941); a world that comes back up is a candidate again. The verdict is mirrored into a concurrent set because the backoff bookkeeping belongs to the keep-awake pass while a join arrives on any thread.

## Verification

- `GlitchGatewayTests`: 34/34 green, including two new tests — both confirmed red with the picker line reverted.
- Solution builds with 0 warnings; `dotnet format --verify-no-changes` clean.
- End-to-end: the production save of the failing world on this build peaks at 86 MB inside the 768 MiB budget.
- Operationally the fleet's per-world fence was raised to 1536m as an interim measure; it can go back to 768m once this ships.

closes #1740
closes #1741

🤖 Generated with [Claude Code](https://claude.com/claude-code)