### PR TITLE
fix(worldgen): the gaming planet is gaming gear, not meadow (#1762)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -24,6 +24,15 @@ envelope at the WebSocket edge; deterministic seed world-gen; SQLite default per
 
 ---
 
+### 🖥️ The gaming planet is gaming gear, not meadow (#1762 follow-up, 2026-09-11, branch fix/gaming-world-more-pcs)
+
+Marcel's playtest: "zu viel Natur", and Ben's first wish — structures shaped like gaming PCs — was missing,
+and everything was rare. `gamer_hills` cuts flora to 0.03 and trees to 0.0015; a fourth landmark row
+`giant-pc` (a 20–26 × 14–18 box 44–59 tall: PC case, a tempered-glass side panel, a glowing RGB strip up the
+front) joins the monitor, keyboard and mouse; the hotspot cells shrink from 2 400 blocks at 60 % to 720 at
+90 %, so each family shows several times per world; a house-sized `pc-tower` prop (2 × 2 × 5–7, monitor strip
+on top) fills the ground between them. Generation 5 only; the `gamer_hills-gen5` golden is re-pinned.
+
 ### 🏝️ The rainbow planet's islands float on the sea (#1757 follow-up, 2026-09-11, branch fix/rainbow-islands-afloat)
 
 Marcel's first playtest of the school club wave: he spawned on land, the islands hung in the sky, the water

--- a/data/planets.json
+++ b/data/planets.json
@@ -804,13 +804,13 @@
     "terrainStyles": ["downs", "flats"],
     "surfaceBlock": "grass", "subSurfaceBlock": "dirt", "deepBlock": "stone", "surfaceDepth": 4,
     "caveThreshold": 0.55, "dataCacheRarity": 0.002,
-    "weather": "dynamic", "stormChance": 0.3, "dayLengthSeconds": 600, "worldRadius": 880, "floraDensity": 0.16, "treeDensity": 0.012, "creatureAbundance": "few", "atmosphere": "breathable", "spawnWeight": 5, "waterAbundance": 0.4,
+    "weather": "dynamic", "stormChance": 0.3, "dayLengthSeconds": 600, "worldRadius": 880, "floraDensity": 0.03, "treeDensity": 0.0015, "creatureAbundance": "few", "atmosphere": "breathable", "spawnWeight": 5, "waterAbundance": 0.4,
     "weatherVolatility": 0.9, "seasonAmplitude": 0.3,
     "weatherEvents": { "drizzle": 1.2, "fog": 1.0 },
     "biomes": [
-      { "surfaceBlock": "grass", "subSurfaceBlock": "dirt", "floraDensityMul": 1.2 },
-      { "surfaceBlock": "dirt",  "subSurfaceBlock": "dirt", "floraDensityMul": 0.8, "treeDensityMul": 0.5 },
-      { "surfaceBlock": "grass", "subSurfaceBlock": "dirt", "floraTheme": "savanna", "floraDensityMul": 1.0, "treeDensityMul": 0.7 }
+      { "surfaceBlock": "grass", "subSurfaceBlock": "dirt", "floraDensityMul": 0.8 },
+      { "surfaceBlock": "dirt",  "subSurfaceBlock": "dirt", "floraDensityMul": 0.4, "treeDensityMul": 0.3 },
+      { "surfaceBlock": "grass", "subSurfaceBlock": "dirt", "floraTheme": "savanna", "floraDensityMul": 0.6, "treeDensityMul": 0.5 }
     ],
     "ores": [
       { "block": "iron_ore",   "rarity": 0.06, "minDepth": 4, "maxDepth": 2048 },

--- a/docs/developer/WORLD_GENERATION.md
+++ b/docs/developer/WORLD_GENERATION.md
@@ -1259,9 +1259,13 @@ player is told (`srv.flowerling.gift`).
 twice; `gaming_pc/monitor/keyboard/mouse` placeable but never craftable; `paul_stem/leaf/petals` with fixed
 colours outside the flora tint; `flora_sunblossom`, `flora_tulip`, `flora_hangkelp`). Eight prop rows at the
 table's tail (`scrap-heap`, `wreck-hull`, `girder` on the scrap tag; the same three as `stray-*` on every
-other solid-ground world at a fortieth of the density; `desk-setup`, `pc-heap` on the gaming tag). The Paul
-flower is the `giant-paul` row of `GiantFloraKinds` (stem 6–10, four leaf slabs, a petal crown; generation 5).
-The gaming landmarks are three `LandmarkKinds` rows in `WorldGenerator.SchoolWaveGen5.cs` (`giant-monitor`
-slab 52–82 × 36–43, `giant-keyboard` plateau with key bumps, `giant-mouse` dome with a cable ridge), hotspot
-cells of 2 400 blocks, painted with the gaming blocks down to the ground. The atlas is **32 × 32** tiles
+other solid-ground world at a fortieth of the density; `desk-setup`, `pc-heap`, `pc-tower` on the gaming tag).
+The Paul flower is the `giant-paul` row of `GiantFloraKinds` (stem 6–10, four leaf slabs, a petal crown;
+generation 5). The gaming landmarks are four `LandmarkKinds` rows in `WorldGenerator.SchoolWaveGen5.cs`
+(`giant-monitor` slab 52–82 × 36–43, `giant-keyboard` plateau with key bumps, `giant-mouse` dome with a cable
+ridge, `giant-pc` box 20–26 × 14–18 × 44–59 with a glass side panel and a glowing RGB strip), painted with the
+gaming blocks down to the ground. Marcel's playtest (2026-09-11, "zu viel Natur … Gaming-PCs, und das oft")
+moved the hotspot cells from 2 400 blocks at 60 % to **720 blocks at 90 %** — several of each family per
+world — added the tower row and the house-sized `pc-tower` prop, and cut the type's flora to 0.03 / trees
+to 0.0015. The atlas is **32 × 32** tiles
 (`BlockTextureAtlas.Cols/Rows`, `GameContent.AtlasTileCapacity = 1024`).

--- a/src/BlocksBeyondTheStars.WorldGeneration/WorldGenerator.SchoolWaveGen5.cs
+++ b/src/BlocksBeyondTheStars.WorldGeneration/WorldGenerator.SchoolWaveGen5.cs
@@ -148,13 +148,35 @@ public sealed partial class WorldGenerator
         }
     }
 
+    /// <summary>A PC tower (Marcel's playtest 2026-09-11): a 2 × 2 case 5–7 high standing on the hill, the top two cells of
+    /// its front a glowing monitor strip — the house-sized step between the desk props and the mountain-sized tower.</summary>
+    private static void StampPcTower(PropStamp s)
+    {
+        var rgb = s.Secondary.IsAir ? s.Material : s.Secondary;
+        int height = 5 + s.ShapeHash % 3;
+        for (int dx = 0; dx <= 1; dx++)
+            for (int dz = 0; dz <= 1; dz++)
+            {
+                int py = s.Generator.SurfaceHeight(s.Planet, s.Wx + dx, s.Wz + dz);
+                for (int dy = 1; dy <= height; dy++)
+                {
+                    bool strip = dx == 0 && dz == 0 && dy >= height - 1;
+                    s.Set(s.Wx + dx, py + dy, s.Wz + dz, strip ? rgb : s.Material);
+                }
+            }
+    }
+
     // ---------------- gaming landmarks (#1762): a monitor, a keyboard and a mouse the size of mountains ----------------
 
     private const long GiantMonitorSalt = 0x6A3E10;
     private const long GiantKeyboardSalt = 0x6A3E20;
     private const long GiantMouseSalt = 0x6A3E30;
-    private const double GamingCellSize = 2400.0; // ≈ 2–3 candidate cells on a default world → about one of each
-    private const double GamingChance = 0.6;
+    private const long GiantPcSalt = 0x6A3E40;
+    // Marcel's playtest 2026-09-11 ("und das oft"): one candidate per 720-block cell at 90 % — every family shows up
+    // several times per world instead of about once (was 2 400 / 60 %), and the four families' grids are offset by
+    // their salts, so a walk of a few hundred blocks passes a monitor, a keyboard, a mouse or a tower.
+    private const double GamingCellSize = 720.0;
+    private const double GamingChance = 0.9;
     private const double GamingMargin = 72.0;     // the widest extent (the keyboard's 40 + its cable) plus slack
 
     /// <summary>The gaming landmarks grow on generation-5 worlds carrying the <c>gaming</c> tag — solid ground, never
@@ -268,6 +290,59 @@ public sealed partial class WorldGenerator
         }
 
         return 0.0;
+    }
+
+    /// <summary>The giant PC tower (Marcel's playtest 2026-09-11: "Landschaftsstrukturen, die aussehen wie Gaming-PCs"):
+    /// a 20–26 × 14–18 box 44–59 tall. Its +X side is a tempered-glass panel, the front (−Z) carries a two-wide
+    /// vertical RGB strip of monitor blocks (they glow), the rest is the PC case.</summary>
+    private double GiantPcOffset(WonderProfile w, int worldX, int worldZ)
+    {
+        if (!TryGetHotspot(w.Seed ^ GiantPcSalt, GamingCellSize, GamingChance, GamingMargin, worldX, worldZ, out ulong h, out double dx, out double dz))
+        {
+            return 0.0;
+        }
+
+        double halfX = 10.0 + ((h >> 16) & 0x3), halfZ = 7.0 + ((h >> 18) & 0x3);
+        if (System.Math.Abs(dx) > halfX || System.Math.Abs(dz) > halfZ)
+        {
+            return 0.0;
+        }
+
+        return 44.0 + ((h >> 20) & 0xF);             // 44..59 tall
+    }
+
+    private BlockId? GiantPcPaint(WonderProfile w, int worldX, int worldZ, int surfaceY, out int fillToY)
+    {
+        fillToY = int.MinValue;
+        double rise = GiantPcOffset(w, worldX, worldZ);
+        if (rise <= 0.0)
+        {
+            return null;
+        }
+
+        var pc = _content.GetBlock("gaming_pc")?.NumericId ?? BlockId.Air;
+        if (pc.IsAir)
+        {
+            return null;
+        }
+
+        // The same hotspot again for the column's place on the box (the offset only says "inside").
+        TryGetHotspot(w.Seed ^ GiantPcSalt, GamingCellSize, GamingChance, GamingMargin, worldX, worldZ, out ulong h, out double dx, out double dz);
+        double halfX = 10.0 + ((h >> 16) & 0x3), halfZ = 7.0 + ((h >> 18) & 0x3);
+        var glass = _content.GetBlock("glass")?.NumericId ?? BlockId.Air;
+        var rgb = _content.GetBlock("gaming_monitor")?.NumericId ?? BlockId.Air;
+        fillToY = surfaceY - (int)rise;
+        if (!glass.IsAir && dx > halfX - 1.0 && System.Math.Abs(dz) < halfZ - 1.0)
+        {
+            return glass;                            // the side panel
+        }
+
+        if (!rgb.IsAir && dz < -halfZ + 1.0 && System.Math.Abs(dx) < 1.0)
+        {
+            return rgb;                              // the front's RGB strip
+        }
+
+        return pc;
     }
 
     private BlockId? GiantMousePaint(WonderProfile w, int worldX, int worldZ, int surfaceY, out int fillToY)

--- a/src/BlocksBeyondTheStars.WorldGeneration/WorldGenerator.Stamps.cs
+++ b/src/BlocksBeyondTheStars.WorldGeneration/WorldGenerator.Stamps.cs
@@ -122,6 +122,8 @@ public sealed partial class WorldGenerator
         new("stray-girder", 0x5C2A6, 157, 0.00015, PropMaterial.Boulder, StampGirder, PropStrayScrap, "scrap_metal", "scrap_pile"),
         new("desk-setup", 0x6A3E1, 163, 0.006, PropMaterial.Boulder, StampDeskSetup, PropGaming, "gaming_pc", "gaming_monitor"),
         new("pc-heap", 0x6A3E2, 167, 0.008, PropMaterial.Boulder, StampPcHeap, PropGaming, "gaming_pc", "gaming_keyboard"),
+        // Marcel's playtest 2026-09-11 ("Strukturen, die aussehen wie Gaming-PCs, und das oft"): house-sized PC towers.
+        new("pc-tower", 0x6A3E3, 173, 0.0025, PropMaterial.Boulder, StampPcTower, PropGaming, "gaming_pc", "gaming_monitor"),
     };
 
     /// <summary>The prop rows active on this world (tests): the classic rows whose material exists here, plus

--- a/src/BlocksBeyondTheStars.WorldGeneration/WorldGenerator.cs
+++ b/src/BlocksBeyondTheStars.WorldGeneration/WorldGenerator.cs
@@ -605,6 +605,9 @@ public sealed partial class WorldGenerator
             static (WorldGenerator g, PlanetType p, WonderProfile w, int x, int z, int y, out int fill) => g.GiantKeyboardPaint(w, x, z, y, out fill)),
         new("giant-mouse", w => w.GamingLandmarks, static (g, p, w, x, z) => g.GiantMouseOffset(w, x, z),
             static (WorldGenerator g, PlanetType p, WonderProfile w, int x, int z, int y, out int fill) => g.GiantMousePaint(w, x, z, y, out fill)),
+        // Marcel's playtest 2026-09-11: the PC tower itself, the structure Ben named first.
+        new("giant-pc", w => w.GamingLandmarks, static (g, p, w, x, z) => g.GiantPcOffset(w, x, z),
+            static (WorldGenerator g, PlanetType p, WonderProfile w, int x, int z, int y, out int fill) => g.GiantPcPaint(w, x, z, y, out fill)),
     };
 
     /// <summary>The landmark families active on this world in precedence order (tests).</summary>

--- a/tests/BlocksBeyondTheStars.Tests/LandscapeLandmarksTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/LandscapeLandmarksTests.cs
@@ -137,9 +137,10 @@ public sealed class LandscapeLandmarksTests
         Assert.Contains("giant-monitor", order);
         Assert.Contains("giant-keyboard", order);
         Assert.Contains("giant-mouse", order);
+        Assert.Contains("giant-pc", order);
         Assert.DoesNotContain("giant-monitor", Gen(1, 5).LandmarkOrderForTest(Content.Planets["meadowlands"]));
 
-        foreach (var (row, maxRise) in new[] { ("giant-monitor", 43.0), ("giant-keyboard", 8.0), ("giant-mouse", 16.0) })
+        foreach (var (row, maxRise) in new[] { ("giant-monitor", 43.0), ("giant-keyboard", 8.0), ("giant-mouse", 16.0), ("giant-pc", 59.0) })
         {
             (double Min, double Max, int Hits) scan = default;
             WorldGenerator? found = null;
@@ -165,7 +166,7 @@ public sealed class LandscapeLandmarksTests
         // #1761 / #1762: the scrap and gaming rows sit at the table's tail (precedence untouched); the scrap
         // planet gets its dense rows, every other solid-ground world the stray ones, and generation 4 none at all.
         var order = WorldGenerator.PropOrderForTest();
-        var tail = new[] { "scrap-heap", "wreck-hull", "girder", "stray-scrap-heap", "stray-wreck-hull", "stray-girder", "desk-setup", "pc-heap" };
+        var tail = new[] { "scrap-heap", "wreck-hull", "girder", "stray-scrap-heap", "stray-wreck-hull", "stray-girder", "desk-setup", "pc-heap", "pc-tower" };
         Assert.Equal(tail, order.Skip(order.Length - tail.Length).ToArray());
 
         var scrap = Gen(1, 5).PropActiveForTest(Content.Planets["scrapyard"], false, true);
@@ -185,6 +186,7 @@ public sealed class LandscapeLandmarksTests
         var gamer = Gen(1, 5).PropActiveForTest(Content.Planets["gamer_hills"], false, false);
         Assert.Contains("desk-setup", gamer);
         Assert.Contains("pc-heap", gamer);
+        Assert.Contains("pc-tower", gamer);
         Assert.Contains("stray-scrap-heap", gamer);
     }
 

--- a/tests/BlocksBeyondTheStars.Tests/WorldGenerationGoldenTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/WorldGenerationGoldenTests.cs
@@ -167,7 +167,7 @@ public sealed class WorldGenerationGoldenTests
             ["rainbow_sea-gen5"] = 0xecea3d3d9016ba55UL, // re-pinned 2026-09-11: islands afloat on the sea (#1757)
             ["flower_fields-gen5"] = 0xe2e2a978c783cfbfUL,
             ["scrapyard-gen5"] = 0x7710a0c97aa3539aUL,
-            ["gamer_hills-gen5"] = 0x7ac9750465c7fd67UL,
+            ["gamer_hills-gen5"] = 0xff174bd31c1655e3UL, // re-pinned 2026-09-11: less nature, more gaming gear (#1762)
             ["meadowlands-gen5"] = 0x6a1d26df3784c73cUL,
         },
         // Linux (ubuntu CI runners): filled in from the first CI run of this test; a group absent here falls


### PR DESCRIPTION
## What

Marcel's playtest of the gaming planet (#1762): "zu viel Natur", and Ben's first wish — landscape structures shaped like gaming PCs — was missing; the monitor, keyboard and mouse showed up about once per world.

- **Less nature.** `gamer_hills` flora 0.16 → 0.03, trees 0.012 → 0.0015, biome multipliers down.
- **The PC tower.** A fourth `LandmarkKinds` row `giant-pc`: a 20–26 × 14–18 box 44–59 tall — PC case, a tempered-glass side panel on +X, a two-wide glowing RGB strip (monitor blocks) up the front.
- **Often.** The hotspot cells of all four gaming families shrink from 2 400 blocks at 60 % to **720 at 90 %**; the four grids are offset by their salts, so a walk of a few hundred blocks passes a monitor, a keyboard, a mouse or a tower.
- **House-sized towers in between.** New prop row `pc-tower` (2 × 2 × 5–7, monitor strip on top) at 0.0025 per column.

Generation 5 only; the `gamer_hills-gen5` golden is re-pinned, no other golden moved. Docs: WORLD_GENERATION.md §15, TODO.md.

## Tests

- `GamingLandmarks_…` covers `giant-pc` (present on generation 5, rise ≤ 59, never digs in).
- `Gen5PropRows_…` covers `pc-tower` at the table's tail and on the gaming tag.
- Landscape + Golden + Content + Flora classes: 160 green; `dotnet format` clean.

## Verification

Local build + `scripts/make-test-world.ps1 -Planet gamer_hills -Force` for Marcel's next look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
