### PR TITLE
feat(worldgen,client): water in different colours per world, and rain to match (#1758)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -24,6 +24,17 @@ envelope at the WebSocket edge; deterministic seed world-gen; SQLite default per
 
 ---
 
+### 💧 Water in different colours, and rain to match (#1758 follow-up, 2026-09-11, branch feat/water-colours-auto)
+
+The children's "water in different colours per world" was built but switched on nowhere but the rainbow
+planet. Every type with a real water sea and an atmosphere (25 types; not the dry, lava or airless bodies)
+now carries `waterTint: "auto"` — a seeded, blue-dominant pick per world. `FluidTints.ForWorld` takes the
+save's terrain generation, so a pre-generation-5 save keeps the classic blue (the colour is computed at
+runtime, not baked). Marcel: "bedenke dabei auch die Farbe des Regens" — `WaterColours.cs` blends the 3D
+drops of rain, drizzle and sleet, the visor's beads, streaks and wet wash, and the underwater wash toward the
+world's colour; rainbow rain cycles through the hues. Tests: every water-sea type opts in and no other does,
+old saves stay blue, the palette rolls more than one family with blue the most common.
+
 ### ✏️ Sophie, not Sophia (2026-09-11, branch docs/sophie)
 
 Marcel: the rainbow planet's inventor is **Sophie**. Renamed in the credits and the rainbow planet description

--- a/client/Assets/BlocksBeyondTheStars/Scripts/WaterColours.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/WaterColours.cs
@@ -1,0 +1,56 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using BlocksBeyondTheStars.Networking.Messages;
+using UnityEngine;
+
+namespace BlocksBeyondTheStars.Client
+{
+    /// <summary>
+    /// The world's water colour for everything that is water but not the sea (#1758, Marcel 2026-09-11: "bedenke
+    /// dabei auch die Farbe des Regens"): the rain drops, the rain beads and streaks on the visor, the wash while
+    /// swimming. The shader recolours the sea from the same two environment fields; this is the C# side of it.
+    /// Mode 0 (every classic world) returns the caller's own colour untouched, so nothing old changes.
+    /// </summary>
+    internal static class WaterColours
+    {
+        /// <summary>True when this world's water is not the classic blue.</summary>
+        public static bool Tinted(WorldEnvironment env) => env != null && env.WaterTintMode > 0;
+
+        /// <summary>The world's water colour at this moment: the fixed tint in mode 1; in mode 2 (the rainbow planet,
+        /// whose sea carries static bands by position) a hue that cycles slowly with time, so rainbow rain falls
+        /// in every colour in turn.</summary>
+        public static Color Tint(WorldEnvironment env, float time)
+        {
+            if (env == null || env.WaterTintMode <= 0)
+            {
+                return new Color(0.20f, 0.42f, 0.85f); // the classic water blue
+            }
+
+            if (env.WaterTintMode >= 2)
+            {
+                return Color.HSVToRGB(Mathf.Repeat(time / 14f, 1f), 0.85f, 1f);
+            }
+
+            int rgb = env.WaterTint;
+            return new Color(((rgb >> 16) & 0xFF) / 255f, ((rgb >> 8) & 0xFF) / 255f, (rgb & 0xFF) / 255f);
+        }
+
+        /// <summary>Pulls <paramref name="baseColor"/> (a rain drop, a bead, a wash) toward the world's water colour by
+        /// <paramref name="amount"/>, keeping its alpha and its paleness: the tint is first lightened toward white so
+        /// a violet sea gives lilac rain, not purple paint. Classic worlds get <paramref name="baseColor"/> back.</summary>
+        public static Color Blend(Color baseColor, WorldEnvironment env, float amount, float time)
+        {
+            if (!Tinted(env))
+            {
+                return baseColor;
+            }
+
+            float lum = 0.299f * baseColor.r + 0.587f * baseColor.g + 0.114f * baseColor.b;
+            var pale = Color.Lerp(Tint(env, time), Color.white, Mathf.Clamp01(lum * 0.6f));
+            var mixed = Color.Lerp(baseColor, pale, amount);
+            mixed.a = baseColor.a;
+            return mixed;
+        }
+    }
+}

--- a/client/Assets/BlocksBeyondTheStars/Scripts/WaterColours.cs.meta
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/WaterColours.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 646d583712b45f542a1c8785ba410e7b

--- a/client/Assets/BlocksBeyondTheStars/Scripts/WeatherFx.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/WeatherFx.cs
@@ -385,7 +385,8 @@ namespace BlocksBeyondTheStars.Client
             {
                 GUI.depth = 10;
                 var prevWater = GUI.color;
-                GUI.color = new Color(0.15f, 0.40f, 0.62f, 0.34f * _underwater);
+                // #1758: the wash takes the world's water colour — swimming in a green sea looks green.
+                GUI.color = WaterColours.Blend(new Color(0.15f, 0.40f, 0.62f, 0.34f * _underwater), Game.Environment, 0.8f, Time.time);
                 GUI.DrawTexture(new Rect(0, 0, Screen.width, Screen.height), Texture2D.whiteTexture);
                 GUI.color = prevWater;
             }
@@ -416,7 +417,7 @@ namespace BlocksBeyondTheStars.Client
                     if (_dtrail[i] > 0.002f)
                     {
                         float tp = _dtrail[i] * h;
-                        GUI.color = new Color(0.6f, 0.7f, 0.85f, a * 0.22f);
+                        GUI.color = WaterColours.Blend(new Color(0.6f, 0.7f, 0.85f, a * 0.22f), Game.Environment, 0.7f, Time.time); // #1758
                         GUI.DrawTexture(new Rect(x - s * 0.18f, y - tp, s * 0.36f, tp), Texture2D.whiteTexture);
                     }
 
@@ -457,7 +458,7 @@ namespace BlocksBeyondTheStars.Client
                     "ash" => new Color(0.30f, 0.22f, 0.18f),
                     "sandstorm" => new Color(0.74f, 0.62f, 0.40f),
                     "snow" or "hail" => new Color(0.72f, 0.78f, 0.84f),
-                    _ => new Color(0.42f, 0.52f, 0.62f),
+                    _ => WaterColours.Blend(new Color(0.42f, 0.52f, 0.62f), env, 0.5f, t), // #1758: wet air in the water's colour
                 };
                 float washStrength = precip == "sandstorm" ? 0.22f : 0.05f;
                 GUI.color = new Color(wash.r, wash.g, wash.b, washStrength + env.Intensity * 0.07f);
@@ -470,7 +471,7 @@ namespace BlocksBeyondTheStars.Client
                     int count = Mathf.RoundToInt(Max * Mathf.Clamp01(0.45f + env.Intensity * 0.55f));
                     float speedBoost = env.Weather == "storm" ? 1.5f : 1f;
                     float slant = env.Weather == "storm" ? 12f : 5f;
-                    GUI.color = new Color(0.62f, 0.78f, 1f, 0.42f);
+                    GUI.color = WaterColours.Blend(new Color(0.62f, 0.78f, 1f, 0.42f), env, 0.75f, t); // #1758: rain in the world's water colour
                     for (int i = 0; i < count; i++)
                     {
                         float y = ((_phase[i] + t * _speed[i] * speedBoost) % 1f) * (h + 40f) - 20f;

--- a/client/Assets/BlocksBeyondTheStars/Scripts/WeatherFx3D.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/WeatherFx3D.cs
@@ -139,7 +139,10 @@ namespace BlocksBeyondTheStars.Client
                 Debug.Log($"[Weather3D] precipitation '{precip}' (weather {env.Weather}, intensity {env.Intensity:0.00}, exposed {Game?.ExposedToSky})");
             }
 
-            Color drop = ShaderColor.Srgb(s.Color);
+            // #1758: WATER precipitation takes the world's water colour (rain, drizzle, sleet); snow, hail, ash, sand,
+            // acid, meteors and spores keep their own look. A rainbow world's rain cycles through the colours.
+            Color styled = precip is "rain" or "drizzle" or "sleet" ? WaterColours.Blend(s.Color, env, 0.75f, Time.time) : s.Color;
+            Color drop = ShaderColor.Srgb(styled);
             if (_mat.color != drop) { _mat.color = drop; } // all drops share one material → one precip form at a time
             // Intensity comes from the SMOOTHED client value (#900), so an episode's swell and fade shows
             // as a ramp in the drop count rather than a 5 s staircase.

--- a/data/planets.json
+++ b/data/planets.json
@@ -1,6 +1,6 @@
 [
   {
-    "key": "rocky", "baseTemperature": 12, "nameKey": "planet.rocky.name", "atmosphereHeight": 190, "cloudColor": 15593458, "cloudDensity": 0.35,
+    "key": "rocky", "waterTint": "auto", "baseTemperature": 12, "nameKey": "planet.rocky.name", "atmosphereHeight": 190, "cloudColor": 15593458, "cloudDensity": 0.35,
     "terrainTags": ["buttes", "hoodoos", "inselbergs"],
     "baseHeight": 64, "amplitude": 14, "terrainScale": 48.0, "terrainStyle": "mesa",
     "terrainStyles": ["mesa", "hills", "canyons", "downs"],
@@ -23,7 +23,7 @@
     ]
   },
   {
-    "key": "ice", "floraTheme": "tundra", "baseTemperature": -38, "nameKey": "planet.ice.name", "atmosphereHeight": 200, "cloudColor": 14478069, "cloudDensity": 0.5,
+    "key": "ice", "waterTint": "auto", "floraTheme": "tundra", "baseTemperature": -38, "nameKey": "planet.ice.name", "atmosphereHeight": 200, "cloudColor": 14478069, "cloudDensity": 0.5,
     "terrainTags": ["glacial"],
     "baseHeight": 60, "amplitude": 10, "terrainScale": 56.0,
     "terrainStyles": ["hills", "flats", "glacial"],
@@ -94,7 +94,7 @@
     ]
   },
   {
-    "key": "jungle", "floraTheme": "tropical", "baseTemperature": 28, "nameKey": "planet.jungle.name", "atmosphereHeight": 240, "cloudColor": 15922422, "cloudDensity": 0.6,
+    "key": "jungle", "waterTint": "auto", "floraTheme": "tropical", "baseTemperature": 28, "nameKey": "planet.jungle.name", "atmosphereHeight": 240, "cloudColor": 15922422, "cloudDensity": 0.6,
     "terrainTags": ["wetland", "karst", "reef"],
     "baseHeight": 66, "amplitude": 16, "terrainScale": 44.0,
     "terrainStyles": ["hills", "karst", "downs", "stone-forest"],
@@ -139,7 +139,7 @@
     ]
   },
   {
-    "key": "swamp", "floraTheme": "swamp", "baseTemperature": 22, "nameKey": "planet.swamp.name", "atmosphereHeight": 230, "cloudColor": 13159360, "cloudDensity": 0.75,
+    "key": "swamp", "waterTint": "auto", "floraTheme": "swamp", "baseTemperature": 22, "nameKey": "planet.swamp.name", "atmosphereHeight": 230, "cloudColor": 13159360, "cloudDensity": 0.75,
     "terrainTags": ["wetland"],
     "baseHeight": 58, "amplitude": 8, "terrainScale": 52.0, "terrainStyle": "flats",
     "terrainStyles": ["flats", "downs"],
@@ -159,7 +159,7 @@
     ]
   },
   {
-    "key": "varied", "floraTheme": "temperate", "baseTemperature": 16, "nameKey": "planet.varied.name", "atmosphereHeight": 240, "cloudColor": 15725044, "cloudDensity": 0.5,
+    "key": "varied", "waterTint": "auto", "floraTheme": "temperate", "baseTemperature": 16, "nameKey": "planet.varied.name", "atmosphereHeight": 240, "cloudColor": 15725044, "cloudDensity": 0.5,
     "terrainTags": ["buttes"],
     "baseHeight": 64, "amplitude": 18, "terrainScale": 46.0,
     "surfaceBlock": "grass", "subSurfaceBlock": "dirt", "deepBlock": "stone", "surfaceDepth": 4,
@@ -182,7 +182,7 @@
     ]
   },
   {
-    "key": "ocean", "floraTheme": "temperate", "baseTemperature": 20, "nameKey": "planet.ocean.name", "atmosphereHeight": 230, "cloudColor": 13623026, "cloudDensity": 0.55,
+    "key": "ocean", "waterTint": "auto", "floraTheme": "temperate", "baseTemperature": 20, "nameKey": "planet.ocean.name", "atmosphereHeight": 230, "cloudColor": 13623026, "cloudDensity": 0.55,
     "terrainTags": ["wetland", "reef"],
     "baseHeight": 60, "amplitude": 20, "terrainScale": 60.0, "terrainStyle": "flats",
     "terrainStyles": ["flats", "archipelago"],
@@ -207,7 +207,7 @@
     ]
   },
   {
-    "key": "savanna", "floraTheme": "savanna", "baseTemperature": 32, "nameKey": "planet.savanna.name", "atmosphereHeight": 210, "cloudColor": 15261109, "cloudDensity": 0.3,
+    "key": "savanna", "waterTint": "auto", "floraTheme": "savanna", "baseTemperature": 32, "nameKey": "planet.savanna.name", "atmosphereHeight": 210, "cloudColor": 15261109, "cloudDensity": 0.3,
     "terrainTags": ["buttes", "inselbergs"],
     "baseHeight": 64, "amplitude": 10, "terrainScale": 58.0,
     "terrainStyles": ["hills", "downs", "flats"],
@@ -229,7 +229,7 @@
     ]
   },
   {
-    "key": "highland", "floraTheme": "alpine", "baseTemperature": 8, "nameKey": "planet.highland.name", "atmosphereHeight": 280, "cloudColor": 13292509, "cloudDensity": 0.45,
+    "key": "highland", "waterTint": "auto", "floraTheme": "alpine", "baseTemperature": 8, "nameKey": "planet.highland.name", "atmosphereHeight": 280, "cloudColor": 13292509, "cloudDensity": 0.45,
     "baseHeight": 72, "amplitude": 30, "terrainScale": 40.0, "terrainStyle": "mountains",
     "terrainStyles": ["mountains", "fjordlands", "canyons"],
     "surfaceBlock": "stone", "subSurfaceBlock": "dirt", "deepBlock": "stone", "surfaceDepth": 3,
@@ -253,7 +253,7 @@
     ]
   },
   {
-    "key": "crystal_living", "floraTheme": "crystal", "exotic": true, "baseTemperature": 2, "nameKey": "planet.crystal_living.name", "atmosphereHeight": 200, "cloudColor": 14734576, "cloudDensity": 0.35,
+    "key": "crystal_living", "waterTint": "auto", "floraTheme": "crystal", "exotic": true, "baseTemperature": 2, "nameKey": "planet.crystal_living.name", "atmosphereHeight": 200, "cloudColor": 14734576, "cloudDensity": 0.35,
     "terrainTags": ["crystal"],
     "baseHeight": 60, "amplitude": 20, "terrainScale": 48.0, "terrainStyle": "spires",
     "surfaceBlock": "crystal", "subSurfaceBlock": "stone", "deepBlock": "stone", "surfaceDepth": 3,
@@ -300,7 +300,7 @@
     ]
   },
   {
-    "key": "tundra", "floraTheme": "tundra", "baseTemperature": -22, "nameKey": "planet.tundra.name", "atmosphereHeight": 220, "cloudColor": 14606326, "cloudDensity": 0.5,
+    "key": "tundra", "waterTint": "auto", "floraTheme": "tundra", "baseTemperature": -22, "nameKey": "planet.tundra.name", "atmosphereHeight": 220, "cloudColor": 14606326, "cloudDensity": 0.5,
     "terrainTags": ["glacial"],
     "baseHeight": 62, "amplitude": 14, "terrainScale": 52.0, "terrainStyle": "hills",
     "terrainStyles": ["hills", "downs", "drumlins"],
@@ -325,7 +325,7 @@
     ]
   },
   {
-    "key": "fungal", "floraTheme": "fungal", "exotic": true, "baseTemperature": 18, "nameKey": "planet.fungal.name", "atmosphereHeight": 220, "cloudColor": 9337256, "cloudDensity": 0.6,
+    "key": "fungal", "waterTint": "auto", "floraTheme": "fungal", "exotic": true, "baseTemperature": 18, "nameKey": "planet.fungal.name", "atmosphereHeight": 220, "cloudColor": 9337256, "cloudDensity": 0.6,
     "terrainTags": ["karst"],
     "baseHeight": 60, "amplitude": 14, "terrainScale": 48.0, "terrainStyle": "hills",
     "terrainStyles": ["hills", "karst", "downs", "stone-forest"],
@@ -350,7 +350,7 @@
     ]
   },
   {
-    "key": "corrupted", "floraTheme": "alien", "exotic": true, "baseTemperature": 24, "nameKey": "planet.corrupted.name", "atmosphereHeight": 230, "cloudColor": 8030298, "cloudDensity": 0.55,
+    "key": "corrupted", "waterTint": "auto", "floraTheme": "alien", "exotic": true, "baseTemperature": 24, "nameKey": "planet.corrupted.name", "atmosphereHeight": 230, "cloudColor": 8030298, "cloudDensity": 0.55,
     "terrainTags": ["buttes", "hoodoos"],
     "baseHeight": 64, "amplitude": 16, "terrainScale": 46.0, "terrainStyle": "canyons",
     "terrainStyles": ["canyons", "shattered", "badlands"],
@@ -394,7 +394,7 @@
     ]
   },
   {
-    "key": "skylands", "floraTheme": "temperate", "exotic": true, "baseTemperature": 16, "nameKey": "planet.skylands.name", "atmosphereHeight": 320, "cloudColor": 14081244, "cloudDensity": 0.4,
+    "key": "skylands", "waterTint": "auto", "floraTheme": "temperate", "exotic": true, "baseTemperature": 16, "nameKey": "planet.skylands.name", "atmosphereHeight": 320, "cloudColor": 14081244, "cloudDensity": 0.4,
     "baseHeight": 56, "amplitude": 8, "terrainScale": 52.0, "terrainStyle": "flats",
     "surfaceBlock": "grass", "subSurfaceBlock": "dirt", "deepBlock": "stone", "surfaceDepth": 4,
     "caveThreshold": 0.72, "dataCacheRarity": 0.0022,
@@ -414,7 +414,7 @@
     ]
   },
   {
-    "key": "tablelands", "floraTheme": "savanna", "baseTemperature": 24, "nameKey": "planet.tablelands.name", "atmosphereHeight": 200, "cloudColor": 15450749, "cloudDensity": 0.25,
+    "key": "tablelands", "waterTint": "auto", "floraTheme": "savanna", "baseTemperature": 24, "nameKey": "planet.tablelands.name", "atmosphereHeight": 200, "cloudColor": 15450749, "cloudDensity": 0.25,
     "terrainTags": ["buttes", "hoodoos", "inselbergs", "wind"],
     "baseHeight": 62, "amplitude": 26, "terrainScale": 58.0, "terrainStyle": "tablelands",
     "terrainStyles": ["tablelands", "terraces", "mesa", "labyrinth"],
@@ -459,7 +459,7 @@
     ]
   },
   {
-    "key": "karst", "floraTheme": "tropical", "exotic": true, "baseTemperature": 27, "nameKey": "planet.karst.name", "atmosphereHeight": 210, "cloudColor": 14210014, "cloudDensity": 0.5,
+    "key": "karst", "waterTint": "auto", "floraTheme": "tropical", "exotic": true, "baseTemperature": 27, "nameKey": "planet.karst.name", "atmosphereHeight": 210, "cloudColor": 14210014, "cloudDensity": 0.5,
     "terrainTags": ["wetland", "karst"],
     "baseHeight": 60, "amplitude": 18, "terrainScale": 46.0, "terrainStyle": "karst",
     "terrainStyles": ["karst", "hills", "downs", "stone-forest"],
@@ -504,7 +504,7 @@
     ]
   },
   {
-    "key": "boreal", "minTerrainGeneration": 1, "authoredCreatures": ["leni"], "floraTheme": "tundra", "baseTemperature": -4, "nameKey": "planet.boreal.name", "atmosphereHeight": 230, "cloudColor": 14606326, "cloudDensity": 0.55,
+    "key": "boreal", "waterTint": "auto", "minTerrainGeneration": 1, "authoredCreatures": ["leni"], "floraTheme": "tundra", "baseTemperature": -4, "nameKey": "planet.boreal.name", "atmosphereHeight": 230, "cloudColor": 14606326, "cloudDensity": 0.55,
     "terrainTags": ["glacial", "karst"],
     "baseHeight": 63, "amplitude": 14, "terrainScale": 50.0, "terrainStyle": "hills",
     "terrainStyles": ["hills", "downs", "drumlins"],
@@ -528,7 +528,7 @@
     ]
   },
   {
-    "key": "archipelago", "minTerrainGeneration": 1, "floraTheme": "tropical", "baseTemperature": 26, "nameKey": "planet.archipelago.name", "atmosphereHeight": 220, "cloudColor": 15922422, "cloudDensity": 0.55,
+    "key": "archipelago", "waterTint": "auto", "minTerrainGeneration": 1, "floraTheme": "tropical", "baseTemperature": 26, "nameKey": "planet.archipelago.name", "atmosphereHeight": 220, "cloudColor": 15922422, "cloudDensity": 0.55,
     "terrainTags": ["wetland", "reef"],
     "baseHeight": 60, "amplitude": 18, "terrainScale": 56.0, "terrainStyle": "archipelago",
     "terrainStyles": ["archipelago", "flats"],
@@ -550,7 +550,7 @@
     ]
   },
   {
-    "key": "glacier", "minTerrainGeneration": 1, "authoredCreatures": ["leni"], "floraTheme": "alpine", "exotic": true, "baseTemperature": -45, "nameKey": "planet.glacier.name", "atmosphereHeight": 240, "cloudColor": 14606326, "cloudDensity": 0.4,
+    "key": "glacier", "waterTint": "auto", "minTerrainGeneration": 1, "authoredCreatures": ["leni"], "floraTheme": "alpine", "exotic": true, "baseTemperature": -45, "nameKey": "planet.glacier.name", "atmosphereHeight": 240, "cloudColor": 14606326, "cloudDensity": 0.4,
     "terrainTags": ["glacial"],
     "baseHeight": 64, "amplitude": 20, "terrainScale": 52.0, "terrainStyle": "glacial",
     "terrainStyles": ["glacial", "hills"],
@@ -573,7 +573,7 @@
     ]
   },
   {
-    "key": "meadowlands", "minTerrainGeneration": 1, "floraTheme": "temperate", "baseTemperature": 16, "nameKey": "planet.meadowlands.name", "atmosphereHeight": 230, "cloudColor": 15592941, "cloudDensity": 0.45,
+    "key": "meadowlands", "waterTint": "auto", "minTerrainGeneration": 1, "floraTheme": "temperate", "baseTemperature": 16, "nameKey": "planet.meadowlands.name", "atmosphereHeight": 230, "cloudColor": 15592941, "cloudDensity": 0.45,
     "terrainTags": [],
     "baseHeight": 64, "amplitude": 12, "terrainScale": 54.0, "terrainStyle": "downs",
     "terrainStyles": ["downs", "hills"],
@@ -637,7 +637,7 @@
     ]
   },
   {
-    "key": "frozen_ocean", "minTerrainGeneration": 1, "authoredCreatures": ["leni"], "floraTheme": "tundra", "baseTemperature": -40, "nameKey": "planet.frozen_ocean.name", "atmosphereHeight": 220, "cloudColor": 14606326, "cloudDensity": 0.45,
+    "key": "frozen_ocean", "waterTint": "auto", "minTerrainGeneration": 1, "authoredCreatures": ["leni"], "floraTheme": "tundra", "baseTemperature": -40, "nameKey": "planet.frozen_ocean.name", "atmosphereHeight": 220, "cloudColor": 14606326, "cloudDensity": 0.45,
     "terrainTags": ["glacial"],
     "baseHeight": 60, "amplitude": 16, "terrainScale": 60.0, "terrainStyle": "flats",
     "terrainStyles": ["flats", "archipelago"],
@@ -660,7 +660,7 @@
     ]
   },
   {
-    "key": "coral_sea", "minTerrainGeneration": 3, "floraTheme": "tropical", "baseTemperature": 27, "nameKey": "planet.coral_sea.name", "atmosphereHeight": 220, "cloudColor": 15922422, "cloudDensity": 0.5,
+    "key": "coral_sea", "waterTint": "auto", "minTerrainGeneration": 3, "floraTheme": "tropical", "baseTemperature": 27, "nameKey": "planet.coral_sea.name", "atmosphereHeight": 220, "cloudColor": 15922422, "cloudDensity": 0.5,
     "terrainTags": ["wetland", "reef"],
     "baseHeight": 58, "amplitude": 14, "terrainScale": 60.0, "terrainStyle": "archipelago",
     "terrainStyles": ["archipelago", "flats"],
@@ -682,7 +682,7 @@
     ]
   },
   {
-    "key": "icecap", "minTerrainGeneration": 3, "authoredCreatures": ["leni"], "floraTheme": "tundra", "exotic": true, "baseTemperature": -30, "nameKey": "planet.icecap.name", "atmosphereHeight": 240, "cloudColor": 14606326, "cloudDensity": 0.4,
+    "key": "icecap", "waterTint": "auto", "minTerrainGeneration": 3, "authoredCreatures": ["leni"], "floraTheme": "tundra", "exotic": true, "baseTemperature": -30, "nameKey": "planet.icecap.name", "atmosphereHeight": 240, "cloudColor": 14606326, "cloudDensity": 0.4,
     "terrainTags": ["glacial"],
     "baseHeight": 66, "amplitude": 22, "terrainScale": 52.0, "terrainStyle": "glacial",
     "terrainStyles": ["glacial", "mountains", "hills"],
@@ -705,7 +705,7 @@
     ]
   },
   {
-    "key": "river_lowlands", "minTerrainGeneration": 3, "floraTheme": "temperate", "baseTemperature": 15, "nameKey": "planet.river_lowlands.name", "atmosphereHeight": 230, "cloudColor": 15592941, "cloudDensity": 0.5,
+    "key": "river_lowlands", "waterTint": "auto", "minTerrainGeneration": 3, "floraTheme": "temperate", "baseTemperature": 15, "nameKey": "planet.river_lowlands.name", "atmosphereHeight": 230, "cloudColor": 15592941, "cloudDensity": 0.5,
     "terrainTags": ["wetland"],
     "baseHeight": 62, "amplitude": 10, "terrainScale": 58.0, "terrainStyle": "flats",
     "terrainStyles": ["flats", "downs"],
@@ -751,7 +751,7 @@
     ]
   },
   {
-    "key": "flower_fields", "minTerrainGeneration": 5, "floraTheme": "floral", "baseTemperature": 19, "nameKey": "planet.flower_fields.name", "atmosphereHeight": 230, "cloudColor": 15592941, "cloudDensity": 0.4,
+    "key": "flower_fields", "waterTint": "auto", "minTerrainGeneration": 5, "floraTheme": "floral", "baseTemperature": 19, "nameKey": "planet.flower_fields.name", "atmosphereHeight": 230, "cloudColor": 15592941, "cloudDensity": 0.4,
     "terrainTags": [],
     "baseHeight": 64, "amplitude": 10, "terrainScale": 56.0, "terrainStyle": "downs",
     "terrainStyles": ["downs", "flats"],
@@ -798,7 +798,7 @@
     ]
   },
   {
-    "key": "gamer_hills", "minTerrainGeneration": 5, "floraTheme": "temperate", "baseTemperature": 18, "nameKey": "planet.gamer_hills.name", "atmosphereHeight": 230, "cloudColor": 15592941, "cloudDensity": 0.4,
+    "key": "gamer_hills", "waterTint": "auto", "minTerrainGeneration": 5, "floraTheme": "temperate", "baseTemperature": 18, "nameKey": "planet.gamer_hills.name", "atmosphereHeight": 230, "cloudColor": 15592941, "cloudDensity": 0.4,
     "terrainTags": ["karst", "gaming"],
     "baseHeight": 64, "amplitude": 10, "terrainScale": 58.0, "terrainStyle": "downs",
     "terrainStyles": ["downs", "flats"],

--- a/docs/developer/WORLD_GENERATION.md
+++ b/docs/developer/WORLD_GENERATION.md
@@ -1223,7 +1223,13 @@ counterpart of `FloraTints.ForWorld`: empty `waterTint` = the classic blue (mode
 `"#rrggbb"` = fixed. The server ships `EnvironmentState.WaterTint/WaterTintMode`, `Sky.cs` sets
 `_Sc_WaterTint/_Sc_WaterMode`, and the transparent shader's water branch (both subshaders) recolours by
 luminance. The block `water` stays the single fluid id — the automaton, the creatures and worldgen never
-learn about colour.
+learn about colour. Since Marcel's go on 2026-09-11 every type with a real water sea and an atmosphere
+(25 of them, from `rocky` to `gamer_hills`; not the dry, lava or airless bodies) carries `"auto"`, and
+`ForWorld` takes the SAVE's terrain generation: the colour is computed at runtime, not baked, so the gate is
+what keeps a pre-generation-5 save blue. The palette stays blue-dominant (55 % classic blue, then teal, green,
+yellow, violet, red). Rain follows the water (`WaterColours.cs`): the 3D drops of rain, drizzle and sleet, the
+visor's beads, streaks and wet wash, and the underwater wash blend toward the world's colour (a rainbow world's
+rain cycles through the hues); snow, hail, ash, sand, acid, meteors and spores keep their own look.
 
 **Hanging flora (#1759).** `FloraCatalog.Species.Hanging` — the plant roots in the block ABOVE. The roster
 activates `flora_hangkelp` on generation-5 worlds only (`MinGeneration`), worldgen places it at

--- a/src/BlocksBeyondTheStars.GameServer/GameServerWeather.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerWeather.cs
@@ -191,8 +191,8 @@ public sealed partial class GameServer
         // formula lives with the per-species colours (#1716) — one file for every flora colour.
         _floraTint = Shared.World.FloraTints.ForWorld(_meta.Seed, _world.LocationId);
         // #1758: the water colour, the same way — classic blue unless the type opts in (the rainbow planet, the
-        // "auto" palette of the generation-5 water types).
-        var (waterRgb, waterMode) = Shared.World.FluidTints.ForWorld(_meta.Seed, _world.LocationId, _world.Planet);
+        // "auto" palette of the water types) AND the save is generation 5: older saves keep their blue.
+        var (waterRgb, waterMode) = Shared.World.FluidTints.ForWorld(_meta.Seed, _world.LocationId, _world.Planet, _meta.Description.TerrainGeneration);
         _waterTint = waterRgb;
         _waterTintMode = (int)waterMode;
         // One seeded daytime sky hue per WORLD (blue → green → yellow → red, blue-dominant), so worlds with an

--- a/src/BlocksBeyondTheStars.Shared/World/FluidTints.cs
+++ b/src/BlocksBeyondTheStars.Shared/World/FluidTints.cs
@@ -42,11 +42,14 @@ public static class FluidTints
     };
 
     /// <summary>The water colour and mode of one world. Deterministic from the seed and the body, like every
-    /// other per-world look; the same historical location hash as <see cref="FloraTints.ForWorld"/>.</summary>
-    public static (int Rgb, Mode Mode) ForWorld(long worldSeed, string? locationKey, PlanetType? planet)
+    /// other per-world look; the same historical location hash as <see cref="FloraTints.ForWorld"/>.
+    /// <paramref name="terrainGeneration"/> is the SAVE's generation: the colour is computed at runtime, not baked
+    /// into the world, so without this gate an old save would change colour the day its type opted in. Below
+    /// <see cref="WorldDescription.AuthoredContentGeneration"/> every world keeps the classic blue.</summary>
+    public static (int Rgb, Mode Mode) ForWorld(long worldSeed, string? locationKey, PlanetType? planet, int terrainGeneration)
     {
         string spec = planet?.WaterTint?.Trim() ?? string.Empty;
-        if (spec.Length == 0)
+        if (spec.Length == 0 || terrainGeneration < WorldDescription.AuthoredContentGeneration)
         {
             return (ClassicWater, Mode.Classic);
         }

--- a/tests/BlocksBeyondTheStars.Tests/FluidTintTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/FluidTintTests.cs
@@ -1,0 +1,84 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using BlocksBeyondTheStars.Shared.Content;
+using BlocksBeyondTheStars.Shared.Definitions;
+using BlocksBeyondTheStars.Shared.World;
+using Xunit;
+
+namespace BlocksBeyondTheStars.Tests;
+
+/// <summary>The per-world water colour (#1758): which types opt in, what an old save keeps, what a new one rolls.</summary>
+public sealed class FluidTintTests
+{
+    private static readonly GameContent Content = ContentLoader.LoadFromDirectory(TestPaths.DataDir());
+
+    [Fact]
+    public void EveryWaterSeaTypeWithAir_OptsIntoAWaterColour()
+    {
+        // Marcel 2026-09-11 ("ja mach das"): the children's "water in different colours per world" — every type
+        // with a real water sea and an atmosphere carries a water tint; dry, lava and airless bodies stay blue.
+        foreach (var p in Content.Planets.Values)
+        {
+            if (p.Key is "orbital_station" or "ship_interior")
+            {
+                continue;
+            }
+
+            bool air = !string.Equals(p.Atmosphere, "none", StringComparison.OrdinalIgnoreCase);
+            double water = p.WaterAbundance ?? (air ? 0.55 : 0.0);
+            bool sea = air && water >= 0.3 && (p.LavaAbundance ?? 0.0) <= 0.0;
+            if (sea)
+            {
+                Assert.False(string.IsNullOrEmpty(p.WaterTint), $"{p.Key} has a water sea and air but no waterTint");
+            }
+            else
+            {
+                Assert.True(string.IsNullOrEmpty(p.WaterTint), $"{p.Key} has no water sea yet a waterTint");
+            }
+        }
+    }
+
+    [Fact]
+    public void AutoTint_KeepsOldSavesBlue_AndRollsPerWorldOnGenerationFive()
+    {
+        var ocean = Content.GetPlanet("ocean")!;
+        Assert.Equal("auto", ocean.WaterTint);
+        Assert.Equal((FluidTints.ClassicWater, FluidTints.Mode.Classic), FluidTints.ForWorld(4242, "sys0-p1", ocean, 4));
+        Assert.Equal((FluidTints.ClassicWater, FluidTints.Mode.Classic), FluidTints.ForWorld(4242, "sys0-p1", ocean, 0));
+
+        var a = FluidTints.ForWorld(4242, "sys0-p1", ocean, WorldDescription.AuthoredContentGeneration);
+        Assert.Equal(FluidTints.Mode.Tint, a.Mode);
+        Assert.Equal(a, FluidTints.ForWorld(4242, "sys0-p1", ocean, WorldDescription.AuthoredContentGeneration));
+
+        // The palette is blue-dominant but not all blue: across many worlds more than one colour family shows up,
+        // and the classic blue stays the most common pick.
+        var families = new HashSet<int>();
+        int classicLike = 0, total = 0;
+        for (long seed = 1; seed <= 60; seed++)
+            for (int body = 0; body < 6; body++)
+            {
+                var (rgb, mode) = FluidTints.ForWorld(seed * 7919, $"sys{body}-p{body}", ocean, WorldDescription.AuthoredContentGeneration);
+                Assert.Equal(FluidTints.Mode.Tint, mode);
+                int r = (rgb >> 16) & 0xFF, g = (rgb >> 8) & 0xFF, b = rgb & 0xFF;
+                families.Add(b > r && b > g ? 0 : g > r ? 1 : 2); // blue / green-teal / warm
+                if (System.Math.Abs(r - 0x33) <= 16 && System.Math.Abs(g - 0x6B) <= 16 && System.Math.Abs(b - 0xD9) <= 16)
+                {
+                    classicLike++;
+                }
+
+                total++;
+            }
+
+        Assert.True(families.Count >= 2, "every world rolled the same colour family");
+        Assert.True(classicLike >= total * 0.35, $"the classic blue should stay the most common pick ({classicLike}/{total})");
+    }
+
+    [Fact]
+    public void RainbowType_IsRainbowOnlyOnGenerationFive()
+    {
+        var rainbow = Content.GetPlanet("rainbow_sea")!;
+        Assert.Equal(FluidTints.Mode.Rainbow, FluidTints.ForWorld(1, "sys0-p0", rainbow, 5).Mode);
+        Assert.Equal(FluidTints.Mode.Classic, FluidTints.ForWorld(1, "sys0-p0", rainbow, 4).Mode);
+    }
+}


### PR DESCRIPTION
## What

The children's "water in different colours per world" (#1758) was built in the wave but switched on nowhere but the rainbow planet. Marcel: "ja mach das" — and "bedenke dabei auch die Farbe des Regens".

- **25 planet types** — every type with a real water sea and an atmosphere (`rocky` … `gamer_hills`; not the dry, lava or airless bodies) — carry `waterTint: "auto"`: a seeded, blue-dominant pick per world (55 % classic blue, then teal, green, yellow, violet, red, each with a little per-world jitter).
- **Old saves stay blue.** `FluidTints.ForWorld` takes the save's terrain generation; the colour is computed at runtime, not baked into the world, so this gate is what protects every pre-generation-5 save.
- **Rain follows the water.** New `WaterColours.cs` (client): the 3D drops of rain, drizzle and sleet, the visor's beads, streaks and wet wash, and the underwater wash blend toward the world's colour; on the rainbow planet the rain cycles through the hues. Snow, hail, ash, sand, acid, meteors and spores keep their own look; a classic world gets every colour back untouched.

## Tests

- `FluidTintTests`: every water-sea type opts in and no other does (a policy test for future types); an old save stays blue; the palette rolls more than one colour family with blue the most common; the rainbow type is rainbow on generation 5 only.
- Tint + Flora + Content + gen-5 world classes: 65 green; `dotnet format` clean.

## Verification

- Local Unity build (client change) — result in the PR comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
