### PR TITLE
fix(client,ux): chat yields to VEGA, the ship menu and the shell screens boot like the HUD, singleplayer waits for a fresh world (#1795–#1797)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -24,6 +24,26 @@ envelope at the WebSocket edge; deterministic seed world-gen; SQLite default per
 
 ---
 
+### 💬 Chat yields to VEGA + the ship menu boots like the HUD (2026-09-12, branch feat/chat-vega-lane-menu-holo, LOCAL — not merged)
+
+Two of Marcel's playtest notes. **Chat ↔ VEGA:** the chat overlay (#643) and VEGA's speech panel + objective chip
+(#482) had both been placed in the "free" left HUD column — the chat's scrollback (y 280…590, sorted above VEGA)
+drew straight across a story line and its input row sat exactly on the chip. The chat now yields: `ChatUi.ResolveLane`
+(pure, EditMode-tested) ends the scrollback above the speech panel while a line is up, stacks the input row directly
+under the shortened scrollback while typing with either VEGA element up, and keeps the old lane when VEGA is quiet;
+`VegaPanel` exposes `SpeechVisible` / `ChipVisible` and the two lane constants. The scrollback is also measured against
+its lane now (TextGenerator, scale 1) so a shorter band drops the oldest rows instead of growing upward over the vitals.
+**Ship menu:** the three frames are UiHolo panels (the HUD's shader, same colour) and `ShowMode` plays the HUD's
+boot-up feel on open and on every tab change — header fade, then sidebar → list → detail wipe on left→right with a
+0.07 s stagger while each pane's content fades up behind the wipe; never on the live rebuilds, instant under reduced
+motion. The shell screens get the same treatment (`UiKit.BootScreen`, called by AppShell after each build): main menu,
+settings, credits, editors and save-select fade in as a whole while their top-level elements rise in build order with
+a short stagger and their frames — now UiHolo panels — wipe on. **Singleplayer connect race:** a fresh world took 16 s of server-side generation while the client's
+connect budget was the remote one (initial dial + 6 × 2 s ≈ 14 s) — it gave up in the very second the server logged
+"started on port", and the menu blamed the antivirus. `ConnectRetryPolicy` (pure, EditMode-tested) now gives the
+bundled local server a patient budget (knock once a second, ceiling 120 s) and `LocalServerLauncher.Ready` relays the
+server's startup line so the client dials the instant it listens; remote hosts keep the short #409 budget.
+
 ### 🚀 Release v2026.9.6 — the new-planets release (2026-09-12, branch release/2026.9.6)
 
 Everything merged since v2026.9.5 (17 PRs, 41 issues): the school club's generation-5 planets (#1756–#1765, follow-ups

--- a/client/Assets/BlocksBeyondTheStars/Scripts/AppShell.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/AppShell.cs
@@ -104,6 +104,11 @@ namespace BlocksBeyondTheStars.Client
         private readonly LocalServerLauncher _localServer = new LocalServerLauncher();
         private bool _hostLocal;
 
+        /// <summary>The bundled server this shell is starting for the world being entered, or null when the
+        /// target is a remote host. GameBootstrap's connect loop keeps knocking while it comes up
+        /// (<see cref="ConnectRetryPolicy"/>) instead of applying the remote-host retry budget.</summary>
+        public LocalServerLauncher LocalServer => _hostLocal ? _localServer : null;
+
         /// <summary>The in-process singleplayer host (browser builds; usable in the editor for testing).
         /// Null until the first browser-singleplayer start; survives returns to the menu stopped.</summary>
         public BrowserLocalServer BrowserServer { get; private set; }
@@ -1533,6 +1538,7 @@ namespace BlocksBeyondTheStars.Client
             if (Phase == ShellPhase.MainMenu && _uiMenu == null)
             {
                 _uiMenu = UiMainMenu.Build(this);
+                UiKit.BootScreen(_uiMenu); // the HUD's boot-up feel for the shell screens too (#1796)
                 WhatsNew.BeginFetch(this); // one-per-session background load of the release notes (#543)
 
                 // Land the bombastic intro sting on the first menu reveal (logo + full UI), rather
@@ -1662,6 +1668,7 @@ namespace BlocksBeyondTheStars.Client
             if (Phase == ShellPhase.Settings && _uiSettings == null)
             {
                 _uiSettings = UiSettings.Build(this);
+                UiKit.BootScreen(_uiSettings);
             }
             else if (Phase != ShellPhase.Settings && _uiSettings != null)
             {
@@ -1672,6 +1679,7 @@ namespace BlocksBeyondTheStars.Client
             if (Phase == ShellPhase.Credits && _uiCredits == null)
             {
                 _uiCredits = UiCredits.Build(this);
+                UiKit.BootScreen(_uiCredits);
             }
             else if (Phase != ShellPhase.Credits && _uiCredits != null)
             {
@@ -1682,6 +1690,7 @@ namespace BlocksBeyondTheStars.Client
             if (Phase == ShellPhase.Editors && _uiEditors == null)
             {
                 _uiEditors = UiEditors.Build(this);
+                UiKit.BootScreen(_uiEditors);
             }
             else if (Phase != ShellPhase.Editors && _uiEditors != null)
             {
@@ -1692,6 +1701,7 @@ namespace BlocksBeyondTheStars.Client
             if (Phase == ShellPhase.SaveSelect && _uiSaveSelect == null)
             {
                 _uiSaveSelect = UiSaveSelect.Build(this);
+                UiKit.BootScreen(_uiSaveSelect);
             }
             else if (Phase != ShellPhase.SaveSelect && _uiSaveSelect != null)
             {

--- a/client/Assets/BlocksBeyondTheStars/Scripts/ChatUi.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/ChatUi.cs
@@ -34,12 +34,56 @@ namespace BlocksBeyondTheStars.Client
         private int _openFrame = -1;
         private float _nextRefresh = float.MaxValue;
         private const int MaxLog = 40;
-        private const int VisibleLines = 12; // the 310-px lane fits 12 rows; a /tp list is usually 8-15 lines
+        private const int VisibleLines = 12; // the full 310-px lane fits 12 rows; a /tp list is usually 8-15 lines
         private const float FadeSeconds = 12f;   // how long a line stays up in the Auto mode
         private const float FadeOutSeconds = 0.6f; // the dim-out at the end (one Text = the block fades as one)
 
-        // The free left lane in HUD reference space (1536×864) — see EnsureBuilt.
+        // The left lane in HUD reference space (1536×864) — see EnsureBuilt and ResolveLane.
         private const float LaneX = 10f, LaneW = 380f;
+        private const float LaneTop = 280f, LaneBottom = 590f; // between the toast (268) and VEGA's chip (594)
+        private const float InputRowY = 596f, InputRowH = 44f, LaneGap = 6f;
+
+        // VEGA visibility as of the last refresh — the lane is re-resolved when either flips (Update).
+        private bool _vegaSpeechSeen, _vegaChipSeen;
+
+        /// <summary>Where the scrollback and the input row sit this frame, in HUD reference units.</summary>
+        public readonly struct ChatLane
+        {
+            public ChatLane(float logY, float logH, float inputY)
+            {
+                LogY = logY;
+                LogH = logH;
+                InputY = inputY;
+            }
+
+            public float LogY { get; }
+
+            public float LogH { get; }
+
+            public float InputY { get; }
+        }
+
+        /// <summary>
+        /// Lane arbitration with VEGA: the chat (#643) and VEGA's speech panel + objective chip (#482) were
+        /// both placed in the "free" left column, and the chat — sorted above VEGA — drew straight across a
+        /// story line while its input row sat exactly on the objective chip. VEGA is the story-critical,
+        /// transient one, so the chat yields: while a speech line is up the scrollback ends above the
+        /// panel, and while typing with either VEGA element up the input row stacks directly under the
+        /// (shortened) scrollback instead of on top of the chip. With VEGA quiet the lane is the old one.
+        /// Pure so an EditMode test can pin the geometry.
+        /// </summary>
+        public static ChatLane ResolveLane(bool typing, bool speechVisible, bool chipVisible)
+        {
+            float bottom = speechVisible ? VegaPanel.SpeechY - LaneGap : LaneBottom;
+            float inputY = InputRowY;
+            if (typing && (speechVisible || chipVisible))
+            {
+                inputY = bottom - InputRowH;
+                bottom = inputY - LaneGap;
+            }
+
+            return new ChatLane(LaneTop, Mathf.Max(0f, bottom - LaneTop), inputY);
+        }
 
         /// <summary>A scrollback entry with the (unscaled) time it arrived, which is what the fade reads.</summary>
         private readonly struct ChatLine
@@ -108,6 +152,16 @@ namespace BlocksBeyondTheStars.Client
             if (_canvas != null && !_capturing && _canvas.enabled == hideForContext)
             {
                 _canvas.enabled = !hideForContext;
+            }
+
+            // Lane arbitration (see ResolveLane): whenever VEGA's speech panel or objective chip appears or
+            // goes, the scrollback re-lays out around it. Two bool reads per frame — no allocation.
+            var vega = VegaPanel.Instance;
+            bool speechUp = vega != null && vega.SpeechVisible;
+            bool chipUp = vega != null && vega.ChipVisible;
+            if (speechUp != _vegaSpeechSeen || chipUp != _vegaChipSeen)
+            {
+                RefreshLog();
             }
 
             // Fade tick: the scrollback ages out on its own, so re-render when the next line is due to go
@@ -756,6 +810,17 @@ namespace BlocksBeyondTheStars.Client
                 return;
             }
 
+            // Lane first: the geometry decides how many lines fit below.
+            var vega = VegaPanel.Instance;
+            _vegaSpeechSeen = vega != null && vega.SpeechVisible;
+            _vegaChipSeen = vega != null && vega.ChipVisible;
+            var lane = ResolveLane(_typing, _vegaSpeechSeen, _vegaChipSeen);
+            UiKit.Place(_log.gameObject, LaneX, lane.LogY, LaneW, lane.LogH);
+            if (_inputRow != null)
+            {
+                UiKit.Place(_inputRow.gameObject, LaneX, lane.InputY, LaneW, InputRowH);
+            }
+
             _nextRefresh = float.MaxValue;
             var mode = Mode;
 
@@ -790,14 +855,37 @@ namespace BlocksBeyondTheStars.Client
                 }
             }
 
+            // Fit the block to the lane: the Text is LowerLeft + Overflow, so an over-tall block would grow
+            // UPWARD out of the lane over the vitals and the toast. Drop the oldest lines until what is
+            // left fits — measured with the Text's own generator at scale 1 (canvas units), at most a dozen
+            // cheap measurements per refresh, and refreshes are rare (a new line, a fade tick, a VEGA flip).
+            string block = Join(from);
+            if (_log.font != null && _lines.Count > from)
+            {
+                var settings = _log.GetGenerationSettings(new Vector2(LaneW, 0f));
+                settings.scaleFactor = 1f;
+                var gen = _log.cachedTextGeneratorForLayout;
+                while (from < _lines.Count - 1 && gen.GetPreferredHeight(block, settings) > lane.LogH)
+                {
+                    from++;
+                    block = Join(from);
+                }
+            }
+
+            _log.text = block;
+            _log.color = new Color(0.86f, 0.93f, 1f, alpha);
+        }
+
+        /// <summary>The scrollback from index <paramref name="from"/> to the newest line, one per row.</summary>
+        private string Join(int from)
+        {
             var sb = new System.Text.StringBuilder();
             for (int i = from; i < _lines.Count; i++)
             {
                 sb.AppendLine(_lines[i].Text);
             }
 
-            _log.text = sb.ToString();
-            _log.color = new Color(0.86f, 0.93f, 1f, alpha);
+            return sb.ToString();
         }
 
         private void OnDestroy()
@@ -824,18 +912,21 @@ namespace BlocksBeyondTheStars.Client
             _canvas.sortingOrder = 25; // below menus (50) / map (60), above the HUD (10) and the world
             var root = _canvas.transform;
 
-            // Both rows live in the free left lane between the vitals panel (ends y 260) and the scan panel
+            // Both rows live in the left lane between the vitals panel (ends y 260) and the scan panel
             // (starts y 650). The old bottom-left placement covered ~85 % of the scan panel plus the left
             // hotbar cells and the controls hint line. WIDTH IS CAPPED for the same reason the scan panel
             // caps its own: the hotbar backplate owns x 400…1136, so this lane must not reach x 400.
             // In the flight view the lane is clear too — its instruments sit at the very bottom (y 818+).
-            _log = UiKit.AddText(root, LaneX, 280, LaneW, 310, string.Empty, 16, new Color(0.86f, 0.93f, 1f, 0.8f), TextAnchor.LowerLeft);
+            // The lane is SHARED with VEGA (speech panel y 396…586, objective chip y 594…642): these rects
+            // are the VEGA-quiet defaults, RefreshLog re-places both rows via ResolveLane whenever VEGA
+            // shows or hides one of hers.
+            _log = UiKit.AddText(root, LaneX, LaneTop, LaneW, LaneBottom - LaneTop, string.Empty, 16, new Color(0.86f, 0.93f, 1f, 0.8f), TextAnchor.LowerLeft);
             _log.horizontalOverflow = HorizontalWrapMode.Wrap;
             _log.verticalOverflow = VerticalWrapMode.Overflow;
             _log.supportRichText = true;
 
             // Input row (hidden until typing), directly under the scrollback and clear of the scan panel.
-            _inputRow = UiKit.AddPanel(root, LaneX, 596, LaneW, 44, UiKit.Panel).rectTransform;
+            _inputRow = UiKit.AddPanel(root, LaneX, InputRowY, LaneW, InputRowH, UiKit.Panel).rectTransform;
             var inputGo = new GameObject("ChatInput", typeof(RectTransform));
             inputGo.transform.SetParent(_inputRow, false);
             UiKit.Place(inputGo, 8, 6, LaneW - 16f, 32);

--- a/client/Assets/BlocksBeyondTheStars/Scripts/ConnectRetryPolicy.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/ConnectRetryPolicy.cs
@@ -1,0 +1,67 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+namespace BlocksBeyondTheStars.Client
+{
+    /// <summary>
+    /// When the client re-dials a server that has not answered yet, and when it stops. Pure so the policy
+    /// can be pinned by an EditMode test; <see cref="GameBootstrap"/> feeds it the timers.
+    ///
+    /// Two very different situations share the retry loop:
+    /// <list type="bullet">
+    /// <item><b>Remote host</b> (LAN / official world / typed address): the server is either there or it is not —
+    /// a handful of attempts over ~14 s, then give up loudly so a mistyped address does not strand the player
+    /// in an empty void (#409).</item>
+    /// <item><b>Bundled local server</b> (singleplayer / self-hosting): the process was spawned a moment ago and is
+    /// generating the world. A FRESH world took 16 s on a fast machine (2026-09-12 Player.log), more on a
+    /// slow one, more still with an antivirus first-scan of the freshly built EXE — while the old budget was
+    /// the remote one, so the client gave up in the very second the server reported ready. Here the client
+    /// keeps knocking (cheaply, once a second) for as long as the server is still coming up, connects the
+    /// moment the launcher relays the server's "started on port" line, and only gives up after a generous
+    /// ceiling. A server process that dies is caught by the shell's launch watcher, not by this budget.</item>
+    /// </list>
+    /// </summary>
+    public static class ConnectRetryPolicy
+    {
+        public enum Verdict { Wait, Retry, GiveUp }
+
+        /// <summary>Remote hosts: attempts after the initial dial, and the pause between them.</summary>
+        public const int RemoteRetries = 6;
+        public const float RemoteIntervalSeconds = 2f;
+
+        /// <summary>Bundled local server: pause between knocks, and the ceiling on the whole wait.</summary>
+        public const float LocalIntervalSeconds = 1f;
+        public const float LocalBudgetSeconds = 120f;
+
+        /// <param name="localServer">True when the target is the bundled server this client spawned.</param>
+        /// <param name="localReadySignal">True when the local launcher has just relayed the server's
+        /// "started on port" line and that signal has not been acted on yet — connect right now.</param>
+        /// <param name="sinceLastAttempt">Seconds since the previous dial.</param>
+        /// <param name="retries">Re-dials so far (the initial dial is not counted).</param>
+        /// <param name="waitedTotal">Seconds since the initial dial.</param>
+        public static Verdict Next(bool localServer, bool localReadySignal, float sinceLastAttempt, int retries, float waitedTotal)
+        {
+            if (!localServer)
+            {
+                if (sinceLastAttempt < RemoteIntervalSeconds)
+                {
+                    return Verdict.Wait;
+                }
+
+                return retries < RemoteRetries ? Verdict.Retry : Verdict.GiveUp;
+            }
+
+            if (waitedTotal >= LocalBudgetSeconds)
+            {
+                return Verdict.GiveUp;
+            }
+
+            if (localReadySignal)
+            {
+                return Verdict.Retry;
+            }
+
+            return sinceLastAttempt >= LocalIntervalSeconds ? Verdict.Retry : Verdict.Wait;
+        }
+    }
+}

--- a/client/Assets/BlocksBeyondTheStars/Scripts/ConnectRetryPolicy.cs.meta
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/ConnectRetryPolicy.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7c1f561920caf8ab076aeefc8191fd22
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/client/Assets/BlocksBeyondTheStars/Scripts/CraftingTechShipUI.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/CraftingTechShipUI.cs
@@ -103,6 +103,14 @@ namespace BlocksBeyondTheStars.Client
 
         private const float W = 1920f, H = 1080f;
 
+        // Holo chrome (the HUD's UiHolo panels, not the bitmap sprite) for the three frames, so the menu can
+        // boot the way the HUD does: each frame wipes on left→right with a short stagger while its pane's
+        // content fades up behind the wipe. Frames in sidebar → list → detail order; a null Shape means the
+        // holo shader is unavailable (bitmap fallback) and only the fades play.
+        private readonly Image[] _frames = new Image[3];
+        private readonly CanvasGroup[] _paneGroups = new CanvasGroup[3];
+        private CanvasGroup _headerGroup;
+
         // --- public control (from GameMenu) ---
 
         public void ShowMode(Mode mode)
@@ -129,7 +137,70 @@ namespace BlocksBeyondTheStars.Client
             RebuildSidebar();
             RebuildList();
             RebuildDetail();
-            UiKit.TransitionIn(_canvas.gameObject); // fade-in on open + tab change
+            PlayReveal(); // the HUD's boot-up feel on open + tab change
+        }
+
+        /// <summary>
+        /// The menu's take on the HUD's boot reveal (<see cref="HudUi"/> → <see cref="UiHolo.PlayReveal"/>):
+        /// the whole screen still fades (backdrop, logo, footer — the old TransitionIn), the header fades
+        /// first, then the three holo frames wipe on left→right one after another and each pane's content
+        /// fades up once its frame's wipe is past the half-way mark. Played on open AND on every tab change
+        /// (ShowMode) — never on the live rebuilds Update triggers, those would flicker. Timings are kept
+        /// short enough that LB/RB cycling through the tabs stays snappy; a re-trigger mid-play restarts
+        /// cleanly because every tween is keyed to its target. Instant under reduced motion.
+        /// </summary>
+        private void PlayReveal()
+        {
+            UiKit.TransitionIn(_canvas.gameObject);
+            if (UiKit.ReducedMotion)
+            {
+                if (_headerGroup != null)
+                {
+                    _headerGroup.alpha = 1f;
+                }
+
+                for (int i = 0; i < _frames.Length; i++)
+                {
+                    var s = _frames[i] != null ? _frames[i].GetComponent<UiHolo.Shape>() : null;
+                    if (s != null)
+                    {
+                        s.Reveal = 1f;
+                    }
+
+                    if (_paneGroups[i] != null)
+                    {
+                        _paneGroups[i].alpha = 1f;
+                    }
+                }
+
+                return;
+            }
+
+            const float wipe = 0.30f, stagger = 0.07f, lead = 0.04f, contentFade = 0.22f;
+            if (_headerGroup != null)
+            {
+                _headerGroup.alpha = 0f;
+                UiTween.Alpha(_headerGroup, 1f, 0.18f, UiTween.Ease.OutQuad);
+            }
+
+            for (int i = 0; i < _frames.Length; i++)
+            {
+                float at = lead + i * stagger;
+                var shape = _frames[i] != null ? _frames[i].GetComponent<UiHolo.Shape>() : null;
+                if (shape != null)
+                {
+                    UiTween.Kill(shape);
+                    shape.Reveal = 0f;
+                    UiTween.To(0f, 1f, wipe, r => { if (shape != null) { shape.Reveal = r; } }, UiTween.Ease.OutCubic, at, null, shape);
+                }
+
+                var group = _paneGroups[i];
+                if (group != null)
+                {
+                    group.alpha = 0f;
+                    UiTween.Alpha(group, 1f, contentFade, UiTween.Ease.OutQuad, at + wipe * 0.45f);
+                }
+            }
         }
 
         private string _pendingCategory; // a category to select when the mode next opens (e.g. "market")
@@ -498,14 +569,22 @@ namespace BlocksBeyondTheStars.Client
             _header.SetParent(root, false);
             UiKit.Place(_header.gameObject, 0, 0, W, 132);
 
-            // Panels.
-            UiKit.AddPanel(root, 40, 150, 320, 820, UiKit.Panel);    // sidebar
-            UiKit.AddPanel(root, 380, 150, 820, 820, UiKit.Panel);   // list
-            UiKit.AddPanel(root, 1220, 150, 660, 820, UiKit.Panel);  // detail
+            // Panels — holo chrome (same shader + colour family as the HUD's panels), see PlayReveal.
+            _frames[0] = UiHolo.AddPanel(root, 40, 150, 320, 820, UiKit.Panel, 12f, 1.5f, 1f);    // sidebar
+            _frames[1] = UiHolo.AddPanel(root, 380, 150, 820, 820, UiKit.Panel, 12f, 1.5f, 1f);   // list
+            _frames[2] = UiHolo.AddPanel(root, 1220, 150, 660, 820, UiKit.Panel, 12f, 1.5f, 1f);  // detail
 
             _sidebar = MakeScroll(root, 50, 162, 300, 796);
             _listContent = MakeScroll(root, 392, 220, 796, 742);
             _detail = MakeScroll(root, 1232, 162, 636, 796);
+
+            // One CanvasGroup per scroll VIEW (the content under it is rebuilt per tab; the view survives),
+            // so a pane's content can fade up behind its frame's wipe. Header likewise — BuildHeader clears
+            // its children, not the header object itself.
+            _paneGroups[0] = _sidebar.parent.gameObject.AddComponent<CanvasGroup>();
+            _paneGroups[1] = _listContent.parent.gameObject.AddComponent<CanvasGroup>();
+            _paneGroups[2] = _detail.parent.gameObject.AddComponent<CanvasGroup>();
+            _headerGroup = _header.gameObject.AddComponent<CanvasGroup>();
 
             // Gate row between the tab bar and the panels (#1071/#1072): "what do I need" (hint), "where is it"
             // (live distance + arrow), a Show-on-compass button and a "craft one" jump. Used to sit INSIDE the

--- a/client/Assets/BlocksBeyondTheStars/Scripts/GameBootstrap.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/GameBootstrap.cs
@@ -1810,6 +1810,12 @@ namespace BlocksBeyondTheStars.Client
         private bool _joinSendFailureLogged;
         private float _retryTimer;
         private int _retries;
+        private float _connectWaited;   // seconds since the initial dial (the local-server ceiling)
+        private bool _localReadyDialed; // the launcher's "started on port" signal has been acted on
+
+        /// <summary>The bundled server this client spawned (set by WorldRig from the shell), or null for a
+        /// remote host. Switches the connect loop to the patient local budget — see <see cref="ConnectRetryPolicy"/>.</summary>
+        public LocalServerLauncher LocalServer;
 
         private void Start()
         {
@@ -2551,25 +2557,38 @@ namespace BlocksBeyondTheStars.Client
                 }
                 else
                 {
-                    // Safety net: re-attempt the connection a few times (e.g. the local
-                    // singleplayer server is still starting up).
+                    // Re-dial until the server answers — ConnectRetryPolicy decides how patiently: a remote
+                    // host gets a few attempts, the bundled local server gets as long as a fresh world takes
+                    // to generate (it used to get the remote budget and lost the race by seconds).
                     _retryTimer += Time.deltaTime;
-                    if (_retryTimer >= 2f)
+                    _connectWaited += Time.deltaTime;
+                    bool local = LocalServer != null;
+                    bool readySignal = local && !_localReadyDialed && LocalServer.Ready;
+                    switch (ConnectRetryPolicy.Next(local, readySignal, _retryTimer, _retries, _connectWaited))
                     {
-                        if (_retries < 6)
-                        {
+                        case ConnectRetryPolicy.Verdict.Retry:
+                            if (readySignal)
+                            {
+                                _localReadyDialed = true;
+                                Debug.Log($"Local server reports ready after {_connectWaited:0.0} s — connecting.");
+                            }
+
                             _retryTimer = 0f;
                             _retries++;
                             Network.Connect(Host, Port);
-                        }
-                        else if (string.IsNullOrEmpty(ConnectFailedReason))
-                        {
-                            // All retries spent and still no connection: give up loudly. Disconnected
-                            // never fires for a never-connected session, so this flag is the only
-                            // signal AppShell gets to bail back to the menu with a message (#409).
-                            Debug.LogError($"Could not connect to {Host}:{Port} after {_retries} retries — giving up.");
-                            ConnectFailedReason = Localizer?.Get("ui.connect.failed") ?? "Could not connect to the server.";
-                        }
+                            break;
+
+                        case ConnectRetryPolicy.Verdict.GiveUp:
+                            if (string.IsNullOrEmpty(ConnectFailedReason))
+                            {
+                                // All retries spent and still no connection: give up loudly. Disconnected
+                                // never fires for a never-connected session, so this flag is the only
+                                // signal AppShell gets to bail back to the menu with a message (#409).
+                                Debug.LogError($"Could not connect to {Host}:{Port} after {_retries} retries ({_connectWaited:0} s) — giving up.");
+                                ConnectFailedReason = Localizer?.Get("ui.connect.failed") ?? "Could not connect to the server.";
+                            }
+
+                            break;
                     }
                 }
             }

--- a/client/Assets/BlocksBeyondTheStars/Scripts/LocalServerLauncher.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/LocalServerLauncher.cs
@@ -30,6 +30,15 @@ namespace BlocksBeyondTheStars.Client
         public int Port { get; private set; } = DefaultPort;
         public bool IsRunning => _process != null && !_process.HasExited;
 
+        // Set from the stdout reader thread when the server prints its "started on port" line — the
+        // moment it accepts connections. Volatile: read on the main thread by GameBootstrap's retry loop.
+        private volatile bool _ready;
+
+        /// <summary>True once the spawned server has reported that it listens (its startup log line). A
+        /// fresh world can take 15 s+ to generate first; this is what lets the client connect the instant the
+        /// server is there instead of guessing with a fixed retry budget (see <see cref="ConnectRetryPolicy"/>).</summary>
+        public bool Ready => _ready;
+
         /// <summary>Root folder holding the singleplayer save worlds (one subfolder per world).</summary>
         public static string SavesRoot => Path.Combine(AppPaths.Root, "singleplayer-saves");
 
@@ -258,8 +267,22 @@ namespace BlocksBeyondTheStars.Client
                 return false;
             }
 
+            _ready = false;
             var proc = new Process { StartInfo = _pendingPsi, EnableRaisingEvents = true };
-            proc.OutputDataReceived += (_, e) => { if (!string.IsNullOrEmpty(e.Data)) Debug.Log($"[server] {e.Data}"); };
+            proc.OutputDataReceived += (_, e) =>
+            {
+                if (string.IsNullOrEmpty(e.Data))
+                {
+                    return;
+                }
+
+                Debug.Log($"[server] {e.Data}");
+                // GameServer.Start's final line: "Server '<name>' started on port <n>, world '<w>' (...)".
+                if (!_ready && e.Data.Contains("started on port"))
+                {
+                    _ready = true;
+                }
+            };
             proc.ErrorDataReceived += (_, e) => { if (!string.IsNullOrEmpty(e.Data)) Debug.LogWarning($"[server] {e.Data}"); };
 
             try

--- a/client/Assets/BlocksBeyondTheStars/Scripts/UiEditors.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/UiEditors.cs
@@ -41,7 +41,7 @@ namespace BlocksBeyondTheStars.Client
             UiKit.AddButton(root, bx, y, bw, bh, shell.L("ui.menu.back"), () => shell.GoTo(ShellPhase.MainMenu), "btn_exit");
 
             // Description panel (right): what the editors export + the developer-tool caveat.
-            UiKit.AddPanel(root, 980f, 244f, 560f, 420f, UiKit.PanelFill);
+            UiHolo.AddPanel(root, 980f, 244f, 560f, 420f, UiKit.Panel, 18f, 1.5f, 1f); // holo frame — wipes on with the screen boot (#1796)
             UiKit.AddText(root, 1004f, 262f, 520f, 24f, shell.L("ui.editors.info_title"), 17, UiKit.Cyan, TextAnchor.MiddleLeft, FontStyle.Bold);
             UiKit.AddText(root, 1004f, 300f, 520f, 250f, shell.L("ui.editors.info_body"), 16, UiKit.TextCol, TextAnchor.UpperLeft).horizontalOverflow = HorizontalWrapMode.Wrap;
             UiKit.AddText(root, 1004f, 560f, 520f, 90f, shell.L("ui.editors.dev.note"), 14, UiKit.Warn, TextAnchor.UpperLeft).horizontalOverflow = HorizontalWrapMode.Wrap;

--- a/client/Assets/BlocksBeyondTheStars/Scripts/UiKit.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/UiKit.cs
@@ -184,6 +184,55 @@ namespace BlocksBeyondTheStars.Client
         /// <summary>Set from <see cref="ClientSettings.Apply"/>: reduced-effects users keep instant panel snaps.</summary>
         public static bool ReducedMotion;
 
+        /// <summary>
+        /// The HUD's boot-up feel for a whole shell screen (main menu, settings, save select, …): the screen
+        /// fades in as a whole, every top-level element rises and fades up in build order with a short stagger
+        /// (the systems coming online one after another), and every holo frame under the root wipes on
+        /// left→right (<see cref="UiHolo.PlayReveal"/>). Call once right after the screen is built. Elements
+        /// that are inactive at that moment (modal dialogs, overlays) are skipped — they get their own
+        /// TransitionIn when they open. Instant under <see cref="ReducedMotion"/>.
+        /// </summary>
+        public static void BootScreen(GameObject canvasRoot, float stagger = 0.035f, float maxStagger = 0.45f)
+        {
+            if (canvasRoot == null)
+            {
+                return;
+            }
+
+            TransitionIn(canvasRoot);
+            var root = canvasRoot.transform;
+            if (ReducedMotion)
+            {
+                UiHolo.PlayReveal(root); // snaps every shape to fully drawn
+                return;
+            }
+
+            int n = 0;
+            for (int i = 0; i < root.childCount; i++)
+            {
+                var child = root.GetChild(i) as RectTransform;
+                if (child == null || !child.gameObject.activeSelf)
+                {
+                    continue;
+                }
+
+                var group = child.GetComponent<CanvasGroup>();
+                if (group == null)
+                {
+                    group = child.gameObject.AddComponent<CanvasGroup>();
+                }
+
+                float delay = Mathf.Min(n * stagger, maxStagger);
+                n++;
+                group.alpha = 0f;
+                UiTween.Alpha(group, 1f, 0.24f, UiTween.Ease.OutQuad, delay);
+                var home = child.anchoredPosition;
+                UiTween.Move(child, home + new Vector2(0f, -10f), home, 0.28f, UiTween.Ease.OutCubic, delay);
+            }
+
+            UiHolo.PlayReveal(root, 0.34f, 0.06f, 0.04f);
+        }
+
         /// <summary>Fade+rise-in transition (~0.14 s, unscaled) on a UI root: attaches/reuses a CanvasGroup
         /// and animates alpha 0→1 plus a small upward slide. Instant under <see cref="ReducedMotion"/>.
         /// Canvas roots only fade (their RectTransform is driven by the canvas).</summary>

--- a/client/Assets/BlocksBeyondTheStars/Scripts/UiMainMenu.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/UiMainMenu.cs
@@ -26,7 +26,7 @@ namespace BlocksBeyondTheStars.Client
             UiNav.Enable(canvas.gameObject); // let a gamepad drive the menu (inert on keyboard/mouse)
 
             // --- SYSTEM CHECK panel (decorative flavour) ---
-            UiKit.AddPanel(root, 40f, 40f, 280f, 220f, UiKit.PanelFill);
+            UiHolo.AddPanel(root, 40f, 40f, 280f, 220f, UiKit.Panel, 18f, 1.5f, 1f); // holo frame — wipes on with the screen boot (#1796)
             UiKit.AddText(root, 60f, 54f, 250f, 22f, shell.L("ui.menu.system_check"), 16, UiKit.Cyan, TextAnchor.MiddleLeft, FontStyle.Bold);
             string[] sysKeys = { "ui.sys.engines", "ui.sys.shields", "ui.sys.life_support", "ui.sys.comms", "ui.sys.navigation" };
             string[] sysIcons = { "sys_engines", "sys_shields", "sys_life", "sys_comms", "sys_nav" };
@@ -86,7 +86,7 @@ namespace BlocksBeyondTheStars.Client
             }
             // Accented like the native menu: the name gates every play action (#221); panel edges flush
             // with the button column, content inset — see the native branch below.
-            UiKit.AddPanel(root, bx, by - 10f, bw, 100f, new Color(0.12f, 0.45f, 0.62f, 0.22f));
+            UiHolo.AddPanel(root, bx, by - 10f, bw, 100f, new Color(0.12f, 0.45f, 0.62f, 0.22f), 14f, 1.2f, 0.8f);
             UiKit.AddText(root, bx + 16f, by, bw - 32f, 24f, shell.L("ui.menu.connect_name"), 17, UiKit.Cyan, TextAnchor.MiddleLeft, FontStyle.Bold);
             // Capped at the server's join limit (#1368): a longer name was truncated server-side, so the settings
             // remembered a name that was not the player's actual id.
@@ -299,7 +299,7 @@ namespace BlocksBeyondTheStars.Client
             // The name is the gate for every play action (#221) — make the field read as step one, not
             // as a side note: an accented backdrop + bold cyan label instead of the plain grey line.
             // The panel's outer edges sit exactly on the button column (bx..bx+bw); content insets instead.
-            UiKit.AddPanel(root, bx, by - 10f, bw, 100f, new Color(0.12f, 0.45f, 0.62f, 0.22f));
+            UiHolo.AddPanel(root, bx, by - 10f, bw, 100f, new Color(0.12f, 0.45f, 0.62f, 0.22f), 14f, 1.2f, 0.8f);
             UiKit.AddText(root, bx + 16f, by, bw - 32f, 24f, shell.L("ui.menu.connect_name"), 17, UiKit.Cyan, TextAnchor.MiddleLeft, FontStyle.Bold);
             UiKit.AddInput(root, bx + 16f, by + 30f, bw - 32f, 46f, natName[0], v => natName[0] = v, maxLength: Protocol.MaxPlayerNameLength); // the server's join cap (#1368)
             var natWarn = UiKit.AddText(root, bx, by + 80f, bw, 22f, "", 14,
@@ -353,7 +353,7 @@ namespace BlocksBeyondTheStars.Client
             // --- World / server info panel (bottom-right, decorative) ---
             // Its bottom edge (672+250=922) lines up with the menu column's last entry ("Quit" ends
             // at 434+62*7+54=922), so the two columns close on one shared baseline.
-            UiKit.AddPanel(root, 1290f, 672f, 590f, 250f, UiKit.PanelFill);
+            UiHolo.AddPanel(root, 1290f, 672f, 590f, 250f, UiKit.Panel, 18f, 1.5f, 1f);
             UiKit.AddText(root, 1314f, 688f, 540f, 24f, shell.L("ui.menu.world_info"), 16, UiKit.Cyan, TextAnchor.MiddleLeft, FontStyle.Bold);
             AddInfo(root, 728f, "info_mode", shell.L("ui.info.mode_title"), shell.L("ui.info.mode_desc"));
             AddInfo(root, 792f, "info_multiplayer", shell.L("ui.info.mp_title"), shell.L("ui.info.mp_desc"));

--- a/client/Assets/BlocksBeyondTheStars/Scripts/UiSaveSelect.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/UiSaveSelect.cs
@@ -120,7 +120,7 @@ namespace BlocksBeyondTheStars.Client
             UiKit.AddText(root, 364f, 180f, 1000f, 26f, shell.L(host ? "ui.host.subtitle" : "ui.save.subtitle"), 18, UiKit.CyanDim, TextAnchor.MiddleLeft);
 
             // ── Existing worlds (left) ────────────────────────────────────────────────────────
-            var left = UiKit.AddPanel(root, 90f, 250f, 720f, 640f, UiKit.PanelFill).transform;
+            var left = UiHolo.AddPanel(root, 90f, 250f, 720f, 640f, UiKit.Panel, 18f, 1.5f, 1f).transform; // holo frames — wipe on with the screen boot (#1796)
             UiKit.AddText(left, 20f, 16f, 680f, 26f, shell.L("ui.save.existing"), 18, UiKit.Cyan, TextAnchor.MiddleLeft, FontStyle.Bold);
 
             // Delete-confirmation dialog (built below, shown on demand) — captured by the row buttons.
@@ -152,7 +152,7 @@ namespace BlocksBeyondTheStars.Client
             }
 
             // ── New world (right) ─────────────────────────────────────────────────────────────
-            var right = UiKit.AddPanel(root, 850f, 250f, 700f, 540f, UiKit.PanelFill).transform;
+            var right = UiHolo.AddPanel(root, 850f, 250f, 700f, 540f, UiKit.Panel, 18f, 1.5f, 1f).transform;
             UiKit.AddText(right, 20f, 16f, 660f, 26f, shell.L("ui.save.new"), 18, UiKit.Cyan, TextAnchor.MiddleLeft, FontStyle.Bold);
             var nameLabel = UiKit.AddText(right, 20f, 54f, 660f, 24f, shell.L("ui.save.name"), 15, UiKit.TextCol, TextAnchor.MiddleLeft);
 
@@ -296,7 +296,7 @@ namespace BlocksBeyondTheStars.Client
             // ── Host options (host mode only): player cap + optional join password ───────────────
             if (host)
             {
-                var bar = UiKit.AddPanel(root, 850f, 800f, 700f, 186f, UiKit.PanelFill).transform;
+                var bar = UiHolo.AddPanel(root, 850f, 800f, 700f, 186f, UiKit.Panel, 18f, 1.5f, 1f).transform;
                 UiKit.AddText(bar, 20f, 8f, 300f, 24f, shell.L("ui.host.max_players"), 15, UiKit.TextCol, TextAnchor.MiddleLeft);
                 Text count = null;
                 UiKit.AddButton(bar, 20f, 38f, 46f, 46f, "-", () =>

--- a/client/Assets/BlocksBeyondTheStars/Scripts/VegaPanel.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/VegaPanel.cs
@@ -33,9 +33,10 @@ namespace BlocksBeyondTheStars.Client
 
         // Left-column layout in HUD reference units (1536×864). The column is full: vitals end at y 260,
         // the toast sits at 268, the scan panel starts at 650 and the hotbar backplate owns y 742…834 /
-        // x 400…1136. These two constants are what a layout tweak should move (#482).
-        private const float SpeechY = 396f, SpeechH = 190f;
-        private const float ChipY = 594f;
+        // x 400…1136. These two constants are what a layout tweak should move (#482). They are public
+        // because the chat overlay shares the lane and yields to whichever of the two is up (ChatUi).
+        public const float SpeechY = 396f, SpeechH = 190f;
+        public const float ChipY = 594f;
 
         // The speech body's text rect — the page splitter (#736) measures wrapped lines against exactly
         // this box, so a page can never be taller than what VerticalWrapMode.Truncate would show.
@@ -161,6 +162,13 @@ namespace BlocksBeyondTheStars.Client
 
         /// <summary>The live panel (one per rig), for client-side one-shot hints (<see cref="SayLocal"/>).</summary>
         public static VegaPanel Instance { get; private set; }
+
+        /// <summary>Whether the speech panel (y <see cref="SpeechY"/>…) is currently drawn. The chat overlay
+        /// polls this to keep its scrollback out of the same left-column band.</summary>
+        public bool SpeechVisible => _speech != null && _speech.activeSelf;
+
+        /// <summary>Whether the objective chip (y <see cref="ChipY"/>…) is currently drawn — see <see cref="SpeechVisible"/>.</summary>
+        public bool ChipVisible => _chip != null && _chip.activeSelf;
 
         /// <summary>A client-side hint spoken in VEGA's voice without a server round-trip (#1663) — for UI
         /// lessons only the client knows the moment for (the first time a screen opens). Follows the advisor

--- a/client/Assets/BlocksBeyondTheStars/Scripts/WorldRig.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/WorldRig.cs
@@ -32,6 +32,7 @@ namespace BlocksBeyondTheStars.Client
             // to the in-browser server directly instead of opening any socket.
             boot.Loopback = shell.BrowserServer != null && shell.BrowserServer.Running ? shell.BrowserServer.Link : null;
             boot.Host = shell.Host;
+            boot.LocalServer = shell.LocalServer; // null for remote hosts — picks the patient local connect budget
             // A port that doesn't parse can only come from the hand-typed connect dialog, and that dialog
             // exists for LAN/self-host joins — so fall back to the hosted-world port, not the official one (#978).
             boot.Port = int.TryParse(shell.Port, out var p) && p > 0 ? p : LocalServerLauncher.DefaultPort;

--- a/client/Assets/Tests/EditMode/ChatLaneEditModeTests.cs
+++ b/client/Assets/Tests/EditMode/ChatLaneEditModeTests.cs
@@ -1,0 +1,104 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using BlocksBeyondTheStars.Client;
+using NUnit.Framework;
+
+namespace BlocksBeyondTheStars.Client.Tests.EditMode
+{
+    /// <summary>
+    /// The chat overlay shares the HUD's left column with VEGA (speech panel y 396…586, objective chip
+    /// y 594…642, HUD reference 1536×864). Before the lane arbitration the chat's scrollback (y 280…590)
+    /// drew straight across a story line and its input row (y 596…640) sat exactly on the chip. These pin
+    /// the geometry <see cref="ChatUi.ResolveLane"/> hands out for every VEGA / typing combination.
+    /// </summary>
+    public sealed class ChatLaneEditModeTests
+    {
+        private const float LaneTop = 280f, LaneBottom = 590f, InputH = 44f, Gap = 6f;
+
+        private static float Bottom(ChatUi.ChatLane lane) => lane.LogY + lane.LogH;
+
+        [Test]
+        public void VegaQuiet_KeepsTheOriginalLane()
+        {
+            var lane = ChatUi.ResolveLane(typing: false, speechVisible: false, chipVisible: false);
+            Assert.That(lane.LogY, Is.EqualTo(LaneTop));
+            Assert.That(Bottom(lane), Is.EqualTo(LaneBottom));
+            Assert.That(lane.InputY, Is.EqualTo(596f));
+
+            var typing = ChatUi.ResolveLane(typing: true, speechVisible: false, chipVisible: false);
+            Assert.That(typing.LogH, Is.EqualTo(lane.LogH), "typing alone never shortens the scrollback");
+            Assert.That(typing.InputY, Is.EqualTo(596f));
+        }
+
+        [Test]
+        public void SpeechUp_ScrollbackEndsAboveThePanel()
+        {
+            var lane = ChatUi.ResolveLane(typing: false, speechVisible: true, chipVisible: false);
+            Assert.That(lane.LogY, Is.EqualTo(LaneTop));
+            Assert.That(Bottom(lane), Is.LessThan(VegaPanel.SpeechY));
+            Assert.That(Bottom(lane), Is.EqualTo(VegaPanel.SpeechY - Gap));
+            Assert.That(lane.LogH, Is.GreaterThan(60f), "room for a few lines above the speech panel");
+        }
+
+        [Test]
+        public void ChipOnly_NotTyping_ScrollbackUnchanged()
+        {
+            // The chip (y 594+) never overlapped the scrollback — only the input row — so the log keeps its lane.
+            var lane = ChatUi.ResolveLane(typing: false, speechVisible: false, chipVisible: true);
+            Assert.That(Bottom(lane), Is.EqualTo(LaneBottom));
+            Assert.That(Bottom(lane), Is.LessThan(VegaPanel.ChipY));
+        }
+
+        [Test]
+        public void ChipUp_Typing_InputRowStacksUnderTheScrollback()
+        {
+            var lane = ChatUi.ResolveLane(typing: true, speechVisible: false, chipVisible: true);
+            Assert.That(lane.InputY + InputH, Is.LessThanOrEqualTo(VegaPanel.ChipY), "input row clear of the chip");
+            Assert.That(Bottom(lane) + Gap, Is.EqualTo(lane.InputY), "input row sits directly under the log");
+            Assert.That(lane.LogH, Is.GreaterThan(200f), "the log still shows most of its rows");
+        }
+
+        [Test]
+        public void SpeechAndChipUp_Typing_EverythingStaysAboveVega()
+        {
+            var lane = ChatUi.ResolveLane(typing: true, speechVisible: true, chipVisible: true);
+            Assert.That(lane.InputY + InputH, Is.LessThanOrEqualTo(VegaPanel.SpeechY - Gap));
+            Assert.That(Bottom(lane) + Gap, Is.EqualTo(lane.InputY));
+            Assert.That(lane.LogY, Is.EqualTo(LaneTop));
+            Assert.That(lane.LogH, Is.GreaterThan(0f));
+        }
+
+        [Test]
+        public void EveryCombination_StaysInsideTheColumnAndNeverGoesNegative()
+        {
+            foreach (bool typing in new[] { false, true })
+            {
+                foreach (bool speech in new[] { false, true })
+                {
+                    foreach (bool chip in new[] { false, true })
+                    {
+                        var lane = ChatUi.ResolveLane(typing, speech, chip);
+                        Assert.That(lane.LogY, Is.EqualTo(LaneTop), $"top fixed ({typing},{speech},{chip})");
+                        Assert.That(lane.LogH, Is.GreaterThanOrEqualTo(0f));
+                        Assert.That(Bottom(lane), Is.LessThanOrEqualTo(LaneBottom));
+                        Assert.That(lane.InputY, Is.LessThanOrEqualTo(596f));
+                        if (speech)
+                        {
+                            Assert.That(Bottom(lane), Is.LessThan(VegaPanel.SpeechY), $"log clear of speech ({typing},{chip})");
+                            if (typing)
+                            {
+                                Assert.That(lane.InputY + InputH, Is.LessThan(VegaPanel.SpeechY), $"input clear of speech ({chip})");
+                            }
+                        }
+
+                        if (chip && typing)
+                        {
+                            Assert.That(lane.InputY + InputH, Is.LessThanOrEqualTo(VegaPanel.ChipY), $"input clear of chip ({speech})");
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/client/Assets/Tests/EditMode/ChatLaneEditModeTests.cs.meta
+++ b/client/Assets/Tests/EditMode/ChatLaneEditModeTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9eab89cbef0770c66413c9c93465d0e1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/client/Assets/Tests/EditMode/ConnectRetryPolicyEditModeTests.cs
+++ b/client/Assets/Tests/EditMode/ConnectRetryPolicyEditModeTests.cs
@@ -1,0 +1,71 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using BlocksBeyondTheStars.Client;
+using NUnit.Framework;
+using static BlocksBeyondTheStars.Client.ConnectRetryPolicy;
+
+namespace BlocksBeyondTheStars.Client.Tests.EditMode
+{
+    /// <summary>
+    /// The connect re-dial policy. A fresh singleplayer world took 16 s of server-side generation while
+    /// the client's budget was the remote one (initial dial + 6 × 2 s ≈ 14 s), so the client gave up in
+    /// the very second the server reported ready. Local servers now get a patient budget and an
+    /// immediate dial on the launcher's ready signal; remote hosts keep the short budget of #409.
+    /// </summary>
+    public sealed class ConnectRetryPolicyEditModeTests
+    {
+        [Test]
+        public void Remote_RetriesOnTheIntervalThenGivesUp()
+        {
+            Assert.That(Next(false, false, 1.9f, 0, 1.9f), Is.EqualTo(Verdict.Wait));
+            Assert.That(Next(false, false, 2.0f, 0, 2.0f), Is.EqualTo(Verdict.Retry));
+            Assert.That(Next(false, false, 2.0f, RemoteRetries - 1, 12f), Is.EqualTo(Verdict.Retry));
+            Assert.That(Next(false, false, 2.0f, RemoteRetries, 14f), Is.EqualTo(Verdict.GiveUp));
+            Assert.That(Next(false, false, 1.0f, RemoteRetries, 14f), Is.EqualTo(Verdict.Wait), "give-up also waits for the interval");
+        }
+
+        [Test]
+        public void Remote_IgnoresTheLocalReadySignal()
+        {
+            Assert.That(Next(false, true, 0.5f, 0, 0.5f), Is.EqualTo(Verdict.Wait));
+        }
+
+        [Test]
+        public void Local_KeepsKnockingWellPastTheRemoteBudget()
+        {
+            // The 2026-09-12 case: the server needed 16 s; the remote budget had already given up.
+            Assert.That(Next(true, false, LocalIntervalSeconds, RemoteRetries + 4, 16f), Is.EqualTo(Verdict.Retry));
+            Assert.That(Next(true, false, LocalIntervalSeconds, 60, 60f), Is.EqualTo(Verdict.Retry));
+            Assert.That(Next(true, false, LocalIntervalSeconds, 119, 119f), Is.EqualTo(Verdict.Retry));
+        }
+
+        [Test]
+        public void Local_KnocksOncePerIntervalNotEveryFrame()
+        {
+            Assert.That(Next(true, false, LocalIntervalSeconds - 0.1f, 3, 5f), Is.EqualTo(Verdict.Wait));
+            Assert.That(Next(true, false, LocalIntervalSeconds, 3, 5f), Is.EqualTo(Verdict.Retry));
+        }
+
+        [Test]
+        public void Local_ReadySignalDialsImmediately()
+        {
+            Assert.That(Next(true, true, 0.05f, 3, 5f), Is.EqualTo(Verdict.Retry), "no waiting for the interval once the server says it listens");
+        }
+
+        [Test]
+        public void Local_GivesUpOnlyAtTheCeiling()
+        {
+            Assert.That(Next(true, false, LocalIntervalSeconds, 200, LocalBudgetSeconds - 0.5f), Is.EqualTo(Verdict.Retry));
+            Assert.That(Next(true, false, LocalIntervalSeconds, 200, LocalBudgetSeconds), Is.EqualTo(Verdict.GiveUp));
+            Assert.That(Next(true, true, 0f, 200, LocalBudgetSeconds), Is.EqualTo(Verdict.GiveUp), "the ceiling beats a late ready signal");
+        }
+
+        [Test]
+        public void Budgets_AreWhatTheDocsPromise()
+        {
+            Assert.That(RemoteRetries * RemoteIntervalSeconds, Is.LessThanOrEqualTo(15f), "a mistyped address must still fail fast (#409)");
+            Assert.That(LocalBudgetSeconds, Is.GreaterThanOrEqualTo(60f), "a slow machine's fresh world must fit");
+        }
+    }
+}

--- a/client/Assets/Tests/EditMode/ConnectRetryPolicyEditModeTests.cs.meta
+++ b/client/Assets/Tests/EditMode/ConnectRetryPolicyEditModeTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1dadddf6e4c66464e1c16ef113fdd41e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
Three of Marcel's playtest notes of 2026-09-12, all client-side.

## #1795 Chat overlay drew across VEGA's speech panel

The chat (#643) and VEGA's speech panel + objective chip (#482) were both placed in the "free" left HUD column and nobody arbitrated the lane — the scrollback (sorted above VEGA) covered a story line, the input row sat exactly on the chip.

- `ChatUi.ResolveLane` (pure): while a speech line is up the scrollback ends above the panel; while typing with either VEGA element up the input row stacks directly under the shortened scrollback; with VEGA quiet the lane is unchanged.
- The scrollback is measured against its lane (TextGenerator at scale 1), so a shorter band drops the oldest rows instead of growing upward over the vitals and the toast.
- `VegaPanel` exposes `SpeechVisible` / `ChipVisible` and its two lane constants; `ChatUi.Update` re-lays out on a flip (two bool reads per frame).
- EditMode: `ChatLaneEditModeTests` (6) pins every VEGA × typing combination.

## #1796 The ship menu and the shell screens boot like the HUD

- `CraftingTechShipUI`: the three frames are `UiHolo.AddPanel` holo panels (the HUD's shader, same colour). `ShowMode` plays a menu-flavoured boot on open and on every tab change — header fade, then sidebar → list → detail wipe on left→right with a 0.07 s stagger while each pane's content (a CanvasGroup on the scroll view) fades up once its frame's wipe is past half-way. Never on the live rebuilds `Update` triggers; instant under reduced motion; a re-trigger mid-play restarts cleanly (tweens keyed to their targets).
- `UiKit.BootScreen` for the shell screens (main menu, settings, credits, editors, save-select): whole-screen fade, top-level elements rise in build order with a short stagger, holo frames wipe on. Their frames are holo panels now; hidden dialogs are skipped and keep their own TransitionIn.

## #1797 Singleplayer gave up before a fresh world had finished generating

Player.log: the bundled server logged `started on port 31550` at 10:22:45 — and the client logged `Could not connect … after 6 retries — giving up` in the same second. The connect budget was the remote one (initial dial + 6 × 2 s ≈ 14 s, #409); a fresh world needs 16 s+ here, more on a slow machine or with an antivirus first-scan.

- `ConnectRetryPolicy` (pure): remote hosts keep the short budget; the bundled local server knocks once a second with a 120 s ceiling and dials immediately on the launcher's ready signal.
- `LocalServerLauncher.Ready`: set from the stdout reader when the server prints its "started on port" line. `AppShell.LocalServer` → `WorldRig` → `GameBootstrap.LocalServer` selects the budget; a dying server process is still caught by the shell's launch watcher.
- EditMode: `ConnectRetryPolicyEditModeTests` (7).

## Verification

- Local Unity Windows build: `Build Finished, Result: Success` (three builds along the way, last one 12:57 with everything in).
- Unity EditMode: 13/13 for the two new classes.
- `TODO.md` work-log entry.

closes #1795
closes #1796
closes #1797

🤖 Generated with [Claude Code](https://claude.com/claude-code)