### PR TITLE
fix(client,ux): the singleplayer progress bar covers the server boot instead of a nameless "Loading world" curtain (#1800)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -24,6 +24,22 @@ envelope at the WebSocket edge; deterministic seed world-gen; SQLite default per
 
 ---
 
+### ⏳ Singleplayer: the progress bar covers the server boot, not a nameless curtain (#1800, 2026-09-12, branch fix/sp-loading-handoff)
+
+Marcel's playtest note after the generation-5/6 worldgen: a new singleplayer world showed the progress bar (0 → 100 %
+in 2.5 s), then a dark "Loading world…" curtain with **no world name** for 10–20 s, then the same curtain with the
+system · planet name. The shell's `LoadingScreen` was purely time-based and handed off to `LaunchGame` after MinShow no
+matter what; the rig's `WorldLoadingOverlay` then rose with an empty `LocationName` (it only arrives with the join),
+while the bundled server still did its whole boot behind it — SQLite init + NetCodec warm-up, `BuildGalaxy`, `LoadWorld`
+with every structure stamp, and only then the transport (Player.log 2026-09-12: 10.6 s rainbow sea, 20.2 s coral sea).
+`LoadingHandoffPolicy` (pure, EditMode-tested) now holds the bar screen on `AppShell.LocalServerBooting` — the desktop
+twin of the browser host's `BrowserWorldBooting` gate (#771) — until `LocalServerLauncher.Ready` relays the server's
+"started on port" line; the bar creeps from 60 % toward 85 % meanwhile and snaps to 100 % on ready. A server that lives
+but never reports ready is given up on at the connect loop's 120 s ceiling (`AbortLocalServerBoot` → menu +
+`ui.sp.server_failed`); a server that dies is still caught by the launch watcher. The nameless curtain now covers only
+the rig build + dial + join (~1 s); in-game hosting shares the path. Stage-based real progress (server stage lines)
+stays a possible follow-up.
+
 ### 💬 Chat yields to VEGA + the ship menu boots like the HUD (2026-09-12, branch feat/chat-vega-lane-menu-holo, LOCAL — not merged)
 
 Two of Marcel's playtest notes. **Chat ↔ VEGA:** the chat overlay (#643) and VEGA's speech panel + objective chip

--- a/client/Assets/BlocksBeyondTheStars/Scripts/AppShell.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/AppShell.cs
@@ -124,6 +124,14 @@ namespace BlocksBeyondTheStars.Client
         public bool BrowserWorldBooting { get; private set; }
         private bool _serverPending;                          // prepared, waiting to spawn once the screen is up
         private System.Threading.Tasks.Task<bool> _serverLaunch; // the off-thread spawn (so Process.Start can't freeze us)
+
+        /// <summary>The desktop twin of <see cref="BrowserWorldBooting"/>: true while the bundled server this
+        /// shell spawned for the world being entered has not yet reported that it listens (its "started on
+        /// port" line, relayed by <see cref="LocalServerLauncher.Ready"/>). A fresh world generates for
+        /// 10–20 s first. The loading screen holds its hand-off on this (<see cref="LoadingHandoffPolicy"/>),
+        /// so the progress bar — not the rig's nameless "Loading world…" curtain — covers the boot (#1800).
+        /// False when no bundled server was launched (remote join, or the manual-server fallback).</summary>
+        public bool LocalServerBooting => _hostLocal && (_serverPending || _serverLaunch != null) && !_localServer.Ready;
         private GameObject _gameRoot;
 
         public bool ContentReady { get; private set; }
@@ -840,7 +848,7 @@ namespace BlocksBeyondTheStars.Client
                 Port = _localServer.Port.ToString();
                 Password = password ?? "";
                 HostInfo = hosting ? $"{LocalLanIp()}:{_localServer.Port}" : "";
-                _loading.MinShow = 2.5f; // give the server time to start listening
+                _loading.MinShow = 2.5f; // minimum only — the hand-off then waits for the server's ready line (LocalServerBooting)
                 _serverPending = true;
             }
             else
@@ -1075,6 +1083,17 @@ namespace BlocksBeyondTheStars.Client
             Cursor.lockState = CursorLockMode.Locked;
             Cursor.visible = false;
             Phase = ShellPhase.InGame;
+        }
+
+        /// <summary>The loading screen waited the whole <see cref="LoadingHandoffPolicy.LocalBootCeilingSeconds"/>
+        /// for the bundled server to report ready and it never did (alive but wedged, or its log line never
+        /// came): stop it and go back to the menu with the launch-failed notice instead of launching into a
+        /// world that cannot be joined. A server that DIES is caught earlier by the launch watcher in Update.</summary>
+        public void AbortLocalServerBoot()
+        {
+            Debug.LogError($"Local server did not report ready within {LoadingHandoffPolicy.LocalBootCeilingSeconds:0} s — returning to menu.");
+            ReturnToMenu();
+            MenuNotice = L("ui.sp.server_failed");
         }
 
         // NOTE (#413 N2): Alt-Tab cursor re-lock used to live in an OnApplicationFocus handler here — with
@@ -1631,7 +1650,8 @@ namespace BlocksBeyondTheStars.Client
 
             // With the loading screen now on screen, spawn the prepared local server on a background thread —
             // so a blocking Process.Start (Defender first-scan of the freshly-built EXE) can't freeze the menu
-            // or the loading bar. The connect happens after MinShow, by which time it's listening.
+            // or the loading bar. The loading screen then holds until the server reports that it listens
+            // (LocalServerBooting → LoadingHandoffPolicy), so the rig dials a server that is already there.
             if (_serverPending && _uiLoading != null)
             {
                 _serverPending = false;

--- a/client/Assets/BlocksBeyondTheStars/Scripts/LoadingHandoffPolicy.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/LoadingHandoffPolicy.cs
@@ -1,0 +1,71 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using System;
+
+namespace BlocksBeyondTheStars.Client
+{
+    /// <summary>
+    /// When the shell loading screen (the progress bar) hands off to the in-game rig, and what the bar
+    /// shows while it waits. Pure so an EditMode test can pin it; <see cref="LoadingScreen"/> feeds it the
+    /// timers and <see cref="AppShell"/> the two boot gates.
+    ///
+    /// Desktop singleplayer spawns the bundled server, which generates a FRESH world before it listens —
+    /// 10–20 s on a fast machine (Player.log 2026-09-12: 10.6 s rainbow sea, 20.2 s coral sea with two
+    /// settlements). The bar used to run 0→100 % in 2.5 s and launch regardless, so the player then stared
+    /// at the rig's nameless "Loading world…" curtain for the whole server boot: the world name only
+    /// arrives with the join, and the join cannot happen before the server is up (#1800). The bar screen
+    /// now holds until the launcher relays the server's "started on port" line — the gate the browser
+    /// in-process host has had since #771 — and the curtain only covers the join and the first chunks.
+    /// </summary>
+    public static class LoadingHandoffPolicy
+    {
+        public enum Verdict { Hold, Launch, GiveUp }
+
+        /// <summary>Ceiling on the server-boot hold: a process that lives but never reports ready would
+        /// otherwise pin the loading screen forever. Same figure as the connect loop's local budget.</summary>
+        public const float LocalBootCeilingSeconds = ConnectRetryPolicy.LocalBudgetSeconds;
+
+        /// <summary>While the server boots the bar creeps from the floor toward the cap (never reaching it),
+        /// so it visibly keeps working instead of parking at "100 %"; the ready signal snaps it to full.</summary>
+        public const float HoldFloor = 0.60f;
+        public const float HoldCap = 0.85f;
+        public const float HoldTauSeconds = 12f;
+
+        /// <param name="elapsed">Seconds the loading screen has been up.</param>
+        /// <param name="minShow">Minimum on-screen time before any hand-off (the shell's MinShow).</param>
+        /// <param name="browserBooting">The WebGL in-process host is still bringing its world up (#771).</param>
+        /// <param name="localBooting">The bundled desktop server was spawned and has not reported ready.</param>
+        public static Verdict Next(float elapsed, float minShow, bool browserBooting, bool localBooting)
+        {
+            if (elapsed < minShow || browserBooting)
+            {
+                return Verdict.Hold;
+            }
+
+            if (localBooting)
+            {
+                return elapsed >= LocalBootCeilingSeconds ? Verdict.GiveUp : Verdict.Hold;
+            }
+
+            return Verdict.Launch;
+        }
+
+        /// <summary>Bar fill 0..1: the plain time ramp when nothing holds the launch, the creeping hold band
+        /// while the bundled server boots (monotonic in <paramref name="elapsed"/>, strictly below
+        /// <see cref="HoldCap"/>), and back to the ramp — i.e. 100 % — the moment the server reports ready.</summary>
+        public static float Progress(float elapsed, float minShow, bool localBooting)
+        {
+            float ramp = minShow <= 0f ? 1f : Clamp01(elapsed / minShow);
+            if (!localBooting)
+            {
+                return ramp;
+            }
+
+            float creep = (HoldCap - HoldFloor) * (1f - (float)Math.Exp(-Math.Max(0f, elapsed) / HoldTauSeconds));
+            return Math.Min(ramp, HoldFloor) + creep;
+        }
+
+        private static float Clamp01(float v) => v < 0f ? 0f : (v > 1f ? 1f : v);
+    }
+}

--- a/client/Assets/BlocksBeyondTheStars/Scripts/LoadingHandoffPolicy.cs.meta
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/LoadingHandoffPolicy.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6dff2d4c774d2909486ac67f61962bc4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/client/Assets/BlocksBeyondTheStars/Scripts/LoadingScreen.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/LoadingScreen.cs
@@ -18,8 +18,9 @@ namespace BlocksBeyondTheStars.Client
         /// <summary>How long to hold the loading screen before launching (raised when hosting a local server).</summary>
         public float MinShow = 0.6f;
 
-        /// <summary>Time-based load progress 0..1 (no real asset/world progress reported yet).</summary>
-        public float Progress => MinShow <= 0f ? 1f : Mathf.Clamp01(_elapsed / MinShow);
+        /// <summary>Bar fill 0..1: the time ramp over MinShow, or the creeping hold band while the bundled
+        /// server still generates its world (<see cref="LoadingHandoffPolicy.Progress"/>).</summary>
+        public float Progress => LoadingHandoffPolicy.Progress(_elapsed, MinShow, _shell.LocalServerBooting);
 
         public LoadingScreen(AppShell shell) => _shell = shell;
 
@@ -36,15 +37,25 @@ namespace BlocksBeyondTheStars.Client
                 return;
             }
 
-            // The browser singleplayer host boots asynchronously (cloud-save lookup, then worldgen) and
-            // hands its in-memory wire to the rig at launch. Launching on the timer alone raced that boot
-            // and left the rig without a wire, so the browser world "could not connect" (#771) — MinShow
-            // is the minimum time the screen shows, never a deadline the world start has to beat.
+            // MinShow is the minimum time the screen shows, never a deadline the world start has to beat:
+            // the browser singleplayer host boots asynchronously (cloud-save lookup, then worldgen) and
+            // hands its in-memory wire to the rig at launch — launching on the timer alone raced that boot
+            // and left the rig without a wire (#771). The bundled desktop server likewise generates a fresh
+            // world for 10–20 s before it listens; handing off earlier only swapped this screen for the
+            // rig's nameless "Loading world…" curtain for the rest of the boot (#1800). A server that never
+            // reports ready is given up on at the policy's ceiling instead of pinning the screen forever.
             _elapsed += Time.deltaTime;
-            if (_elapsed >= MinShow && !_shell.BrowserWorldBooting)
+            switch (LoadingHandoffPolicy.Next(_elapsed, MinShow, _shell.BrowserWorldBooting, _shell.LocalServerBooting))
             {
-                _elapsed = 0f;
-                _shell.LaunchGame();
+                case LoadingHandoffPolicy.Verdict.Launch:
+                    _elapsed = 0f;
+                    _shell.LaunchGame();
+                    break;
+
+                case LoadingHandoffPolicy.Verdict.GiveUp:
+                    _elapsed = 0f;
+                    _shell.AbortLocalServerBoot();
+                    break;
             }
         }
 

--- a/client/Assets/BlocksBeyondTheStars/Scripts/LocalServerLauncher.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/LocalServerLauncher.cs
@@ -148,6 +148,8 @@ namespace BlocksBeyondTheStars.Client
                 return true;
             }
 
+            _ready = false; // a previous run's ready flag must not pass as this one's (the shell gates the loading screen on it)
+
             Port = port;
             if (string.IsNullOrWhiteSpace(worldName))
             {
@@ -338,6 +340,7 @@ namespace BlocksBeyondTheStars.Client
             {
                 _process.Dispose();
                 _process = null;
+                _ready = false;
             }
         }
 

--- a/client/Assets/Tests/EditMode/LoadingHandoffPolicyEditModeTests.cs
+++ b/client/Assets/Tests/EditMode/LoadingHandoffPolicyEditModeTests.cs
@@ -1,0 +1,86 @@
+// Blocks Beyond the Stars — Copyright (c) 2026 Justus Dütscher & Marcel Dütscher (JuMaVe Games)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of Blocks Beyond the Stars. See LICENSE for the full AGPL-3.0 text.
+using NUnit.Framework;
+using static BlocksBeyondTheStars.Client.LoadingHandoffPolicy;
+
+namespace BlocksBeyondTheStars.Client.Tests.EditMode
+{
+    /// <summary>
+    /// The loading screen's hand-off: the progress-bar screen used to launch the rig on a 2.5 s timer while
+    /// the bundled server still needed 10–20 s to generate a fresh world, leaving the player on a nameless
+    /// "Loading world…" curtain for the whole boot (#1800). The bar screen now holds until the server reports
+    /// ready, with a ceiling, and the bar creeps instead of parking at 100 %.
+    /// </summary>
+    public sealed class LoadingHandoffPolicyEditModeTests
+    {
+        private const float MinShow = 2.5f;
+
+        [Test]
+        public void HoldsForMinShowThenLaunchesWhenNothingBoots()
+        {
+            Assert.That(Next(2.4f, MinShow, false, false), Is.EqualTo(Verdict.Hold));
+            Assert.That(Next(2.5f, MinShow, false, false), Is.EqualTo(Verdict.Launch));
+        }
+
+        [Test]
+        public void HoldsWhileTheBundledServerBoots()
+        {
+            // The 2026-09-12 case: the server needed 20 s; the old timer had launched at 2.5 s.
+            Assert.That(Next(2.5f, MinShow, false, true), Is.EqualTo(Verdict.Hold));
+            Assert.That(Next(20f, MinShow, false, true), Is.EqualTo(Verdict.Hold));
+            Assert.That(Next(20.2f, MinShow, false, false), Is.EqualTo(Verdict.Launch), "ready: launch right away");
+        }
+
+        [Test]
+        public void HoldsWhileTheBrowserHostBootsWithoutACeiling()
+        {
+            Assert.That(Next(5f, MinShow, true, false), Is.EqualTo(Verdict.Hold));
+            Assert.That(Next(LocalBootCeilingSeconds + 30f, MinShow, true, false), Is.EqualTo(Verdict.Hold), "the #771 gate is unchanged");
+        }
+
+        [Test]
+        public void GivesUpOnTheServerOnlyAtTheCeiling()
+        {
+            Assert.That(Next(LocalBootCeilingSeconds - 0.5f, MinShow, false, true), Is.EqualTo(Verdict.Hold));
+            Assert.That(Next(LocalBootCeilingSeconds, MinShow, false, true), Is.EqualTo(Verdict.GiveUp));
+        }
+
+        [Test]
+        public void MinShowStillAppliesWhenAServerBoots()
+        {
+            Assert.That(Next(1f, MinShow, false, true), Is.EqualTo(Verdict.Hold));
+        }
+
+        [Test]
+        public void Progress_IsThePlainRampWhenNothingHolds()
+        {
+            Assert.That(Progress(0f, MinShow, false), Is.EqualTo(0f));
+            Assert.That(Progress(1.25f, MinShow, false), Is.EqualTo(0.5f).Within(1e-4f));
+            Assert.That(Progress(10f, MinShow, false), Is.EqualTo(1f));
+            Assert.That(Progress(3f, 0f, false), Is.EqualTo(1f), "a zero MinShow counts as done");
+        }
+
+        [Test]
+        public void Progress_CreepsMonotonicallyBelowTheCapWhileTheServerBoots()
+        {
+            float last = -1f;
+            for (float t = 0f; t <= 60f; t += 0.5f)
+            {
+                float p = Progress(t, MinShow, true);
+                Assert.That(p, Is.GreaterThanOrEqualTo(last), $"t={t}");
+                Assert.That(p, Is.LessThan(HoldCap), $"t={t}");
+                last = p;
+            }
+
+            Assert.That(Progress(20f, MinShow, true), Is.GreaterThan(Progress(2.5f, MinShow, true)), "still visibly moving");
+        }
+
+        [Test]
+        public void Progress_SnapsToFullTheMomentTheServerIsReady()
+        {
+            Assert.That(Progress(20f, MinShow, true), Is.LessThan(HoldCap));
+            Assert.That(Progress(20f, MinShow, false), Is.EqualTo(1f));
+        }
+    }
+}

--- a/client/Assets/Tests/EditMode/LoadingHandoffPolicyEditModeTests.cs.meta
+++ b/client/Assets/Tests/EditMode/LoadingHandoffPolicyEditModeTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e992d3054294b6ba5f19cbd6ee4727ab
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
closes #1800

## What

Desktop singleplayer showed three screens in a row: the progress bar (0 → 100 % in 2.5 s), a dark **nameless** "Loading world…" curtain for 10–20 s, then the curtain with the system · planet name. The nameless step was exactly the bundled server's boot: the shell's `LoadingScreen` was time-based and handed off to `LaunchGame` after MinShow no matter what, the rig's `WorldLoadingOverlay` rose with an empty `LocationName` (it only arrives with the join), and the server was still generating its world behind it (SQLite init + NetCodec warm-up, `BuildGalaxy`, `LoadWorld` with every stamp pass, then the transport — Player.log 2026-09-12: 10.6 s rainbow sea, 20.2 s coral sea).

## How

- `LoadingHandoffPolicy` (pure, EditMode-tested): `Next(elapsed, minShow, browserBooting, localBooting)` → Hold / Launch / GiveUp, and `Progress(...)` for the bar.
- `AppShell.LocalServerBooting` — the desktop twin of the browser host's `BrowserWorldBooting` gate (#771): true while a bundled server was spawned for this world and `LocalServerLauncher.Ready` has not relayed its "started on port" line yet. `LoadingScreen.Update` holds the hand-off on it after MinShow.
- The bar creeps from 60 % toward 85 % while the server boots (monotonic, never reaches the cap) and snaps to 100 % on ready — no parked "100 %".
- Ceiling: a server that lives but never reports ready is given up on after 120 s (`ConnectRetryPolicy.LocalBudgetSeconds`) via `AppShell.AbortLocalServerBoot` → menu + `ui.sp.server_failed`. A server that dies is still caught by the existing launch watcher, which already runs in the Loading phase.
- `LocalServerLauncher` resets `Ready` in `Prepare` and `Stop` so a previous run's flag cannot pass as this one's.
- Comments that described the old "connect after MinShow" timing updated; TODO.md entry.

Result: the nameless curtain covers only the rig build + dial + join (~1 s); the named curtain covers the chunk streaming as before. In-game hosting shares the path. Remote joins and the browser build are unchanged. Stage-based real progress (server stage lines parsed by the launcher) stays a possible follow-up.

## Verification

- Unity EditMode tests: see the run summary in the PR conversation.
- Local Unity build (`scripts/build-client.ps1` in the worktree): see the PR conversation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
