### PR TITLE
fix(client): fourth InputField.GenerateCaret crash — a focused field survives canvas.enabled = false (#1804)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -24,6 +24,23 @@ envelope at the WebSocket edge; deterministic seed world-gen; SQLite default per
 
 ---
 
+### ⌨️ Fourth `InputField.GenerateCaret` crash: a focused field survives `canvas.enabled = false` (#1804, 2026-09-12, branch fix/caret-canvas-disable)
+
+Lyxette's v2026.9.6 crash report — the same uGUI `NullReferenceException` as v2026.9.2 (Lyxette), v2026.9.5 (Justus,
+#1791) and #1683. Reading uGUI 2.0.0's `GenerateCaret`, the only real null is `m_TextComponent.canvas`: `Graphic.canvas`
+is null once no ancestor Canvas is active and enabled. `SetActive(false)` / destroy can never get there — uGUI's own
+`InputField.OnDisable` deactivates the field first — so #1634, #1683 and #1791 cured the selection leak, not the crash.
+The crash needs a screen that hides with `canvas.enabled = false` while a field is focused: the GameObject stays active,
+the caret blink keeps queueing rebuilds, the next one throws (twice a second until something deactivates the field).
+The only such screen with text fields is `CraftingTechShipUI` (Funk, photo note, crew/companion/base names, missions,
+search); Esc/Tab are guarded by `typingRecent` and a mouse click deselects first, so the path is the programmatic
+close — `GameMenu.CloseForTransition` on `HyperjumpStarted` (incl. the #1614 transit arrival, new in 9.6) or the
+`SpaceViewActive` flip. Fix: `InputFocusGuard` (on every `UiKit.AddInput` field) now also handles
+`OnCanvasHierarchyChanged` — focused + `textComponent.canvas == null` → deactivate + deselect — and
+`CraftingTechShipUI.Hide()` hands focus back explicitly (`UiKit.ReleaseTextFieldFocus(_canvas.transform)`) before the
+canvas goes. Not reproducible from the payload (no log tail); manual check: TAB menu → click into the search box →
+hyperjump → no exception in `Player.log`.
+
 ### 💬 Chat window: holo panel + outline text like VEGA, fitted to the lines, gone when the chat closes (#1799, 2026-09-12, branch feat/chat-window-contrast)
 
 Marcel's playtest note after #1798: the chat text was often unreadable for want of a background. The scrollback was the

--- a/client/Assets/BlocksBeyondTheStars/Scripts/CraftingTechShipUI.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/CraftingTechShipUI.cs
@@ -227,6 +227,10 @@ namespace BlocksBeyondTheStars.Client
         {
             if (_canvas != null)
             {
+                // #1804: this screen closes programmatically (GameMenu.CloseForTransition on a hyperjump / transit
+                // arrival) while the player may be typing a Funk line or a photo note. A field left focused under a
+                // disabled canvas throws in the next caret rebuild — hand focus back before the canvas goes.
+                UiKit.ReleaseTextFieldFocus(_canvas.transform);
                 _canvas.enabled = false;
             }
 

--- a/client/Assets/BlocksBeyondTheStars/Scripts/UiKit.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/UiKit.cs
@@ -65,6 +65,41 @@ namespace BlocksBeyondTheStars.Client
             return field != null && field.isFocused;
         }
 
+        /// <summary>Hands keyboard focus back before a screen hides itself with <c>canvas.enabled = false</c> (#1804).
+        /// A field left focused under a disabled canvas crashes the next caret rebuild; <see cref="InputFocusGuard"/>
+        /// catches the canvas toggle on every field, this is the explicit hand-back for screens that close
+        /// programmatically while the player may be typing. <paramref name="within"/> limits it to fields under that
+        /// transform, so another screen's field is never touched.</summary>
+        public static void ReleaseTextFieldFocus(Transform within = null)
+        {
+            var es = EventSystem.current;
+            var selected = es != null ? es.currentSelectedGameObject : null;
+            if (selected == null || (within != null && !selected.transform.IsChildOf(within)))
+            {
+                return;
+            }
+
+            var field = selected.GetComponent<InputField>();
+            if (field == null)
+            {
+                return;
+            }
+
+            var guard = selected.GetComponent<InputFocusGuard>();
+            if (guard != null)
+            {
+                guard.Release();
+                return;
+            }
+
+            if (field.isFocused)
+            {
+                field.DeactivateInputField();
+            }
+
+            es.SetSelectedGameObject(null);
+        }
+
         private static Font _font;
         private static Sprite _panelSprite;
         private static Sprite _dialogSprite;
@@ -1267,12 +1302,16 @@ namespace BlocksBeyondTheStars.Client
     }
 
     /// <summary>
-    /// Releases keyboard focus when an input field's dialog is deactivated (#1791). uGUI never deselects a
-    /// deactivated <see cref="InputField"/> on its own: the caret keeps its place in the canvas rebuild queue, and
-    /// rebuilding it once the field's own objects are gone throws inside <c>InputField.GenerateCaret</c> — a client
-    /// crash the feedback dialog (#1683) and the chat box (#1634) each fixed for themselves before a third dialog
-    /// crashed the same way. Attached by <see cref="UiKit.AddInput"/> to every field it builds, so the release runs
-    /// from the field's own <c>OnDisable</c> — before any rebuild — whichever screen hides it.
+    /// Releases keyboard focus when an input field's screen goes away (#1791, #1804). Screens hide two ways.
+    /// <c>SetActive(false)</c> / destroy: uGUI's own <c>InputField.OnDisable</c> deactivates the field, and this
+    /// guard only drops the EventSystem selection uGUI leaves behind (#1634 — a hidden field otherwise stays the
+    /// "selected" object until the next world click). <c>canvas.enabled = false</c>: the GameObject stays active,
+    /// nothing deactivates the field, the caret blink keeps queueing rebuilds, and the next one dereferences
+    /// <c>Text.canvas</c>, which is null once no enabled Canvas sits above the field — the
+    /// <c>NullReferenceException</c> in <c>InputField.GenerateCaret</c> behind four crash reports (#1683, #1791,
+    /// #1804; the per-dialog fixes before this one only covered the first path). Unity sends
+    /// <c>OnCanvasHierarchyChanged</c> to every child when a parent Canvas is toggled, so the release runs before that
+    /// rebuild. Attached by <see cref="UiKit.AddInput"/> to every field it builds.
     /// </summary>
     public sealed class InputFocusGuard : MonoBehaviour
     {
@@ -1280,7 +1319,21 @@ namespace BlocksBeyondTheStars.Client
 
         public void Init(InputField field) => _field = field;
 
-        private void OnDisable()
+        private void OnDisable() => Release();
+
+        private void OnCanvasHierarchyChanged()
+        {
+            // Exactly the property GenerateCaret dereferences. It re-caches through parent canvases, so a nested
+            // canvas toggled under a still-enabled root leaves the field alone; only a field with NO live canvas
+            // above it is released.
+            if (_field != null && _field.isFocused && _field.textComponent != null && _field.textComponent.canvas == null)
+            {
+                Release();
+            }
+        }
+
+        /// <summary>Deactivates the field if it is focused and drops the EventSystem selection if it points here.</summary>
+        public void Release()
         {
             if (_field == null)
             {


### PR DESCRIPTION
closes #1804

## Summary

Lyxette's v2026.9.6 crash report is the **fourth** `InputField.GenerateCaret` NullReferenceException (v2026.9.2 Lyxette, v2026.9.5 Justus/#1791, #1683). Reading uGUI 2.0.0's `GenerateCaret`, the only dereference that can be a real `null` is `m_TextComponent.canvas.targetDisplay`: `Graphic.canvas` returns `null` once no ancestor Canvas is active **and enabled**.

The `SetActive(false)` / destroy paths can never reach that line — uGUI's own `InputField.OnDisable` deactivates the field and unregisters it from the rebuild queue first. So #1634, #1683 and #1791 cured the EventSystem selection leak, not the crash. The crash needs a screen that hides with **`canvas.enabled = false`** while one of its fields is focused: the GameObject stays active, nothing deactivates the field, the caret blink keeps queueing rebuilds, and the next one throws (twice a second until something deactivates the field).

The only such screen with text fields is `CraftingTechShipUI` (Funk, photo note, crew/companion/base names, missions, search). Esc/Tab are guarded by `typingRecent` in `GameMenu` and a mouse click deselects the field first, so the path is the **programmatic close**: `GameMenu.CloseForTransition` on `HyperjumpStarted` (incl. the #1614 transit arrival, new in 9.6) or the `SpaceViewActive` flip — Lyxette types Funk lines and photo notes in the TAB menu constantly, and his 9.2 crash came 22 s after his hyperjump report.

## Changes

- `InputFocusGuard` (on every `UiKit.AddInput` field, #1791) now also handles `OnCanvasHierarchyChanged`: focused + `textComponent.canvas == null` → deactivate + clear the selection. `Text.canvas` is exactly the property `GenerateCaret` dereferences and re-caches through parent canvases, so a nested canvas toggled under a live root leaves the field alone. `OnDisable` and the new handler share one `Release()`.
- `UiKit.ReleaseTextFieldFocus(Transform within = null)` — explicit hand-back for screens that close programmatically; `CraftingTechShipUI.Hide()` calls it scoped to its own canvas before `_canvas.enabled = false`.
- TODO.md entry.

## Verification

- Not reproducible from the payload (no log tail in client crash reports). Manual check: TAB menu → click into the search box → `/hyperjump` → no exception in `Player.log`, field released.
- CI never compiles `client/Assets`: local Unity player build on this branch — result noted in the PR conversation before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
