### PR TITLE
fix(client,ux): the chat input takes keys again when opened over an empty scrollback (#1806)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -24,6 +24,16 @@ envelope at the WebSocket edge; deterministic seed world-gen; SQLite default per
 
 ---
 
+### ⌨️ Chat input takes keys again when opened over an empty scrollback (#1806, 2026-09-12, branch fix/chat-input-focus-order)
+
+Marcel's playtest of #1801: open the chat with no lines on screen and the input row appears but takes no keys — no text,
+no Esc, and Enter would not reopen it. Since #1801 the row lives inside the holo window, and the window is inactive
+whenever it has nothing to show; `ChatUi.OpenInput` focused the field BEFORE `RefreshLog` woke the window, and uGUI's
+`ActivateInputField` silently no-ops on a field under an inactive parent. With `_typing` already set, the player was
+stuck. Fix: wake and place the window first, then focus (while typing the window always has a height). No automated
+coverage possible for the MonoBehaviour order; verified with a local Unity build. Engine rule for any future field
+inside a togglable panel: activate the hierarchy, then the field.
+
 ### 💬 Chat window: holo panel + outline text like VEGA, fitted to the lines, gone when the chat closes (#1799, 2026-09-12, branch feat/chat-window-contrast)
 
 Marcel's playtest note after #1798: the chat text was often unreadable for want of a background. The scrollback was the

--- a/client/Assets/BlocksBeyondTheStars/Scripts/ChatUi.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/ChatUi.cs
@@ -311,8 +311,15 @@ namespace BlocksBeyondTheStars.Client
             Game.ChatTyping = true;
             _inputRow.gameObject.SetActive(true);
             _input.text = string.Empty;
-            _input.ActivateInputField();
+
+            // Wake and place the window BEFORE focusing the field (#1806): the input row lives inside the
+            // holo window since #1801, and the window is inactive whenever it has nothing to show (empty
+            // scrollback, aged-out lines, muted). uGUI's ActivateInputField silently no-ops on a field
+            // under an inactive parent — the row then appeared but took no keys, and with _typing already
+            // set neither Enter nor Esc could get the player out. While typing the window always has a
+            // height (ResolveWindow), so RefreshLog is guaranteed to activate it.
             RefreshLog();
+            _input.ActivateInputField();
         }
 
         private void OnDisable()


### PR DESCRIPTION
closes #1806

## What

Open the chat (Enter) with no lines on screen and the input row appeared but took no keys — no text, no Esc, and Enter would not reopen it. Marcel hit this on a local build of main right after #1801 (VEGA happened to be open; not the trigger).

## Why

Since #1801 the input row lives inside the holo window, and the window is `SetActive(false)` whenever it has nothing to show (empty scrollback, aged-out Auto lines, muted / Off). `ChatUi.OpenInput` called `_input.ActivateInputField()` BEFORE `RefreshLog()` — the call that wakes the window. uGUI's `ActivateInputField` early-outs on `!IsActive()` (`isActiveAndEnabled` is false under an inactive parent), so the field never got focus, while `_typing` / `Game.ChatTyping` were already set: Enter ignored, hotkeys suppressed, and Esc unseen (the field handles it only while focused). With lines on screen the window was already active, which is why the #1801 playtest passed.

## Fix

Swap the two calls: `RefreshLog()` first (while typing the window always has a height, so it is guaranteed to activate), then `ActivateInputField()`. Comment in code records the rule for any future field inside a togglable panel: activate the hierarchy, then the field.

## Verification

- No automated coverage possible (MonoBehaviour call order).
- Local Unity player build on this exact tree: `Build Finished, Result: Success`, 0 `error CS`, fresh `BlocksBeyondTheStars.Client.dll`.
- Playtest to do on the main-checkout build: fresh join, wait > 12 s so the scrollback is empty, Enter, type, Esc; then again with VEGA speaking.

TODO.md updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)