### PR TITLE
fix(worldgen,city): a light in the ceiling of every room of the G.D.S. city (#1808)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -124,6 +124,10 @@ rare; the landing pad inside the city). Design record: docs/developer/WORLD_GENE
   on a city world, centres the city on pad 0, pins it as settlement 0 (`city:gds`); phases B–D moved into
   `CommitSettlements`.
 - **Cool rooms**: `InCityShelter` (inside the footprint + roofed) → 22 °C.
+- **Lit rooms** (#1808, 2026-09-12, branch fix/city-interior-lights): Marcel's first walk — every room was dark.
+  `StampBuilding(ceilingLight:)` sets a warm strip light INTO the deck above every storey (centre cell, 2×2 grid
+  over wide rooms); towers get shaft lights in the roof and at both red bands; `CityGenerator.Set` no longer
+  leaves a tint on a cell overwritten by a light. Ordinary settlements unchanged. Existing saves stay dark.
 - **G.D.S.**: `guard_post` marker → role `guardian` (machine, purple chassis, `NetNpc.Look = "gds_guard"`, leash
   14); client stripe band + glowing pupils (`PlayerAvatar.SetGuardianLook`); `DialogDefinition.PlanetTypes`
   filter + two G.D.S. dialogues; guardian greeting persona; `npc.role/greet.guardian`; VEGA `vega.hint.world.gds`;

--- a/docs/developer/WORLD_GENERATION.md
+++ b/docs/developer/WORLD_GENERATION.md
@@ -1398,6 +1398,14 @@ is kept on `LoadedWorld.CityFootprint`.
 **Cool rooms** (`GameServerTemperature.InCityShelter`). Inside the footprint AND `RoofedAt` → the effective
 temperature is `CityComfortC` = 22 °C. Streets, gardens and the plaza stay desert-hot. No climate physics.
 
+**Lit rooms** (#1808). `StampBuilding` takes an optional `ceilingLight`: a light block set INTO the deck above
+every storey — the centre cell of a room up to nine wide, a quarter-point 2×2 grid over a wider one
+(`CeilingLightCells`). Set into the deck rather than hung under it, the roof stays a solid cover for
+`RoofedAt` and nothing pokes into the walkway. The city passes the warm strip light for every house, shop and
+the hall; the towers get a light in the roof over the shaft and one in each outer wall at both red bands.
+`CityGenerator.Set` drops the tint of a cell it overwrites with a non-tint block, so a light in a purple deck
+is not purple. Ordinary settlements pass nothing and are unchanged.
+
 **The G.D.S.** Marker `guard_post` → NPC role `guardian`: always a machine, chassis `0x3A1F5C`, plating
 `0x4B2A78`, legs `0x2C1746`, `NetNpc.Look = "gds_guard"` (additive), `GuardianLeash` 14 blocks so they walk a
 beat; the client draws a red stripe band on the chest and the abdomen and swaps the pupils for self-lit red

--- a/src/BlocksBeyondTheStars.WorldGeneration/CityGenerator.cs
+++ b/src/BlocksBeyondTheStars.WorldGeneration/CityGenerator.cs
@@ -167,13 +167,13 @@ public static class CityGenerator
 
             int idx = (x * h + y) * l + z;
             blocks[idx] = b;
-            if (b == 0)
-            {
-                mods.Remove(idx);
-            }
-            else if (tint != 0 && (b == wall || b == stone || b == paving))
+            if (tint != 0 && b != 0 && (b == wall || b == stone || b == paving))
             {
                 mods[idx] = (tint, 0);
+            }
+            else
+            {
+                mods.Remove(idx); // air, an untinted stamp or a light over a tinted cell: no tint survives
             }
         }
 
@@ -265,7 +265,7 @@ public static class CityGenerator
         void House(int ox, int oz, int fp, int storeys, int doorSide, bool red)
         {
             tint = red ? Red : Purple;
-            SettlementGenerator.StampBuilding(Set, ox, oz, fp, storeys, wall, wall, glass, ladder, doorSide, 0, rng, ruined: false);
+            SettlementGenerator.StampBuilding(Set, ox, oz, fp, storeys, wall, wall, glass, ladder, doorSide, 0, rng, ruined: false, ceilingLight: lamp);
             tint = 0;
             SettlementGenerator.DecorateAround(Set, ox, oz, fp, doorSide, lamp, fern, false, rng);
             buildings++;
@@ -447,7 +447,7 @@ public static class CityGenerator
         void StampTower(int mx, int mz, bool west, bool north)
         {
             // A 7×7 watch tower, 14 tall, purple with two red bands, in the corner that faces the wall; two
-            // guards at its foot, a lamp on top.
+            // guards at its foot, a lamp on top and lights inside the shaft.
             int fp = 7, height = 14;
             int ox = west ? mx + 2 : mx + ModuleSize - 2 - fp;
             int oz = north ? mz + 2 : mz + ModuleSize - 2 - fp;
@@ -478,6 +478,14 @@ public static class CityGenerator
             }
 
             Set(ox + fp / 2, height + 1, oz + fp / 2, lamp);
+            // The shaft is lit too (#1808): a light set into the roof over the middle and one into each of the
+            // two outer walls at every red band, so the climb never goes dark.
+            Set(ox + fp / 2, height, oz + fp / 2, lamp);
+            int wx = ox + (west ? 0 : fp - 1), wz = oz + (north ? 0 : fp - 1);
+            Set(wx, 4, oz + 3, lamp);
+            Set(ox + 3, 4, wz, lamp);
+            Set(wx, 9, oz + 3, lamp);
+            Set(ox + 3, 9, wz, lamp);
             markers.Add(new SettlementMarker("guard_post", new Vector3i(ox + dx + (west ? 2 : -2), 1, oz + 3)));
             markers.Add(new SettlementMarker("guard_post", new Vector3i(ox + 3, 1, oz + dz + (north ? 2 : -2))));
             buildings++;

--- a/src/BlocksBeyondTheStars.WorldGeneration/SettlementGenerator.cs
+++ b/src/BlocksBeyondTheStars.WorldGeneration/SettlementGenerator.cs
@@ -609,7 +609,8 @@ public static class SettlementGenerator
     /// <summary>Stamps one hollow building of N storeys with a roof, a door on a chosen side, a window
     /// band and an accent stripe; multi-storey buildings get climbable ladders between decks.</summary>
     internal static void StampBuilding(System.Action<int, int, int, ushort> set, int ox, int oz, int fp, int storeys,
-        ushort wall, ushort accent, ushort glass, ushort ladder, int doorSide, int roofStyle, System.Random rng, bool ruined)
+        ushort wall, ushort accent, ushort glass, ushort ladder, int doorSide, int roofStyle, System.Random rng, bool ruined,
+        ushort ceilingLight = 0)
     {
         int height = storeys * FloorH;
         for (int x = 0; x < fp; x++)
@@ -670,6 +671,33 @@ public static class SettlementGenerator
         }
 
         StampRoof(set, ox, oz, fp, height, roofStyle, wall, accent, rng);
+
+        // Ceiling lights (#1808): a light block set INTO the deck above every storey — one over the middle
+        // of a small room, a 2×2 grid over a wide one — so the rooms are lit and the roof stays a solid
+        // cover (the cool-room check reads the ceiling as a roof, and nothing hangs into the walkway).
+        if (ceilingLight != 0)
+        {
+            foreach (var (lx, lz) in CeilingLightCells(fp))
+            {
+                for (int f = 1; f <= storeys; f++)
+                {
+                    set(ox + lx, f * FloorH, oz + lz, ceilingLight);
+                }
+            }
+        }
+    }
+
+    /// <summary>Where the ceiling lights of a room <paramref name="fp"/> wide go: the centre cell up to nine
+    /// wide, a quarter-point 2×2 grid beyond that. Local (x, z) cells, always inside the shell.</summary>
+    internal static (int X, int Z)[] CeilingLightCells(int fp)
+    {
+        if (fp <= 9)
+        {
+            return new[] { (fp / 2, fp / 2) };
+        }
+
+        int a = fp / 4, b = fp - 1 - fp / 4;
+        return new[] { (a, a), (b, a), (a, b), (b, b) };
     }
 
     /// <summary>Caps a building: a flat parapet (a low accent rim) or a pitched, stepped roof.</summary>

--- a/tests/BlocksBeyondTheStars.Tests/CityWorldTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/CityWorldTests.cs
@@ -194,6 +194,67 @@ public sealed class CityWorldTests : IDisposable
         Assert.True(trunks >= 12, $"trees in the gardens, found {trunks} trunks");
     }
 
+    [Fact]
+    public void CityComposer_LightsEveryRoom_AndKeepsTheCeilingsSolid()
+    {
+        // #1808: every building has a light in the ceiling of every storey, and the towers' shafts are lit.
+        var a = CityGenerator.Generate(42, _content, StandardZones());
+        ushort lamp = _content.GetBlock("strip_light_warm")!.NumericId.Value;
+        ushort wall = _content.GetBlock("iron_wall")!.NumericId.Value;
+
+        // Every door marker belongs to a house; the cell straight above its threshold row is a room, and the
+        // deck over that room holds a lamp somewhere on the same storey within the house's reach.
+        int litHouses = 0, doors = 0;
+        foreach (var m in a.Markers)
+        {
+            if (m.Type != "door_slide") continue;
+            doors++;
+            bool lit = false;
+            for (int dx = -7; dx <= 7 && !lit; dx++)
+                for (int dz = -7; dz <= 7 && !lit; dz++)
+                {
+                    int x = m.LocalPos.X + dx, z = m.LocalPos.Z + dz;
+                    if (x < 0 || z < 0 || x >= a.Width || z >= a.Length) continue;
+                    lit = a.Get(x, 4, z) == lamp;
+                }
+
+            if (lit) litHouses++;
+        }
+
+        Assert.True(doors >= 20);
+        Assert.Equal(doors, litHouses);
+
+        // Ceiling lights sit IN the deck, never below it: the cell under every deck lamp is air (the room),
+        // so the roof stays a solid cover for the cool-room check.
+        int deckLamps = 0, lowBandLamps = 0;
+        for (int x = 0; x < a.Width; x++)
+            for (int z = 0; z < a.Length; z++)
+                for (int y = 4; y <= 12; y += 4)
+                {
+                    if (a.Get(x, y, z) != lamp) continue;
+                    ushort below = a.Get(x, y - 1, z);
+                    if (below == 0) deckLamps++;
+                    else if (y == 4 && below == wall) lowBandLamps++; // a tower's lower band lamp
+                    // anything else is a lamp post (stone below) — not a ceiling light
+                    Assert.Equal(0, a.GetModifier(x, y, z).Tint);
+                }
+
+        Assert.True(deckLamps >= 30, $"a deck lamp per storey per building, found {deckLamps}");
+        Assert.Equal(8, lowBandLamps);
+
+        // The four corner towers: a lamp set into the roof over the shaft and one in each red band.
+        int shaftRoofLamps = 0, bandLamps = 0;
+        for (int x = 0; x < a.Width; x++)
+            for (int z = 0; z < a.Length; z++)
+            {
+                if (a.Get(x, 14, z) == lamp && a.Get(x, 13, z) == 0) shaftRoofLamps++;
+                if (a.Get(x, 9, z) == lamp && (a.Get(x, 8, z) == wall)) bandLamps++;
+            }
+
+        Assert.Equal(4, shaftRoofLamps);
+        Assert.True(bandLamps >= 8, $"two band lamps per tower, found {bandLamps}");
+    }
+
     private static ulong Hash(SettlementStructure s)
     {
         ulong h = 1469598103934665603UL;


### PR DESCRIPTION
Marcel's first walk through the G.D.S. city (#1793): every room was pitch dark. The composer only placed lamp posts outside — streets, plaza, module corners — and the strip windows let no desert sky in.

## What changes

- `SettlementGenerator.StampBuilding` takes an optional `ceilingLight`: a light block set **into** the deck above every storey — one over the middle of a room up to nine wide, a quarter-point 2×2 grid over a wider one (`CeilingLightCells`). The light replaces a deck/roof cell, so the roof stays a solid cover: `RoofedAt` still reads it as a ceiling (cool rooms keep working) and nothing hangs into the walkway. Default 0 — the ordinary settlements are byte-for-byte unchanged.
- `CityGenerator`: every house, market shop and the hall pass the warm strip light; the four watch towers get a light set into the roof over the shaft and one into each outer wall at both red bands, so the ladder climb is lit.
- `CityGenerator.Set`: a block that is not a tint target now drops the tint of the cell it overwrites — a light set into a purple deck no longer inherits the purple (strip lights are tintable).

## Verification

- New `CityComposer_LightsEveryRoom_AndKeepsTheCeilingsSolid`: every door marker has a ground-storey ceiling lamp within its house's reach, every deck lamp has the room (air) below it and carries no tint, the eight lower tower band lamps stand on wall, four tower roof lamps sit over an open shaft.
- City + settlement suites green; `dotnet format --verify-no-changes` clean.
- Local Unity player build: see the last commit message.

Existing saves keep their dark rooms — the city is stamped once at world creation.

closes #1808

🤖 Generated with [Claude Code](https://claude.com/claude-code)
