### PR TITLE
fix(client,ux): world options — the planet-type list scrolls instead of running under the footer (#1811)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -35,6 +35,18 @@ third/fourth `GenerateCaret` crash (#1788–#1792/#1804, PRs #1794/#1805). CHANG
 `data/whatsnew.json` re-exported with the DE+EN release post. Protocol stays 5, saves migrate unchanged; the city world
 reaches new galaxies only. Fleet: server image `2026.9.7`, worldhost re-pinned if `Shared/**` changed, reports unchanged.
 
+### 🪐 World options: the planet-type list scrolls instead of running under the footer (#1811, 2026-09-12, branch fix/1811-worldopt-planet-list-scroll)
+
+Marcel's screenshot: on *World options → Planet type frequencies* the last left rows (Rock planet, Savanna world) sat under
+"Reset overrides", and the white slider handles fused into tall columns. The page fitted its row pitch to the type count
+but clamped it at 40 px; 37 selectable types (the city world #1793 was the latest) need 19 rows per column → 68 px under
+the footer, clicks landing on the buttons. The handles were 42 px tall: a horizontal uGUI `Slider` stretches the handle
+over the slider height and ADDS `sizeDelta.y` (16 + 26). Fix: the rows live in a clipped `ScrollRect` viewport between the
+note and the footer at a fixed 56 px pitch (inline auto-hide scrollbar, pad navigation scrolls via `UiNav`); handles are
+16 + 10 = 26 px on every world-options page. "Reset overrides" now also moves the sliders back (the map was cleared, the
+rows kept their old values), and the page re-reads the options each time it opens. `WorldOptionsLayoutTests` gained the
+advanced-page guards (viewport above the footer, fixed pitch, handle fits a row); verified with a local Unity build.
+
 ### ⌨️ Chat input takes keys again when opened over an empty scrollback (#1806, 2026-09-12, branch fix/chat-input-focus-order)
 
 Marcel's playtest of #1801: open the chat with no lines on screen and the input row appears but takes no keys — no text,

--- a/client/Assets/BlocksBeyondTheStars/Scripts/UiWorldOptions.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/UiWorldOptions.cs
@@ -21,6 +21,14 @@ namespace BlocksBeyondTheStars.Client
         /// y 64). Every page places its bottom controls on this line so nothing overlaps or misaligns.</summary>
         private const float FooterY = 778f;
 
+        /// <summary>The advanced page's scrolling planet-type list: view-local top and height of its viewport
+        /// (from under the page note to 16 px above the footer) and the fixed row pitch inside it. The list
+        /// scrolls instead of squeezing its rows (#1811: 37 types at a 40 px floor ran 68 px under the
+        /// footer buttons); WorldOptionsLayoutTests holds these sums.</summary>
+        private const float AdvancedListY = 86f;
+        private const float AdvancedListH = 676f;
+        private const float AdvancedRowPitch = 56f;
+
         /// <summary>Builds the (initially hidden) overlay; returns its root for the caller to toggle.</summary>
         public static GameObject Build(AppShell shell, Transform root, WorldCreationOptions opt)
         {
@@ -143,15 +151,17 @@ namespace BlocksBeyondTheStars.Client
                 main.SetActive(false);
                 structures.SetActive(true);
             });
+            System.Action refreshAdvanced = null;
             UiKit.AddButton(main.transform, 620f, FooterY, 560f, 48f, shell.L("ui.worldopt.advanced"), () =>
             {
                 main.SetActive(false);
                 advanced.SetActive(true);
+                refreshAdvanced?.Invoke(); // a preset may have replaced the per-type map since the page was built
             });
             UiKit.AddButton(main.transform, 1290f, FooterY, 280f, 48f, shell.L("ui.worldopt.done"), () => overlay.SetActive(false), "btn_singleplayer");
 
             // ── Advanced: per-planet-type frequencies ──────────────────────────────────────
-            BuildAdvanced(shell, advanced.transform, opt, freqSteps, () =>
+            refreshAdvanced = BuildAdvanced(shell, advanced.transform, opt, freqSteps, () =>
             {
                 advanced.SetActive(false);
                 main.SetActive(true);
@@ -170,10 +180,20 @@ namespace BlocksBeyondTheStars.Client
 
         /// <summary>The advanced page: every selectable planet type with its own frequency slider.
         /// Untouched rows follow the data weights + the simple exotic slider; touched rows write the
-        /// per-type override map (which replaces ALL weights server-side once any entry exists).</summary>
-        private static void BuildAdvanced(AppShell shell, Transform parent, WorldCreationOptions opt,
+        /// per-type override map (which replaces ALL weights server-side once any entry exists).
+        /// Returns a refresher that re-reads every row from <paramref name="opt"/>.</summary>
+        private static System.Action BuildAdvanced(AppShell shell, Transform parent, WorldCreationOptions opt,
             string[] freqSteps, System.Action onBack)
         {
+            var rebuilders = new List<System.Action>();
+            void Refresh()
+            {
+                foreach (var r in rebuilders)
+                {
+                    r();
+                }
+            }
+
             UiKit.AddText(parent, 30f, 4f, 1000f, 28f, shell.L("ui.worldopt.advanced_title"), 18, UiKit.Cyan, TextAnchor.MiddleLeft, FontStyle.Bold);
             var note = UiKit.AddText(parent, 30f, 34f, 1520f, 44f, shell.L("ui.worldopt.advanced_note"), 14, UiKit.CyanDim, TextAnchor.UpperLeft);
             note.horizontalOverflow = HorizontalWrapMode.Wrap;
@@ -189,7 +209,7 @@ namespace BlocksBeyondTheStars.Client
                 .ToList();
             if (types is null)
             {
-                return;
+                return Refresh;
             }
 
             // Default index = the type's data weight mapped onto the Frequency scale (display only).
@@ -201,24 +221,25 @@ namespace BlocksBeyondTheStars.Client
                 _ => 4,     // Frequent
             };
 
-            // Two columns whose row pitch follows the type count (#1649 added eight types — 29 selectable): the
-            // longer column must end above the footer, so the pitch shrinks from the comfortable 56 px down to
-            // 40 px (a slider row is 40 px tall) before the list would ever run under the Back button.
-            const float FirstRowY = 86f;
+            // Two columns at a fixed pitch inside a scrolling viewport between the note and the footer. The type
+            // count is data (37 selectable since #1793) and only grows, so the list scrolls rather than squeezing
+            // its rows: a fitted pitch clamped at 40 px ran the left column 68 px under the footer buttons (#1811).
+            var content = BuildAdvancedViewport(parent);
             int perColumn = Mathf.Max(1, Mathf.CeilToInt(types.Count / 2f));
-            float pitch = Mathf.Clamp((FooterY - 16f - FirstRowY) / perColumn, 40f, 56f);
+            content.sizeDelta = new Vector2(0f, perColumn * AdvancedRowPitch);
+            const float FirstRowY = 4f;
             float x = 30f, y = FirstRowY;
             int row = 0;
             foreach (var p in types)
             {
                 string key = p.Key;
                 string label = shell.L(p.NameKey) + (p.Exotic ? " ◆" : string.Empty);
-                AddSliderRow(parent, x, y, 740f, label, freqSteps,
+                AddSliderRow(content, x, y, 740f, label, freqSteps,
                     () => opt.PlanetTypes.TryGetValue(key, out var v) ? v : DefaultIndex(p.SpawnWeight),
                     v => opt.PlanetTypes[key] = v,
-                    rebuilders: null);
+                    rebuilders);
 
-                y += pitch;
+                y += AdvancedRowPitch;
                 if (++row == perColumn)
                 {
                     x = 820f;
@@ -226,7 +247,50 @@ namespace BlocksBeyondTheStars.Client
                 }
             }
 
-            UiKit.AddButton(parent, 30f, FooterY, 420f, 48f, shell.L("ui.worldopt.advanced_reset"), () => opt.PlanetTypes.Clear());
+            // Reset also moves the sliders back — before, the map was cleared but every row kept showing its override.
+            UiKit.AddButton(parent, 30f, FooterY, 420f, 48f, shell.L("ui.worldopt.advanced_reset"), () =>
+            {
+                opt.PlanetTypes.Clear();
+                Refresh();
+            });
+            return Refresh;
+        }
+
+        /// <summary>The advanced page's clipped, vertically scrolling viewport (AdvancedListY..+AdvancedListH);
+        /// returns its content, onto which rows are placed absolutely (top-left) like everywhere else on the
+        /// page. The caller sizes the content's height from the row count.</summary>
+        private static RectTransform BuildAdvancedViewport(Transform parent)
+        {
+            var viewGo = new GameObject("PlanetTypeScroll", typeof(RectTransform));
+            viewGo.transform.SetParent(parent, false);
+            UiKit.Place(viewGo, 0f, AdvancedListY, 1580f, AdvancedListH);
+
+            var scroll = viewGo.AddComponent<ScrollRect>();
+            scroll.horizontal = false;
+            scroll.vertical = true;
+            scroll.movementType = ScrollRect.MovementType.Clamped;
+            scroll.scrollSensitivity = 28f;
+            viewGo.AddComponent<RectMask2D>();
+
+            // A near-transparent graphic so the wheel/drag has something to hit between the rows.
+            var hit = viewGo.AddComponent<Image>();
+            hit.color = new Color(0f, 0f, 0f, 0.001f);
+
+            var contentGo = new GameObject("Content", typeof(RectTransform));
+            contentGo.transform.SetParent(viewGo.transform, false);
+            var content = contentGo.GetComponent<RectTransform>();
+            content.anchorMin = new Vector2(0f, 1f);
+            content.anchorMax = new Vector2(1f, 1f);
+            content.pivot = new Vector2(0.5f, 1f);
+            content.anchoredPosition = Vector2.zero;
+            content.sizeDelta = Vector2.zero;
+
+            scroll.viewport = viewGo.GetComponent<RectTransform>();
+            scroll.content = content;
+
+            // Shows that the list continues below the fold; auto-hides if every type ever fits again.
+            UiKit.AddInlineScrollbar(scroll);
+            return content;
         }
 
         /// <summary>The authored-structures page: how readily hand-designed station/settlement templates are
@@ -324,7 +388,9 @@ namespace BlocksBeyondTheStars.Client
             var handleGo = new GameObject("Handle", typeof(RectTransform));
             handleGo.transform.SetParent(go.transform, false);
             var handleRt = handleGo.GetComponent<RectTransform>();
-            handleRt.sizeDelta = new Vector2(18f, 26f);
+            // A horizontal Slider stretches the handle over the slider's full 16 px height, so y is ADDED to it:
+            // 10 → a 26 px handle. The old 26 made it 42 px — taller than a row, so stacked handles merged (#1811).
+            handleRt.sizeDelta = new Vector2(18f, 10f);
             var handle = handleGo.AddComponent<Image>();
             handle.sprite = UiKit.SolidSprite;
             handle.color = Color.white;

--- a/tests/BlocksBeyondTheStars.Client.Tests/WorldOptionsLayoutTests.cs
+++ b/tests/BlocksBeyondTheStars.Client.Tests/WorldOptionsLayoutTests.cs
@@ -101,4 +101,50 @@ public sealed class WorldOptionsLayoutTests
             + $"buttons start at y={footerY}. The bottom row would be drawn underneath them and could not be "
             + $"clicked (#983). Reduce RowH, drop a row, or move the row to the other column.");
     }
+
+    /// <summary>The planet-type page is data-driven (one row per selectable type in <c>data/planets.json</c>),
+    /// so its rows live in a scrolling viewport. That viewport — not the row count — must end above the
+    /// footer (#1811: a fitted pitch clamped at 40 px ran 37 types 68 px under the buttons).</summary>
+    [Fact]
+    public void AdvancedPage_ListViewport_EndsAboveTheFooterButtons()
+    {
+        string source = Source();
+        float footerY = Constant(source, @"FooterY = ([0-9.]+)f;", "FooterY");
+        float listY = Constant(source, @"const float AdvancedListY = ([0-9.]+)f;", "AdvancedListY");
+        float listH = Constant(source, @"const float AdvancedListH = ([0-9.]+)f;", "AdvancedListH");
+
+        Assert.True(
+            listY + listH + MinClearance <= footerY,
+            $"The planet-type list viewport ends at y={listY + listH}, but the footer buttons start at y={footerY} (#1811).");
+    }
+
+    /// <summary>The list must scroll, never squeeze: its content is sized from the row count at a fixed pitch
+    /// that leaves a gap between rows — so adding planet types lengthens the scroll range instead of pushing
+    /// rows under the footer or into each other.</summary>
+    [Fact]
+    public void AdvancedPage_Rows_ScrollAtAFixedPitch()
+    {
+        string source = Source();
+        float pitch = Constant(source, @"const float AdvancedRowPitch = ([0-9.]+)f;", "AdvancedRowPitch");
+
+        Assert.True(pitch >= LabelH + MinClearance, $"AdvancedRowPitch {pitch} leaves no gap between {LabelH} px rows.");
+        Assert.Matches(@"content\.sizeDelta = new Vector2\(0f, perColumn \* AdvancedRowPitch\);", source);
+        Assert.Matches(@"y \+= AdvancedRowPitch;", source);
+        Assert.DoesNotMatch(@"Mathf\.Clamp\(\(FooterY", source); // the fitted, clamped pitch that overflowed
+    }
+
+    /// <summary>A horizontal uGUI Slider stretches its handle over the slider height and ADDS sizeDelta.y, so the
+    /// handle's real height is slider height + sizeDelta.y. It must fit inside a row, or the handles of stacked
+    /// rows merge into one white column (#1811: 16 + 26 = 42 px on a 40 px pitch).</summary>
+    [Fact]
+    public void SliderHandle_FitsInsideARow()
+    {
+        string source = Source();
+        float sliderH = Constant(source, @"UiKit\.Place\(go, x \+ 290f, y \+ 12f, w - 290f - 150f, ([0-9.]+)f\);", "the slider height");
+        float handleExtra = Constant(source, @"handleRt\.sizeDelta = new Vector2\([0-9.]+f, ([0-9.]+)f\);", "the handle sizeDelta.y");
+
+        Assert.True(
+            sliderH + handleExtra <= LabelH - MinClearance,
+            $"The slider handle is {sliderH + handleExtra} px tall, but a row is {LabelH} px — stacked handles would touch.");
+    }
 }


### PR DESCRIPTION
closes #1811

## Problem

On **World options → Planet type frequencies** the last rows of the left column (Rock planet, Savanna world) were drawn under the footer buttons and could not be clicked, and the slider handles fused into tall white columns.

- The page fitted its row pitch to the type count but clamped it at **40 px**. 37 selectable types → 19 rows per column → the column ended at y 846, the footer starts at y 778.
- A horizontal uGUI `Slider` stretches its handle over the 16 px slider height and **adds** `sizeDelta.y`: 16 + 26 = 42 px handles on a 40 px pitch.

## Fix

- `UiWorldOptions.BuildAdvanced`: rows go into a clipped `ScrollRect` viewport (`AdvancedListY`/`AdvancedListH`, ending 16 px above the footer) at a fixed `AdvancedRowPitch` of 56 px; the content height follows the row count. Inline auto-hide scrollbar; pad navigation already scrolls the selection into view via `UiNav`.
- Slider handle `sizeDelta.y` 26 → 10 (26 px real height) on every world-options page.
- "Reset overrides" now refreshes the sliders (before, the map was cleared but the rows kept showing the overrides), and the page re-reads the options each time it opens (a preset may have changed them).
- `WorldOptionsLayoutTests`: three new guards — list viewport ends above the footer, rows use the fixed pitch (no fitted clamp), slider handle fits inside a row.

## Verification

- `dotnet test tests/BlocksBeyondTheStars.Client.Tests --filter WorldOptionsLayoutTests` → 5/5 passed; `dotnet format --verify-no-changes` clean.
- Local Unity player build of this tree: `Build Finished, Result: Success`, 0 `error CS`.
- Playtest still open: scroll the list, drag sliders inside it, reset overrides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
