### PR TITLE
fix(server,client): player reports 2026-09-12 evening — glow past the seam, diggable Guardian core, roof spawn, ruin pillars, station saplings, doorway leak, 2-block gaps (#1829–#1839)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -24,6 +24,47 @@ envelope at the WebSocket edge; deterministic seed world-gen; SQLite default per
 
 ---
 
+### 🛰️ Player reports 2026-09-12, evening — the glow past the seam, the diggable Guardian core, the roof spawn, ruin pillars, station saplings, the doorway "leak", 2-block gaps again (#1829–#1839, 2026-09-13, branch fix/player-reports-2026-09-12-night)
+
+Justus (eight F1 reports, v2026.9.7 — asteroid world + the Guardian core) and Lyxette (four, her station). Every report was
+read against the server snapshot and the code first; the ideas from the same evening are filed as #1840–#1847 (drones on
+asteroids, sinking into lava, zero-g construction, codex find location, notes tab, chat banner, furniture, a grass block).
+
+- **#1829 The mining glow vanished "too far from the ship"** — `MiningFx` was the one view script that never mapped server
+  coordinates through `ScenePos`: the server echoes the canonical cell, the outline lives in the unbounded scene space, and
+  past a wrap seam (Z −314 → +319 in the report, period 640 on a 1296 asteroid) the crack compare never matched and the
+  final-hit flash popped a world-lap away. Both messages now map through `SceneCell`.
+- **#1830 The Guardian core could be mined** — no finale guard in `HandleMine`/`BreakArea`, and the column is a bare-hand
+  light block on a one-shot stamp. `IsGuardianCoreProtected` covers the 3×3 heart (pedestal, column, pillars, panes) from
+  the floor plate to the pillar tops; the shell stays diggable (Route B). `@srv.protect.core` EN+DE.
+- **#1831 No breach hint after joining a save on the core body** — `FinaleView` learned the system only from `WorldReset`;
+  `JoinAccepted` never reached it, so the fire hold mined the core instead of channelling. The gate now reads the star
+  map's active location id (`guardian_finale*`), off in the space view, with the name as fallback.
+- **#1832 "Craft an item" over the finale** — the VEGA onboarding chip beat `story.obj.finale` unconditionally; once the
+  Guardian system is revealed the story objective wins (key, target, progress).
+- **#1833 Docking put Lyxette on the airless roof** — `TryFindStandableInStation` accepted any standable cell up to the top
+  of the build; the roof's outer face qualified and was nearest once the centre column was walled in. Two passes now: a
+  cell inside a sealed pocket first, anything standable only when no pocket exists; boarding sets `AwaitingSpawnAdopt`.
+- **#1834 Ruin pillars and glowing runes placed as plain cubes** — `ancient_brick`/`rune_stone` were not in
+  `TintableDefaults`, so `HandlePlace` stripped the form and glow that `BreakBlockAt` had put into the item; the client
+  ghost showed the pillar anyway. Both keys added; `HeldPlaceShape` now mirrors the `Shapeable` gate.
+- **#1835 Saplings never grew on a station** — the void-enclosure probe ran at the crown cell, whose floor is the air
+  trunk column → "opens to the void" for ever. Judged at the sapling's cell now (berry bushes have no ripening by design).
+- **#1836 False "station is no longer airtight"** — `FillStationPocket` declared a hull breach whenever the START cell was
+  airtight, which a built/stamped door cell and a water cell are; every door transit and pond dip fired the one-shot
+  warning, and the toast had no lifetime. The fill now seeds from the head/neighbour of a door or fluid cell and takes the
+  first sealed pocket; the client clears the banner when life support reports the station sealed again.
+- **#1837 2-block openings still wedged (the #1790 probe was one column short)** — the lintel sits in the NEXT column and
+  the step-up engages at contact, radius + skin before it. `UpdateStepOffset(move)` now samples ahead along the move
+  (centre + both shoulders, `AheadProbe` 0.55 m beyond the capsule edge) as well.
+- **#1838 Fall damage for a flyer** — `HandleFallDamage` now bails for `CreativeFlightFor || Fly`, like `InSpace`.
+- **#1839 "You take damage!" on lava** — `InferDamageCause` samples feet and feet−1, matching the server's `InLava`.
+
+Tests: core column unmineable + protection box, finale objective over the tutorial chip, flyer takes no fall damage,
+ruin masonry shapeable/tintable, roof spawn (25-long hall with a packed centre), doorway/pond pocket, sapling grows in a
+sealed station hall. Local Unity player build before merge (client: MiningFx, FinaleView, HudUi, PlayerController,
+GameBootstrap).
+
 ### 🔭 View distance goes to 16 — and the view streams as a disc (#1813, 2026-09-12, branch feat/view-distance-16)
 
 Marcel: raise the view-distance maximum to 16 chunks; a native desktop client's first run now starts at 8, the browser

--- a/client/Assets/BlocksBeyondTheStars/Scripts/FinaleView.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/FinaleView.cs
@@ -59,7 +59,14 @@ namespace BlocksBeyondTheStars.Client
 
         private GUIStyle _box, _title, _body, _choice, _hint, _bar, _barFill;
 
-        private bool OnGuardianWorld => string.Equals(_systemName, GuardianSystemName, System.StringComparison.Ordinal);
+        /// <summary>On the finale body, on foot. #1831: judged by the location id first — <c>JoinAccepted</c> names the
+        /// system too, but only <c>WorldReset</c> ever reached <see cref="_systemName"/>, so a save joined while
+        /// standing in the core chamber had no breach hint and the fire hold MINED the core instead of channelling
+        /// the hack. The system name stays as the fallback for a star map that has not arrived yet.</summary>
+        private bool OnGuardianWorld
+            => !(Game?.SpaceViewActive ?? false)
+               && ((Game?.StarMap?.ActiveLocationId is { } here && here.StartsWith("guardian_finale", System.StringComparison.Ordinal))
+                   || string.Equals(_systemName, GuardianSystemName, System.StringComparison.Ordinal));
         private bool FinaleActive => Game?.Story != null && Game.Story.GuardianSystemRevealed && !Game.Story.GuardianDefeated;
 
         /// <summary>True while holding the breach control would do something: finale live, on the Guardian

--- a/client/Assets/BlocksBeyondTheStars/Scripts/GameBootstrap.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/GameBootstrap.cs
@@ -1117,6 +1117,10 @@ namespace BlocksBeyondTheStars.Client
         /// <summary>Last server feedback line (craft result / rejection / message) for a HUD toast.</summary>
         public string LastMessage { get; private set; } = string.Empty;
 
+        /// <summary>The resolved station hull-open warning while it is the toast (#1836) — cleared once the station
+        /// reports the pocket sealed again, so the banner does not outlive the leak.</summary>
+        private string _stationAirWarning = string.Empty;
+
         /// <summary>Shows a transient HUD message from a client-side system (e.g. the VEGA autopilot).</summary>
         public void ShowMessage(string text) => LastMessage = text ?? string.Empty;
 
@@ -1236,8 +1240,9 @@ namespace BlocksBeyondTheStars.Client
             // #1473: a player-built station's hull is open — no air outside a sealed pocket until it is patched.
             if (text == "@station_air_lost")
             {
-                return Localizer?.Get("ui.station.air_lost")
+                _stationAirWarning = Localizer?.Get("ui.station.air_lost")
                     ?? "Warning: the station is no longer airtight — helmet on until the hull is patched!";
+                return _stationAirWarning;
             }
 
             // #1559: the pocket is closed but bigger than the life-support budget.
@@ -3209,6 +3214,13 @@ namespace BlocksBeyondTheStars.Client
             Hunger = m.Hunger;
             SuitClimateActive = m.SuitClimateActive;
             LifeSupportSource = m.LifeSupportSource;
+            if (m.LifeSupportSource == 2 && _stationAirWarning.Length > 0 && LastMessage == _stationAirWarning)
+            {
+                // #1836: the station reports the pocket sealed again — the hull-open banner has no lifetime of its own
+                // and would stay pinned over a breathing player until the next server line replaced it.
+                LastMessage = string.Empty;
+                _stationAirWarning = string.Empty;
+            }
             // Comfort: auto-stow loose materials into the cargo hold the moment you board the ship (off by
             // default — opt in via Settings). Fires only on the not-aboard → aboard edge, and reuses the same
             // server-authoritative bulk "stow all" intent the cargo tab's button sends.

--- a/client/Assets/BlocksBeyondTheStars/Scripts/HudUi.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/HudUi.cs
@@ -363,10 +363,17 @@ namespace BlocksBeyondTheStars.Client
         private string InferDamageCause()
         {
             var p = Game.PlayerPosition;
-            var id = Game.World != null
-                ? Game.World.GetBlock(Mathf.FloorToInt(p.x), Mathf.FloorToInt(p.y), Mathf.FloorToInt(p.z))
-                : default;
-            if (Game.Content?.BlockById(id)?.Key == "lava") { return "ui.hud.dmg_lava"; }
+            if (Game.World != null && Game.Content != null)
+            {
+                // #1839: lava carries a collider, so the player stands ON it — the feet cell is air and the melt is
+                // one below. The same two cells the server's InLava reads, so the cause matches the damage.
+                int bx = Mathf.FloorToInt(p.x), by = Mathf.FloorToInt(p.y), bz = Mathf.FloorToInt(p.z);
+                if (Game.Content.BlockById(Game.World.GetBlock(bx, by, bz))?.Key == "lava"
+                    || Game.Content.BlockById(Game.World.GetBlock(bx, by - 1, bz))?.Key == "lava")
+                {
+                    return "ui.hud.dmg_lava";
+                }
+            }
             if (Game.Oxygen <= 0.5f) { return "ui.hud.dmg_suffocate"; }
             if (Game.Hunger <= 0.5f) { return "ui.hud.dmg_starve"; }
             // Exposure damage (#666): the suit is out of energy and climate control lost the fight —

--- a/client/Assets/BlocksBeyondTheStars/Scripts/MiningFx.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/MiningFx.cs
@@ -107,9 +107,13 @@ namespace BlocksBeyondTheStars.Client
 
         private void OnMineProgress(MiningProgress m)
         {
-            _crackX = m.X;
-            _crackY = m.Y;
-            _crackZ = m.Z;
+            // #1829: the server echoes the CANONICAL cell; the outline lives in scene space (the transform runs
+            // unbounded across the wrap seam). Map it once here so the crack compare and the pickup still match
+            // after a lap — past the seam the tint never lit and the mined tile never flew ("Wo ist die Animation?").
+            var scene = SceneCell(m.X, m.Y, m.Z);
+            _crackX = scene.x;
+            _crackY = scene.y;
+            _crackZ = scene.z;
             _crackFrac = Mathf.Clamp01(m.Fraction);
             _crackAt = Time.time;
             if (Game?.World != null)
@@ -122,7 +126,8 @@ namespace BlocksBeyondTheStars.Client
 
         private void OnBlock(BlockChanged m)
         {
-            var pos = new Vector3(m.X + 0.5f, m.Y + 0.5f, m.Z + 0.5f);
+            var cell = SceneCell(m.X, m.Y, m.Z); // #1829: canonical → scene, else the flash pops one world-lap away
+            var pos = new Vector3(cell.x + 0.5f, cell.y + 0.5f, cell.z + 0.5f);
             SpawnBurst(pos, m.Block == 0 ? _digMat : _placeMat);
             if (m.Block != 0)
             {
@@ -130,11 +135,24 @@ namespace BlocksBeyondTheStars.Client
             }
 
             FlashAt(pos); // the final-hit pop
-            if (m.X == _crackX && m.Y == _crackY && m.Z == _crackZ && _crackBlock.Value != 0)
+            if (cell.x == _crackX && cell.y == _crackY && cell.z == _crackZ && _crackBlock.Value != 0)
             {
                 HudUi.Instance?.FlyPickup(pos, _crackBlock); // mined tile flies into the hotbar
                 _crackBlock = default;
             }
+        }
+
+        /// <summary>A canonical block cell as the scene cell nearest the player (<see cref="GameBootstrap.ScenePos"/>);
+        /// the identity when no game is wired up (edit-mode rigs).</summary>
+        private Vector3Int SceneCell(int x, int y, int z)
+        {
+            if (Game == null)
+            {
+                return new Vector3Int(x, y, z);
+            }
+
+            var p = Game.ScenePos(x + 0.5f, y + 0.5f, z + 0.5f);
+            return new Vector3Int(Mathf.FloorToInt(p.x), y, Mathf.FloorToInt(p.z));
         }
 
         /// <summary>A bright one-shot pop slightly proud of the broken block — the "final hit" flash.</summary>

--- a/client/Assets/BlocksBeyondTheStars/Scripts/PlayerController.cs
+++ b/client/Assets/BlocksBeyondTheStars/Scripts/PlayerController.cs
@@ -2172,7 +2172,7 @@ namespace BlocksBeyondTheStars.Client
         /// Problem"; the earlier skin-width fix only removed part of the cause). Step height is therefore capped
         /// to the headroom actually available, which still climbs slabs and stair treads in the open.
         /// </summary>
-        private void UpdateStepOffset()
+        private void UpdateStepOffset(Vector3 move)
         {
             float capsuleTop = _crouched ? CrouchHeight : StandHeight;
 
@@ -2187,6 +2187,24 @@ namespace BlocksBeyondTheStars.Client
             float reach = _controller.radius + _controller.skinWidth;
             float diag = reach * 0.7071f;
             var feet = transform.position;
+
+            // #1837: the lintel of a 2-high doorway sits in the NEXT column, and the step-up engages the moment the
+            // forward sweep touches it — with the capsule centre still radius + skin (plus a frame of approach) short
+            // of that column, where every footprint sample above reads air. So the 0.6 m sweep stayed armed, the
+            // raised capsule (1.8 + 0.6) met the lintel at 2.0 and the walk wedged; a crouch or a jump got through
+            // ("Ich kann immernoch nur unter 2 Blöcken durch wenn ich springe oder mich ducke"). Sample the column
+            // ahead along the move as well — centre and both shoulders — so the cap is set before the sweep can reach.
+            bool moving = move.x * move.x + move.z * move.z > 1e-6f;
+            float ax = 0f, az = 0f, lx = 0f, lz = 0f;
+            if (moving)
+            {
+                var dir = new Vector3(move.x, 0f, move.z).normalized;
+                ax = dir.x * (reach + AheadProbe);
+                az = dir.z * (reach + AheadProbe);
+                lx = -dir.z * reach;
+                lz = dir.x * reach;
+            }
+
             for (float probe = 0.1f; probe <= DefaultStepOffset + 0.05f; probe += 0.1f)
             {
                 float up = capsuleTop + probe;
@@ -2194,7 +2212,9 @@ namespace BlocksBeyondTheStars.Client
                     || CeilingAt(feet, up, reach, 0f) || CeilingAt(feet, up, -reach, 0f)
                     || CeilingAt(feet, up, 0f, reach) || CeilingAt(feet, up, 0f, -reach)
                     || CeilingAt(feet, up, diag, diag) || CeilingAt(feet, up, -diag, diag)
-                    || CeilingAt(feet, up, diag, -diag) || CeilingAt(feet, up, -diag, -diag))
+                    || CeilingAt(feet, up, diag, -diag) || CeilingAt(feet, up, -diag, -diag)
+                    || (moving && (CeilingAt(feet, up, ax, az)
+                        || CeilingAt(feet, up, ax + lx, az + lz) || CeilingAt(feet, up, ax - lx, az - lz))))
                 {
                     headroom = Mathf.Max(0f, probe - 0.1f);
                     break;
@@ -2212,6 +2232,10 @@ namespace BlocksBeyondTheStars.Client
         /// <summary>The step height used in the open — matches the value WorldRig sets up so a slab (0.5) and each
         /// stair tread are walked up without jumping.</summary>
         private const float DefaultStepOffset = 0.6f;
+
+        /// <summary>How far beyond the capsule edge the step-offset probe looks along the move (#1837): past the
+        /// contact distance (radius + skin) and a frame of approach, into the column the next sweep would enter.</summary>
+        private const float AheadProbe = 0.55f;
 
         // --- Observer mode (issue #487) -------------------------------------------------------------
 
@@ -3223,7 +3247,7 @@ namespace BlocksBeyondTheStars.Client
 
             // Cap the auto-step to the headroom above the head before moving, so a 2-block-high opening stays
             // walkable instead of wedging the capsule (see UpdateStepOffset).
-            UpdateStepOffset();
+            UpdateStepOffset(move);
 
             _controller.Move(move * Time.deltaTime);
 
@@ -3985,6 +4009,14 @@ namespace BlocksBeyondTheStars.Client
             int shape = BlocksBeyondTheStars.Shared.State.ItemKey.Shape(held);
             if (shape > 0)
             {
+                // #1834: the server honours a carried form only on a Shapeable block (HandlePlace); on anything else
+                // the item places a plain cube — so the ghost and the rotate key must say cube too, not pillar.
+                string placed = Game?.Content?.GetItem(BlocksBeyondTheStars.Shared.State.ItemKey.Base(held))?.PlacesBlock;
+                if (!string.IsNullOrEmpty(placed) && Game.Content.GetBlock(placed) is { Shapeable: false })
+                {
+                    return 0;
+                }
+
                 cycle = PropOrientation.Full; // a crafted form is a building block: all 24 orientations
                 return shape;
             }

--- a/data/locales/de.json
+++ b/data/locales/de.json
@@ -3844,6 +3844,7 @@
   "srv.protect.factory": "Diese Fabrik ist geschützt — beanspruche sie mit einem Zugangscode, um umzubauen.",
   "srv.protect.settlement": "Diese Siedlung ist geschützt.",
   "srv.protect.station": "Diese Station ist geschützt.",
+  "srv.protect.core": "Der Wächter-Kern hält deinem Werkzeug stand — knacke ihn, statt ihn abzubauen.",
   "srv.ration.food_only": "In den Rationsspender passt nur Essen.",
   "srv.ration.full": "Der Rationsspender ist voll.",
   "srv.ration.no_food": "Dieses Essen hast du nicht.",

--- a/data/locales/en.json
+++ b/data/locales/en.json
@@ -3844,6 +3844,7 @@
   "srv.protect.factory": "This factory is protected — claim it with an access code to rebuild it.",
   "srv.protect.settlement": "This settlement is protected.",
   "srv.protect.station": "This station is protected.",
+  "srv.protect.core": "The Guardian core is beyond your tools — breach it, don't dig it.",
   "srv.ration.food_only": "Only food can go in the ration dispenser.",
   "srv.ration.full": "The ration dispenser is full.",
   "srv.ration.no_food": "You don't have that food.",

--- a/src/BlocksBeyondTheStars.GameServer/GameServer.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServer.cs
@@ -3999,6 +3999,15 @@ public sealed partial class GameServer
         }
     }
 
+    /// <summary>Test seam (#1838): the client reported a hard landing at <paramref name="impactSpeed"/>.</summary>
+    public void FallDamageForTest(string playerId, float impactSpeed)
+    {
+        if (FindSessionByPlayerId(playerId) is { } session)
+        {
+            HandleFallDamage(session, new FallDamageIntent { ImpactSpeed = impactSpeed });
+        }
+    }
+
     /// <summary>Runs the authoritative mine validator for a player until the block breaks (used by local
     /// play / tests). Hard blocks now need several drill hits, so this applies hits up to a safe cap.</summary>
     public void MineBlock(string playerId, int x, int y, int z)
@@ -4174,6 +4183,14 @@ public sealed partial class GameServer
             return; // piloting in space — there is no on-foot fall to take
         }
 
+        if (Rules.CreativeFlightFor(p.ModeOverride) || p.Fly)
+        {
+            // #1838: a suit that can fly never takes a fall. The client's own guard only knows the ACTIVE flight
+            // mode (cleared by the double-tap toggle, water and ladders), so a flyer who dropped down a shaft with
+            // the mode off reported a real impact — and died of it ("Den Sturz hast du nicht überlebt").
+            return;
+        }
+
         float over = intent.ImpactSpeed - FallSafeImpactSpeed;
         if (over <= 0f)
         {
@@ -4277,6 +4294,14 @@ public sealed partial class GameServer
         if (!harvestingPlant && IsStationBlock(pos))
         {
             Reject(session, "mine", "@srv.protect.station");
+            return;
+        }
+
+        // #1830: the Guardian core is breached, not dug out — its column was a bare-hand light block and the
+        // one-shot stamp never brought it back once a player had mined it.
+        if (IsGuardianCoreProtected(pos))
+        {
+            Reject(session, "mine", "@srv.protect.core");
             return;
         }
 
@@ -4497,6 +4522,7 @@ public sealed partial class GameServer
                     var p = new Vector3i(center.X + dx, center.Y + dy, center.Z + dz);
                     var b = _world.GetBlock(p);
                     if (b.IsAir || IsShipBlock(p) || IsSettlementProtected(p, b) || IsStationBlock(p)
+                        || IsGuardianCoreProtected(p) // #1830
                         || IsBaseProtected(p, session.State.PlayerId, session.State.IsAdmin))
                     {
                         continue;

--- a/src/BlocksBeyondTheStars.GameServer/GameServerFlora.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerFlora.cs
@@ -198,11 +198,16 @@ public sealed partial class GameServer
             }
         }
 
-        var top = new Vector3i(pos.X, pos.Y + height - 1, pos.Z);
-        if (!IsFloraEnclosedForVoidWorld(top))
+        // #1835: on a void world the hall must hold the tree — judged at the SAPLING's cell, which has the floor the
+        // enclosure probe starts from. The old check ran the probe at the crown cell, whose "floor" is the trunk
+        // column just verified to be air, so it read every sapling on a station as "opens to the void" and retried
+        // for ever ("Warum werden die Setzlinge nicht größer?"). The crown column itself is checked for room above.
+        if (!IsFloraEnclosedForVoidWorld(pos))
         {
-            return false; // a station hall must hold the crown as well
+            return false; // a station hall must hold the tree as well
         }
+
+        var top = new Vector3i(pos.X, pos.Y + height - 1, pos.Z);
 
         var log = new BlockId(_saplingLogId);
         var leaf = new BlockId(_saplingLeafId);

--- a/src/BlocksBeyondTheStars.GameServer/GameServerPlayerStations.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerPlayerStations.cs
@@ -648,13 +648,24 @@ public sealed partial class GameServer
     /// lies nearest to <paramref name="near"/> — the spawn spot when the box centre is built shut (#1493).</summary>
     private bool TryFindStandableInStation(BoardableStation station, Vector3i near, out Vector3i spot)
     {
+        // #1833: two passes — a standable cell that HOLDS AIR first, any standable cell only when the build has no
+        // sealed pocket at all. The roof's outer face is "standable" too (support below, two free cells of vacuum
+        // above) and on a build whose centre column is walled in it was the NEAREST such cell: Lyxette docked and
+        // was set down on top of her station, in the vacuum.
+        _stationAir.Remove(station.Id); // the stamp just rewrote the hull — judge the pockets on what the world holds now
+        return TryFindStandableInStation(station, near, sealedOnly: true, out spot)
+            || TryFindStandableInStation(station, near, sealedOnly: false, out spot);
+    }
+
+    private bool TryFindStandableInStation(BoardableStation station, Vector3i near, bool sealedOnly, out Vector3i spot)
+    {
         spot = default;
         long best = long.MaxValue;
         for (int x = station.BoundsMin.X; x <= station.BoundsMax.X; x++)
             for (int z = station.BoundsMin.Z; z <= station.BoundsMax.Z; z++)
                 for (int y = station.BoundsMin.Y + 1; y <= station.BoundsMax.Y + 1; y++)
                 {
-                    if (!StandableAt(x, y, z))
+                    if (!StandableAt(x, y, z) || (sealedOnly && !InSealedStationPocket(station, new Vector3i(x, y, z))))
                     {
                         continue;
                     }

--- a/src/BlocksBeyondTheStars.GameServer/GameServerShipAi.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerShipAi.cs
@@ -96,16 +96,22 @@ public sealed partial class GameServer
     private void SendVegaObjective(PlayerSession session)
         => SendVegaLine(session, string.Empty, 0);
 
+    /// <summary>#1832: once the Guardian system is revealed the finale IS the objective — the onboarding chip
+    /// ("craft an item") must not sit over it while the player stands in the core chamber. The stages still
+    /// complete in the background; the chip shows the story until the core is won.</summary>
+    private bool FinaleObjectiveOverridesTutorial
+        => StoryActive && _story is not null && _storyState.GuardianSystemRevealed && !_storyState.GuardianDefeated;
+
     private string VegaObjectiveKey(PlayerState p)
     {
         int i = VegaStageIndex(p);
-        return i < VegaStages.Length ? "vega.obj." + VegaStages[i].Id : StoryObjectiveKey(p);
+        return i < VegaStages.Length && !FinaleObjectiveOverridesTutorial ? "vega.obj." + VegaStages[i].Id : StoryObjectiveKey(p);
     }
 
     private int VegaObjectiveTarget(PlayerState p)
     {
         int i = VegaStageIndex(p);
-        if (i < VegaStages.Length)
+        if (i < VegaStages.Length && !FinaleObjectiveOverridesTutorial)
         {
             return VegaStages[i].Target;
         }
@@ -120,7 +126,7 @@ public sealed partial class GameServer
     {
         var p = session.State;
         int i = VegaStageIndex(p);
-        if (i < VegaStages.Length)
+        if (i < VegaStages.Length && !FinaleObjectiveOverridesTutorial)
         {
             return VegaStages[i].Id == "mine" ? session.VegaMineCount : 0;
         }

--- a/src/BlocksBeyondTheStars.GameServer/GameServerSpaceStations.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerSpaceStations.cs
@@ -287,6 +287,7 @@ public sealed partial class GameServer
         session.State.AboardShip = false;
         session.State.InEva = false; // docking ends any spacewalk — the station has life support
         session.SentChunks.Clear();
+        session.AwaitingSpawnAdopt = true; // #1833: like every other server teleport — the client's stale stream must not drag them back (#865)
         MarkArrivedOnBody(session, station.Id); // boarding marks the station visited → a travel-screen target
 
         Send(session, new SpaceClosed { Reason = "@srv.station.docked", ShipDisabled = false });

--- a/src/BlocksBeyondTheStars.GameServer/GameServerStationAir.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerStationAir.cs
@@ -192,6 +192,31 @@ public sealed partial class GameServer
         leak = StationLeak.Hull;
         if (IsStationAirtightCell(start))
         {
+            // #1836: a door cell (built or stamped) and a fluid cell count as walls for the fill, but the player DOES
+            // stand in them — in the doorway between two rooms, in the pond of the arboretum. Reading that as "inside
+            // a wall → hull open" fired the breach warning on every door transit. Judge the pocket from the air the
+            // player is actually breathing: the head cell or a neighbour, whichever holds a sealed pocket.
+            if (StartCellIsPassable(start))
+            {
+                foreach (var alt in StartCellAlternatives(start))
+                {
+                    if (IsStationAirtightCell(alt))
+                    {
+                        continue;
+                    }
+
+                    var pocket = FillStationPocket(station, alt, out sealedPocket, out leak);
+                    if (sealedPocket)
+                    {
+                        pocket.Add(start);
+                        return pocket;
+                    }
+                }
+
+                sealedPocket = false;
+                leak = StationLeak.Hull;
+            }
+
             cells.Add(start);
             return cells; // standing inside a wall cell: no pocket to breathe from
         }
@@ -248,6 +273,35 @@ public sealed partial class GameServer
         }
 
         return cells;
+    }
+
+    /// <summary>A cell the fill treats as a wall although a player can occupy it: a door (built into an air cell or a
+    /// stamped door block) or a fluid (#1836).</summary>
+    private bool StartCellIsPassable(Vector3i c)
+    {
+        var id = _world.GetBlockIfLoaded(c);
+        if (id.IsAir)
+        {
+            return PlayerDoorFillsCell(c);
+        }
+
+        if (IsFluid(id.Value))
+        {
+            return true;
+        }
+
+        return _content.BlockById(id)?.Key.StartsWith("door_", System.StringComparison.Ordinal) == true;
+    }
+
+    /// <summary>Where to look for the pocket around an occupied wall-like cell: the head first (a pond is one deep, a
+    /// doorway is walked through upright), then the four sides.</summary>
+    private static IEnumerable<Vector3i> StartCellAlternatives(Vector3i c)
+    {
+        yield return new Vector3i(c.X, c.Y + 1, c.Z);
+        yield return new Vector3i(c.X + 1, c.Y, c.Z);
+        yield return new Vector3i(c.X - 1, c.Y, c.Z);
+        yield return new Vector3i(c.X, c.Y, c.Z + 1);
+        yield return new Vector3i(c.X, c.Y, c.Z - 1);
     }
 
     /// <summary>Airtight for station purposes: an airtight full cube (walls, glass, force field), any door block

--- a/src/BlocksBeyondTheStars.GameServer/GameServerStoryFinale.cs
+++ b/src/BlocksBeyondTheStars.GameServer/GameServerStoryFinale.cs
@@ -334,6 +334,29 @@ public sealed partial class GameServer
         return dx * dx + dy * dy + dz * dz <= (double)CoreChamberReach * CoreChamberReach;
     }
 
+    /// <summary>#1830: the heart of the Guardian core — the 3×3 pedestal, the core column, its corner pillars and
+    /// panes, from the plated floor to the pillar tops — cannot be mined. The column is a bare-hand light block and
+    /// the chamber stamp is one-shot (<see cref="StampGuardianCoreChamber"/>), so a mined core never came back:
+    /// "3: Ich kann ihn abbauen." The shell stays diggable — Route B (mining down through it) is a documented way
+    /// in, and the hack is a channel, not a demolition.</summary>
+    private bool IsGuardianCoreProtected(Vector3i pos)
+    {
+        var aw = _worlds.Active;
+        if (!aw.HasCoreChamber)
+        {
+            return false;
+        }
+
+        var c = aw.CoreChamberCenter; // (ax, floorY + 1, az) — see the stamp
+        int dx = WorldConstants.WrapDeltaX(pos.X - c.X, _world.Circumference); // int overload: the wrapped column delta
+        int dz = pos.Z - c.Z;
+        int dy = pos.Y - (c.Y - 1); // relative to the chamber floor level
+        return dx >= -1 && dx <= 1 && dz >= -1 && dz <= 1 && dy >= -1 && dy <= 5;
+    }
+
+    /// <summary>Test seam (#1830): whether the active world protects the cell as part of the Guardian core.</summary>
+    public bool IsGuardianCoreProtectedForTest(int x, int y, int z) => IsGuardianCoreProtected(new Vector3i(x, y, z));
+
     /// <summary>Applies the finale respawn rule (P6): if the ship would respawn the clone inside the Guardian
     /// system and a pre-finale return location was recorded for this player, returns that body instead (and
     /// consumes the record) so the clone re-grows on the world it launched from. Otherwise returns

--- a/src/BlocksBeyondTheStars.Shared/Content/GameContent.cs
+++ b/src/BlocksBeyondTheStars.Shared/Content/GameContent.cs
@@ -399,6 +399,7 @@ public sealed class GameContent
         "moss_stone", "sandstone", "scree", "bone", // #1647 landscape-variety terrain set (tar keeps its fluid look)
         "iron_wall", "steel_wall", "bronze_block", "brass_block", "steel_floor", "metal_panel", "concrete",
         "cargo_floor", "medbay_panel", "lab_panel", "engine_panel",
+        "ancient_brick", "rune_stone", // #1834 ruin masonry: a mined pillar keeps its form, a mined rune its glow
     };
 
     private void MarkTintableDefaults()

--- a/tests/BlocksBeyondTheStars.Tests/GameServerFinaleTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/GameServerFinaleTests.cs
@@ -286,4 +286,62 @@ public sealed class GameServerFinaleTests : IDisposable
             // best-effort temp cleanup
         }
     }
+    // ---------------- Player reports 2026-09-12: the core is breached, not dug out (#1830 / #1832 / #1838) ----------------
+
+    [Fact]
+    public void The_core_column_cannot_be_mined()
+    {
+        var server = Started(out var repo);
+        using (repo)
+        {
+            var pilot = server.AddLocalPlayer("Pilot");
+            var centre = server.LoadGuardianCoreForTest();
+            pilot.CurrentLocationId = SvGameServer.GuardianCoreBodyId;
+            pilot.State.Position = new Vector3f(centre.X + 2.5f, centre.Y + 0.5f, centre.Z + 2.5f);
+
+            var core = new Vector3i(centre.X, centre.Y, centre.Z); // the light column at the heart of the chamber
+            ushort before = server.World.GetBlock(core).Value;
+            Assert.NotEqual(0, before);
+            Assert.True(server.IsGuardianCoreProtectedForTest(core.X, core.Y, core.Z));
+
+            server.MineBlock("Pilot", core.X, core.Y, core.Z); // a bare hand — the column is a 0.5-hardness light block
+            Assert.Equal(before, server.World.GetBlock(core).Value);
+
+            // The shell around it stays diggable (Route B) and so does the world beyond the chamber.
+            Assert.False(server.IsGuardianCoreProtectedForTest(core.X + 5, core.Y, core.Z));
+            Assert.False(server.IsGuardianCoreProtectedForTest(core.X + 8, core.Y, core.Z + 8));
+        }
+    }
+
+    [Fact]
+    public void The_finale_objective_beats_the_tutorial_chip_once_the_system_is_revealed()
+    {
+        var server = Started(out var repo);
+        using (repo)
+        {
+            server.AddLocalPlayer("Pilot");
+            Assert.StartsWith("vega.obj.", server.ObjectiveKeyForTest("Pilot")); // a fresh player is in VEGA's onboarding
+
+            CompleteTheArc(server);
+            Assert.Equal("story.obj.finale", server.ObjectiveKeyForTest("Pilot")); // …until the finale is on the map
+        }
+    }
+
+    [Fact]
+    public void A_flying_player_takes_no_fall_damage()
+    {
+        var server = Started(out var repo);
+        using (repo)
+        {
+            var pilot = server.AddLocalPlayer("Pilot");
+            pilot.State.Health = 100f;
+            pilot.State.Fly = true;
+            server.FallDamageForTest("Pilot", 18f); // over the safe 14 — a hard landing on foot
+            Assert.Equal(100f, pilot.State.Health);
+
+            pilot.State.Fly = false;
+            server.FallDamageForTest("Pilot", 18f);
+            Assert.True(pilot.State.Health < 100f, "without flight the same landing hurts");
+        }
+    }
 }

--- a/tests/BlocksBeyondTheStars.Tests/PlayerStationReportsTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/PlayerStationReportsTests.cs
@@ -713,6 +713,144 @@ public sealed class PlayerStationReportsTests : IDisposable
         Assert.Equal(16.0, beam!.Stats["tractor_range"]);
     }
 
+    // ---------------- Player reports 2026-09-12 (Lyxette): the roof spawn, the doorway "leak", the sapling ----------------
+
+    /// <summary>A sealed 25×5×5 hall (cells x −2…22, y/z −2…2) with its floor row plated over AND a 1-high crawl gap
+    /// up to x = 19, so the only standable cells INSIDE sit at the far +X end — while the roof's outer face above
+    /// the box centre is standable too (support below, vacuum above) and NEARER. Before #1833 the spawn search
+    /// took the roof.</summary>
+    private static string BuildLongHallWithABlockedCentre(SvGameServer server, PlayerSession pilot)
+    {
+        string playerId = pilot.State.PlayerId;
+        server.EnterSpace(playerId);
+        pilot.State.InEva = true;
+        pilot.State.InstantBuild = true;
+        server.DeployStationCoreForTest(playerId);
+        string id = server.OwnedStationIdForTest(playerId)!;
+        for (int x = -2; x <= 22; x++)
+            for (int y = -2; y <= 2; y++)
+                for (int z = -2; z <= 2; z++)
+                {
+                    if (x == 0 && y == 0 && z == 0)
+                    {
+                        continue; // the core
+                    }
+
+                    bool shell = x == -2 || x == 22 || Math.Abs(y) == 2 || Math.Abs(z) == 2;
+                    bool doorway = x == 22 && y == -1 && z == 0;
+                    bool packed = (y == -1 || y == 1) && x <= 19; // floor and ceiling rows built over → 1-high gap only
+                    if ((shell && !doorway) || packed)
+                    {
+                        Edit(server, playerId, id, x, y, z, "iron_wall");
+                    }
+                }
+
+        Edit(server, playerId, id, 22, -1, 0, "door_slide");
+        Assert.True(server.StationIsBoardableForTest(id));
+        return id;
+    }
+
+    [Fact]
+    public void Docking_NeverSpawnsOnTheRoof_WhenTheHullHoldsAir()
+    {
+        string id;
+        {
+            var s1 = NewServer("roofspawn", out var repo1);
+            using (repo1)
+            {
+                var pilot = s1.AddLocalPlayer("Owner");
+                id = BuildLongHallWithABlockedCentre(s1, pilot);
+                BoardOwnStation(s1, "Owner", id); // the first stamp cuts its pad through the packed centre column
+                repo1.Flush();
+            }
+        }
+
+        Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+
+        var s2 = NewServer("roofspawn", out var repo2);
+        using (repo2)
+        {
+            var pilot = s2.AddLocalPlayer("Owner");
+            pilot.State.AboardShip = true;
+            BoardOwnStation(s2, "Owner", id); // the top-up restores the packed centre → the spawn has to move
+
+            var feet = new Vector3i((int)Math.Floor(pilot.State.Position.X), (int)Math.Floor(pilot.State.Position.Y), (int)Math.Floor(pilot.State.Position.Z));
+            Assert.Equal(BoxWorld(0, -1, 0).Y, feet.Y); // on the deck (world y 65) — not on the roof (y 69)
+            Assert.True(feet.X >= BoxWorld(20, 0, 0).X, $"the spawn moved to the free end of the hall, not up: {feet}");
+            Assert.True(s2.StationPocketSizeForTest(id, feet) > 0, "…and it holds air");
+        }
+    }
+
+    [Fact]
+    public void StandingInTheDoorway_OrInThePond_KeepsTheRoomSealed()
+    {
+        var s = NewServer("doorair", out var repo);
+        using (repo)
+        {
+            var pilot = s.AddLocalPlayer("Owner");
+            string id = BuildSealedBox(s, pilot);
+            BoardOwnStation(s, "Owner", id);
+
+            var inside = BoxWorld(1, -1, 0);
+            var door = BoxWorld(2, -1, 0); // the slide door in the +X wall
+            Assert.True(s.StationPocketSizeForTest(id, inside) > 0, "the box holds air");
+            Assert.True(s.StationPocketSizeForTest(id, door) > 0, "the doorway is part of that pocket, not a hole in the hull (#1836)");
+
+            var water = _content.GetBlock("water")!.NumericId;
+            s.World.SetBlock(inside, water);
+            Assert.True(s.StationPocketSizeForTest(id, inside) > 0, "a pond cell is breathed from its head cell, not a wall (#1836)");
+        }
+    }
+
+    /// <summary>A sealed 5×5×11 shaft of a hall (cells −2…2 in x/z, y −2…8): room for a trunk of five and its crown.</summary>
+    private static string BuildTallSealedBox(SvGameServer server, PlayerSession pilot)
+    {
+        string playerId = pilot.State.PlayerId;
+        server.EnterSpace(playerId);
+        pilot.State.InEva = true;
+        pilot.State.InstantBuild = true;
+        server.DeployStationCoreForTest(playerId);
+        string id = server.OwnedStationIdForTest(playerId)!;
+        for (int x = -2; x <= 2; x++)
+            for (int y = -2; y <= 8; y++)
+                for (int z = -2; z <= 2; z++)
+                {
+                    bool shell = Math.Abs(x) == 2 || Math.Abs(z) == 2 || y == -2 || y == 8;
+                    bool doorway = x == 2 && y == -1 && z == 0;
+                    if (shell && !doorway)
+                    {
+                        Edit(server, playerId, id, x, y, z, "iron_wall");
+                    }
+                }
+
+        Edit(server, playerId, id, 2, -1, 0, "door_slide");
+        Assert.True(server.StationIsBoardableForTest(id));
+        return id;
+    }
+
+    [Fact]
+    public void ASapling_GrowsIntoATree_InsideASealedStationHall()
+    {
+        var s = NewServer("sapling", out var repo);
+        using (repo)
+        {
+            var pilot = s.AddLocalPlayer("Owner");
+            string id = BuildTallSealedBox(s, pilot);
+            BoardOwnStation(s, "Owner", id);
+
+            var soil = BoxWorld(1, -1, 1);
+            var cell = BoxWorld(1, 0, 1);
+            pilot.State.Inventory.Add("dirt", 1, 99);
+            pilot.State.Inventory.Add("sapling", 1, 99);
+            s.PlaceBlock("Owner", soil.X, soil.Y, soil.Z, "dirt");
+            s.PlaceBlock("Owner", cell.X, cell.Y, cell.Z, "sapling");
+            Assert.Equal(_content.GetBlock("flora_sapling")!.NumericId.Value, s.World.GetBlock(cell).Value);
+
+            s.Tick(200.0); // > SaplingGrowSeconds — before #1835 the crown probe failed forever on a void world
+            Assert.Equal(_content.GetBlock("wood_log")!.NumericId.Value, s.World.GetBlock(cell).Value);
+        }
+    }
+
     public void Dispose()
     {
         Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();

--- a/tests/BlocksBeyondTheStars.Tests/TintedBlocksTests.cs
+++ b/tests/BlocksBeyondTheStars.Tests/TintedBlocksTests.cs
@@ -157,4 +157,18 @@ public sealed class TintedBlocksTests : IDisposable
         }
         catch { }
     }
+    /// <summary>#1834: the ruin stamps build narrow pillars (BlockShape.Post) and glowing runes from these two
+    /// blocks; mining recovers form and glow into the item, and placing must keep them — before, both keys were
+    /// missing from the shapeable/tintable set and every "Alter Ziegel · Pfeiler" came back as a plain cube.</summary>
+    [Fact]
+    public void RuinMasonry_KeepsItsFormAndGlow_OnPlacement()
+    {
+        foreach (var key in new[] { "ancient_brick", "rune_stone" })
+        {
+            var def = _content.GetBlock(key);
+            Assert.NotNull(def);
+            Assert.True(def!.Tintable, key + " must be tintable (glow)");
+            Assert.True(def.Shapeable, key + " must be shapeable (pillar)");
+        }
+    }
 }


### PR DESCRIPTION
Closes #1829
Closes #1830
Closes #1831
Closes #1832
Closes #1833
Closes #1834
Closes #1835
Closes #1836
Closes #1837
Closes #1838
Closes #1839

## Player reports 2026-09-12, evening (Justus ×8, Lyxette ×4, v2026.9.7)

Every report was read against the server snapshot and the code before anything was changed. The ideas from the same evening are filed as #1840–#1847 and are not part of this PR.

| Issue | What was wrong | Fix |
|---|---|---|
| #1829 | The mining glow vanished "too far from the ship": `MiningFx` compared the scene cell with the canonical cell the server echoes; past a wrap seam nothing matched | Both messages map through `SceneCell` (`Game.ScenePos`) |
| #1830 | The Guardian core column (a bare-hand light block on a one-shot stamp) could be mined and never came back | `IsGuardianCoreProtected` guards the 3×3 heart in `HandleMine` and `BreakArea`; `@srv.protect.core` EN+DE; the shell stays diggable (Route B) |
| #1831 | No breach hint after joining a save on the core body — `FinaleView` learned the system only from `WorldReset` | Gate on the star map location id (`guardian_finale*`), off in the space view, name as fallback |
| #1832 | "Craft an item" shown inside the core chamber — the VEGA tutorial chip beat the finale objective | Story objective wins once the Guardian system is revealed (key, target, progress) |
| #1833 | Docking put Lyxette on the airless roof — the spawn search accepted any standable cell up to the top of the build | Two passes: a cell inside a sealed pocket first; boarding sets `AwaitingSpawnAdopt` |
| #1834 | Mined ruin pillars / glowing runes placed as plain cubes — `ancient_brick`/`rune_stone` missing from `TintableDefaults`, ghost ignored the gate | Both keys added; `HeldPlaceShape` mirrors `Shapeable` |
| #1835 | Saplings never grew on a station — the void-enclosure probe ran at the crown cell whose floor is the air trunk | Probe at the sapling cell |
| #1836 | False "station is no longer airtight" while standing in a door cell or in the pond; toast never expired | Seed the fill from head/neighbour of a door or fluid start cell; client clears the banner when sealed again |
| #1837 | 2-block openings still wedged on 2026.9.7 — the #1790 probe covered the current footprint, the lintel sits in the next column | `UpdateStepOffset(move)` samples ahead along the move (`AheadProbe` 0.55 m, centre + shoulders) |
| #1838 | Fall damage for a flyer | `HandleFallDamage` bails for `CreativeFlightFor || Fly` |
| #1839 | "You take damage!" instead of the lava cause when standing ON lava | `InferDamageCause` samples feet and feet−1 |

## Verification

- `dotnet build -warnaserror`: 0 warnings, 0 errors. `dotnet format --verify-no-changes`: clean.
- Targeted server suites (finale, stations, flora, saplings, ship AI, story, content, locales): 200/200 green, including the seven new tests.
- Local Unity player build in the worktree: see the merge note below (required before merge — PR CI does not compile `client/Assets`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
